### PR TITLE
fix(core): surface connector error code + http status on UCS connector errors

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -977,7 +977,12 @@ impl UnifiedConnectorServiceError {
         let status_code = u16::try_from(connector_error.http_status_code?).ok()?;
 
         Some(Self::ConnectorError(Box::new(ConnectorErrorInner {
-            code: connector_error.error_code,
+            code: connector_error
+                .error_info
+                .as_ref()
+                .and_then(|error_info| error_info.connector_details.as_ref())
+                .and_then(|connector_details| connector_details.code.clone())
+                .unwrap_or_else(|| connector_error.error_code.clone()),
             message: connector_error.error_message,
             status_code,
             reason: connector_error

--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -178,6 +178,7 @@ where
                                         network_error_message: network_error_message.clone(),
                                         connector_metadata: None,
                                     });
+                                router_data.connector_http_status_code = Some(status_code);
                                 return Ok((
                                     router_data,
                                     (),
@@ -312,6 +313,7 @@ where
                                 // Return Ok with router_data containing the error response
                                 // This ensures the connector error flows through the normal
                                 // response handling path (same as direct connector errors)
+                                router_data.connector_http_status_code = Some(status_code);
                                 return Ok((
                                     router_data,
                                     (),

--- a/crates/router/src/core/payments/gateway/cancel_gateway.rs
+++ b/crates/router/src/core/payments/gateway/cancel_gateway.rs
@@ -153,6 +153,7 @@ where
                                     connector_metadata: None,
                                 },
                             );
+                            router_data.connector_http_status_code = Some(status_code);
                             return Ok((
                                 router_data,
                                 (),

--- a/crates/router/src/core/payments/gateway/capture_gateway.rs
+++ b/crates/router/src/core/payments/gateway/capture_gateway.rs
@@ -155,6 +155,7 @@ where
                                     connector_metadata: None,
                                 },
                             );
+                            router_data.connector_http_status_code = Some(status_code);
                             return Ok((
                                 router_data,
                                 (),

--- a/crates/router/src/core/payments/gateway/psync_gateway.rs
+++ b/crates/router/src/core/payments/gateway/psync_gateway.rs
@@ -233,6 +233,7 @@ where
                                             connector_metadata: None,
                                         },
                                     );
+                                    router_data.connector_http_status_code = Some(status_code);
                                     return Ok((
                                         router_data,
                                         (),

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -3120,6 +3120,7 @@ pub async fn call_unified_connector_service_for_refund_execute(
                             network_error_message: network_error_message.clone(),
                             connector_metadata: None,
                         });
+                        router_data.connector_http_status_code = Some(status_code);
                         return Ok((router_data, (), payments_grpc::RefundResponse::default()));
                     }
                     let api_error = report.current_context().switch();
@@ -3255,6 +3256,7 @@ pub async fn call_unified_connector_service_for_refund_sync(
                             network_error_message: network_error_message.clone(),
                             connector_metadata: None,
                         });
+                        router_data.connector_http_status_code = Some(status_code);
                         return Ok((router_data, (), payments_grpc::RefundResponse::default()));
                     }
                     let api_error = report.current_context().switch();


### PR DESCRIPTION
## What

On a connector 4xx/5xx surfaced through the Unified Connector Service (UCS / shadow execution), the `RouterData` hyperswitch produces on the **error path** diverged from the direct/native connector path in two ways, both flagged by shadow-validation as router-data diffs:

- **`router.valueDiff:response.Err.code`** — surfaced `code` was the generic discriminator `CONNECTOR_ERROR_RESPONSE` instead of the real connector error code.
- **`router.typeDiff:connector_http_status_code`** — `number` on the native path, `null` on the UCS path.

UCS already encodes the data correctly — the proto `ConnectorError` carries `http_status_code` and `error_info.connector_details.code`. The divergence was entirely in the hyperswitch-side mapping.

## Root cause

1. `crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs` — `decode_connector_error_response` set `ConnectorErrorInner.code` from `connector_error.error_code` (the discriminator) instead of `error_info.connector_details.code`.
2. Every UCS connector-error gateway branch builds `router_data.response = Err(ErrorResponse { .. })` and returns early, but — unlike the success path — never sets `router_data.connector_http_status_code = Some(status_code)`, leaving it `None`.

## Fix

- The shared decoder now prefers `error_info.connector_details.code`, falling back to the discriminator only when absent → fixes `response.Err.code` for **all** flows in one place.
- `connector_http_status_code = Some(status_code)` added to **all 7** UCS connector-error branches: authorize (regular + MIT recurring charge), psync, refund (execute + sync), cancel, capture.

No UCS/proto change required.

## Verification (live, against the noon shadow-validation stack)

Reproduced the production condition — noon returns a structured 4xx (HTTP 400) on a rejected business identifier, the same error path the prod diffs hit — and confirmed each flow's error path moves from **diff → no-diff** on the fixed binary (only the inherent `external_latency` timing difference remains):

| Flow | Branch | Result |
|---|---|---|
| authorize | `authorize_gateway.rs` (regular) | before → after, resolved |
| psync | `psync_gateway.rs` | resolved |
| refund | `unified_connector_service.rs` (execute) | resolved |
| repeat_payment | `authorize_gateway.rs` (MIT recurring charge) | resolved |

Each: `typeDiff {}`, `valueDiff` = only `external_latency`. Success-path regression checked clean (no new diffs). cancel/capture share the identical one-line fix (no validation issues filed for those flows).

## Relationship to existing PRs

Consolidates and extends the per-flow autofix PRs #12963 (psync status), #12967 (shared code), and #12991 (authorize status) into a single coherent change, and additionally fixes the **refund** branches in `unified_connector_service.rs`, which none of those PRs cover. Those PRs are left open for maintainers to triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
