### PR TITLE
fix(core): map UCS PSync response metadata into connector_metadata

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -266,6 +266,14 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
             .as_ref()
             .and_then(|e| e.connector_details.as_ref());
 
+        // Parse connector_metadata round-tripped from UCS via the response `metadata`
+        // field, so PSync mirrors HS-native which carries request.connector_meta into
+        // the response connector_metadata.
+        let parsed_connector_metadata: Option<serde_json::Value> = response
+            .metadata
+            .clone()
+            .and_then(|secret| serde_json::from_str(&secret.expose()).ok());
+
         let response = if let Some(error_code) =
             connector_details.and_then(|details| details.code.clone())
         {
@@ -330,7 +338,7 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
                             .transpose()?,
                     ),
                     mandate_reference: Box::new(response.mandate_reference.map(hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from).transpose()?),
-                    connector_metadata: None,
+                    connector_metadata: parsed_connector_metadata,
                     network_txn_id: response.network_transaction_id.clone(),
                     network_txn_link_id: response.network_txn_link_id.clone(),
                     connector_response_reference_id: response.merchant_transaction_id,


### PR DESCRIPTION
## What

Paired HS fix for the shadow-validation router diff on **nexixpay / psync**:

```
router.typeDiff:response.Ok.TransactionResponse.connector_metadata
```

On PSync, HS-native sets `connector_metadata = request.connector_meta` (the connector
metadata stored at authorize time), but the UCS-service response mapping hard-coded
`connector_metadata: None`, producing a type diff (object vs null).

## Change (HS↔UCS mapping only — no connector transformer change)

- `crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`
  — in the `PaymentServiceGetResponse → PaymentsResponseData` (PSync) mapping, parse the
  proto `metadata` field back into `connector_metadata` (mirrors how the authorize mapping
  parses `connector_feature_data`). The success-path `TransactionResponse.connector_metadata`
  is now populated from the round-tripped metadata instead of `None`.

This is the HS half of the round-trip; the UCS half (echo on the nexixpay PSync response
+ serialize into the proto `metadata` field) is in the paired connector-service PR.

## No proto / Cargo rev bump needed

The proto `metadata` field (`PaymentServiceGetResponse` field #21) already exists in the
pinned UCS gRPC client, so this PR compiles against the current `tag` pin — no `rev` bump.

## Verification

- `cargo build --bin router` and `cargo build --features v2` compile clean; `cargo fmt`,
  `cargo clippy` clean.
- Live nexixpay PSync shadow is not locally reproducible (sync needs a completed 3DS
  authorize + sandbox order). **Source-parity verified:** with the paired UCS PR, the
  UCS-mapped PSync `connector_metadata` equals HS-native's `request.connector_meta`,
  resolving the `router.typeDiff`.

Depends on the paired connector-service PR (cross-linked below).

Closes #12954

---
Paired UCS PR: juspay/connector-service#1665
