### PR TITLE
feat(user): POST /user/launch_trace — federated Trace session mint (superseded by #13081)

### DIFF
--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -449,6 +449,14 @@ enabled = false                                # Enable or disable chat features
 hyperswitch_ai_host = "http://0.0.0.0:8000"    # Hyperswitch ai workflow host
 encryption_key = ""                            # Key to encrypt and decrypt chats
 
+# Federated HyperSage Trace session mint (juspay/hypersage#1040).
+# enabled=true requires sage_base_url + infra_key to be populated;
+# the boot validator refuses to start otherwise.
+[trace_integration]
+enabled = false                                # Master switch for federated Trace sessions
+sage_base_url = ""                             # e.g. "https://sage.<env>.hyperswitch.io"
+infra_key = ""                                 # Shared secret; KMS-decrypted at boot per SecretsHandler
+
 [proxy_status_mapping]
 proxy_connector_http_status_code = false    # If enabled, the http status code of the connector will be proxied in the response
 

--- a/config/development.toml
+++ b/config/development.toml
@@ -1533,6 +1533,14 @@ enabled = false
 hyperswitch_ai_host = "http://0.0.0.0:8000"
 encryption_key = ""
 
+# Federated HyperSage Trace session mint (juspay/hypersage#1040).
+# Off by default. When enabled, sage_base_url + infra_key MUST be set —
+# the boot validator refuses to start an enabled+empty configuration.
+[trace_integration]
+enabled = false
+sage_base_url = "http://localhost:8001"
+infra_key = ""
+
 [proxy_status_mapping]
 proxy_connector_http_status_code = false    # If enabled, the http status code of the connector will be proxied in the response
 [list_dispute_supported_connectors]

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -1355,6 +1355,12 @@ enabled = false
 hyperswitch_ai_host = "http://0.0.0.0:8000"
 encryption_key = ""
 
+# Federated HyperSage Trace session mint (juspay/hypersage#1040).
+[trace_integration]
+enabled = false
+sage_base_url = "http://localhost:8001"
+infra_key = ""
+
 [authentication_providers]
 click_to_pay = {connector_list = "adyen, cybersource, trustpay"}
 

--- a/crates/api_models/src/launch_trace.rs
+++ b/crates/api_models/src/launch_trace.rs
@@ -1,0 +1,63 @@
+//! Request / response types for `POST /user/launch_trace`.
+//!
+//! Mints a federated HyperSage Trace session for a Control Center user
+//! who clicked the Trace launcher. The HS BE handler reads the user's
+//! identity from the verified `AuthToken` (NEVER from the request body)
+//! and proxies a mint request to HyperSage's
+//! `POST /api/sage/session` endpoint with a shared infra-key Bearer.
+//!
+//! The HyperSage side is documented in
+//! <https://github.com/juspay/hypersage/blob/main/docs/SAGE_SESSION_API.md>.
+//!
+//! Tracking: juspay/hypersage#1040 (parent), #1066 (spike), #1067 (impl).
+
+use common_utils::events::{ApiEventMetric, ApiEventsType};
+use serde::{Deserialize, Serialize};
+
+/// The response returned to the CC frontend. The browser is expected
+/// to redirect (or pop a new tab) to `handoff_url`; HyperSage's
+/// `GET /handoff` endpoint will swap the URL-carried token for an
+/// `HttpOnly` cookie and 302 to `/trace`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaunchTraceResponse {
+    /// Absolute URL the browser navigates to. Single-use; the embedded
+    /// token dies on first redeem (60s TTL on the HyperSage side).
+    pub handoff_url: String,
+
+    /// ISO-8601 UTC instant after which the handoff URL is dead.
+    /// Optional during the dark-launch window because the HyperSage
+    /// response may or may not include it; surfaced to the client only
+    /// when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+impl ApiEventMetric for LaunchTraceResponse {
+    fn get_api_event_type(&self) -> Option<ApiEventsType> {
+        // `Miscellaneous` matches what `get_active_user_details`
+        // emits — federation isn't payment-scoped and the
+        // response carries no domain ids the event-bus would index.
+        Some(ApiEventsType::Miscellaneous)
+    }
+}
+
+/// Outbound request body to HyperSage `POST /api/sage/session`. NOT
+/// part of the HS BE public API surface — declared here only so the
+/// shape is co-located with the response type for one-PR review.
+///
+/// HyperSage's auth_users + merchant_ids allowlist is the authoritative
+/// merchant-access barrier (see
+/// `hypersage/docs/SAGE_SESSION_API.md` §2). HS BE's responsibility
+/// is identity attestation only — pass through the claims we extracted
+/// from the verified AuthToken.
+#[derive(Debug, Clone, Serialize)]
+pub struct SageSessionRequest {
+    pub user_id: String,
+    pub merchant_id: String,
+    pub profile_id: String,
+    pub org_id: String,
+    pub role: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_jti: Option<String>,
+}

