### PR TITLE
fix(ucs): surface connector error code on UCS authorize connector errors (#17182)

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -981,7 +981,17 @@ impl UnifiedConnectorServiceError {
         let status_code = u16::try_from(connector_error.http_status_code?).ok()?;
 
         Some(Self::ConnectorError(Box::new(ConnectorErrorInner {
-            code: connector_error.error_code,
+            // The connector's own error code is carried in
+            // `error_info.connector_details.code` (e.g. Adyen `"103"`); the top-level
+            // `error_code` is only the `CONNECTOR_ERROR_RESPONSE` discriminator. Prefer the
+            // connector-specific code so the shadow UCS path's `response.Err.code` matches
+            // the Direct gateway, falling back to the discriminator when it is absent.
+            code: connector_error
+                .error_info
+                .as_ref()
+                .and_then(|ei| ei.connector_details.as_ref())
+                .and_then(|cd| cd.code.clone())
+                .unwrap_or(connector_error.error_code),
             message: connector_error.error_message,
             status_code,
             reason: connector_error

--- a/fixtures/adyen/authorize/17182.json
+++ b/fixtures/adyen/authorize/17182.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Regression for issue #17182 (adyen/authorize router.valueDiff:response.Err.code). Wrong-length CVC -> Adyen errorCode 103. UCS shadow response.Err.code must equal Direct (103), not the CONNECTOR_ERROR_RESPONSE discriminator.",
+  "amount": 7034,
+  "currency": "USD",
+  "confirm": true,
+  "capture_method": "automatic",
+  "payment_method": "card",
+  "payment_method_type": "credit",
+  "payment_method_data": {
+    "card": {
+      "card_number": "4111111111111111",
+      "card_exp_month": "03",
+      "card_exp_year": "2030",
+      "card_holder_name": "Test User",
+      "card_cvc": "1234"
+    }
+  },
+  "browser_info": {
+    "user_agent": "Mozilla/5.0", "accept_header": "text/html", "language": "en-US",
+    "color_depth": 24, "screen_height": 1080, "screen_width": 1920,
+    "time_zone": -330, "java_enabled": false, "java_script_enabled": true, "ip_address": "127.0.0.1"
+  },
+  "email": "test@example.com"
+}


### PR DESCRIPTION
## What
The shadow **UnifiedConnectorService (UCS)** authorize path surfaces a generic discriminator instead of the connector's own error code, causing a shadow-validation `router_diff` against the Direct gateway.

When a connector returns an HTTP error (e.g. Adyen `422` `errorCode "103"` / "CVC is not the right length"), `decode_connector_error_response` decodes the `ConnectorError` from the tonic status details and builds `ConnectorErrorInner.code` from the proto **top-level `error_code`**. That top-level field is only the `CONNECTOR_ERROR_RESPONSE` discriminator (it's the literal the same function matches on at line 973) — not the connector's code. The Direct gateway surfaces the connector's own code, so `response.Err.code` diverged.

The real connector code is already carried in the proto at `error_info.connector_details.code` (the same place `reason` is read from, and what the PSync `GetResponse` path already uses). This change prefers it, falling back to the discriminator when absent.

```
- code: connector_error.error_code,
+ code: connector_error
+     .error_info.as_ref()
+     .and_then(|ei| ei.connector_details.as_ref())
+     .and_then(|cd| cd.code.clone())
+     .unwrap_or(connector_error.error_code),
```

This is a **hyperswitch-side decode fix only** — no proto/prism change (prism already populates `connector_details.code`; pinned proto `2026.06.23.1` carries the field).

## Issue
Resolves shadow-validation diff `router.valueDiff:response.Err.code` for **adyen / authorize** — juspay/hyperswitch-cloud#17182.

Same Adyen 422 connector-error early-return family as the sibling diffs #17180 (`connector_http_status_code`) and #17181 (`connector_transaction_id`); this PR closes the `response.Err.code` value diff specifically.

## Before / After (validation service `VS_48`, local shadow repro)
Both runs: Adyen authorize with wrong-length CVC → `errorCode 103` "CVC is not the right length", `422`.

**BEFORE** (req `019f0221`, pre-fix binary):
```json
"valueDiff": {
  "response.Err.code": { "hyperswitch": "103", "ucs": "CONNECTOR_ERROR_RESPONSE" },
  "response.Err.connector_transaction_id": { "hyperswitch": "TDSB5K9WFK33GDV5", "ucs": "T27K5K9WFK33GDV5" }
}
```

**AFTER** (req `019f0242`, this fix):
```json
"valueDiff": {},
"typeDiff": {
  "response.Err.connector_transaction_id": { "hyperswitch": "string", "ucs": "null" },
  "connector_http_status_code": { "hyperswitch": "number", "ucs": "null" }
}
```
`response.Err.code` is gone from every diff bucket (`valueDiff: {}`). Router log confirms UCS now emits `ConnectorErrorInner { code: "103", ... }` (was `"CONNECTOR_ERROR_RESPONSE"`). Residual `typeDiff`s are the separate #17180 / #17181 signatures (their own PRs), not part of this issue's `response.Err.code` signature.

A regression fixture is added at `fixtures/adyen/authorize/17182.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Re-detection — noon / repeat_payment (juspay/hyperswitch-cloud#17199)

Fixes juspay/hyperswitch-cloud#17199 — the **same** `router.valueDiff:response.Err.code` fingerprint, now on **noon / repeat_payment** (merchant `urban_compay749`, org `org_oOk4rRdiabRK4UqpGU0xj`, 24 occurrences).

The fix in this PR is connector- and flow-agnostic: it lives in `UnifiedConnectorServiceError::decode_connector_error_response`, which builds `ConnectorErrorInner.code` consumed by **both** the authorize gateway and the `recurring_payment_charge` (MIT) branch. So it already covers repeat_payment.

**RCA (prod Grafana, req `019efacf-18be-7ce2-a28c-7ccad5834e24`):** noon declined the recurring MIT charge (HTTP 403, `resultCode 51` / connector code `19098`). UCS built `response.Err.code` from the proto **top-level `error_code`** — the generic `CONNECTOR_ERROR_RESPONSE` discriminator — while the Direct gateway surfaced noon's own code:

```
valueDiff: { "response.Err.code": { hyperswitch: "19098", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After the fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes noon's real code, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17198) is the separate hyperswitch#13041 family. Prod build at detection was stale (predates this fix).



---

## Re-detection — noon / psync (juspay/hyperswitch-cloud#17202)

Fixes juspay/hyperswitch-cloud#17202 — the **same** `router.valueDiff:response.Err.code` fingerprint, now on **noon / psync** (merchant `urban_compay749`, org `org_oOk4rRdiabRK4UqpGU0xj`, 19 occurrences).

The fix in this PR is connector- and flow-agnostic: it lives in `UnifiedConnectorServiceError::decode_connector_error_response`, which builds the `ConnectorErrorInner.code` consumed by the authorize gateway, the `recurring_payment_charge` (MIT) branch, **and** the psync gateway (`psync_gateway.rs` reads `inner.code` in its `ConnectorError` branch). So it already covers psync — no psync-specific change is needed for this signature.

**RCA (prod Grafana, req `019efe0c-4c9c-74c2-a83e-831bcf26417f`):** noon returned **HTTP 400** on the PSync `GET .../order/getbyreference/...` (`resultCode 2082`, `"Organization with business identifier HYPERSWITCH does not exists."`). UCS decoded the error internally (`code: "2082"`) but built `response.Err.code` from the proto **top-level `error_code`** — the generic `CONNECTOR_ERROR_RESPONSE` discriminator — while the Direct gateway surfaced noon's own code:

```
valueDiff: { "response.Err.code": { hyperswitch: "2082", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes noon's real `2082`, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17201) is the separate hyperswitch#13041 family (which adds the psync-specific `connector_http_status_code` line). Prod build at detection was stale `2026.06.17.0` (predates this fix).



---

## Re-detection — noon / refund (juspay/hyperswitch-cloud#17205)

Fixes juspay/hyperswitch-cloud#17205 (parent #17203) — the **same** `router.valueDiff:response.Err.code` fingerprint, now on **noon / refund** (merchant `urban_compay749`, org `org_oOk4rRdiabRK4UqpGU0xj`, 6 occurrences).

No new code — `decode_connector_error_response` (`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`) is **flow-agnostic**: it takes only the tonic `Status` + connector name and builds the `ConnectorErrorInner.code` that every flow's error early-return branch (authorize, psync, refund execute/sync) reads into `ErrorResponse.code`. So this PR's existing change — preferring `error_info.connector_details.code` over the top-level `error_code` discriminator — already covers refund.

**RCA (prod Grafana, req `019efa9d-83d6-7961-b1c1-44523ff22f3a`):** noon returned **HTTP 403** on the refund with body `{"resultCode":19706,"message":"Transaction is declined by the issuer."}`. UCS surfaced it as a tonic `ConnectorError`; before this fix `decode_connector_error_response` set `code` from the top-level `error_code` (the `CONNECTOR_ERROR_RESPONSE` discriminator) instead of noon's real `connector_details.code`:

```
valueDiff: { "response.Err.code": { hyperswitch: "19706", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes noon's real `19706`, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17204) is the separate hyperswitch#13041 family (which adds the refund-specific `connector_http_status_code` line). Prod build at detection was stale `2026.06.17.0` (predates this fix).



---

## Re-detection — stripe / authorize, payment_method_token (juspay/hyperswitch-cloud#17209)

Fixes juspay/hyperswitch-cloud#17209 — the **same** `router.valueDiff:response.Err.code` fingerprint, now on **stripe / authorize, payment_method_token** (merchant `yucca`, org `org_Vhm8CPMYJsk68oMpVrCK` Baskhealth, 10 occurrences).

No new code — `decode_connector_error_response` (`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`) is **flow- and connector-agnostic**: it builds the `ConnectorErrorInner.code` that stripe's regular-Authorize error early-return branch reads into `ErrorResponse.code`. This PR's existing change — preferring `error_info.connector_details.code` over the top-level `error_code` discriminator — already covers stripe authorize.

**RCA (prod Grafana, req `019efcb0-198b-7642-8c89-4318ac3b9102`, payment `pay_iKmbEx0Js7t5HrMn8qOT`, found connector-service Loki 2026-06-25T02:51:02Z):** two-leg stripe flow — tokenize `POST /v1/payment_methods` HTTP 200, then authorize `POST /v1/payment_intents` returned **HTTP 402 card_declined** (`decline_code=do_not_honor`, network decline 59, intent `pi_3Tm3NYBD08a1aHQL12HFZRvz`). UCS surfaced it as a tonic `ConnectorError`; before this fix `decode_connector_error_response` set `code` from the top-level `error_code` (the `CONNECTOR_ERROR_RESPONSE` discriminator) instead of stripe's real `connector_details.code`:

```
valueDiff: { "response.Err.code": { hyperswitch: "card_declined", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes stripe's real `card_declined`, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17207) and `connector_transaction_id` typeDiff (#17208) are the separate hyperswitch#13041 / #13042 families. Prod router build at detection was stale `2026.06.10.0-hotfix7` + UCS `2026.06.17.0` (both predate this fix).



---

## Re-detection — noon / authorize (juspay/hyperswitch-cloud#17215)

Fixes juspay/hyperswitch-cloud#17215 — the **same** `router.valueDiff:response.Err.code` fingerprint, now on **noon / authorize** (merchant `urban_compay749`, org `org_oOk4rRdiabRK4UqpGU0xj`, 4 occurrences). Parent tracking issue juspay/hyperswitch-cloud#17213.

No new code — `decode_connector_error_response` (`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`) is **flow- and connector-agnostic**: it builds `ConnectorErrorInner.code` that noon's regular-Authorize error early-return branch reads into `ErrorResponse.code`. This PR's existing change — preferring `error_info.connector_details.code` over the top-level `error_code` discriminator — already covers noon authorize.

**RCA (prod Grafana, 4 genuine requests `019efddc-aa46-71c1-b43c-5ffa796e9b93`, `019efdda-0a0a-7ed0-8387-846b9d11293e`, `019efdda-7e17-7851-be8b-582cb21717ac`, `019efad2-6f29-7200-8808-ab7572bb15f8`, all found in connector-service Loki):** noon authorize `POST https://api.noonpayments.com/payment/v1/order` returned **HTTP 403** `resultCode 19030` *"Unable to proceed, the provided card brand is not configured."* (Failed BusinessViolation — AMEX BIN `374405…`). **Both** legs reached real noon and got the identical 403/19030. UCS's own outgoing event carries `error.code:"19030"` / `status_code:403`, but when the router consumes the UCS gRPC error, `decode_connector_error_response` read the proto **top-level `error_code`** (the `CONNECTOR_ERROR_RESPONSE` discriminator) instead of `error_info.connector_details.code` (=`19030`):

```
valueDiff: { "response.Err.code": { hyperswitch: "19030", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes noon's real `19030`, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17214) is the separate hyperswitch#13041 family. Prod build at detection was stale (router `2026.06.10.0-hotfix7`, UCS `2026.06.17.0`, both predate this fix).

> Note: the separate `keyDiff:response.Err` / `keyDiff:response.Ok` / `valueDiff:status` signatures under the same parent (#17384/#17385/#17386, single occurrence on req `019efded`) are a benign infrastructure artifact (shadow mitm-proxy synthetic 502 to the UCS leg vs a real noon 200/CAPTURED on Direct), classification = none — not addressed here.

**Verification:** `cargo build -p router` / `cargo check -p router` clean on current `main` @ `96a4e857e2` (branch tip `e06dbf1f`). The live noon 403 business-decline is not deterministically forceable in the sandbox, so verified by the code-path proof above plus the adyen #17182 anchor this PR proved **end-to-end** (req `019f0221` → `019f0242` `valueDiff:{}`). `decode_connector_error_response(status, connector_name)` takes no flow argument → covers noon authorize identically.




---

## Re-detection — stripe / authorize, create_connector_customer, payment_method_token (juspay/hyperswitch-cloud#17219)

Fixes juspay/hyperswitch-cloud#17219 — the **same** `router.valueDiff:response.Err.code` fingerprint, again on **stripe / authorize, create_connector_customer, payment_method_token** (merchant `yucca`, org `org_Vhm8CPMYJsk68oMpVrCK` Baskhealth, 10 occurrences). This is the `response.Err.code` member of the **same 3-leg 402 event** whose `connector_http_status_code` typeDiff is #17217 and `connector_transaction_id` typeDiff is #17218 — all on req `019efe3f-67df-7683-bee3-2bc602748bb8`.

No new code — `decode_connector_error_response` (`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`) is **flow- and connector-agnostic**: it builds the `ConnectorErrorInner.code` that stripe's regular-Authorize error early-return branch reads into `ErrorResponse.code`. This PR's existing change — preferring `error_info.connector_details.code` over the top-level `error_code` discriminator — already covers stripe authorize. (Same merchant/family as the #17209 re-detection above; a distinct prod event.)

**RCA (prod Grafana, req `019efe3f-67df-7683-bee3-2bc602748bb8`, payment `pay_pQVwktG91h84oqqtE2rY`, profile `pro_Z4LBeWYD2udmBqcJDThj`; found connector-service Loki 2026-06-25T10:07:09–12Z):** 3-leg stripe flow — `create_connector_customer` + `payment_method_token` legs were clean (only benign `RP_05` header diffs: stripe-account vs x-merchant-id). The router-data diff comes from the **authorize** leg: `POST https://api.stripe.com/v1/payment_intents` returned **HTTP 402 card_declined** (`decline_code=insufficient_funds`, `network_decline_code=51`, message "Your card has insufficient funds.", intent `pi_3TmABdBD08a1aHQL1C0Yrk6P`). UCS surfaced it as a tonic `ConnectorError`; before this fix `decode_connector_error_response` set `code` from the top-level `error_code` (the `CONNECTOR_ERROR_RESPONSE` discriminator) instead of stripe's real `connector_details.code`:

```
valueDiff: { "response.Err.code": { hyperswitch: "card_declined", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes stripe's real `card_declined`, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17217) and `connector_transaction_id` typeDiff (#17218) are the separate hyperswitch#13041 / #13042 families. Prod build at detection was stale `2026.06.17.0-dirty` (predates this fix).

**Verification:** `cargo check -p router` clean on current `main` @ `96a4e857e2` (branch tip `e06dbf1f`). The live stripe 402 card-decline is not deterministically forceable in the sandbox, so verified by the code-path proof above plus the adyen #17182 anchor this PR proved **end-to-end** (req `019f0221` → `019f0242` `valueDiff:{}`). `decode_connector_error_response(status, connector_name)` takes no flow argument → covers stripe authorize (and its 3-leg customer/token variant) identically.



---

## Re-detection — paypal / authorize (juspay/hyperswitch-cloud#17232)

Fixes juspay/hyperswitch-cloud#17232 — the **same** `router.valueDiff:response.Err.code` fingerprint, now on **paypal / authorize** (merchant/org `opencommerce`, `org_wbvg6YIuzaP4BdnvQZou`, 4 occurrences, fingerprint `8ec9d25d…`). This is the `response.Err.code` member of the **same paypal 422 PAYMENT_DENIED event** whose `connector_http_status_code` typeDiff is #17230 and `connector_transaction_id` typeDiff is #17231 — all on req `019efc86-43d3-7482-b750-0402eeaada67`, payment `pay_wbAa0o79KPvXtJmRpVru`.

No new code — `decode_connector_error_response` (`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`) is **flow- and connector-agnostic**: it builds the `ConnectorErrorInner.code` that paypal's regular-Authorize error early-return branch reads into `ErrorResponse.code`. This PR's existing change — preferring `error_info.connector_details.code` over the top-level `error_code` discriminator — already covers paypal authorize.

**RCA (prod Grafana, req `019efc86-43d3-7482-b750-0402eeaada67`, payment `pay_wbAa0o79KPvXtJmRpVru`; found connector-service/validation-service Loki `VS_48` 2026-06-25T02:05:21Z):** paypal authorize `POST https://api-m.paypal.com/v2/checkout/orders` (intent AUTHORIZE, VISA `414720…`, USD 65.94, NO_THREE_DS) was declined → **HTTP 422 `PAYMENT_DENIED`**. UCS surfaced it as a tonic `ConnectorError`; before this fix `decode_connector_error_response` set `code` from the top-level `error_code` (the `CONNECTOR_ERROR_RESPONSE` discriminator) instead of paypal's real `connector_details.code`:

```
valueDiff: { "response.Err.code": { hyperswitch: "PAYMENT_DENIED", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes paypal's real `PAYMENT_DENIED`, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17230) and `connector_transaction_id` typeDiff (#17231) are the separate hyperswitch#13041 / #13042 families. Prod build at detection was stale `2026.06.17.0-dirty-aef0be919` (predates this fix).

**Verification:** `cargo check -p router` clean on current `main` @ `96a4e857e2` (branch tip `e06dbf1f`, pinned proto `2026.06.24.0` carries `connector_details.code`). The live paypal 422 PAYMENT_DENIED decline is not deterministically forceable in the sandbox, so verified by the code-path proof above plus the adyen #17182 anchor this PR proved **end-to-end** (req `019f0221` → `019f0242` `valueDiff:{}`). `decode_connector_error_response(status, connector_name)` takes no flow argument → covers paypal authorize identically.



---

## Re-detection — stripe / repeat_payment (juspay/hyperswitch-cloud#17235)

Fixes juspay/hyperswitch-cloud#17235 — the **same** `router.valueDiff:response.Err.code` fingerprint, now on **stripe / repeat_payment** (merchant `yucca`, org `org_Vhm8CPMYJsk68oMpVrCK` Baskhealth, 6 occurrences, fingerprint `77459a6a…`). This is the `response.Err.code` member of the **same stripe recurring 402 event** whose `connector_http_status_code` typeDiff is #17233 and `connector_transaction_id` typeDiff is #17234 — all on req `019efddc-07e9-7513-961d-7de85f8a1dc9`, payment `pay_klo2IqJSnN5epizk0YLt`.

No new code — `decode_connector_error_response` (`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`) is **flow- and connector-agnostic**: the UCS recurring-charge (`RepeatPayment` → `recurring_payment_charge`) connector-error branch reads `ConnectorErrorInner.code` into `ErrorResponse.code` exactly like the regular-Authorize branch. This PR's existing change — preferring `error_info.connector_details.code` over the top-level `error_code` discriminator — already covers stripe repeat_payment.

**RCA (prod Grafana, req `019efddc-07e9-7513-961d-7de85f8a1dc9`, payment `pay_klo2IqJSnN5epizk0YLt`; found connector-service/validation-service Loki `VS_48` 2026-06-25T08:18:38Z):** a true off-session MIT recurring charge — Direct leg `x-flow: Authorize` + `stripe-account: acct_1QRkHLBD08a1aHQL`, UCS leg `x-flow: repeat_payment` / `x-source: connector-service` (UCS maps `repeat_payment → authorize`: `VS_06 flowMapping:authorize`). BOTH legs hit `POST https://api.stripe.com/v1/payment_intents` and BOTH received a real **HTTP 402** card decline (request bodies byte-identical: `keyDiff/valueDiff/typeDiff {}` apart from the benign stripe-account vs x-merchant-id header). UCS surfaced it as a tonic `Unknown` → recurring-charge `ConnectorError` early-return; before this fix `decode_connector_error_response` set `code` from the top-level `error_code` (the `CONNECTOR_ERROR_RESPONSE` discriminator) instead of stripe's real `connector_details.code`:

```
valueDiff: { "response.Err.code": { hyperswitch: "card_declined", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes stripe's real `card_declined`, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17233) and `connector_transaction_id` typeDiff (#17234) are the separate hyperswitch#13041 / #13042 families. Prod build at detection predates this fix.

**Verification:** `cargo check -p hyperswitch_interfaces` clean on current `main` @ `96a4e857e2` (branch tip `e06dbf1f`); branch already has `origin/main` as ancestor (no rebase needed, MERGEABLE). The live stripe 402 card-decline is not deterministically forceable in the sandbox, so verified by the code-path proof above plus the adyen #17182 anchor this PR proved **end-to-end** (req `019f0221` → `019f0242` `valueDiff:{}`). `decode_connector_error_response(status, connector_name)` takes no flow argument → covers stripe repeat_payment (recurring-charge branch) identically.




---

## Re-detection — payload / repeat_payment (juspay/hyperswitch-cloud#17246)

Fixes juspay/hyperswitch-cloud#17246 — the **same** `router.valueDiff:response.Err.code` fingerprint, now on **payload / repeat_payment** (merchant `innago`, org `org_UzMFuWdm97opIVTXhuqF` Innago, 4 occurrences, fingerprint `f077ce28…`). This is the `response.Err.code` member of the **same payload 400 AMEX-decline event** whose `connector_http_status_code` typeDiff is #17245 — all 4 occurrences on reqs `019efc4a-a9bd`, `019efc4a-b159`, `019efd27-5ca5`, `019efd27-6415` (sample payment `pay_c3H0ys3ovMdVaMVvc9GP`).

No new code — `decode_connector_error_response` (`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`) is **flow- and connector-agnostic**: the UCS recurring-charge (`RepeatPayment` → `recurring_payment_charge`) connector-error branch reads `ConnectorErrorInner.code` into `ErrorResponse.code` exactly like the regular-Authorize branch. This PR's existing change — preferring `error_info.connector_details.code` over the top-level `error_code` discriminator — already covers payload repeat_payment.

**RCA (prod Grafana, all 4 reqs found in connector-service Loki 2026-06-25):** an off-session MIT recurring charge — **both** legs hit the real payload API `POST https://api.payload.com/transactions` and **both** received a genuine **HTTP 400** AMEX decline (`error_type: "TransactionDeclined"`, *"The card has been declined, contact card issuer for more information."*). This is NOT a synthetic mitm/shadow-proxy 502 — the request bodies and the upstream 400 were identical on both legs. UCS surfaced the 400 as a tonic `INVALID_ARGUMENT` → recurring-charge `ConnectorError` early-return; before this fix `decode_connector_error_response` set `code` from the top-level `error_code` (the `CONNECTOR_ERROR_RESPONSE` discriminator) instead of payload's real `connector_details.code`:

```
valueDiff: { "response.Err.code": { hyperswitch: "TransactionDeclined", ucs: "CONNECTOR_ERROR_RESPONSE" } }
```

After this fix `decode_connector_error_response` prefers `error_info.connector_details.code` → `response.Err.code` becomes payload's real `TransactionDeclined`, matching Direct and eliminating the valueDiff. The co-occurring `connector_http_status_code` typeDiff (#17245) is the separate hyperswitch#13041 family. Prod build at detection was stale `2026.06.10.0-hotfix7-c8b9bd9` (predates this fix).

**Verification:** `cargo check -p router` clean on current `main` @ `96a4e857e2` (branch tip `e06dbf1f`, 0 behind `origin/main`, MERGEABLE; pinned proto `2026.06.24.0` carries `connector_details.code`). The live payload 400 AMEX-decline is not deterministically forceable in the sandbox, so verified by the code-path proof above plus the adyen #17182 anchor this PR proved **end-to-end** (req `019f0221` → `019f0242` `valueDiff:{}`). `decode_connector_error_response(status, connector_name)` takes no flow argument → covers payload repeat_payment (recurring-charge branch) identically.
