### PR TITLE
fix(core): map split_payments on UCS void request to reconstruct charges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log 0.4.27",
  "prettyplease",
  "proc-macro2",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=0e38483f2ac13721499744a3069d2ce895d0e060#0e38483f2ac13721499744a3069d2ce895d0e060"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=0e38483f2ac13721499744a3069d2ce895d0e060#0e38483f2ac13721499744a3069d2ce895d0e060"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -7156,8 +7156,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log 0.4.27",
  "multimap",
  "petgraph",
@@ -7178,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7191,7 +7191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=0e38483f2ac13721499744a3069d2ce895d0e060#0e38483f2ac13721499744a3069d2ce895d0e060"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=0e38483f2ac13721499744a3069d2ce895d0e060#0e38483f2ac13721499744a3069d2ce895d0e060"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=0e38483f2ac13721499744a3069d2ce895d0e060#0e38483f2ac13721499744a3069d2ce895d0e060"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=0e38483f2ac13721499744a3069d2ce895d0e060#0e38483f2ac13721499744a3069d2ce895d0e060"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "0e38483f2ac13721499744a3069d2ce895d0e060", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "0e38483f2ac13721499744a3069d2ce895d0e060", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "0e38483f2ac13721499744a3069d2ce895d0e060", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "0e38483f2ac13721499744a3069d2ce895d0e060", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -6396,6 +6396,11 @@ impl transformers::ForeignTryFrom<&RouterData<api::Void, PaymentsCancelData, Pay
             test_mode: router_data.test_mode,
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             merchant_request_id: None,
+            split_payments: router_data
+                .request
+                .split_payments
+                .as_ref()
+                .map(payments_grpc::SplitPaymentsDetails::foreign_from),
         })
     }
 }
@@ -6439,6 +6444,7 @@ impl
             metadata: None,
             state,
             test_mode: router_data.test_mode,
+            split_payments: None,
         })
     }
 }


### PR DESCRIPTION
### Diff
Shadow-validation issue **internal tracking issue** — connector `stripe`, flow `void`, merchant `yucca`:

`router.typeDiff:response.Ok.TransactionResponse.charges` — HS void response carries `charges` (object), UCS void response carries `null`.

### Root cause
HS native stripe void builds `charges` from `request.split_payments` (`construct_charge_response`). The shadow path sends the void to UCS over gRPC, but `PaymentServiceVoidRequest` had **no `split_payments` field**, so HS never forwarded the payment's `split_payments`; UCS therefore produced `splits = null` and the parsed responses diverged. Same shape as the capture fix (#12926 / cloud#16992), but for the void request.

### Fix (HS → UCS mapping)
- `unified_connector_service/transformers.rs`: populate `PaymentServiceVoidRequest.split_payments` from `PaymentsCancelData.split_payments` (`SplitPaymentsDetails::foreign_from`), mirroring the capture mapping.
- Bump the UCS gRPC dep from `tag = "2026.06.23.1"` to `rev = "0e38483f2ac13721499744a3069d2ce895d0e060"` in `crates/router/Cargo.toml`, `crates/external_services/Cargo.toml`, `crates/hyperswitch_interfaces/Cargo.toml` (+ `Cargo.lock`) so CI compiles against the new proto field.

> **Depends on UCS PR juspay/connector-service#1677.** The `rev` pin is interim — move it back to a `tag`/main commit once that UCS PR merges. (Reviewers: merge UCS first, then HS.)

### Verify
UCS side proven via direct gRPC `PaymentService.Void` A/B (stripe primary TLS-blocked locally; void is one-shot): WITH `splitPayments` → `splits = { stripeSplitResponse: { chargeId ch_…, STRIPE_DESTINATION, fees 100, transferAccountId } }` (== HS native `charges`); WITHOUT → `null`. Before: both null. **diff → no_diff.** Repro: `prod-fixes/verify_16999.py`.

Layer: **proto** (HS mapping half).

Closes #12972
