### PR TITLE
feat(core): send split_payments to UCS on void to rebuild charge response (#16999)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=748657ecf99d0879f09084e2b6ec50e82d417629#748657ecf99d0879f09084e2b6ec50e82d417629"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=748657ecf99d0879f09084e2b6ec50e82d417629#748657ecf99d0879f09084e2b6ec50e82d417629"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=748657ecf99d0879f09084e2b6ec50e82d417629#748657ecf99d0879f09084e2b6ec50e82d417629"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=748657ecf99d0879f09084e2b6ec50e82d417629#748657ecf99d0879f09084e2b6ec50e82d417629"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=748657ecf99d0879f09084e2b6ec50e82d417629#748657ecf99d0879f09084e2b6ec50e82d417629"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=748657ecf99d0879f09084e2b6ec50e82d417629#748657ecf99d0879f09084e2b6ec50e82d417629"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "748657ecf99d0879f09084e2b6ec50e82d417629", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "748657ecf99d0879f09084e2b6ec50e82d417629", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "748657ecf99d0879f09084e2b6ec50e82d417629", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "748657ecf99d0879f09084e2b6ec50e82d417629", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -6396,6 +6396,11 @@ impl transformers::ForeignTryFrom<&RouterData<api::Void, PaymentsCancelData, Pay
             test_mode: router_data.test_mode,
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             merchant_request_id: None,
+            split_payments: router_data
+                .request
+                .split_payments
+                .as_ref()
+                .map(payments_grpc::SplitPaymentsDetails::foreign_from),
         })
     }
 }
@@ -6439,6 +6444,7 @@ impl
             metadata: None,
             state,
             test_mode: router_data.test_mode,
+            split_payments: None,
         })
     }
 }


### PR DESCRIPTION
## What

Client + rev-pin half of shadow-validation diff **#16999** (`stripe` / `void`, merchant `yucca`,
env prod):

```
router.typeDiff:response.Ok.TransactionResponse.charges   { "hyperswitch": "object", "ucs": "null" }
```

The Direct gateway returns the split-charge `charges` object on the void response; the UCS path
returned `charges: null`. The void *response* mapping (`response.splits -> charges`,
`transformers.rs`) already exists — only the **request** side was missing: the UCS void request
did not carry `split_payments`, so prism could not rebuild the charge response.

This is the void sibling of the capture fix #12926 / prism #1615.

## Changes

| Site | Change |
|---|---|
| `core/unified_connector_service/transformers.rs` | set `split_payments` on `PaymentServiceVoidRequest` from `PaymentsCancelData.split_payments` (main Void flow); `None` for the PreAuthorizeVoid builder |
| `external_services`, `hyperswitch_interfaces`, `router` `Cargo.toml` + `Cargo.lock` | rev-pin all `connector-service` deps to the prism branch carrying `PaymentServiceVoidRequest.split_payments=13` |

Depends on prism **juspay/hyperswitch-prism#1629** (proto + decode). **Draft** until #1629 merges and
a CalVer tag is cut; then flip the `rev` back to the tag and undraft.

## Proof

Verified end-to-end against a prism built from #1629 (real Stripe sandbox authorize→void, direct gRPC):

- **Before** (void request without `split_payments`): void response has **no** `splits` → `charges: null` (the prod signature).
- **After** (void request carries `split_payments`): void response carries `splits: { stripeSplitResponse: { chargeId, chargeType: STRIPE_DIRECT, transferAccountId, … } }` → HS maps `response.splits -> charges` = object, matching Direct → typeDiff resolved.

Fixes juspay/hyperswitch-cloud#16999
