### PR TITLE
fix(router): map cybersource setup_mandate error connector_transaction_id from UCS error details

### DIFF
--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2855,7 +2855,16 @@ impl
                     .and_then(|cd| cd.reason.clone()),
                 status_code,
                 attempt_status,
-                connector_transaction_id: connector_transaction_id.get_optional_response_id(),
+                // On a failed setup_mandate there is no `connector_recurring_payment_id`
+                // (it is only populated on success), so prefer the connector's transaction
+                // id surfaced in the error details. This mirrors the connector's primary
+                // `get_error_response`, which sets `connector_transaction_id` to the
+                // transaction id even on a decline.
+                connector_transaction_id: error_info
+                    .connector_details
+                    .as_ref()
+                    .and_then(|cd| cd.connector_transaction_id.clone())
+                    .or_else(|| connector_transaction_id.get_optional_response_id()),
                 connector_response_reference_id: Some(
                     response.merchant_recurring_payment_id.clone(),
                 )


### PR DESCRIPTION
## Summary

Fix HS↔UCS shadow-validation diff `router.typeDiff:response.Err.connector_transaction_id`
for **cybersource / setup_mandate** (declined zero-dollar mandate setup).

On a **failed** `setup_mandate`, the HS-primary cybersource transformer sets
`ErrorResponse.connector_transaction_id = Some(<transaction id>)` (cybersource
`get_error_response`), but the **UCS shadow** path reconstructs the `ErrorResponse` with
`connector_transaction_id = None`, producing a type diff (HS `string` vs UCS `null`).

### Root cause (HS→UCS mapping)

In `crates/router/src/core/unified_connector_service/transformers.rs`, the
`PaymentServiceSetupRecurringResponse` → `Result<_, ErrorResponse>` mapping derives
`connector_transaction_id` **only** from `response.connector_recurring_payment_id`:

```rust
let connector_transaction_id = response
    .connector_recurring_payment_id
    .as_ref()
    .map(|id| ResponseId::ConnectorTransactionId(id.clone()))
    .unwrap_or(ResponseId::NoResponseId);
...
connector_transaction_id: connector_transaction_id.get_optional_response_id(),
```

`connector_recurring_payment_id` is only populated on **success** (UCS sets it to `None`
in the error builder of `generate_payment_setup_recurring_response`). So on a decline it
resolves to `NoResponseId` → `None`.

The real connector transaction id **is** carried over gRPC — UCS populates it in
`ErrorInfo.connector_details.connector_transaction_id` (`ConnectorErrorDetails`, proto
tag 4) from `err.connector_transaction_id`. The mapping just never read it on the error
path.

### Fix

In the error branch, prefer `error_info.connector_details.connector_transaction_id`
(falling back to the recurring-id mapping), mirroring the connector's primary
`get_error_response`, which sets `connector_transaction_id` to the transaction id even on
a decline. HS→UCS-mapping-only change — no proto change, no UCS change (the proto field
already exists and is already populated by UCS).

## Diff signature

`router.typeDiff:response.Err.connector_transaction_id` — cybersource / setup_mandate
(merchant `flowbird`).

## Repro

`prod-fixes/repro_17014.py`: zero-amount `payment_type=setup_mandate` on cybersource,
billing ZIP `46282` to force a processor decline; read the `/router-data/requests`
verdict (not `bodyComparison`).

## Before → after

- **Before:** HS-primary `response.Err.connector_transaction_id = Some(<id>)`,
  UCS-shadow-mapped `= None` → `router.typeDiff:response.Err.connector_transaction_id`.
- **After:** UCS-shadow-mapped reads `error.connector_details.connector_transaction_id =
  Some(<id>)` → matches HS-primary → diff gone.

> **Verification note:** cybersource is not reachable from this validation environment
> (HS-primary fails TLS to `apitest.cybersource.com` → `CE_01`, and the MITM proxy cannot
> reach cybersource → no VS verdict), so a live shadow `no_diff` could not be captured
> here. Verified instead by **source parity**: HS-primary and UCS both emit the same
> transaction id, the proto field is populated, and the mapping now reads it — plus local
> `cargo build` / `clippy` / `fmt` / `test` / spell-check. Same environmental block
> documented for the sibling fix #16972 family.

## Layer category

HS→UCS gRPC response mapping (`router/src/core/unified_connector_service/transformers.rs`).

Closes #12949
