### PR TITLE
fix(events): suppress shadow UCS connector logs

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2781,24 +2781,23 @@ where
         }
     };
 
-    // Emit the Hyperswitch -> UCS connector event (shared with the other wrapper); it lands in
-    // connector_events with `destination = unified_connector_service`, `execution_mode` primary
-    // or shadow.
-    emit_ucs_connector_event(
-        state,
-        std::any::type_name::<T>(),
-        connector_name,
-        payment_id,
-        merchant_id,
-        refund_id,
-        dispute_id,
-        payout_id,
-        grpc_request_body,
-        status_code,
-        response_body,
-        external_latency,
-        execution_mode,
-    );
+    if let ExecutionMode::Primary = execution_mode {
+        emit_ucs_connector_event(
+            state,
+            std::any::type_name::<T>(),
+            connector_name,
+            payment_id,
+            merchant_id,
+            refund_id,
+            dispute_id,
+            payout_id,
+            grpc_request_body,
+            status_code,
+            response_body,
+            external_latency,
+            execution_mode,
+        );
+    }
 
     // Set external latency on router data
     router_result.map(|mut router_data| {
@@ -2913,24 +2912,23 @@ where
         }
     };
 
-    // Emit the Hyperswitch -> UCS connector event (shared with the other wrapper); it lands in
-    // connector_events with `destination = unified_connector_service`, `execution_mode` primary
-    // or shadow.
-    emit_ucs_connector_event(
-        state,
-        std::any::type_name::<T>(),
-        connector_name,
-        payment_id,
-        merchant_id,
-        refund_id,
-        dispute_id,
-        payout_id,
-        grpc_request_body,
-        status_code,
-        response_body,
-        external_latency,
-        execution_mode,
-    );
+    if let ExecutionMode::Primary = execution_mode {
+        emit_ucs_connector_event(
+            state,
+            std::any::type_name::<T>(),
+            connector_name,
+            payment_id,
+            merchant_id,
+            refund_id,
+            dispute_id,
+            payout_id,
+            grpc_request_body,
+            status_code,
+            response_body,
+            external_latency,
+            execution_mode,
+        );
+    }
 
     // Set external latency on router data
     router_result.map(|mut router_data| {

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -192,13 +192,23 @@ impl SessionState {
             ExecutionMode::Shadow => Some("shadow"),
             ExecutionMode::NotApplicable => None,
         };
+        let config_override = match unified_connector_service_execution_mode {
+            ExecutionMode::Shadow => Some(
+                serde_json::json!({
+                    "events": {
+                        "enabled": false
+                    }
+                })
+                .to_string(),
+            ),
+            _ => None,
+        };
         GrpcHeadersUcs::builder()
             .tenant_id(tenant_id)
             .request_id(request_id)
             .shadow_mode(shadow_mode)
             .proxy_name(proxy_name)
-            // no override: UCS emits in all modes, distinguished downstream by `execution_mode`
-            .config_override(None)
+            .config_override(config_override)
     }
     #[cfg(all(feature = "revenue_recovery", feature = "v2"))]
     pub fn get_recovery_grpc_headers(&self) -> GrpcRecoveryHeaders {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Restores the primary-mode guard around UCS connector event emission and restores the UCS config override that disables UCS-side event publishing for shadow mode.

Original PR: https://github.com/juspay/hyperswitch/pull/13068
Tracking issue: https://github.com/juspay/hyperswitch-cloud/issues/17446

Follow-up steps to re-enable shadow UCS connector events:

1. Add and deploy the ClickHouse ingestion migration for connector analytics so `source`, `destination`, and `execution_mode` are persisted for connector event rows.
2. Update dashboard/cloud analytics queries to use the new dimensions, especially `execution_mode`, so shadow UCS rows do not mix with primary connector metrics.
3. Once those are live, remove this temporary suppression and re-enable shadow UCS connector event emission.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you do not have an issue, we would recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Shadow UCS connector events should not be emitted until downstream ClickHouse storage can reliably distinguish them using the new event metadata fields. Without this guard, shadow events can be published into the connector events stream before the ClickHouse schema migration and dashboard query changes are available.

Cloud tracking issue: https://github.com/juspay/hyperswitch-cloud/issues/17446

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- `cargo check -p router`

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible