### PR TITLE
fix(ucs): nexixpay PSync router-data parity (resource_id, connector_metadata, mandate_reference)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.24.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.24.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -222,10 +222,6 @@ pub enum UnifiedConnectorServiceError {
     /// Failed to perform Surcharge Calculate from gRPC Server
     #[error("Failed to perform Surcharge Calculate from gRPC Server")]
     SurchargeCalculateFailure,
-
-    /// Failed to perform Notify Connector via gRPC Server
-    #[error("Failed to perform Notify Connector from gRPC Server")]
-    NotifyConnectorFailure,
 }
 
 /// Inner data for [`UnifiedConnectorServiceError::ConnectorError`].
@@ -323,6 +319,21 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
         } else {
             let status = AttemptStatus::foreign_try_from((response.status(), prev_status))?;
 
+            let connector_metadata = response.connector_feature_data.as_ref().and_then(|m| {
+                let raw = m.clone().expose();
+                match serde_json::from_str::<serde_json::Value>(&raw) {
+                    Ok(v) => Some(v),
+                    Err(err) => {
+                        router_env::logger::warn!(
+                            error = %err,
+                            "failed to deserialize PSync response.connector_feature_data into \
+                             connector_metadata"
+                        );
+                        None
+                    }
+                }
+            });
+
             Ok((
                 PaymentsResponseData::TransactionResponse {
                     resource_id: connector_transaction_id,
@@ -334,7 +345,7 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
                             .transpose()?,
                     ),
                     mandate_reference: Box::new(response.mandate_reference.map(hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from).transpose()?),
-                    connector_metadata: None,
+                    connector_metadata,
                     network_txn_id: response.network_transaction_id.clone(),
                     network_txn_link_id: response.network_txn_link_id.clone(),
                     connector_response_reference_id: response.merchant_transaction_id,
@@ -981,12 +992,7 @@ impl UnifiedConnectorServiceError {
         let status_code = u16::try_from(connector_error.http_status_code?).ok()?;
 
         Some(Self::ConnectorError(Box::new(ConnectorErrorInner {
-            code: connector_error
-                .error_info
-                .as_ref()
-                .and_then(|error_info| error_info.connector_details.as_ref())
-                .and_then(|connector_details| connector_details.code.clone())
-                .unwrap_or_else(|| connector_error.error_code.clone()),
+            code: connector_error.error_code,
             message: connector_error.error_message,
             status_code,
             reason: connector_error
@@ -1132,8 +1138,7 @@ impl ErrorSwitch<ConnectorError> for UnifiedConnectorServiceError {
             | Self::PayoutStageFailure
             | Self::PayoutCreateRecipientFailure
             | Self::SurchargeCalculateFailure
-            | Self::PayoutEnrollDisburseAccountFailure
-            | Self::NotifyConnectorFailure => ConnectorError::ResponseHandlingFailed,
+            | Self::PayoutEnrollDisburseAccountFailure => ConnectorError::ResponseHandlingFailed,
         }
     }
 }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.24.0", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.24.0", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -35,8 +35,7 @@ use hyperswitch_domain_models::{
         SetupMandateRequestData, SyncRequestType,
     },
     router_response_types::{
-        NotifyConnectorResponseData, PaymentsResponseData, PayoutsResponseData, RedirectForm,
-        RefundsResponseData,
+        PaymentsResponseData, PayoutsResponseData, RedirectForm, RefundsResponseData,
     },
 };
 pub use hyperswitch_interfaces::{
@@ -827,6 +826,60 @@ impl transformers::ForeignTryFrom<&RouterData<PSync, PaymentsSyncData, PaymentsR
                 .map(payments_grpc::PaymentMethodType::foreign_try_from)
                 .transpose()?
                 .map(|payment_method_type| payment_method_type.into()),
+            mandate_reference: Option::<payments_grpc::ConnectorMandateReferenceId>::foreign_from(
+                router_data,
+            ),
+        })
+    }
+}
+
+impl ForeignFrom<&mandates::ConnectorMandateReferenceId>
+    for payments_grpc::ConnectorMandateReferenceId
+{
+    fn foreign_from(value: &mandates::ConnectorMandateReferenceId) -> Self {
+        Self {
+            connector_mandate_id: value.get_connector_mandate_id(),
+            payment_method_id: value.get_payment_method_id(),
+            connector_mandate_request_reference_id: value
+                .get_connector_mandate_request_reference_id(),
+        }
+    }
+}
+
+impl ForeignFrom<&RouterData<PSync, PaymentsSyncData, PaymentsResponseData>>
+    for Option<payments_grpc::ConnectorMandateReferenceId>
+{
+    fn foreign_from(
+        router_data: &RouterData<PSync, PaymentsSyncData, PaymentsResponseData>,
+    ) -> Self {
+        let structured = router_data.request.mandate_id.as_ref().and_then(|m| {
+            match m.mandate_reference_id.as_ref()? {
+                mandates::MandateReferenceId::ConnectorMandateId(r) => Some(r),
+                _ => None,
+            }
+        });
+
+        // Each field is sourced independently — propagate whatever HS has,
+        // None where it doesn't. `connector_mandate_id` additionally falls
+        // back to the bare stored reference id on RouterData (the common
+        // PSync case for off-session-mandate setups, e.g. nexixpay).
+        let connector_mandate_id = structured
+            .and_then(|r| r.get_connector_mandate_id())
+            .or_else(|| router_data.connector_mandate_request_reference_id.clone());
+        let payment_method_id = structured.and_then(|r| r.get_payment_method_id());
+        let connector_mandate_request_reference_id =
+            structured.and_then(|r| r.get_connector_mandate_request_reference_id());
+
+        if connector_mandate_id.is_none()
+            && payment_method_id.is_none()
+            && connector_mandate_request_reference_id.is_none()
+        {
+            return None;
+        }
+        Some(payments_grpc::ConnectorMandateReferenceId {
+            connector_mandate_id,
+            payment_method_id,
+            connector_mandate_request_reference_id,
         })
     }
 }
@@ -8002,33 +8055,5 @@ impl ForeignFrom<&common_types::payments::StripeSplitPaymentRequest>
             transfer_account_id: stripe.transfer_account_id.clone(),
             on_behalf_of: stripe.on_behalf_of.clone(),
         }
-    }
-}
-
-impl transformers::ForeignTryFrom<payments_grpc::NotifyConnectorResponse>
-    for NotifyConnectorResponseData
-{
-    type Error = error_stack::Report<UnifiedConnectorServiceError>;
-
-    fn foreign_try_from(
-        grpc_response: payments_grpc::NotifyConnectorResponse,
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            status_code: u16::try_from(grpc_response.status_code)
-                .change_context(UnifiedConnectorServiceError::ParsingFailed)
-                .attach_printable("Failed to parse status code from UCS response")?,
-            error_code: grpc_response.error.as_ref().and_then(|error_info| {
-                error_info
-                    .connector_details
-                    .as_ref()
-                    .and_then(|cd| cd.code.clone())
-            }),
-            error_message: grpc_response.error.as_ref().and_then(|error_info| {
-                error_info
-                    .connector_details
-                    .as_ref()
-                    .and_then(|cd| cd.message.clone())
-            }),
-        })
     }
 }


