### PR TITLE
fix(core): populate connector_http_status_code on UCS authorize connector error

### DIFF
--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -178,6 +178,11 @@ where
                                         network_error_message: network_error_message.clone(),
                                         connector_metadata: None,
                                     });
+                                // Mirror the success path: propagate the connector HTTP status
+                                // code from the UCS connector error so that
+                                // `connector_http_status_code` is populated (matching the
+                                // direct-connector authorize path) instead of being left `None`.
+                                router_data.connector_http_status_code = Some(status_code);
                                 return Ok((
                                     router_data,
                                     (),
@@ -309,6 +314,11 @@ where
                                         network_error_message: network_error_message.clone(),
                                         connector_metadata: None,
                                     });
+                                // Mirror the success path: propagate the connector HTTP status
+                                // code from the UCS connector error so that
+                                // `connector_http_status_code` is populated (matching the
+                                // direct-connector authorize path) instead of being left `None`.
+                                router_data.connector_http_status_code = Some(status_code);
                                 // Return Ok with router_data containing the error response
                                 // This ensures the connector error flows through the normal
                                 // response handling path (same as direct connector errors)


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
On a connector decline routed through the Unified Connector Service (UCS), the authorize
gateway receives the failure as a gRPC `ConnectorError`. The error branch in
`authorize_gateway.rs` builds `router_data.response = Err(ErrorResponse { status_code, .. })`
and returns early — but, unlike the **success** path (which sets
`router_data.connector_http_status_code = Some(ucs_data.status_code)`), it never propagates
the connector HTTP status code onto `router_data.connector_http_status_code`. It is therefore
left `None`, while the direct/native-connector authorize path populates it from the connector's
real HTTP status.

Shadow-validation (HS↔UCS) flagged this as:

```
router.typeDiff:connector_http_status_code   (hyperswitch: number, ucs: null)
```

for `noon / authorize` on a declined payment (connector returns its structured decline, e.g.
noon `19030`, with a 4xx HTTP status).

This is the **authorize-flow analog** of the same omission fixed for PSync in #12963. The fix
mirrors that one: in **both** UCS gRPC-error branches of the authorize gateway (the regular
`payment_authorize` path and the MIT `recurring_payment_charge` path), set
`router_data.connector_http_status_code = Some(status_code)` — the connector status code
already decoded into the `ConnectorError`.

## How did you reproduce it
Production shadow-validation logs for `noon / authorize`:
- The HS↔UCS connector **request** bodies are byte-identical (request comparison empty; only the
  ignore-listed `x-merchant-id` header differs), so the divergence is purely on the response
  mapping — not a request difference.
- The UCS shadow call **reached the connector and processed a response** (not a timeout), and the
  native path surfaced the connector's HTTP status while the UCS path reported `null`.

**Before → After:** shadow verdict for `connector_http_status_code` goes from `diff`
(hyperswitch `number` / ucs `null`) → `no_diff` (both populated with the connector HTTP status).

noon's sandbox is not reachable from the local shadow stack (TLS), so this was verified by
source-parity against the native authorize path and the merged-pattern PSync fix, plus a clean
local `cargo build` / `cargo fmt`. Same verification approach as #12963.

## Category
HS→UCS mapping (router gateway). No UCS / proto change required — the connector status code is
already carried in the decoded `ConnectorError`.

Closes #12990
