### PR TITLE
feat(connector-service): consume MandateAmountData.amount_money

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.30.1#c379a1ff7792dbc6af7856adfaf0036266e1d814"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.30.1#c379a1ff7792dbc6af7856adfaf0036266e1d814"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.30.1#c379a1ff7792dbc6af7856adfaf0036266e1d814"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.30.1#c379a1ff7792dbc6af7856adfaf0036266e1d814"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.30.1#c379a1ff7792dbc6af7856adfaf0036266e1d814"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.30.1#c379a1ff7792dbc6af7856adfaf0036266e1d814"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.30.1", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.30.1", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.30.1", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.30.1", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -5868,68 +5868,85 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
         let mandate_type = mandate_data
             .mandate_type
             .as_ref()
-            .map(|domain_mandate_type| match domain_mandate_type {
-                MandateDataType::SingleUse(amount_data) => payments_grpc::MandateType {
-                    mandate_type: Some(payments_grpc::mandate_type::MandateType::SingleUse(
-                        #[allow(deprecated)]
-                        payments_grpc::MandateAmountData {
-                            amount: amount_data.amount.get_amount_as_i64(),
-                            amount_type: None,
-                            amount_money: Some(payments_grpc::Money {
-                                minor_amount: amount_data.amount.get_amount_as_i64(),
-                                currency: payments_grpc::Currency::foreign_try_from(
-                                    amount_data.currency,
-                                )
-                                .unwrap_or(payments_grpc::Currency::Unspecified)
-                                .into(),
-                            }),
-                            frequency: None,
-                            currency: payments_grpc::Currency::foreign_try_from(
-                                amount_data.currency,
-                            )
-                            .unwrap_or(payments_grpc::Currency::Unspecified)
-                            .into(),
-                            start_date: amount_data.start_date.map(
-                                |dt: time::PrimitiveDateTime| dt.assume_utc().unix_timestamp(),
+            .map(|domain_mandate_type|
+                     -> Result<_, error_stack::Report<UnifiedConnectorServiceError>> {
+                match domain_mandate_type {
+                    MandateDataType::SingleUse(amount_data) => {
+                        let currency =
+                            payments_grpc::Currency::foreign_try_from(amount_data.currency)?;
+                        Ok(payments_grpc::MandateType {
+                            mandate_type: Some(
+                                payments_grpc::mandate_type::MandateType::SingleUse(
+                                    #[allow(deprecated)]
+                                    payments_grpc::MandateAmountData {
+                                        amount: amount_data.amount.get_amount_as_i64(),
+                                        amount_type: None,
+                                        amount_money: Some(payments_grpc::Money {
+                                            minor_amount: amount_data
+                                                .amount
+                                                .get_amount_as_i64(),
+                                            currency: currency.into(),
+                                        }),
+                                        frequency: None,
+                                        currency: currency.into(),
+                                        start_date: amount_data.start_date.map(
+                                            |dt: time::PrimitiveDateTime| {
+                                                dt.assume_utc().unix_timestamp()
+                                            },
+                                        ),
+                                        end_date: amount_data.end_date.map(
+                                            |dt: time::PrimitiveDateTime| {
+                                                dt.assume_utc().unix_timestamp()
+                                            },
+                                        ),
+                                    },
+                                ),
                             ),
-                            end_date: amount_data.end_date.map(|dt: time::PrimitiveDateTime| {
-                                dt.assume_utc().unix_timestamp()
-                            }),
-                        },
-                    )),
-                },
-                MandateDataType::MultiUse(amount_data_opt) => payments_grpc::MandateType {
-                    mandate_type: amount_data_opt.as_ref().map(|amount_data| {
-                        #[allow(deprecated)]
-                        payments_grpc::mandate_type::MandateType::MultiUse(
-                            payments_grpc::MandateAmountData {
-                                amount: amount_data.amount.get_amount_as_i64(),
-                                amount_type: None,
-                                amount_money: Some(payments_grpc::Money {
-                                    minor_amount: amount_data.amount.get_amount_as_i64(),
-                                    currency: payments_grpc::Currency::foreign_try_from(
-                                        amount_data.currency,
-                                    )
-                                    .unwrap_or(payments_grpc::Currency::Unspecified)
-                                    .into(),
-                                }),
-                                frequency: None,
-                                currency: payments_grpc::Currency::foreign_try_from(
+                        })
+                    }
+                    MandateDataType::MultiUse(amount_data_opt) => {
+                        let mandate_type_inner = amount_data_opt
+                            .as_ref()
+                            .map(|amount_data| {
+                                let currency = payments_grpc::Currency::foreign_try_from(
                                     amount_data.currency,
+                                )?;
+                                Ok::<_, error_stack::Report<UnifiedConnectorServiceError>>(
+                                    payments_grpc::mandate_type::MandateType::MultiUse(
+                                        #[allow(deprecated)]
+                                        payments_grpc::MandateAmountData {
+                                            amount: amount_data.amount.get_amount_as_i64(),
+                                            amount_type: None,
+                                            amount_money: Some(payments_grpc::Money {
+                                                minor_amount: amount_data
+                                                    .amount
+                                                    .get_amount_as_i64(),
+                                                currency: currency.into(),
+                                            }),
+                                            frequency: None,
+                                            currency: currency.into(),
+                                            start_date: amount_data.start_date.map(
+                                                |dt: time::PrimitiveDateTime| {
+                                                    dt.assume_utc().unix_timestamp()
+                                                },
+                                            ),
+                                            end_date: amount_data.end_date.map(
+                                                |dt: time::PrimitiveDateTime| {
+                                                    dt.assume_utc().unix_timestamp()
+                                                },
+                                            ),
+                                        },
+                                    ),
                                 )
-                                .unwrap_or(payments_grpc::Currency::Unspecified)
-                                .into(),
-                                start_date: amount_data.start_date.map(
-                                    |dt: time::PrimitiveDateTime| dt.assume_utc().unix_timestamp(),
-                                ),
-                                end_date: amount_data.end_date.map(
-                                    |dt: time::PrimitiveDateTime| dt.assume_utc().unix_timestamp(),
-                                ),
-                            },
-                        )
-                    }),
-                },
-            });
+                            })
+                            .transpose()?;
+                        Ok(payments_grpc::MandateType {
+                            mandate_type: mandate_type_inner,
+                        })
+                    }
+                }
+            })
+            .transpose()?;
 
         Ok(Self {
             update_mandate_id: mandate_data.update_mandate_id.clone(),

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -5875,6 +5875,14 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                         payments_grpc::MandateAmountData {
                             amount: amount_data.amount.get_amount_as_i64(),
                             amount_type: None,
+                            amount_money: Some(payments_grpc::Money {
+                                minor_amount: amount_data.amount.get_amount_as_i64(),
+                                currency: payments_grpc::Currency::foreign_try_from(
+                                    amount_data.currency,
+                                )
+                                .unwrap_or(payments_grpc::Currency::Unspecified)
+                                .into(),
+                            }),
                             frequency: None,
                             currency: payments_grpc::Currency::foreign_try_from(
                                 amount_data.currency,
@@ -5897,6 +5905,14 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                             payments_grpc::MandateAmountData {
                                 amount: amount_data.amount.get_amount_as_i64(),
                                 amount_type: None,
+                                amount_money: Some(payments_grpc::Money {
+                                    minor_amount: amount_data.amount.get_amount_as_i64(),
+                                    currency: payments_grpc::Currency::foreign_try_from(
+                                        amount_data.currency,
+                                    )
+                                    .unwrap_or(payments_grpc::Currency::Unspecified)
+                                    .into(),
+                                }),
                                 frequency: None,
                                 currency: payments_grpc::Currency::foreign_try_from(
                                     amount_data.currency,

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -5871,6 +5871,7 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
             .map(|domain_mandate_type| match domain_mandate_type {
                 MandateDataType::SingleUse(amount_data) => payments_grpc::MandateType {
                     mandate_type: Some(payments_grpc::mandate_type::MandateType::SingleUse(
+                        #[allow(deprecated)]
                         payments_grpc::MandateAmountData {
                             amount: amount_data.amount.get_amount_as_i64(),
                             amount_type: None,
@@ -5891,6 +5892,7 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                 },
                 MandateDataType::MultiUse(amount_data_opt) => payments_grpc::MandateType {
                     mandate_type: amount_data_opt.as_ref().map(|amount_data| {
+                        #[allow(deprecated)]
                         payments_grpc::mandate_type::MandateType::MultiUse(
                             payments_grpc::MandateAmountData {
                                 amount: amount_data.amount.get_amount_as_i64(),


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Dependency updates
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description

Consumes the new `MandateAmountData.amount_money` field added in UCS PR #1708.

- **Cargo.toml**: Bumped `unified-connector-service-client` and `unified-connector-service-cards` from tag `2026.06.23.1` → `2026.06.30.1`
- **transformers.rs**: Populates `amount_money: Some(payments_grpc::Money { minor_amount, currency })` in both `SingleUse` and `MultiUse` `MandateAmountData` struct literals

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

The upstream proto deprecated `MandateAmountData.amount` (int64) and `.currency` in favor of `optional Money amount_money = 7`. This PR consumes the new field so the deprecated fields can eventually be removed.

## How did you test it?

- `cargo check -p router` ✅
- `cargo clippy -p router` ✅
- `cargo fmt --check` ✅

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
