### PR TITLE
feat(sdk_config): added bank redirect for empty payment experience in sdk config api

### DIFF
--- a/crates/router/src/core/superposition_sdk_config.rs
+++ b/crates/router/src/core/superposition_sdk_config.rs
@@ -348,17 +348,27 @@ fn translate_to_sdk_payment_methods(
     for (payment_method_type, connectors) in &pms_ctx.banks_consolidated_hm {
         let bank_names = get_banks(state, *payment_method_type, connectors.clone())
             .change_context(errors::ApiErrorResponse::InternalServerError)?;
-        let (_, rules) = consolidated_rules
+        let (criteria, rules) = consolidated_rules
             .entry((api_enums::PaymentMethod::BankRedirect, *payment_method_type))
             .or_insert_with(|| (Some(PaymentMethodCriteria::BankName), Vec::new()));
+        let mut has_banks = false;
         for bank_code_res in bank_names {
             for bank_name in bank_code_res.bank_name {
+                has_banks = true;
                 let criteria_value = format_criteria_value(None, Some(bank_name.to_string()), None);
                 rules.push(SdkCriteriaRule {
                     criteria_value,
                     eligible_connectors: bank_code_res.eligible_connectors.clone(),
                 });
             }
+        }
+        if !has_banks {
+            *criteria = None;
+            let criteria_value = format_criteria_value(None, None, None);
+            rules.push(SdkCriteriaRule {
+                criteria_value,
+                eligible_connectors: connectors.clone(),
+            });
         }
     }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently we are not getting bank redirects as a part of sdk config api since payment experience is none, in this PR we are handling the edge case by pushing payment experience as default

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

### Key Modifications in `crates/router/src/core/superposition_sdk_config.rs`
1. **Tracks Bank Presence**:
   Introduces a `has_banks` flag within the translation loop for `BankRedirect` payment methods (`banks_consolidated_hm`).
2. **Implements Default Fallback**:
   If a bank redirect payment method type has no configured banks (such as `Blik`, `Giropay`, or `Sofort`), the PR ensures it is not filtered out. It does this by:
   - Resetting the `payment_method_criteria` to `None` (rather than `Some(PaymentMethodCriteria::BankName)`).
   - Adding a default `SdkCriteriaRule` with `criteria_value` set to `"default"` and using the eligible connectors list.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

SDK config api
```shell
curl --location 'localhost:8080/v1/sdk/configs/web/sdk_config.json' \
--header 'authorization: cHJvZmlsZV9pZD1wcm9fNjFZbHNGQlMzMkFLZURJa3NBOFcscHVibGlzaGFibGVfa2V5PXBrX2Rldl9mNzM4NDg2ODVlMTY0N2Q4OWI4OGUzMzJiZTNhNWRjOSxjbGllbnRfc2VjcmV0PXBheV9VRGZXNFgxalh0YklheUdyS1NOdV9zZWNyZXRfUmVHbWdWZmlRZ29YRUlZbFgzck8sY3VzdG9tZXJfaWQ9U3RyaXBlQ3VzdG9tZXIsY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfdVRTYWwwMjRWbE5LM25hS2F5M2sscGF5bWVudF9pZD1wYXlfVURmVzRYMWpYdGJJYXlHcktTTnU=' \
--header 'api-key: pk_dev_f73848685e1647d89b88e332be3a5dc9' \
--data ''
```

Response
```shell
{
    "raw_configs": {
        "contexts": [],
        "overrides": {},
        "default_configs": {},
        "dimensions": {
            "variantIds": {
                "schema": {
                    "pattern": ".*",
                    "type": "string"
                },
                "position": 0,
                "dimension_type": {
                    "REGULAR": {}
                },
                "dependency_graph": {}
            }
        }
    },
    "resolved_configs": null,
    "context_used": {
        "profile_id": "pro_61YlsFBS32AKeDIksA8W",
        "merchant_id": "new_sahkal",
        "organization_id": "org_LgRN7Tom0tjaevMIJXGA",
        "connector": [
            "trustpay",
            "cybersource"
        ]
    },
    "payment_methods": [
        {
            "payment_method": "bank_redirect",
            "payment_method_types": [
                {
                    "payment_method_type": "blik",
                    "payment_method_criteria": null,
                    "criteria_rules": [
                        {
                            "criteria_value": "default",
                            "eligible_connectors": [
                                "trustpay"
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "payment_method": "card",
            "payment_method_types": [
                {
                    "payment_method_type": "credit",
                    "payment_method_criteria": "card_network",
                    "criteria_rules": [
                        {
                            "criteria_value": "Visa",
                            "eligible_connectors": [
                                "cybersource",
                                "trustpay"
                            ]
                        },
                        {
                            "criteria_value": "Mastercard",
                            "eligible_connectors": [
                                "cybersource",
                                "trustpay"
                            ]
                        }
                    ]
                },
                {
                    "payment_method_type": "debit",
                    "payment_method_criteria": "card_network",
                    "criteria_rules": [
                        {
                            "criteria_value": "Visa",
                            "eligible_connectors": [
                                "cybersource",
                                "trustpay"
                            ]
                        },
                        {
                            "criteria_value": "Mastercard",
                            "eligible_connectors": [
                                "cybersource",
                                "trustpay"
                            ]
                        }
                    ]
                }
            ]
        },
        {
            "payment_method": "pay_later",
            "payment_method_types": [
                {
                    "payment_method_type": "affirm",
                    "payment_method_criteria": "payment_experience",
                    "criteria_rules": [
                        {
                            "criteria_value": "redirect_to_url",
                            "eligible_connectors": [
                                "trustpay"
                            ]
                        }
                    ]
                },
                {
                    "payment_method_type": "afterpay_clearpay",
                    "payment_method_criteria": "payment_experience",
                    "criteria_rules": [
                        {
                            "criteria_value": "redirect_to_url",
                            "eligible_connectors": [
                                "trustpay"
                            ]
                        }
                    ]
                },
                {
                    "payment_method_type": "klarna",
                    "payment_method_criteria": "payment_experience",
                    "criteria_rules": [
                        {
                            "criteria_value": "redirect_to_url",
                            "eligible_connectors": [
                                "trustpay"
                            ]
                        }
                    ]
                }
            ]
        }
    ],
    "account_config": {
        "profile": {
            "collect_shipping_details_from_wallet_connector": false,
            "collect_billing_details_from_wallet_connector": false,
            "always_collect_billing_details_from_wallet_connector": false,
            "always_collect_shipping_details_from_wallet_connector": false,
            "vaulting_action": "skip"
        }
    }
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
