### PR TITLE
test(cypress): add novalnet Paypal wallet Mandate coverage

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Novalnet.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Novalnet.js
@@ -72,6 +72,15 @@ const billingAddress = {
   },
 };
 
+const paypalMandateCustomerAcceptance = {
+  acceptance_type: "online",
+  accepted_at: "2026-06-29T12:00:00Z",
+  online: {
+    ip_address: "192.168.1.1",
+    user_agent: "Mozilla/5.0",
+  },
+};
+
 export const connectorDetails = {
   card_pm: {
     PaymentIntent: {
@@ -841,6 +850,35 @@ export const connectorDetails = {
           },
         },
       }),
+    PaypalRedirectMandateCIT: getCustomExchange({
+      Request: {
+        payment_method: "wallet",
+        payment_method_type: "paypal",
+        authentication_type: "no_three_ds",
+        billing: billingAddress,
+        payment_method_data: {
+          wallet: {
+            paypal_redirect: {},
+          },
+        },
+        setup_future_usage: "off_session",
+        mandate_data: {
+          customer_acceptance: paypalMandateCustomerAcceptance,
+          mandate_type: {
+            single_use: {
+              amount: 6000,
+              currency: "EUR",
+            },
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
   },
   webhook: {
     TransactionIdConfig: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -561,7 +561,7 @@ export const CONNECTOR_LISTS = {
     MBWAY_WALLET: ["multisafepay"],
     SKRILL_WALLET: ["paysafe"],
     PAYSAFECARD_GIFT_CARD: ["paysafe"],
-    PAYPAL_MANDATE: ["globalpay", "paypal"],
+    PAYPAL_MANDATE: ["globalpay", "novalnet", "paypal"],
     PAYPAL_WALLET_MANDATE: ["adyen"],
     KAKAO_PAY_WALLET_MANDATE: ["adyen"],
     GCASH_WALLET_MANDATE: ["adyen"],


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Added novalnet PayPal wallet Mandate (CIT) test coverage to the existing Cypress test suite. A new `PaypalRedirectMandateCIT` config key was added to `Novalnet.js` under the `wallet_pm` section with novalnet-specific mandate data (single_use mandate, amount=6000 EUR, billing country=DE, acceptance_type=online). The `novalnet` connector was registered in `CONNECTOR_LISTS.INCLUDE.PAYPAL_MANDATE` in `Utils.js` so the existing `19-Wallet.cy.js` PayPal Mandate CIT flow test context now runs for novalnet. No new spec file was needed — the existing wallet spec covers this flow.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

No API schema changes. No database schema changes. No application configuration changes. Only Cypress test config files were modified.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Add novalnet PayPal wallet Mandate test cases. The novalnet connector supports PayPal wallet mandates (CIT flow) but had no Cypress test coverage for this flow. This PR closes that gap by adding the necessary config data and registering the connector in the PayPal Mandate inclusion list, enabling the existing wallet mandate spec to run against novalnet.

Linked issues:
- Closes #13066
- Related: BAN-252 (Paperclip pipeline parent issue — Add novalnet Paypal wallet Mandate test cases)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Full regression suite was executed against the changed connector(s). All `RUNNER_RESULT` blocks from the QA pipeline are included verbatim below.

### Changed-spec verification — `novalnet`

```
RUNNER_RESULT:
  Connector: novalnet
  SpecFile: cypress/e2e/spec/Payment/19-Wallet.cy.js
  PrereqsUsed: spec/Payment/01-,02-,03-
  TotalTests: 36
  Passed: 17
  Failed: 0
  Skipped: 19 (pending — expected skips for non-novalnet wallet types)
  OverallStatus: PASS

  Failures: none
  FlakeyTests: none
  BlockedReasons: none
```

### Full regression — `novalnet`

```
RUNNER_RESULT:
  Connector: novalnet
  SpecFile: cypress/e2e/spec/Payment/19-Wallet.cy.js
  PrereqsUsed: spec/Payment/01-,02-,03-
  TotalTests: 36
  Passed: 17
  Failed: 0
  Skipped: 19 (pending — expected skips for non-novalnet wallet types)
  OverallStatus: PASS

  Failures: none
  FlakeyTests: none
  BlockedReasons: none
```

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| novalnet | 36 | 17 | 0 | 19 | PASS |

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