--- a/crates/api_models/src/lib.rs
+++ b/crates/api_models/src/lib.rs
@@ -24,6 +24,7 @@ pub mod feature_matrix;
 pub mod files;
 pub mod gsm;
 pub mod health_check;
+pub mod launch_trace;
 pub mod mandates;
 pub mod merchant_connector_webhook_management;
 pub mod oidc;

--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -315,6 +315,32 @@ impl SecretsHandler for settings::ChatSettings {
 }
 
 #[async_trait::async_trait]
+impl SecretsHandler for settings::TraceIntegrationSettings {
+    /// KMS-decrypt the federated infra key only when the flag is on.
+    /// Matches the `ChatSettings` impl above so a disabled
+    /// integration costs zero secret-fetch calls at boot.
+    async fn convert_to_raw_secret(
+        value: SecretStateContainer<Self, SecuredSecret>,
+        secret_management_client: &dyn SecretManagementInterface,
+    ) -> CustomResult<SecretStateContainer<Self, RawSecret>, SecretsManagementError> {
+        let trace_settings = value.get_inner();
+
+        let infra_key = if trace_settings.enabled {
+            secret_management_client
+                .get_secret(trace_settings.infra_key.clone())
+                .await?
+        } else {
+            trace_settings.infra_key.clone()
+        };
+
+        Ok(value.transition_state(|trace_settings| Self {
+            infra_key,
+            ..trace_settings
+        }))
+    }
+}
+
+#[async_trait::async_trait]
 impl SecretsHandler for settings::NetworkTokenizationService {
     async fn convert_to_raw_secret(
         value: SecretStateContainer<Self, SecuredSecret>,
@@ -516,6 +542,14 @@ pub(crate) async fn fetch_raw_secrets(
         .expect("Failed to decrypt chat configs");
 
     #[allow(clippy::expect_used)]
+    let trace_integration = settings::TraceIntegrationSettings::convert_to_raw_secret(
+        conf.trace_integration,
+        secret_management_client,
+    )
+    .await
+    .expect("Failed to decrypt trace_integration configs");
+
+    #[allow(clippy::expect_used)]
     let superposition =
         external_services::superposition::SuperpositionClientConfig::convert_to_raw_secret(
             conf.superposition,
@@ -533,6 +567,7 @@ pub(crate) async fn fetch_raw_secrets(
         server: conf.server,
         application_source: conf.application_source,
         chat,
+        trace_integration,
         master_database,
         redis: conf.redis,
         log: conf.log,

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -83,6 +83,7 @@ pub struct Settings<S: SecretState> {
     pub proxy: Proxy,
     pub env: Env,
     pub chat: SecretStateContainer<ChatSettings, S>,
+    pub trace_integration: SecretStateContainer<TraceIntegrationSettings, S>,
     pub master_database: SecretStateContainer<Database, S>,
     #[cfg(feature = "olap")]
     pub replica_database: SecretStateContainer<Database, S>,
@@ -241,6 +242,21 @@ pub struct ChatSettings {
     pub enabled: bool,
     pub hyperswitch_ai_host: String,
     pub encryption_key: Secret<String>,
+}
+
+/// Federated HyperSage Trace session settings (issue
+/// juspay/hypersage#1040). Off by default everywhere. The
+/// `validate()` impl lives in `crates/router/src/configs/validations.rs`
+/// alongside the other config validators; the boot-time chain in
+/// `Settings::validate` calls it to refuse boot when
+/// `enabled=true` with no `sage_base_url` / `infra_key` — fail-closed
+/// for a half-configured rollout.
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct TraceIntegrationSettings {
+    pub enabled: bool,
+    pub sage_base_url: String,
+    pub infra_key: Secret<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1214,6 +1230,7 @@ impl Settings<SecuredSecret> {
         self.locker.validate()?;
         self.connectors.validate("connectors")?;
         self.chat.get_inner().validate()?;
+        self.trace_integration.get_inner().validate()?;
         self.cors.validate()?;
 
         self.scheduler

--- a/crates/router/src/configs/validations.rs
+++ b/crates/router/src/configs/validations.rs
@@ -359,3 +359,36 @@ impl super::settings::ChatSettings {
         })
     }
 }
+
+impl super::settings::TraceIntegrationSettings {
+    /// Boot-time validator for the federated HyperSage Trace session
+    /// flag (juspay/hypersage#1040). Mirrors HyperSage's own
+    /// `_validate_tokens` guard — refuses to boot the process when
+    /// the flag is on with no upstream URL or no shared infra key.
+    /// Catches sandbox typos before they reach prod; without this, a
+    /// misconfigured deploy would 401 every federated mint and leave
+    /// CC users with a broken Trace launcher silently.
+    pub fn validate(&self) -> Result<(), ApplicationError> {
+        use common_utils::fp_utils::when;
+
+        when(self.enabled && self.sage_base_url.trim().is_empty(), || {
+            Err(ApplicationError::InvalidConfigurationValueError(
+                "trace_integration.sage_base_url must be set if \
+                 trace_integration.enabled is true"
+                    .into(),
+            ))
+        })?;
+        when(
+            self.enabled && self.infra_key.peek().trim().is_empty(),
+            || {
+                Err(ApplicationError::InvalidConfigurationValueError(
+                    "trace_integration.infra_key must be set if \
+                     trace_integration.enabled is true \
+                     (HYPERSAGE_INFRA_KEY in env). Refusing to boot \
+                     rather than serving a half-configured federated path."
+                        .into(),
+                ))
+            },
+        )
+    }
+}

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -2,6 +2,8 @@ pub mod chat;
 pub mod customers_error_response;
 pub mod error_handlers;
 #[cfg(feature = "olap")]
+pub mod launch_trace;
+#[cfg(feature = "olap")]
 pub mod oidc;
 pub mod transformers;
 #[cfg(feature = "olap")]

--- a/crates/router/src/core/errors/launch_trace.rs
+++ b/crates/router/src/core/errors/launch_trace.rs
@@ -1,0 +1,99 @@
+//! Error enum for the federated Trace session mint handler.
+//!
+//! The error → HTTP status mapping intentionally diverges from the
+//! upstream HyperSage status in a few places — see the
+//! `LaunchTraceErrors::switch` impl for the rationale, and the
+//! "Sage 401 → HS 502" note in the parent PR description (a CC user
+//! whose JWT is valid should NEVER be 401'd by HS BE just because the
+//! shared infra key is misconfigured; that's a server-side bug, not
+//! a client auth failure).
+//!
+//! Mirrors `crates/router/src/core/errors/chat.rs`.
+//!
+//! Tracking: juspay/hypersage#1040.
+
+#[derive(Debug, thiserror::Error)]
+pub enum LaunchTraceErrors {
+    /// The feature flag is off in this env. Returned as **404** to
+    /// match HyperSage's own no-oracle policy
+    /// (`docs/SAGE_SESSION_API.md` §3) — neither side reveals whether
+    /// federation is even available without proof of identity.
+    #[error("Federated Trace sessions are not enabled in this environment")]
+    FeatureDisabled,
+
+    /// HyperSage said the role / merchant binding can't be granted.
+    /// E.g., internal role attempting federation, or HS BE constructed
+    /// a request HyperSage refused (422). We do NOT bubble the upstream
+    /// detail to the client — it could leak the bound merchant.
+    #[error("Federated Trace is not available for this role")]
+    Forbidden,
+
+    /// HyperSage's session store is unavailable (Redis down on their
+    /// side, or HyperSage's PG audit write failed in a way that
+    /// surfaced as 503). The CC user can retry.
+    #[error("Federated Trace mint is temporarily unavailable")]
+    UpstreamUnavailable,
+
+    /// Upstream returned 401 — almost always means the shared
+    /// `HYPERSAGE_INFRA_KEY` is wrong / out of sync. Mapped to 502
+    /// because the CC user's JWT is fine; the bug is on the HS side.
+    /// Pages SRE — a single occurrence means rotation drift.
+    #[error("Federated Trace upstream rejected our credentials")]
+    UpstreamCredentialsRejected,
+
+    #[error("Internal server error")]
+    InternalServerError,
+}
+
+impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorResponse>
+    for LaunchTraceErrors
+{
+    fn switch(&self) -> api_models::errors::types::ApiErrorResponse {
+        use api_models::errors::types::{ApiError, ApiErrorResponse as AER};
+        // Sub-code stable across error variants for grep-ability in
+        // dashboards; per-variant disambiguated by the numeric code.
+        let sub_code = "FT"; // Federated Trace
+        match self {
+            Self::FeatureDisabled => {
+                // 404, not 503 — see the docstring for the no-oracle
+                // rationale.
+                AER::NotFound(ApiError::new(sub_code, 1, self.get_error_message(), None))
+            }
+            Self::Forbidden => {
+                AER::Unauthorized(ApiError::new(sub_code, 2, self.get_error_message(), None))
+            }
+            Self::UpstreamUnavailable => {
+                AER::InternalServerError(ApiError::new(sub_code, 3, self.get_error_message(), None))
+            }
+            // 502 is mapped via the InternalServerError variant for
+            // now — actix_web's ApiErrorResponse doesn't have a
+            // dedicated BadGateway today. The structured log line tags
+            // these explicitly so SRE can distinguish.
+            Self::UpstreamCredentialsRejected => {
+                AER::InternalServerError(ApiError::new(sub_code, 4, self.get_error_message(), None))
+            }
+            Self::InternalServerError => {
+                AER::InternalServerError(ApiError::new("HE", 0, self.get_error_message(), None))
+            }
+        }
+    }
+}
+
+impl LaunchTraceErrors {
+    pub fn get_error_message(&self) -> String {
+        match self {
+            // Opaque message: same string for "flag off" and any
+            // future "unknown user / unauthorised merchant" surface.
+            // Matches HyperSage's collapsed 401 detail policy
+            // (see `hypersage/src/web/sessions/federated_resolver.py`
+            // `_OPAQUE_401_DETAIL`).
+            Self::FeatureDisabled => "Not found".to_string(),
+            Self::Forbidden => "Not allowed".to_string(),
+            Self::UpstreamUnavailable => {
+                "Trace federation temporarily unavailable, please retry".to_string()
+            }
+            Self::UpstreamCredentialsRejected => "Trace federation misconfigured".to_string(),
+            Self::InternalServerError => "Something went wrong".to_string(),
+        }
+    }
+}

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -57,6 +57,7 @@ use crate::{db::user_role::ListUserRolesByOrgIdPayload, types::transformers::For
 use crate::{services::email::types as email_types, utils::user as user_utils};
 
 pub mod dashboard_metadata;
+pub mod launch_trace;
 #[cfg(feature = "dummy_connector")]
 pub mod sample_data;
 pub mod theme;

--- a/crates/router/src/core/user/launch_trace.rs
+++ b/crates/router/src/core/user/launch_trace.rs
@@ -1,0 +1,217 @@
+//! Federated HyperSage Trace session minting.
+//!
+//! Proxies a session-mint request to HyperSage's
+//! `POST /api/sage/session` on behalf of a Control Center user who
+//! clicked the Trace launcher. The user's identity is read from the
+//! verified `AuthToken`; HyperSage performs the authoritative
+//! merchant-access gate against its own `auth_users.merchant_ids`
+//! allowlist (see
+//! <https://github.com/juspay/hypersage/blob/main/docs/SAGE_SESSION_API.md>).
+//!
+//! Mirrors the AI-service proxy pattern in
+//! `crates/router/src/core/chat.rs` — outbound HTTP via
+//! `external_services::http_client::send_request` against a shared
+//! `state.conf.proxy` client, bearer-auth header pattern lifted from
+//! `crates/router/src/utils/connector_onboarding/paypal.rs`.
+//!
+//! Tracking: juspay/hypersage#1040 (parent), #1066 (spike), #1067 (impl).
+//!
+//! # Open policy decisions for the dashboard / framework team
+//!
+//! Tagged with `// TODO(launch_trace#1040)` so reviewers can search
+//! the file. Four spots:
+//!
+//! 1. Auth strategy — `DashboardNoPermissionAuth` vs `JWTAuth` with a
+//!    specific `Permission`. See the PR description.
+//! 2. Sage 401 → HS 502 inversion. Refusing to bubble 401 to CC so
+//!    the dashboard doesn't log the user out on an HS-side infra bug.
+//! 3. Role mapping `EntityType` → `{operator, viewer}` with the
+//!    federated cap at `operator`. Tenant/Org → operator, Merchant/
+//!    Profile → viewer, Internal → reject.
+//! 4. 404 on flag-off — no oracle for "the env has federation
+//!    pre-enabled".
+
+use api_models::launch_trace as launch_trace_api;
+use common_utils::{
+    consts::REQUEST_TIME_OUT_FOR_AI_SERVICE,
+    errors::CustomResult,
+    request::{Method, RequestBuilder, RequestContent},
+};
+use error_stack::ResultExt;
+use external_services::http_client;
+use hyperswitch_masking::PeekInterface;
+use router_env::{instrument, logger, tracing};
+
+use crate::{
+    core::errors::launch_trace::LaunchTraceErrors,
+    routes::SessionState,
+    services::{authentication as auth, authorization::roles, ApplicationResponse},
+};
+
+/// Per-launch timeout (seconds). Sage mint is sub-second on the
+/// happy path; the AI-service constant is the closest existing
+/// timeout in the codebase. The `send_request` signature takes
+/// `Option<u64>` (seconds), not `Duration`.
+///
+/// TODO(launch_trace#1040): promote a dedicated
+/// `REQUEST_TIME_OUT_FOR_TRACE_FEDERATION` constant in
+/// `crates/common_utils/src/consts.rs` once the dashboard/framework
+/// review settles on a value. Reusing the AI-service constant for
+/// now keeps the diff small.
+const REQUEST_TIMEOUT_SECS: u64 = REQUEST_TIME_OUT_FOR_AI_SERVICE;
+
+/// HyperSage's documented federated source tag for the audit chain.
+const SAGE_SOURCE: &str = "hyperswitch-cc";
+
+#[instrument(skip_all, fields(user_id, merchant_id))]
+pub async fn launch_trace(
+    state: SessionState,
+    user_from_token: auth::UserFromToken,
+) -> CustomResult<ApplicationResponse<launch_trace_api::LaunchTraceResponse>, LaunchTraceErrors> {
+    let conf = state.conf.trace_integration.get_inner();
+
+    // TODO(launch_trace#1040): no-oracle policy. Returning the same
+    // `LaunchTraceErrors::FeatureDisabled` → 404 here as we'd return
+    // for any other "this user can't federate" outcome (e.g., the
+    // future role-rejection path). Confirms the design choice with
+    // the dashboard team before flag-flip.
+    if !conf.enabled {
+        return Err(error_stack::Report::new(LaunchTraceErrors::FeatureDisabled))
+            .attach_printable("Federated Trace flag is off in this env");
+    }
+
+    // Server-side derive the federated role from EntityType. NEVER
+    // trust a role string from the request body (the request body is
+    // empty by design — but defense in depth).
+    //
+    // TODO(launch_trace#1040): the EntityType → Sage-role mapping is
+    // policy. Current choice:
+    //   Tenant / Organization → "operator"
+    //   Merchant / Profile    → "viewer"
+    //   Internal              → reject (parallel to chat.rs:137-140)
+    // matches the "federated cap at operator" policy in
+    // hypersage/docs/SAGE_SESSION_API.md §2.
+    let role_info = roles::RoleInfo::from_role_id_org_id_tenant_id(
+        &state,
+        &user_from_token.role_id,
+        &user_from_token.org_id,
+        user_from_token
+            .tenant_id
+            .as_ref()
+            .unwrap_or(&state.tenant.tenant_id),
+    )
+    .await
+    .change_context(LaunchTraceErrors::InternalServerError)
+    .attach_printable("Failed to retrieve role information")?;
+
+    if role_info.is_internal() {
+        // Internal users have other channels into HyperSage; they
+        // should not be federating as a regular dashboard user.
+        return Err(error_stack::Report::new(LaunchTraceErrors::Forbidden))
+            .attach_printable("Internal roles are not eligible for federated Trace");
+    }
+
+    let sage_role = map_entity_type_to_sage_role(role_info.get_entity_type());
+
+    // SAFETY: every id MUST come from the verified AuthToken, NEVER
+    // from a request body. The route handler takes an empty body
+    // (`()`) by design — there is nothing to spoof.
+    let request_body = launch_trace_api::SageSessionRequest {
+        user_id: user_from_token.user_id.clone(),
+        merchant_id: user_from_token.merchant_id.get_string_repr().to_owned(),
+        profile_id: user_from_token.profile_id.get_string_repr().to_owned(),
+        org_id: user_from_token.org_id.get_string_repr().to_owned(),
+        role: sage_role.to_owned(),
+        source: SAGE_SOURCE.to_owned(),
+        // Threaded once HS BE starts populating a per-AuthToken jti.
+        // Optional during dark-launch per
+        // hypersage/docs/SAGE_SESSION_API.md §2.
+        subject_jti: None,
+    };
+
+    let url = format!("{}/api/sage/session", conf.sage_base_url);
+
+    let request = RequestBuilder::new()
+        .method(Method::Post)
+        .url(&url)
+        .attach_default_headers()
+        .header(
+            "Authorization",
+            &format!("Bearer {}", conf.infra_key.peek()),
+        )
+        .set_body(RequestContent::Json(Box::new(request_body)))
+        .build();
+
+    let response =
+        http_client::send_request(&state.conf.proxy, request, Some(REQUEST_TIMEOUT_SECS))
+            .await
+            .change_context(LaunchTraceErrors::UpstreamUnavailable)
+            .attach_printable("Error when calling HyperSage /api/sage/session")?;
+
+    // TODO(launch_trace#1040): error mapping policy. We deliberately
+    // diverge from the upstream status in three places:
+    //
+    // - 401 from Sage → HS 502 (UpstreamCredentialsRejected). A 401
+    //   here means HYPERSAGE_INFRA_KEY is wrong / rotated; the CC
+    //   user's JWT was fine. Surfacing 401 to CC would log the user
+    //   out on an HS-side infra bug.
+    // - 404 from Sage → HS 404 (FeatureDisabled, same opaque message
+    //   as flag-off). Preserves Sage's no-oracle policy at
+    //   docs/SAGE_SESSION_API.md §3.
+    // - 503 / network errors → HS 502-equivalent (UpstreamUnavailable).
+    //
+    // Confirm with dashboard team before flag-flip.
+    let status = response.status();
+    if !status.is_success() {
+        if status.as_u16() == 401 {
+            logger::error!(
+                "HyperSage 401 — HYPERSAGE_INFRA_KEY rotation drift or misconfiguration"
+            );
+            return Err(error_stack::Report::new(
+                LaunchTraceErrors::UpstreamCredentialsRejected,
+            ));
+        }
+        if status.as_u16() == 404 {
+            // Unknown user OR user-not-authorised-for-merchant on the
+            // Sage side. Same opaque 404 as flag-off so the CC client
+            // can't distinguish.
+            return Err(error_stack::Report::new(LaunchTraceErrors::FeatureDisabled))
+                .attach_printable("HyperSage returned 404 (user/merchant unauthorized)");
+        }
+        return Err(error_stack::Report::new(
+            LaunchTraceErrors::UpstreamUnavailable,
+        ))
+        .attach_printable(format!("HyperSage returned status {status}"));
+    }
+
+    let parsed = response
+        .json::<launch_trace_api::LaunchTraceResponse>()
+        .await
+        .change_context(LaunchTraceErrors::InternalServerError)
+        .attach_printable("Failed to deserialize HyperSage handoff response")?;
+
+    // Log only the host+path of the handoff URL — the `?t=<token>`
+    // query is a bearer credential (60s TTL, single-use, but still
+    // secret per docs/SAGE_SESSION_API.md §3). Without stripping it,
+    // log aggregation would persist the token long enough for replay.
+    if let Some(url_only) = parsed.handoff_url.split('?').next() {
+        logger::info!(handoff_url_path = %url_only, "launch_trace: minted federated session");
+    }
+
+    Ok(ApplicationResponse::Json(parsed))
+}
+
+/// `EntityType` → Sage role string. Federated cap at `operator` per
+/// `hypersage/docs/SAGE_SESSION_API.md` §2.
+///
+/// TODO(launch_trace#1040): confirm the mapping with the dashboard
+/// team. Tenant + Organization both surface as `operator` because the
+/// federated session is bound to a single merchant; broader-scoped
+/// users still operate on one merchant at a time inside Trace.
+fn map_entity_type_to_sage_role(entity: common_enums::EntityType) -> &'static str {
+    use common_enums::EntityType;
+    match entity {
+        EntityType::Tenant | EntityType::Organization => "operator",
+        EntityType::Merchant | EntityType::Profile => "viewer",
+    }
+}

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -2820,6 +2820,10 @@ impl User {
         route = route
             .service(web::resource("").route(web::get().to(user::get_active_user_details)))
             .service(web::resource("/signin").route(web::post().to(user::user_signin)))
+            // Federated HyperSage Trace session mint
+            // (juspay/hypersage#1040). The handler returns 404 when
+            // the feature flag is off — no oracle for env state.
+            .service(web::resource("/launch_trace").route(web::post().to(user::launch_trace)))
             .service(web::resource("/v2/signin").route(web::post().to(user::user_signin)))
             // signin/signup with sso using openidconnect
             .service(web::resource("/oidc").route(web::post().to(user::sso_sign)))

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -331,7 +331,8 @@ impl From<Flow> for ApiIdentifier {
             | Flow::GetEmbeddedToken
             | Flow::GetUserDetailsInternal
             | Flow::ListUsersInternal
-            | Flow::ListMembersForEntity => Self::User,
+            | Flow::ListMembersForEntity
+            | Flow::LaunchTrace => Self::User,
 
             Flow::GetDataFromHyperswitchAiFlow | Flow::ListAllChatInteractions => Self::AiWorkflow,
 

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -39,6 +39,41 @@ pub async fn get_active_user_details(state: web::Data<AppState>, req: HttpReques
     .await
 }
 
+/// `POST /user/launch_trace` — mint a federated HyperSage Trace
+/// session for a Control Center user who clicked the Trace launcher.
+///
+/// The body is empty by design; the identity is read from the
+/// verified `AuthToken`. The handler proxies a mint request to
+/// HyperSage's `POST /api/sage/session` and returns the handoff URL
+/// the browser navigates to (Phase 5's `/handoff` endpoint on the
+/// HyperSage side will swap the URL token for an HttpOnly cookie).
+///
+/// Tracking: juspay/hypersage#1040 (parent), #1066 (spike), #1067 (impl).
+///
+/// TODO(launch_trace#1040): auth strategy. Using
+/// `DashboardNoPermissionAuth` because federation is an identity-
+/// attestation step, not a payment/account permission. HyperSage
+/// performs the authoritative merchant-access gate against its
+/// `auth_users.merchant_ids` allowlist. Dashboard team to confirm
+/// this is the right call vs. forcing a specific `Permission`.
+#[cfg(feature = "olap")]
+pub async fn launch_trace(state: web::Data<AppState>, http_req: HttpRequest) -> HttpResponse {
+    let flow = Flow::LaunchTrace;
+    Box::pin(api::server_wrap(
+        flow,
+        state,
+        &http_req,
+        (),
+        |state, user: auth::UserFromToken, _, _| user_core::launch_trace::launch_trace(state, user),
+        &auth::DashboardNoPermissionAuth {
+            allow_connected: true,
+            allow_platform: true,
+        },
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
 #[cfg(feature = "email")]
 pub async fn user_signup_with_merchant_id(
     state: web::Data<AppState>,

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -413,6 +413,9 @@ pub enum Flow {
     GetDataFromHyperswitchAiFlow,
     // List all chat interactions
     ListAllChatInteractions,
+    /// Mint a federated HyperSage Trace session for a CC user
+    /// (juspay/hypersage#1040)
+    LaunchTrace,
     /// User Sign Up
     UserSignUp,
     /// User Sign Up


### PR DESCRIPTION
> **Superseded by #13081.** Left in place for reference. All details below preserved from the original draft.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/Build

## Description

Adds `POST /user/launch_trace` — a new dashboard-authenticated endpoint that proxies a federated Trace session mint request on behalf of a Control Center user who clicked the Trace launcher.

**Feature-flagged**, off by default everywhere. The boot validator refuses to start the process if the flag is on with no shared infra key configured (fail-closed for sandbox typos).

This is the Hyperswitch BE half of the federation work. The downstream side has shipped its SessionStore + `POST /api/sage/session` mint endpoint + federated cookie resolver + operator runbook.

**Marked Draft** so the dashboard + framework teams can sign off on four policy decisions before flag-flip — see "Open policy decisions" below. The scaffolding is mechanical and ready; the four risk points are tagged with `// TODO(launch_trace)` in the handler.

## What lands in this PR

| Surface | File | Change |
|---|---|---|
| **Endpoint** | `crates/router/src/routes/user.rs` | `pub async fn launch_trace` — peer of `/signin`; `DashboardNoPermissionAuth { allow_connected: true, allow_platform: true }`; empty body by design |
| **Mount** | `crates/router/src/routes/app.rs` | `.service(web::resource("/launch_trace").route(web::post().to(user::launch_trace)))` inside the `/user` v1 scope |
| **Core handler** | `crates/router/src/core/user/launch_trace.rs` | Reads identity from `UserFromToken`, derives Trace role from `EntityType`, calls `external_services::http_client::send_request` with Bearer infra-key, maps upstream status to typed errors |
| **API types** | `crates/api_models/src/launch_trace.rs` | `LaunchTraceResponse { handoff_url, expires_at }` + internal `SageSessionRequest`; `ApiEventMetric → Miscellaneous` |
| **Settings** | `crates/router/src/configs/settings.rs` | New `TraceIntegrationSettings { enabled, sage_base_url, infra_key }` mirroring `ChatSettings` exactly |
| **Boot validator** | `crates/router/src/configs/validations.rs` | Refuses to boot when `enabled=true` with empty `sage_base_url` or `infra_key` |
| **KMS** | `crates/router/src/configs/secrets_transformers.rs` | `SecretsHandler` impl decrypts `infra_key` only when `enabled` (parallel to `ChatSettings`) |
| **Errors** | `crates/router/src/core/errors/launch_trace.rs` | `LaunchTraceErrors` enum with the divergent status mapping documented below |
| **Flow** | `crates/router_env/src/logger/types.rs` | `Flow::LaunchTrace` |
| **Locking** | `crates/router/src/routes/lock_utils.rs` | `Flow::LaunchTrace → ApiIdentifier::User` |
| **TOMLs** | `config/development.toml`, `config/docker_compose.toml`, `config/deployments/env_specific.toml` | `[trace_integration]` section, off by default |

## Open policy decisions for the dashboard / framework team

Tagged with `// TODO(launch_trace)` in the handler. Reviewer-search-friendly.

### 1. Auth strategy — `DashboardNoPermissionAuth` vs `JWTAuth { permission: ... }`

Currently: `DashboardNoPermissionAuth { allow_connected: true, allow_platform: true }` — same shape as `/list/org` and `/signout`. Federation is an identity-attestation step, not a payment/account permission, and the downstream service performs the authoritative merchant-access gate against its own allowlist (defense-in-depth re-check against the user's federated allow-list).

**Alternative:** force a specific `Permission` (e.g., `Permission::MerchantPaymentRead`). Pro: explicit gate at HS layer. Con: gates legitimate viewer-role users out, since "view your own merchant" isn't naturally any existing permission.

**Recommend:** keep `DashboardNoPermissionAuth`; trust the downstream allowlist as the authoritative barrier.

### 2. Upstream 401 → HS 502 (NOT 401 to client)

Currently: a `401` from the downstream service means the shared infra key is wrong (rotation drift). The CC user's JWT was fine. Bubbling 401 to CC would log the dashboard user out for an HS-side infra bug.

The handler maps upstream 401 → `LaunchTraceErrors::UpstreamCredentialsRejected` → 502-equivalent + paging-grade error log so SRE sees rotation drift immediately.

**Confirm:** is this the right inversion?

### 3. `EntityType` → Trace role mapping

Currently: `Tenant | Organization → "operator"`, `Merchant | Profile → "viewer"`. Internal roles are rejected outright. Federation caps at `operator` per the federated role-cap design.

**Confirm:** is this the right floor for tenant-/org-scoped users? A tenant admin federating in is still bound to a single merchant inside the downstream UI — broader-scoped users still operate one merchant at a time.

### 4. 404 on flag-off (no oracle)

Currently: when `trace_integration.enabled=false`, the handler returns `LaunchTraceErrors::FeatureDisabled` → 404 (not 503 "service unavailable"). Mirrors the downstream service's own no-oracle policy — neither side reveals whether federation is enabled in a given env without proof of identity.

**Confirm:** is this consistent with HS's broader feature-flag conventions, or should it be 503?

## Verification

- [x] `cargo check --package router --features olap,v1` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --package router --features olap,v1 -- -D warnings` — clean
- [ ] Integration test against a real downstream instance — pending end-to-end after the handoff redeem + cookie issuance ship on the downstream side

## Reviewer guidance

- **@juspay/hyperswitch-dashboard** — please review the auth strategy choice (#1) and the role mapping (#3).
- **@juspay/hyperswitch-framework** — please review the settings + secrets-transformer wiring and the error mapping (#2, #4).

## Out of scope

- Integration tests against a live downstream instance (depends on the handoff redeem endpoint which sets the cookie the browser carries on next requests). Will land in a follow-up PR.
- Per-call audit row in HS BE (the downstream service owns its own audit table; HS BE's audit lives in the existing API event logs).
- Network policy restricting downstream ingress to HS BE pods — owned by the infra repo.
- CC frontend launcher button — owned by the CC team.