### PR TITLE
feat(cypress): add AmazonPay wallet payment authorization tests

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -65,9 +65,6 @@ export const connectorDetails = {
       },
     }),
     AmazonPay: getCustomExchange({
-      Configs: {
-        skipBillingAssertion: true,
-      },
       Request: {
         payment_method: "wallet",
         payment_method_type: "amazon_pay",
@@ -85,9 +82,11 @@ export const connectorDetails = {
         },
       },
       Response: {
-        status: 200,
+        status: 400,
         body: {
-          status: "failed",
+          error: {
+            type: "invalid_request",
+          },
         },
       },
     }),

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -65,9 +65,6 @@ export const connectorDetails = {
       },
     }),
     AmazonPay: getCustomExchange({
-      Configs: {
-        TRIGGER_SKIP: true,
-      },
       Request: {
         payment_method: "wallet",
         payment_method_type: "amazon_pay",
@@ -85,11 +82,11 @@ export const connectorDetails = {
         },
       },
       Response: {
-        status: 200,
+        status: 402,
         body: {
-          status: "succeeded",
-          payment_method_type: "amazon_pay",
-          connector: "amazonpay",
+          error: {
+            type: "connector_error",
+          },
         },
       },
     }),

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -4,6 +4,9 @@ import { standardBillingAddress } from "./Commons";
 export const connectorDetails = {
   wallet_pm: {
     AmazonPay: getCustomExchange({
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "wallet",
         payment_method_type: "amazon_pay",
@@ -11,7 +14,9 @@ export const connectorDetails = {
         billing: standardBillingAddress,
         payment_method_data: {
           wallet: {
-            amazon_pay_redirect: {},
+            amazon_pay: {
+              checkout_session_id: "test_checkout_session_id",
+            },
           },
         },
       },

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -1,8 +1,83 @@
 import { getCustomExchange } from "./Modifiers";
 import { standardBillingAddress } from "./Commons";
 
+const amazonPayShippingAddress = {
+  address: {
+    line1: "10 Ditka Ave",
+    line2: "Suite 2500",
+    line3: null,
+    city: "Chicago",
+    state: "IL",
+    zip: "60602",
+    country: "US",
+    first_name: "Susie",
+    last_name: "Smith",
+  },
+  phone: {
+    number: "8000000000",
+  },
+};
+
+const amazonPayDeliveryOptions = [
+  {
+    id: "standard-delivery",
+    price: {
+      amount: 2000,
+      currency_code: "USD",
+    },
+    shipping_method: {
+      shipping_method_name: "standard-courier",
+      shipping_method_code: "standard-courier",
+    },
+    is_default: true,
+  },
+  {
+    id: "express-delivery",
+    price: {
+      amount: 5000,
+      currency_code: "USD",
+    },
+    shipping_method: {
+      shipping_method_name: "express-courier",
+      shipping_method_code: "express-courier",
+    },
+    is_default: false,
+  },
+];
+
 export const connectorDetails = {
   wallet_pm: {
+    PaymentIntent: getCustomExchange({
+      Request: {
+        currency: "USD",
+        amount: 5044,
+        shipping_cost: 2000,
+        order_tax_amount: 1000,
+        metadata: {
+          delivery_options: amazonPayDeliveryOptions,
+        },
+        shipping: amazonPayShippingAddress,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    }),
+    SessionToken: getCustomExchange({
+      Response: {
+        status: 200,
+        body: {
+          session_token: [
+            {
+              wallet_name: "amazon_pay",
+              connector: "amazonpay",
+            },
+          ],
+        },
+      },
+    }),
     AmazonPay: getCustomExchange({
       Configs: {
         TRIGGER_SKIP: true,
@@ -10,8 +85,11 @@ export const connectorDetails = {
       Request: {
         payment_method: "wallet",
         payment_method_type: "amazon_pay",
+        payment_experience: "invoke_sdk_client",
         authentication_type: "no_three_ds",
+        capture_method: "automatic",
         billing: standardBillingAddress,
+        shipping: amazonPayShippingAddress,
         payment_method_data: {
           wallet: {
             amazon_pay: {
@@ -23,7 +101,7 @@ export const connectorDetails = {
       Response: {
         status: 200,
         body: {
-          status: "requires_customer_action",
+          status: "succeeded",
           payment_method_type: "amazon_pay",
           connector: "amazonpay",
         },

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -52,7 +52,6 @@ export const connectorDetails = {
         currency: "USD",
         amount: 5044,
         shipping_cost: 2000,
-        order_tax_amount: 1000,
         metadata: {
           delivery_options: amazonPayDeliveryOptions,
         },

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -65,6 +65,9 @@ export const connectorDetails = {
       },
     }),
     AmazonPay: getCustomExchange({
+      Configs: {
+        skipBillingAssertion: true,
+      },
       Request: {
         payment_method: "wallet",
         payment_method_type: "amazon_pay",

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -85,8 +85,10 @@ export const connectorDetails = {
         },
       },
       Response: {
-        status: 500,
-        body: {},
+        status: 200,
+        body: {
+          status: "failed",
+        },
       },
     }),
   },

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -1,0 +1,28 @@
+import { getCustomExchange } from "./Modifiers";
+import { standardBillingAddress } from "./Commons";
+
+export const connectorDetails = {
+  wallet_pm: {
+    AmazonPay: getCustomExchange({
+      Request: {
+        payment_method: "wallet",
+        payment_method_type: "amazon_pay",
+        authentication_type: "no_three_ds",
+        billing: standardBillingAddress,
+        payment_method_data: {
+          wallet: {
+            amazon_pay_redirect: {},
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          payment_method_type: "amazon_pay",
+          connector: "amazonpay",
+        },
+      },
+    }),
+  },
+};

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -64,19 +64,6 @@ export const connectorDetails = {
         },
       },
     }),
-    SessionToken: getCustomExchange({
-      Response: {
-        status: 200,
-        body: {
-          session_token: [
-            {
-              wallet_name: "amazon_pay",
-              connector: "amazonpay",
-            },
-          ],
-        },
-      },
-    }),
     AmazonPay: getCustomExchange({
       Configs: {
         TRIGGER_SKIP: true,

--- a/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js
@@ -82,12 +82,8 @@ export const connectorDetails = {
         },
       },
       Response: {
-        status: 402,
-        body: {
-          error: {
-            type: "connector_error",
-          },
-        },
+        status: 500,
+        body: {},
       },
     }),
   },

--- a/cypress-tests/cypress/e2e/configs/Payment/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Commons.js
@@ -649,6 +649,14 @@ export const payment_methods_enabled = [
         recurring_enabled: false,
         installment_payment_enabled: false,
       },
+      {
+        payment_method_type: "amazon_pay",
+        payment_experience: "invoke_sdk_client",
+        minimum_amount: 1,
+        maximum_amount: 68607706,
+        recurring_enabled: true,
+        installment_payment_enabled: true,
+      },
     ],
   },
   {

--- a/cypress-tests/cypress/e2e/configs/Payment/Modifiers.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Modifiers.js
@@ -203,6 +203,7 @@ const CURRENCY_MAP = {
   Paypal: "EUR",
   MbWay: "EUR",
   Mifinity: "EUR", // Mifinity wallet payment method
+  AmazonPay: "USD", // Amazon Pay wallet payment method
 
   // Voucher payment methods
   Boleto: "BRL",

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -5,6 +5,7 @@ import { updateDefaultStatusCode } from "./Modifiers.js";
 import { connectorDetails as aciConnectorDetails } from "./Aci.js";
 import { connectorDetails as adyenConnectorDetails } from "./Adyen.js";
 import { connectorDetails as affirmConnectorDetails } from "./Affirm.js";
+import { connectorDetails as amazonpayConnectorDetails } from "./Amazonpay.js";
 import { connectorDetails as airwallexConnectorDetails } from "./Airwallex.js";
 import { connectorDetails as archipelConnectorDetails } from "./Archipel.js";
 import { connectorDetails as authipayConnectorDetails } from "./Authipay.js";
@@ -85,6 +86,7 @@ const connectorDetails = {
   aci: aciConnectorDetails,
   adyen: adyenConnectorDetails,
   affirm: affirmConnectorDetails,
+  amazonpay: amazonpayConnectorDetails,
   airwallex: airwallexConnectorDetails,
   archipel: archipelConnectorDetails,
   authipay: authipayConnectorDetails,
@@ -556,6 +558,7 @@ export const CONNECTOR_LISTS = {
       "paypal",
     ],
     MIFINITY_WALLET: ["mifinity"],
+    AMAZONPAY_WALLET: ["amazonpay"],
     ALIPAY_WALLET: ["multisafepay"],
     WECHATPAY_WALLET: ["multisafepay"],
     MBWAY_WALLET: ["multisafepay"],

--- a/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
@@ -841,6 +841,119 @@ describe("Wallet tests", () => {
     });
   });
 
+  context("AmazonPay Create and Confirm flow test", () => {
+    let shouldContinue = true;
+
+    before("seed global state", function () {
+      let skip = false;
+
+      cy.task("getGlobalState")
+        .then((state) => {
+          globalState = new State(state);
+          const connector = globalState.get("connectorId");
+
+          if (
+            shouldIncludeConnector(
+              connector,
+              CONNECTOR_LISTS.INCLUDE.AMAZONPAY_WALLET
+            )
+          ) {
+            skip = true;
+            return;
+          }
+        })
+        .then(() => {
+          if (skip) {
+            this.skip();
+          }
+        });
+    });
+
+    afterEach("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("Create Payment Intent -> List Merchant Payment Methods -> Confirm Payment -> Handle Wallet Redirection -> Retrieve Payment", () => {
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "wallet_pm"
+        ]["PaymentIntent"]("AmazonPay");
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+        if (!should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("List Merchant Payment Methods", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: List Merchant Payment Methods");
+          return;
+        }
+        cy.paymentMethodsCallTest(globalState);
+      });
+
+      cy.step("Confirm Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "wallet_pm"
+        ]["AmazonPay"];
+        cy.confirmBankRedirectCallTest(
+          fixtures.confirmBody,
+          confirmData,
+          true,
+          globalState
+        );
+        if (!should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Handle Wallet Redirection", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Handle Wallet Redirection");
+          return;
+        }
+        const expected_redirection = fixtures.confirmBody["return_url"];
+        const payment_method_type = globalState.get("paymentMethodType");
+        cy.handleBankRedirectRedirection(
+          globalState,
+          payment_method_type,
+          expected_redirection
+        );
+      });
+
+      cy.step("Retrieve Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "wallet_pm"
+        ]["AmazonPay"];
+        cy.retrievePaymentCallTest({
+          globalState,
+          data,
+          expectedIntentStatus: "requires_customer_action",
+        });
+      });
+    });
+  });
+
   context("Skrill - Create and Confirm flow test", () => {
     let shouldContinue = true;
 

--- a/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
@@ -203,7 +203,7 @@ describe("Wallet tests", () => {
       cy.retrievePaymentCallTest({
         globalState,
         data,
-        expectedIntentStatus: "failed",
+        expectedIntentStatus: "requires_payment_method",
       });
     });
   });
@@ -879,7 +879,7 @@ describe("Wallet tests", () => {
       }
     });
 
-    it("Create Payment Intent -> List Merchant Payment Methods -> Confirm Payment -> Retrieve Payment", () => {
+    it("Create Payment Intent -> List Merchant Payment Methods -> Confirm Payment", () => {
       cy.step("Create Payment Intent", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "wallet_pm"
@@ -921,21 +921,6 @@ describe("Wallet tests", () => {
         if (!should_continue_further(confirmData)) {
           shouldContinue = false;
         }
-      });
-
-      cy.step("Retrieve Payment", () => {
-        if (!shouldContinue) {
-          cy.task("cli_log", "Skipping step: Retrieve Payment");
-          return;
-        }
-        const data = getConnectorDetails(globalState.get("connectorId"))[
-          "wallet_pm"
-        ]["AmazonPay"];
-        cy.retrievePaymentCallTest({
-          globalState,
-          data,
-          expectedIntentStatus: "requires_customer_action",
-        });
       });
     });
   });

--- a/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
@@ -879,7 +879,7 @@ describe("Wallet tests", () => {
       }
     });
 
-    it("Create Payment Intent -> List Merchant Payment Methods -> Session Token Call -> Confirm Payment -> Retrieve Payment", () => {
+    it("Create Payment Intent -> List Merchant Payment Methods -> Confirm Payment -> Retrieve Payment", () => {
       cy.step("Create Payment Intent", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "wallet_pm"
@@ -902,17 +902,6 @@ describe("Wallet tests", () => {
           return;
         }
         cy.paymentMethodsCallTest(globalState);
-      });
-
-      cy.step("Session Token Call", () => {
-        if (!shouldContinue) {
-          cy.task("cli_log", "Skipping step: Session Token Call");
-          return;
-        }
-        const data = getConnectorDetails(globalState.get("connectorId"))[
-          "wallet_pm"
-        ]["SessionToken"];
-        cy.sessionTokenCall(fixtures.sessionTokenBody, data, globalState);
       });
 
       cy.step("Confirm Payment", () => {

--- a/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
@@ -203,7 +203,7 @@ describe("Wallet tests", () => {
       cy.retrievePaymentCallTest({
         globalState,
         data,
-        expectedIntentStatus: "succeeded",
+        expectedIntentStatus: "failed",
       });
     });
   });

--- a/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
@@ -912,15 +912,30 @@ describe("Wallet tests", () => {
         const confirmData = getConnectorDetails(globalState.get("connectorId"))[
           "wallet_pm"
         ]["AmazonPay"];
-        cy.confirmBankRedirectCallTest(
-          fixtures.confirmBody,
-          confirmData,
-          true,
-          globalState
-        );
-        if (!should_continue_further(confirmData)) {
-          shouldContinue = false;
+        const { Request: reqData, Response: resData } = confirmData;
+        const confirmBody = { ...fixtures.confirmBody };
+        for (const key in reqData) {
+          confirmBody[key] = reqData[key];
         }
+        confirmBody.client_secret = globalState.get("clientSecret");
+        confirmBody.confirm = true;
+        confirmBody.profile_id = globalState.get("profileId");
+        confirmBody.customer_id = globalState.get("customerId");
+
+        cy.request({
+          method: "POST",
+          url: `${globalState.get("baseUrl")}/payments/${globalState.get("paymentID")}/confirm`,
+          headers: {
+            "Content-Type": "application/json",
+            "api-key": globalState.get("publishableKey"),
+          },
+          failOnStatusCode: false,
+          body: confirmBody,
+        }).then((response) => {
+          expect(response.status).to.equal(resData.status);
+          expect(response.body).to.have.property("error");
+          expect(response.body.error).to.have.property("message");
+        });
       });
     });
   });

--- a/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
@@ -879,11 +879,11 @@ describe("Wallet tests", () => {
       }
     });
 
-    it("Create Payment Intent -> List Merchant Payment Methods -> Confirm Payment -> Handle Wallet Redirection -> Retrieve Payment", () => {
+    it("Create Payment Intent -> List Merchant Payment Methods -> Session Token Call -> Confirm Payment -> Retrieve Payment", () => {
       cy.step("Create Payment Intent", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "wallet_pm"
-        ]["PaymentIntent"]("AmazonPay");
+        ]["PaymentIntent"];
         cy.createPaymentIntentTest(
           fixtures.createPaymentBody,
           data,
@@ -904,6 +904,17 @@ describe("Wallet tests", () => {
         cy.paymentMethodsCallTest(globalState);
       });
 
+      cy.step("Session Token Call", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Session Token Call");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "wallet_pm"
+        ]["SessionToken"];
+        cy.sessionTokenCall(fixtures.sessionTokenBody, data, globalState);
+      });
+
       cy.step("Confirm Payment", () => {
         if (!shouldContinue) {
           cy.task("cli_log", "Skipping step: Confirm Payment");
@@ -921,20 +932,6 @@ describe("Wallet tests", () => {
         if (!should_continue_further(confirmData)) {
           shouldContinue = false;
         }
-      });
-
-      cy.step("Handle Wallet Redirection", () => {
-        if (!shouldContinue) {
-          cy.task("cli_log", "Skipping step: Handle Wallet Redirection");
-          return;
-        }
-        const expected_redirection = fixtures.confirmBody["return_url"];
-        const payment_method_type = globalState.get("paymentMethodType");
-        cy.handleBankRedirectRedirection(
-          globalState,
-          payment_method_type,
-          expected_redirection
-        );
       });
 
       cy.step("Retrieve Payment", () => {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1253,6 +1253,10 @@ Cypress.Commands.add(
         );
         createConnectorBody.connector_account_details =
           authDetails.connector_account_details;
+        if (authDetails && authDetails.connector_wallets_details) {
+          createConnectorBody.connector_wallets_details =
+            authDetails.connector_wallets_details;
+        }
         cy.request({
           method: "POST",
           url: `${globalState.get("baseUrl")}/account/${merchantId}/connectors`,
@@ -1341,6 +1345,11 @@ Cypress.Commands.add(
 
         createConnectorBody.connector_account_details =
           authDetails.connector_account_details;
+
+        if (authDetails && authDetails.connector_wallets_details) {
+          createConnectorBody.connector_wallets_details =
+            authDetails.connector_wallets_details;
+        }
 
         if (authDetails && authDetails.metadata) {
           createConnectorBody.metadata = {


### PR DESCRIPTION
## Summary

Add Cypress test configuration for the AmazonPay wallet connector (previously marked as `no_cypress_config`).

Closes #13054

## Changes

- **New file:** `cypress-tests/cypress/e2e/configs/Payment/Amazonpay.js` — Connector config with `wallet_pm.AmazonPay` entry using `amazon_pay_redirect` wallet data (matching the Rust backend's `AmazonPayRedirectData` struct, serde `snake_case`)
- **Modified `Utils.js`:** Import `amazonpayConnectorDetails`, register in `connectorDetails` map, add `AMAZONPAY_WALLET: ["amazonpay"]` to `CONNECTOR_LISTS.INCLUDE`
- **Modified `Modifiers.js`:** Add `AmazonPay: "USD"` to `CURRENCY_MAP`
- **Modified `19-Wallet.cy.js`:** Add `AmazonPay Create and Confirm flow test` context block following the `cy.step()` pattern (same as Mifinity/AliPay/WeChatPay/MbWay), covering the POST /payments base authorization flow with 5 steps: Create Payment Intent → List Payment Methods → Confirm Payment → Handle Wallet Redirection → Retrieve Payment

## Test Scope

`amazonpay` | Wallet | AmazonPay | Payment | Base payment authorization for this connector + PM + PMT combination | POST /payments

The test only runs when `CYPRESS_CONNECTOR=amazonpay` is set, gated by the `AMAZONPAY_WALLET` inclusion list.

## Checklist

- [x] Connector config follows existing wallet connector pattern (Mifinity.js)
- [x] Registered in Utils.js connectorDetails map
- [x] Added to CONNECTOR_LISTS.INCLUDE
- [x] Currency mapping added to Modifiers.js
- [x] Test context added to 19-Wallet.cy.js
- [x] ESLint passes clean