### PR TITLE
fix(core): surface connector error code on UCS PSync connector error

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -976,8 +976,21 @@ impl UnifiedConnectorServiceError {
 
         let status_code = u16::try_from(connector_error.http_status_code?).ok()?;
 
+        // Prefer the connector-specific error code (the value the native/direct-connector
+        // path surfaces, e.g. noon's `order.errorCode` / `resultCode`) which UCS carries in
+        // `error_info.connector_details.code`. Fall back to the UCS discriminator
+        // (`CONNECTOR_ERROR_RESPONSE`) only when the connector code is absent. Using the
+        // discriminator directly produced a `response.Err.code` shadow-validation valueDiff
+        // against the native path.
+        let code = connector_error
+            .error_info
+            .as_ref()
+            .and_then(|ei| ei.connector_details.as_ref())
+            .and_then(|cd| cd.code.clone())
+            .unwrap_or_else(|| connector_error.error_code.clone());
+
         Some(Self::ConnectorError(Box::new(ConnectorErrorInner {
-            code: connector_error.error_code,
+            code,
             message: connector_error.error_message,
             status_code,
             reason: connector_error
@@ -1124,6 +1137,67 @@ impl ErrorSwitch<ConnectorError> for UnifiedConnectorServiceError {
             | Self::PayoutCreateRecipientFailure
             | Self::SurchargeCalculateFailure
             | Self::PayoutEnrollDisburseAccountFailure => ConnectorError::ResponseHandlingFailed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod connector_error_decode_tests {
+    use prost::Message;
+
+    use super::*;
+
+    fn status_with(connector_error: payments_grpc::ConnectorError) -> tonic::Status {
+        let details = connector_error.encode_to_vec();
+        tonic::Status::with_details(tonic::Code::Internal, "connector error", details.into())
+    }
+
+    // The UCS connector-error path must surface the connector-specific error code
+    // (carried in `error_info.connector_details.code`), matching the native/direct
+    // connector path — not the generic `CONNECTOR_ERROR_RESPONSE` discriminator.
+    #[test]
+    fn decode_prefers_connector_details_code() {
+        let connector_error = payments_grpc::ConnectorError {
+            error_message: "Order declined".to_string(),
+            error_code: CONNECTOR_ERROR_RESPONSE_CODE.to_string(),
+            http_status_code: Some(400),
+            error_info: Some(payments_grpc::ErrorInfo {
+                connector_details: Some(payments_grpc::ConnectorErrorDetails {
+                    code: Some("19001".to_string()),
+                    message: Some("Order declined".to_string()),
+                    reason: Some("declined".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        };
+
+        match UnifiedConnectorServiceError::from_grpc_error(&status_with(connector_error), "noon") {
+            UnifiedConnectorServiceError::ConnectorError(inner) => {
+                assert_eq!(inner.code, "19001");
+                assert_eq!(inner.status_code, 400);
+                assert_eq!(inner.reason.as_deref(), Some("declined"));
+            }
+            other => panic!("expected ConnectorError, got {other:?}"),
+        }
+    }
+
+    // When the connector code is absent, fall back to the UCS discriminator so the
+    // field is never empty.
+    #[test]
+    fn decode_falls_back_to_discriminator_when_connector_code_absent() {
+        let connector_error = payments_grpc::ConnectorError {
+            error_message: "Bad gateway".to_string(),
+            error_code: CONNECTOR_ERROR_RESPONSE_CODE.to_string(),
+            http_status_code: Some(502),
+            error_info: None,
+        };
+
+        match UnifiedConnectorServiceError::from_grpc_error(&status_with(connector_error), "noon") {
+            UnifiedConnectorServiceError::ConnectorError(inner) => {
+                assert_eq!(inner.code, CONNECTOR_ERROR_RESPONSE_CODE);
+            }
+            other => panic!("expected ConnectorError, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## What

On the **PSync** flow, when the Unified Connector Service (UCS) surfaces a connector HTTP 4xx/5xx error as a gRPC `ConnectorError`, HS's `decode_connector_error_response` populated `ConnectorErrorInner.code` from the **generic UCS discriminator** `error_code` (the constant `CONNECTOR_ERROR_RESPONSE`) instead of the **connector-specific** error code that UCS carries in `error_info.connector_details.code`.

The native / direct-connector path surfaces the real connector code (e.g. noon's `order.errorCode` / `resultCode`), so the UCS error path diverged, producing a shadow-validation **`valueDiff` on `response.Err.code`**.

## Diff signature (shadow validation)

```
router.valueDiff:response.Err.code
```

Production sample (VS_48, `noon` / PSync / merchant `urban_compay749`):

```json
"valueDiff":{"response.Err.code":{"hyperswitch":"****","ucs":"****"}}
```

- `hyperswitch` (native): the connector's real error code (noon `order.errorCode` / `resultCode`).
- `ucs`: `"CONNECTOR_ERROR_RESPONSE"` — the generic UCS discriminator, not the connector code.

## Root cause

`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs::decode_connector_error_response`

UCS encodes the connector error into the proto `ConnectorError`:
- `error_code` = discriminator (`"CONNECTOR_ERROR_RESPONSE"`) — used only to detect that this is a connector HTTP error.
- `error_info.connector_details.code` = the **actual connector error code** (`ErrorResponse.code`).

HS used `connector_error.error_code` for the surfaced `code`, discarding the real connector code.

## Fix

Prefer the connector-specific code from `error_info.connector_details.code`, falling back to the discriminator only when it is absent (so the field is never empty):

```rust
let code = connector_error
    .error_info
    .as_ref()
    .and_then(|ei| ei.connector_details.as_ref())
    .and_then(|cd| cd.code.clone())
    .unwrap_or_else(|| connector_error.error_code.clone());
```

The `error_code != CONNECTOR_ERROR_RESPONSE_CODE` discrimination check is unchanged — only the surfaced `code` value changes. No UCS / proto change is required: UCS already provides the real code in `error_info.connector_details.code`.

## Layer / category

**HS→UCS mapping** (HS-only). Confined to the UCS execution path in the interfaces layer; it does **not** touch any connector transformer or the native PSync path, so HS ground truth is unchanged.

## Verification

- `cargo build --bin router` ✅ (compiles clean).
- `cargo test -p hyperswitch_interfaces --features v1 connector_error_decode` ✅ — **2 new regression tests pass**:
  - `decode_prefers_connector_details_code`: with `connector_details.code = "19001"`, surfaced `code == "19001"` (not the discriminator). With the old code this assertion fails — it genuinely catches the bug.
  - `decode_falls_back_to_discriminator_when_connector_code_absent`: with `error_info = None`, surfaced `code == "CONNECTOR_ERROR_RESPONSE"`.
- `cargo +nightly fmt -p hyperswitch_interfaces -- --check` ✅.
- `cargo clippy -p hyperswitch_interfaces --features v1 --all-targets --no-deps -- -D warnings` ✅.
- Live noon PSync shadow is not locally reproducible (noon outbound is TLS/proxy-blocked on the local stack — consistent with prior noon issues); root cause and fix verified by **source-parity** against the native path plus the runnable unit tests above.

## Relationship

Sibling of #12963 (same noon/PSync error branch — `connector_http_status_code` `typeDiff`). Both stem from the UCS connector-error branch of the PSync gateway not matching the native path.

Closes #12966

---

## Re-detection — fiuu / psync (internal tracking issue)

Fixes internal tracking issue — the **same** `router.valueDiff:response.Err.code` divergence (UCS surfaces the generic `CONNECTOR_ERROR_RESPONSE` discriminator instead of the connector's real code), now on **fiuu / psync** (merchant `my_edge_gi`, org `org_XeMo3kFdfQaCNsP9JrAC`, 1 occurrence, fingerprint `18509e18…`). The fix lives in the flow-agnostic `decode_connector_error_response` in `hyperswitch_interfaces`, which fires for **any** flow whose UCS call surfaces a tonic `ConnectorError` — so it already covers fiuu psync. No new code.

**RCA (prod Grafana, request `019efd64-0bfb-7a31-b4be-b80f42f11981`, 2026-06-25T06:07:34Z):** Both shadow legs hit the **real** fiuu gate-query (`api.merchant.razer.com/RMS/API/gate-query/index.php`) and got the **same** genuine **HTTP 500** (empty body, cloudflare). On the wire prism built a `ConnectorErrorResponse` with **`code = "500"`** (the HTTP status), `message = "internal_server_error"`, `reason = ""`, carried in the gRPC `ConnectorError` as `error_code = "CONNECTOR_ERROR_RESPONSE"` (discriminator) **plus** `error_info.connector_details.code = "500"` (`ForeignFrom<&ErrorResponse>` populates it since `code "500" != NO_ERROR_CODE`). Before this fix HS's `decode_connector_error_response` surfaced `response.Err.code = connector_error.error_code` = the generic `"CONNECTOR_ERROR_RESPONSE"`, while **Direct** surfaced fiuu's `"500"`:

```
valueDiff: { "response.Err.code": { hyperswitch: "500", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix HS prefers `error_info.connector_details.code` → `"500"`, matching the Direct path → the `response.Err.code` valueDiff is eliminated. Verified by source-parity + this PR's `decode_prefers_connector_details_code` unit test (the same mechanism — `connector_details.code` surfaced instead of the discriminator). The live fiuu empty-body-500 is not locally forceable (consistent with this PR's noon anchor); prod build at detection was stale (UCS `2026.06.17.0-dirty`, predates this fix).

(Co-occurring `connector_http_status_code` typeDiff belongs to the separate http-status family — hyperswitch#13041 — not this signature.)
