### PR TITLE
fix(ucs): propagate connector_transaction_id on UCS authorize connector-error path (#17181)

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -242,6 +242,9 @@ pub struct ConnectorErrorInner {
     pub reason: Option<String>,
     /// Name of the connector that returned the error
     pub connector: String,
+    /// Connector's unique transaction identifier (e.g. Adyen `pspReference`), when the
+    /// connector returns one alongside the error response
+    pub connector_transaction_id: Option<String>,
     /// Network decline code from card scheme (e.g. Visa/Mastercard decline code)
     pub network_decline_code: Option<String>,
     /// Network advice code for retry logic
@@ -990,6 +993,11 @@ impl UnifiedConnectorServiceError {
                 .and_then(|ei| ei.connector_details.as_ref())
                 .and_then(|cd| cd.reason.clone()),
             connector: connector_name.to_string(),
+            connector_transaction_id: connector_error
+                .error_info
+                .as_ref()
+                .and_then(|ei| ei.connector_details.as_ref())
+                .and_then(|cd| cd.connector_transaction_id.clone()),
             network_decline_code: connector_error
                 .error_info
                 .as_ref()

--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -150,10 +150,12 @@ where
                                 report.current_context()
                             {
                                 let (code, message, status_code, reason,
+                                     connector_transaction_id,
                                      network_decline_code, network_advice_code,
                                      network_error_message, connector) = (
                                     &inner.code, &inner.message, inner.status_code,
-                                    &inner.reason, &inner.network_decline_code,
+                                    &inner.reason, &inner.connector_transaction_id,
+                                    &inner.network_decline_code,
                                     &inner.network_advice_code, &inner.network_error_message,
                                     &inner.connector,
                                 );
@@ -171,7 +173,7 @@ where
                                         reason: reason.clone(),
                                         status_code,
                                         attempt_status: None,
-                                        connector_transaction_id: None,
+                                        connector_transaction_id: connector_transaction_id.clone(),
                                         connector_response_reference_id: None,
                                         network_decline_code: network_decline_code.clone(),
                                         network_advice_code: network_advice_code.clone(),
@@ -274,6 +276,7 @@ where
                                     message,
                                     status_code,
                                     reason,
+                                    connector_transaction_id,
                                     network_decline_code,
                                     network_advice_code,
                                     network_error_message,
@@ -283,6 +286,7 @@ where
                                     &inner.message,
                                     inner.status_code,
                                     &inner.reason,
+                                    &inner.connector_transaction_id,
                                     &inner.network_decline_code,
                                     &inner.network_advice_code,
                                     &inner.network_error_message,
@@ -302,7 +306,7 @@ where
                                         reason: reason.clone(),
                                         status_code,
                                         attempt_status: None,
-                                        connector_transaction_id: None,
+                                        connector_transaction_id: connector_transaction_id.clone(),
                                         connector_response_reference_id: None,
                                         network_decline_code: network_decline_code.clone(),
                                         network_advice_code: network_advice_code.clone(),


### PR DESCRIPTION
## What

Fixes the `router.typeDiff:response.Err.connector_transaction_id` shadow-validation diff on **adyen / authorize** (issue juspay/hyperswitch-cloud#17181).

When a connector returns a hard 4xx/5xx that the Unified Connector Service surfaces as a tonic `ConnectorError` (gRPC `Status`), the UCS authorize gateway reconstructs a `hyperswitch_domain_models::router_data::ErrorResponse` and returns `Ok` early so the error flows through the normal response path — but it hardcoded `connector_transaction_id: None`. The **Direct** path populates that field from the connector's transaction id (Adyen's `pspReference`), so the shadow/UCS RouterData comparison reported a spurious `response.Err.connector_transaction_id` typeDiff (`string` on hyperswitch vs `null` on UCS).

The data was already available end-to-end — it was just dropped on the read-back:

- prism encodes it into the proto `ConnectorErrorDetails.connector_transaction_id` (field 4) placed in the tonic status details (`domain_types/src/errors.rs` `ForeignFrom<&ErrorResponse> for Option<ErrorInfo>`, line ~597).
- the router's `decode_connector_error_response` decoded `code`, `message`, `reason`, network details… but never `connector_transaction_id`.

This threads it through, hyperswitch-side only (no proto/prism change):

1. `ConnectorErrorInner` gains a `connector_transaction_id: Option<String>` field.
2. `decode_connector_error_response` populates it from `connector_error.error_info.connector_details.connector_transaction_id`.
3. Both connector-error early-return branches in `authorize_gateway.rs` — the regular Authorize path and the recurring-charge path — set it on the reconstructed `ErrorResponse` instead of `None`.

## Root cause (RCA)

- Prod samples (merchant `merchant_1770760984113`, e.g. `019efe73-b351-7470-bdb3-e06e58526d45`): Adyen returned **HTTP 422** `"CVC is not the right length"` (code 103) **with** `pspReference: GX7ZCVK6VGGF5835`.
- UCS converted the 422 into a tonic `Status` → router's `UnifiedConnectorServiceError::ConnectorError` early-return branch. prism's encoded `ConnectorErrorDetails` *did* carry the pspReference, but the router's `ConnectorErrorInner` had no slot for it and the branch hardcoded `connector_transaction_id: None` → `null` on UCS while Direct had the pspReference string.

This is the follow-up explicitly deferred by #13041 (the `connector_http_status_code` fix for the sibling issue #17180), which scoped out the `response.Err.connector_transaction_id` typeDiff.

## Before (prod #17181)

```
typeDiff: { "response.Err.connector_transaction_id": { hyperswitch: "string", ucs: "null" } }
```

## After (local repro of the identical Adyen 422 "CVC is not the right length")

Reproduced via a shadow-mode adyen authorize with a 4-digit CVC that triggers the same 422 (payment `pay_jmiZdQjIC3BWc5KmCzqo`, internal x-request-id `019f0221-cdc4-7f62-98bb-9ccf85ded86d`):

```
summary:  { total_key_differences: 0, total_value_differences: 2, total_type_differences: 1 }
keyDiff:  {}
typeDiff: { "connector_http_status_code": { hyperswitch: "number", ucs: "null" } }
valueDiff: {
  "response.Err.code":                     { hyperswitch: "103", ucs: "CONNECTOR_ERROR_RESPONSE" },
  "response.Err.connector_transaction_id": { hyperswitch: "TDSB5K9WFK33GDV5", ucs: "T27K5K9WFK33GDV5" }
}
```

➡️ **`response.Err.connector_transaction_id` is no longer a typeDiff** — UCS now emits a real connector transaction id (`T27K5K9WFK33GDV5`) instead of `null`. The exact fingerprint (`bfb1c93c…`) tracked by #17181 is resolved.

The id now appears as a *value* difference only because shadow mode makes **two independent Adyen calls** (Direct + shadow-UCS), and Adyen mints a fresh `pspReference` per call — this is non-deterministic by nature (same benign class as idempotency keys / timestamps) and cannot be made to match in code.

## Out of scope (separate signatures, not this issue's fingerprint)

- `connector_http_status_code` typeDiff → issue #17180 / PR #13041 (not yet on `main`).
- `response.Err.code` valueDiff (`103` vs `CONNECTOR_ERROR_RESPONSE`) → distinct signature; the branch uses the generic sentinel error code rather than the connector's native refusal code. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also fixes #17208 — stripe / authorize+payment_method_token (re-detection, same fix)

`router.typeDiff:response.Err.connector_transaction_id` re-detected on **stripe / authorize+payment_method_token** (merchant `yucca`, org `org_Vhm8CPMYJsk68oMpVrCK` Baskhealth). This is the **connector-agnostic** HS-side error-path family — stripe routes through the **regular Authorize** `UnifiedConnectorServiceError::ConnectorError` early-return branch in `authorize_gateway.rs`, the same branch this PR patches, so it is covered with **no new code**.

**Grafana RCA** (prod req `019efcb0-198b-7642-8c89-4318ac3b9102`, payment `pay_iKmbEx0Js7t5HrMn8qOT`; also confirmed `019efc52-f383-74b0-a3ad-03a68f5e2cf9`; found in connector-service Loki 2026-06-25T02:51:00Z): two-leg flow — PaymentMethodToken `POST /v1/payment_methods` HTTP200, then Authorize `POST /v1/payment_intents` **HTTP402 card_declined** (`decline_code=do_not_honor`, network 59), declined intent id `pi_3Tm3NYBD08a1aHQL12HFZRvz`. The **Direct** path populated `connector_transaction_id = pi_3Tm3NYBD08a1aHQL12HFZRvz`; the **shadow UCS** leg surfaced the 402 as a tonic `Status` → the regular-Authorize `ConnectorError` early-return branch, where the old `ConnectorErrorInner` had no `connector_transaction_id` slot and the branch hardcoded `None` → `null` on UCS vs `string` on Direct.

```
Before (prod #17208):
typeDiff: { "response.Err.connector_transaction_id": { hyperswitch: "string", ucs: "null" } }
```

Prod router build `2026.06.10.0-hotfix7` and UCS build `2026.06.17.0` both predate this PR, so the diff is expected on that stale deployment. This PR's change to `decode_connector_error_response` (reads `connector_details.connector_transaction_id`) + setting it on the reconstructed `ErrorResponse` in the regular-Authorize branch makes UCS emit the real intent id (`pi_…`) instead of `null`, dropping the typeDiff — identical mechanism to the adyen end-to-end verification above (`null` → real ctid). Verified: rebased on `main` @ `96a4e857e2`, `cargo build -p router` clean.

Siblings of the same stripe event tracked separately: `connector_http_status_code` typeDiff → #17207 / PR #13041; `response.Err.code` valueDiff (`card_declined` vs `CONNECTOR_ERROR_RESPONSE`) → PR #13043.

Fixes #17208


---

## Also fixes #17218 — stripe / authorize+create_connector_customer+payment_method_token (re-detection, same fix)

`router.typeDiff:response.Err.connector_transaction_id` re-detected on **stripe** (merchant `yucca`, org `org_Vhm8CPMYJsk68oMpVrCK` Baskhealth, prod). This is the **`connector_transaction_id` half of the same 3-leg stripe event** as #17217 (which tracked the `connector_http_status_code` half → PR #13041). Same connector-agnostic HS-side error-path family; stripe routes through the **regular Authorize** `ConnectorError` early-return branch in `authorize_gateway.rs` that this PR patches → covered with **no new code**.

**Grafana RCA** (prod req `019efe3f-67df-7683-bee3-2bc602748bb8`, payment `pay_pQVwktG91h84oqqtE2rY`; found in connector-service Loki 2026-06-25T10:07:09Z, UCS build `2026.06.17.0-dirty-aef0be919` — stale, predates this fix): three stripe legs —

| Leg | Stripe call | HTTP | Outcome |
|---|---|---|---|
| CreateConnectorCustomer | `POST /v1/customers` | 200 | `cus_Ulha71W5p7pldl` — clean, no diff |
| PaymentMethodToken | `POST /v1/payment_methods` | 200 | `pm_1TmABdBD08a1aHQL0yofMpAW` — clean, no diff |
| Authorize | `POST /v1/payment_intents` | **402** | `card_declined` / `insufficient_funds` (network 51), intent `pi_3TmABdBD08a1aHQL1C0Yrk6P` |

The `connector_transaction_id` typeDiff originates **solely from the authorize leg**. The **Direct** path populated `connector_transaction_id = pi_3TmABdBD08a1aHQL1C0Yrk6P`; the **shadow UCS** leg surfaced the 402 as a tonic `Status` → the regular-Authorize `ConnectorError` early-return branch, where the old `ConnectorErrorInner` had no `connector_transaction_id` slot and the branch hardcoded `None` → `null` on UCS vs `string` on Direct. Notably the connector-service event layer shows the UCS `ConnectorError` **already carrying** `connector_transaction_id: "pi_3TmABdBD08a1aHQL1C0Yrk6P"` in the proto `ConnectorErrorDetails` — the `null` is introduced purely on the router decode side, exactly what this PR fixes.

```
Before (prod #17218, authorize leg):
typeDiff: { "response.Err.connector_transaction_id": { hyperswitch: "string", ucs: "null" } }
```

This PR's `decode_connector_error_response` change (reads `connector_details.connector_transaction_id`) + setting it on the reconstructed `ErrorResponse` in the regular-Authorize branch makes UCS emit the real intent id (`pi_…`) instead of `null`, dropping the typeDiff — identical mechanism to the adyen end-to-end verification above (`null` → real ctid). Verified: branch already on `main` @ `96a4e857e2` (main + 1 commit, no rebase needed), `cargo build -p router` clean (exit 0).

Siblings of the same stripe event tracked separately: `connector_http_status_code` typeDiff → #17217 / PR #13041; `response.Err.code` valueDiff (`card_declined` vs `CONNECTOR_ERROR_RESPONSE`) → PR #13043. Latent note: the create-customer / token gateways have no UCS `ConnectorError` early-return branch, but both legs returned 200 here so they do not contribute to this diff.

Fixes #17218



---

## Also fixes #17231 — paypal / authorize (re-detection, same fix)

`router.typeDiff:response.Err.connector_transaction_id` re-detected on **paypal** (org/merchant `opencommerce`, `org_wbvg6YIuzaP4BdnvQZou`, prod, 4 occurrences). This is the **`connector_transaction_id` half of the same paypal authorize error event** as #17230 (which tracked the `connector_http_status_code` half → PR #13041). Same connector-agnostic HS-side error-path family; paypal routes through the **regular Authorize** `ConnectorError` early-return branch in `authorize_gateway.rs` that this PR patches → covered with **no new code**.

**Grafana RCA** (prod req `019efc86-43d3-7482-b750-0402eeaada67`, payment `pay_wbAa0o79KPvXtJmRpVru`; found in connector-service / validation-service Loki 2026-06-25T02:05:21Z, UCS build `2026.06.17.0-dirty-aef0be919` — stale, predates this fix): paypal `POST /v2/checkout/orders` → **HTTP 422** `PAYMENT_DENIED` (`debug_id 1c60d6b737648`). The connector response **already carried** `connector_transaction_id: "1c60d6b737648"` and `status_code: 422`, but UCS surfaced the 422 as a tonic `Status` grpc code 2 / `Unknown` → the regular-Authorize `ConnectorError` early-return branch, where the old `ConnectorErrorInner` had no `connector_transaction_id` slot and the branch hardcoded `None` → `null` on UCS vs the real string on Direct.

```
Before (prod #17231, comparator VS_48 @ 2026-06-25T02:05:21Z):
typeDiff: { "response.Err.connector_transaction_id": { hyperswitch: "string", ucs: "null" } }
```

This PR's `decode_connector_error_response` change (reads `connector_details.connector_transaction_id`) + setting it on the reconstructed `ErrorResponse` in the regular-Authorize branch makes UCS emit the real connector transaction id instead of `null`, dropping the typeDiff — identical mechanism to the adyen end-to-end verification above (`null` → real ctid). Verified: branch already on `main` @ `96a4e857e2` (main + 1 commit, no rebase needed), `cargo build -p router` clean (exit 0).

Siblings of the same paypal event tracked separately: `connector_http_status_code` typeDiff → #17230 / PR #13041; `response.Err.code` valueDiff (`PAYMENT_DENIED` vs `CONNECTOR_ERROR_RESPONSE`) → PR #13043.

Fixes #17231


## Also fixes #17234 — stripe / repeat_payment (re-detection, same fix)

Same connector-error early-return mechanism as #17231/#17218/#17208, surfacing on the **recurring-charge (RepeatPayment / MIT)** branch this time.

- Prod RCA (req `019efddc-07e9-7513-961d-7de85f8a1dc9`, payment `pay_klo2IqJSnN5epizk0YLt`, merchant `yucca`, 2026-06-25T08:18:37Z, found in Loki): a true off-session MIT recurring charge (`/types.RecurringPaymentService/Charge`, `flow_type=RepeatPayment`, ConnectorMandateId `pm_1TKmvcBD08a1aHQLTxVQLeuM`, amount 76500 USD) hit stripe → **HTTP 402** `card_declined` / `decline_code=insufficient_funds`, with stripe `payment_intent.id = pi_3Tm8UaBD08a1aHQL1ZgZzWOR`.
- UCS surfaced the 402 as a tonic `Status` (code 2, `Unknown`) → the **recurring-charge** `ConnectorError` early-return branch in `authorize_gateway.rs`, which (pre-fix) hardcoded `connector_transaction_id: None` → `null` on UCS, while **Direct** decoded the 402 body and recorded `connector_transaction_id = Some("pi_3Tm8UaBD08a1aHQL1ZgZzWOR")`.
- Loki confirms the data was present end-to-end: the connector-service event layer carried `error.connector_transaction_id = "pi_3Tm8UaBD08a1aHQL1ZgZzWOR"`; it was dropped only on the router decode side — exactly what this PR threads through (now set in **both** early-return branches).

This is the `connector_transaction_id` sibling of #17233 (the `connector_http_status_code` half of the same event, covered by #13041) and #13043 (the `response.Err.code` half). No new code — the recurring-charge branch fix already in this PR resolves #17234.

Fixes #17234
