### PR TITLE
feat(router): propagate payment_id and payout_id to UCS as lineage ids

### DIFF
--- a/crates/external_services/src/grpc_client.rs
+++ b/crates/external_services/src/grpc_client.rs
@@ -204,6 +204,13 @@ pub type GrpcHeadersUcsBuilderFinal = GrpcHeadersUcsBuilder<(
 pub struct LineageIds {
     merchant_id: id_type::MerchantId,
     profile_id: id_type::ProfileId,
+    /// Payment this connector call is rooted in, when applicable. Carried as a
+    /// typed lineage key so the consumer need not infer the resource type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payment_id: Option<String>,
+    /// Payout this connector call is rooted in, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payout_id: Option<String>,
 }
 impl LineageIds {
     /// constructor for LineageIds
@@ -211,7 +218,21 @@ impl LineageIds {
         Self {
             merchant_id,
             profile_id,
+            payment_id: None,
+            payout_id: None,
         }
+    }
+    /// attach the rooting payment id (no-op when `None`)
+    #[must_use]
+    pub fn with_payment_id(mut self, payment_id: Option<String>) -> Self {
+        self.payment_id = payment_id;
+        self
+    }
+    /// attach the rooting payout id (no-op when `None`)
+    #[must_use]
+    pub fn with_payout_id(mut self, payout_id: Option<String>) -> Self {
+        self.payout_id = payout_id;
+        self
     }
     /// get url encoded string representation of LineageIds
     pub fn get_url_encoded_string(self) -> Result<String, serde_urlencoded::ser::Error> {

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -3330,7 +3330,8 @@ where
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
         business_profile.get_id().clone(),
-    );
+    )
+    .with_payment_id(Some(router_data.payment_id.clone()));
 
     let execution_mode = match execution_path {
         ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,
@@ -6062,7 +6063,8 @@ where
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
         business_profile.get_id().clone(),
-    );
+    )
+    .with_payment_id(Some(router_data.payment_id.clone()));
 
     let execution_mode = match execution_path {
         ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,
@@ -6647,7 +6649,8 @@ where
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
         business_profile.get_id().clone(),
-    );
+    )
+    .with_payment_id(Some(router_data.payment_id.clone()));
 
     let execution_mode = match execution_path {
         ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,
@@ -6778,7 +6781,8 @@ where
         let lineage_ids = grpc_client::LineageIds::new(
             business_profile.merchant_id.clone(),
             business_profile.get_id().clone(),
-        );
+        )
+        .with_payment_id(Some(router_data.payment_id.clone()));
 
         let execution_mode = match execution_path {
             ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,
@@ -6868,7 +6872,8 @@ where
         let lineage_ids = grpc_client::LineageIds::new(
             business_profile.merchant_id.clone(),
             business_profile.get_id().clone(),
-        );
+        )
+        .with_payment_id(Some(router_data.payment_id.clone()));
 
         router_data
             .call_unified_connector_service_with_external_vault_proxy(
@@ -6974,7 +6979,8 @@ where
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
         business_profile.get_id().clone(),
-    );
+    )
+    .with_payment_id(Some(router_data.payment_id.clone()));
 
     let execution_mode = match execution_path {
         ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,
@@ -8013,7 +8019,8 @@ where
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
         business_profile.get_id().clone(),
-    );
+    )
+    .with_payment_id(Some(router_data.payment_id.clone()));
 
     let execution_mode = match execution_path {
         ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,

--- a/crates/router/src/core/payouts.rs
+++ b/crates/router/src/core/payouts.rs
@@ -4041,7 +4041,10 @@ pub async fn decide_unified_connector_service_payout<F: Clone>(
     let lineage_ids = grpc_client::LineageIds::new(
         payout_data.payouts.merchant_id.clone(),
         payout_data.profile_id.clone(),
-    );
+    )
+    .with_payout_id(Some(
+        payout_data.payouts.payout_id.get_string_repr().to_string(),
+    ));
 
     let execution_mode = match execution_path {
         common_enums::enums::ExecutionPath::UnifiedConnectorService => {

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -239,7 +239,10 @@ pub async fn trigger_refund_to_gateway(
         "Executing refund via {execution_path:?}"
     );
 
-    let lineage_ids = LineageIds::new(payment_intent.merchant_id.clone(), profile_id.clone());
+    let lineage_ids = LineageIds::new(payment_intent.merchant_id.clone(), profile_id.clone())
+        .with_payment_id(Some(
+            payment_intent.payment_id.get_string_repr().to_string(),
+        ));
 
     let execution_mode = match execution_path {
         common_enums::ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,
@@ -916,7 +919,10 @@ pub async fn sync_refund_with_gateway(
         "Executing refund sync via {execution_path:?}"
     );
 
-    let lineage_ids = LineageIds::new(payment_intent.merchant_id.clone(), profile_id.clone());
+    let lineage_ids = LineageIds::new(payment_intent.merchant_id.clone(), profile_id.clone())
+        .with_payment_id(Some(
+            payment_intent.payment_id.get_string_repr().to_string(),
+        ));
 
     let execution_mode = match execution_path {
         common_enums::ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -3050,7 +3050,8 @@ pub async fn call_unified_connector_service_for_refund_execute(
     let profile_id = id_type::ProfileId::from_str(merchant_id.get_string_repr())
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to convert merchant_id to profile_id for UCS refund")?;
-    let lineage_ids = LineageIds::new(merchant_id, profile_id);
+    let lineage_ids = LineageIds::new(merchant_id, profile_id)
+        .with_payment_id(Some(router_data.payment_id.clone()));
     let merchant_reference_id =
         id_type::PaymentReferenceId::from_str(router_data.payment_id.as_str())
             .inspect_err(|err| logger::warn!(error=?err, "Invalid PaymentId for UCS reference id"))
@@ -3184,7 +3185,8 @@ pub async fn call_unified_connector_service_for_refund_sync(
     let profile_id = id_type::ProfileId::from_str(merchant_id.get_string_repr())
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to convert merchant_id to profile_id for UCS refund")?;
-    let lineage_ids = LineageIds::new(merchant_id, profile_id);
+    let lineage_ids = LineageIds::new(merchant_id, profile_id)
+        .with_payment_id(Some(router_data.payment_id.clone()));
     let merchant_reference_id =
         id_type::PaymentReferenceId::from_str(router_data.payment_id.as_str())
             .inspect_err(|err| logger::warn!(error=?err, "Invalid PaymentId for UCS reference id"))
@@ -3342,7 +3344,8 @@ pub async fn call_unified_connector_service_for_surcharge_calculate(
     };
 
     // Build gRPC headers
-    let lineage_ids = LineageIds::new(processor.get_account().get_id().clone(), profile_id.clone());
+    let lineage_ids = LineageIds::new(processor.get_account().get_id().clone(), profile_id.clone())
+        .with_payment_id(Some(payment_id.get_string_repr().to_string()));
     let merchant_reference_id = id_type::PaymentReferenceId::from_str(payment_id.get_string_repr())
         .inspect_err(
             |err| logger::warn!(error=?err, "Invalid PaymentId for surcharge UCS reference id"),


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Enhancement

## Description

When a connector call is executed through the Unified Connector Service (UCS), the only resource reference UCS receives today is an **untyped** value — the resource *type* (whether it is a payment or a payout) can only be inferred indirectly from the flow / gRPC service. That inference is fragile and couples consumers to internal naming.

This PR makes the reference **self-describing** at the source: Hyperswitch — which authoritatively knows the resource type — attaches the typed id as a key in the existing `x-lineage-ids` header, so downstream consumers can key and route on it without inferring anything.

### Changes
- Extend `LineageIds` (in `external_services`) with optional `payment_id` and `payout_id` fields, url-encoded only when present (`#[serde(skip_serializing_if = "Option::is_none")]`), exposed via `with_payment_id` / `with_payout_id` builder methods.
- Attach the id at every UCS-bound connector-call site:
  - **Payments** (`core/payments.rs`, `core/unified_connector_service.rs`) → `payment_id`
  - **Refunds** (refund execute + sync) → the rooting `payment_id`
  - **Surcharge** (UCS) → `payment_id`
  - **Payouts** (`core/payouts.rs`) → `payout_id`

### Notes
- Fully **additive and backward-compatible**: the existing `merchant_id` / `profile_id` lineage keys are unchanged, and the new keys are omitted from the encoded header when not applicable.
- Direct-path (non-UCS) execution is untouched, since its lineage is never transmitted.

## Motivation and Context

Lets a connector-events consumer attribute each UCS connector call to the correct typed resource (payment vs payout) from the data itself, rather than re-deriving the type from flow/service names.

## How did you test it?

- `cargo check -p router` (v1) — passes.
- `cargo check -p router --no-default-features --features "v2,redis-rs"` (v2) — passes.

The new lineage keys ride the existing `LineageIds::get_url_encoded_string()` path; when set they appear as `payment_id=<id>` / `payout_id=<id>` in the `x-lineage-ids` header, and are absent otherwise.

## Checklist
- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