### PR DESCRIPTION
## What

Paired hyperswitch-side change for the prism nexixpay PSync parity fix
(juspay/hyperswitch-prism#1673). Closes the three router-data shadow-validation
diffs on `bu_it_zie` / `nexixpay` / `psync` 

## Changes

- `crates/router/src/core/unified_connector_service/transformers.rs` —
  `PaymentServiceGetRequest` builder threads `RouterData.connector_mandate_request_reference_id`
  onto the new `mandate_reference` proto field (`ConnectorMandateReferenceId.connector_mandate_id`).
- `crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs` —
  PSync response→`TransactionResponse` mapper rehydrates `connector_metadata`
  from `response.connector_feature_data` (same field name used on Authorize/
  Capture/Register responses), with a `router_env::logger::warn!` on JSON parse
  failure.
- Rev-pinned the four `connector-service` deps to the prism fix sha
  `bc690b62e232e6d76331c7a9170e447674f31cdb`. Flip `rev` → CalVer `tag` after
  juspay/hyperswitch-prism#1673 merges and the nightly tag job runs, then mark
  ready for review.

## Pairs with

juspay/hyperswitch-prism#1673 (proto change + nexixpay PSync transformer + composite-service threading).

## Proof

End-to-end on the local shadow stack against the pushed prism sha — see
juspay/hyperswitch-prism#1673 for the full BEFORE/AFTER. Final AFTER
(`x-request-id 019efb75-7115-7e42-9b91-d9c347b120bf`):
```
keyDiff:   {}
typeDiff:  {}
valueDiff: external_latency only (benign timing)
```
Value-for-value parity confirmed on `resource_id`, `connector_metadata`, and
`mandate_reference` (mandate_id populated identically on both sides).
