### PR TITLE
fix(ucs): nexixpay PSync router-data parity (resource_id, connector_metadata, mandate_reference)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.24.0#cd7b17474c6c6be70f8be9a493c34bb98d8557bb"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.29.0#5569f622353390fc618b2a5004a0e88ec085e848"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.24.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.24.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -323,6 +323,21 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
         } else {
             let status = AttemptStatus::foreign_try_from((response.status(), prev_status))?;
 
+            let connector_metadata = response.connector_feature_data.as_ref().and_then(|m| {
+                let raw = m.clone().expose();
+                match serde_json::from_str::<serde_json::Value>(&raw) {
+                    Ok(v) => Some(v),
+                    Err(err) => {
+                        router_env::logger::warn!(
+                            error = %err,
+                            "failed to deserialize PSync response.connector_feature_data into \
+                             connector_metadata"
+                        );
+                        None
+                    }
+                }
+            });
+
             Ok((
                 PaymentsResponseData::TransactionResponse {
                     resource_id: connector_transaction_id,
@@ -334,7 +349,7 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
                             .transpose()?,
                     ),
                     mandate_reference: Box::new(response.mandate_reference.map(hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from).transpose()?),
-                    connector_metadata: None,
+                    connector_metadata,
                     network_txn_id: response.network_transaction_id.clone(),
                     network_txn_link_id: response.network_txn_link_id.clone(),
                     connector_response_reference_id: response.merchant_transaction_id,

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.24.0", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.24.0", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.29.0", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -827,6 +827,56 @@ impl transformers::ForeignTryFrom<&RouterData<PSync, PaymentsSyncData, PaymentsR
                 .map(payments_grpc::PaymentMethodType::foreign_try_from)
                 .transpose()?
                 .map(|payment_method_type| payment_method_type.into()),
+            mandate_reference: Option::<payments_grpc::ConnectorMandateReferenceId>::foreign_from(
+                router_data,
+            ),
+        })
+    }
+}
+
+impl ForeignFrom<&mandates::ConnectorMandateReferenceId>
+    for payments_grpc::ConnectorMandateReferenceId
+{
+    fn foreign_from(value: &mandates::ConnectorMandateReferenceId) -> Self {
+        Self {
+            connector_mandate_id: value.get_connector_mandate_id(),
+            payment_method_id: value.get_payment_method_id(),
+            connector_mandate_request_reference_id: value
+                .get_connector_mandate_request_reference_id(),
+        }
+    }
+}
+
+impl ForeignFrom<&RouterData<PSync, PaymentsSyncData, PaymentsResponseData>>
+    for Option<payments_grpc::ConnectorMandateReferenceId>
+{
+    fn foreign_from(
+        router_data: &RouterData<PSync, PaymentsSyncData, PaymentsResponseData>,
+    ) -> Self {
+        let structured = router_data.request.mandate_id.as_ref().and_then(|m| {
+            match m.mandate_reference_id.as_ref()? {
+                mandates::MandateReferenceId::ConnectorMandateId(r) => Some(r),
+                _ => None,
+            }
+        });
+
+        let connector_mandate_id = structured
+            .and_then(|r| r.get_connector_mandate_id())
+            .or_else(|| router_data.connector_mandate_request_reference_id.clone());
+        let payment_method_id = structured.and_then(|r| r.get_payment_method_id());
+        let connector_mandate_request_reference_id =
+            structured.and_then(|r| r.get_connector_mandate_request_reference_id());
+
+        if connector_mandate_id.is_none()
+            && payment_method_id.is_none()
+            && connector_mandate_request_reference_id.is_none()
+        {
+            return None;
+        }
+        Some(payments_grpc::ConnectorMandateReferenceId {
+            connector_mandate_id,
+            payment_method_id,
+            connector_mandate_request_reference_id,
         })
     }
 }


### PR DESCRIPTION
## What

Paired hyperswitch-side change for the merged prism PSync parity fix
(juspay/hyperswitch-prism#1673). Closes three router-data shadow-validation
diffs on `nexixpay` / `psync`.

## Changes

- **`crates/router/src/core/unified_connector_service/transformers.rs`** —
  `PaymentServiceGetRequest.mandate_reference` is populated from HS
  `RouterData` via a new `ForeignFrom<&RouterData<PSync, ...>>` for
  `Option<payments_grpc::ConnectorMandateReferenceId>`. Sources are merged
  at the field level: structured `request.mandate_id` is preferred
  (carries `payment_method_id` + inner reference id from a saved mandate);
  the bare `RouterData.connector_mandate_request_reference_id` is used as
  a fallback for off-session-mandate PSync (e.g. nexixpay) and only fills
  `connector_mandate_id` — unrelated fields stay `None` rather than being
  forced. The proto conversion is extracted into a reusable
  `ForeignFrom<&mandates::ConnectorMandateReferenceId>`.
- **`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`** —
  PSync response → `TransactionResponse` mapper rehydrates
  `connector_metadata` from `response.connector_feature_data` (matches the
  field name used on Authorize/Capture/Register responses), with a
  `router_env::logger::warn!` on JSON parse failure.
- **Cargo.toml × 3 + Cargo.lock** — bumps the four `connector-service`
  deps to the CalVer tag `2026.06.29.0`, which contains the prism fix.

## Pairs with

juspay/hyperswitch-prism#1673 (merged in tag `2026.06.29.0`).

## Proof

End-to-end on the local shadow stack against tag `2026.06.29.0`:

```
keyDiff:   {}
typeDiff:  {}
valueDiff: external_latency only (benign timing)

mandate_ref ucs: { connector_mandate_id: "taduSrpiEjQIOuki7K", payment_method_id: null, mandate_metadata: null, connector_mandate_request_reference_id: null }
mandate_ref hs:  { connector_mandate_id: "taduSrpiEjQIOuki7K", payment_method_id: null, mandate_metadata: null, connector_mandate_request_reference_id: null }
resource_id    ucs/hs: pay_ISaTxfAYUYMdmm (match)
connector_metadata: matched (full object echo)
```

Value-for-value parity on `resource_id`, `connector_metadata`, and
`mandate_reference`. Only `external_latency` differs (benign timing).