### PR TITLE
fix(docker): pin postgres image to 18 to avoid floating-tag breakage

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -14,7 +14,7 @@ networks:
 services:
   ### Dependencies
   pg:
-    image: docker.io/postgres:latest
+    image: docker.io/postgres:18
     ports:
       - "5432:5432"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - router_net
 
   pg:
-    image: docker.io/postgres:latest
+    image: docker.io/postgres:18
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
## Summary

`docker-compose.yml` and `docker-compose-development.yml` pin the `pg` service to `docker.io/postgres:latest`. `latest` now resolves to **PostgreSQL 18**, whose internal data-directory layout changed. A fresh `docker compose up` from a clean clone works, but any environment that pulls a newer `latest` than its existing `pg_data` volume gets an incompatible data dir — `hyperswitch-pg-1` exits `1`, which cascades into `migration_runner` (exit 1) and `superposition-init` failing.

This pins both compose files to a fixed major (`postgres:18`, matching the current `latest` and the existing `/var/lib/postgresql` mount) so future `latest` bumps no longer silently break local setup.

Closes #13072

## Changes
- `docker-compose.yml` — `pg.image`: `postgres:latest` → `postgres:18`
- `docker-compose-development.yml` — `pg.image`: `postgres:latest` → `postgres:18`

## Test evidence
- `docker compose -f docker-compose.yml config -q` → OK
- `docker compose -f docker-compose-development.yml config -q` → OK
- Rendered config confirms `image: docker.io/postgres:18` with mount target `/var/lib/postgresql`.

No application code touched; config-only change.

## Note for existing local setups
Users with a stale `pg_data` volume from an older Postgres major must reset it once: `docker compose down -v` then `docker compose up`.