### PR TITLE
feat(sdk_config): add merchant level vaulting_action override 

### DIFF
--- a/config/superposition_seed.toml
+++ b/config/superposition_seed.toml
@@ -151,6 +151,12 @@ schema = { type = "boolean" }
 description = "Whether to call the PM modular service for an organization"
 change_reason = "Initial setup"
 
+[default-configs.should_perform_sdk_vaulting]
+value = true
+schema = { type = "boolean" }
+description = "Org level override on top of should_call_pm_modular_service; when false the SDK skips vaulting"
+change_reason = "Initial setup"
+
 [default-configs.should_schedule_modular_forward_compat]
 value = false
 schema = { type = "boolean" }

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -417,6 +417,10 @@ pub mod superposition {
         "should_trigger_backwards_compatibility_inline";
     /// Trigger fingerprint migration configuration key
     pub const SHOULD_TRIGGER_FINGERPRINT_MIGRATION: &str = "should_trigger_fingerprint_migration";
+    /// Perform SDK vaulting action configuration key. Acts as a merchant level override on top of
+    /// `should_call_pm_modular_service`: defaults to `true` for all merchants and can be set to
+    /// `false` for specific merchants to force the SDK to skip tokenization.
+    pub const SHOULD_PERFORM_SDK_VAULTING: &str = "should_perform_sdk_vaulting";
     /// dynamic fields configuration key for sdk config
     pub const DYNAMIC_FIELDS: &str = "dynamic_fields";
     /// payout sync tracker configuration key

--- a/crates/router/src/core/configs/dimension_config.rs
+++ b/crates/router/src/core/configs/dimension_config.rs
@@ -501,6 +501,24 @@ impl DatabaseBackedConfig for ShouldTriggerFingerprintMigration {
 }
 
 config! {
+    superposition_key = SHOULD_PERFORM_SDK_VAULTING,
+    output = bool,
+    default = true,
+    requires = dimension_state::DimensionsWithProviderMerchantId,
+    targeting_key = id_type::CustomerId
+}
+
+impl DatabaseBackedConfig for ShouldPerformSdkVaulting {
+    const KEY: &'static str = "should_perform_sdk_vaulting";
+
+    fn db_key(dimensions: &impl dimension_state::DimensionsBase) -> Option<String> {
+        dimensions
+            .get_provider_merchant_id()
+            .map(|id| format!("{}_{}", Self::KEY, id.get_string_repr()))
+    }
+}
+
+config! {
     superposition_key = PAYOUT_TRACKER_MAPPING,
     output = RetryMapping,
     default = RetryMapping::default(),

--- a/crates/router/src/core/configs/dimension_config.rs
+++ b/crates/router/src/core/configs/dimension_config.rs
@@ -504,7 +504,7 @@ config! {
     superposition_key = SHOULD_PERFORM_SDK_VAULTING,
     output = bool,
     default = true,
-    requires = dimension_state::DimensionsWithProviderMerchantId,
+    requires = dimension_state::DimensionsWithOrgId,
     targeting_key = id_type::CustomerId
 }
 
@@ -513,7 +513,7 @@ impl DatabaseBackedConfig for ShouldPerformSdkVaulting {
 
     fn db_key(dimensions: &impl dimension_state::DimensionsBase) -> Option<String> {
         dimensions
-            .get_provider_merchant_id()
+            .get_organization_id()
             .map(|id| format!("{}_{}", Self::KEY, id.get_string_repr()))
     }
 }

--- a/crates/router/src/core/payment_methods/utils.rs
+++ b/crates/router/src/core/payment_methods/utils.rs
@@ -830,7 +830,7 @@ pub async fn get_organization_eligibility_config_for_pm_modular_service(
 
 pub async fn get_should_perform_sdk_vaulting(
     state: &SessionState,
-    dimensions: &dimension_state::DimensionsWithProviderMerchantId,
+    dimensions: &dimension_state::DimensionsWithOrgId,
 ) -> bool {
     dimensions
         .get_should_perform_sdk_vaulting(

--- a/crates/router/src/core/payment_methods/utils.rs
+++ b/crates/router/src/core/payment_methods/utils.rs
@@ -828,6 +828,19 @@ pub async fn get_organization_eligibility_config_for_pm_modular_service(
         .await
 }
 
+pub async fn get_should_perform_sdk_vaulting(
+    state: &SessionState,
+    dimensions: &dimension_state::DimensionsWithProviderMerchantId,
+) -> bool {
+    dimensions
+        .get_should_perform_sdk_vaulting(
+            state.store.as_ref(),
+            state.superposition_service.as_ref(),
+            None,
+        )
+        .await
+}
+
 pub async fn get_should_schedule_modular_forward_compat(
     state: &SessionState,
     dimensions: &dimension_state::DimensionsWithProviderMerchantId,

--- a/crates/router/src/core/superposition_sdk_config.rs
+++ b/crates/router/src/core/superposition_sdk_config.rs
@@ -447,13 +447,18 @@ async fn build_account_config(
         .with_provider_merchant_id(platform.get_provider().get_provider_merchant_id());
     let feature_config = crate::core::utils::get_feature_config(state, platform, &dimensions).await;
 
-    // Merchant level override on top of the modular service flag. Defaults to `true` for all
-    // merchants; when set to `false` for a specific merchant, the SDK is told to skip vaulting.
+    // Org level override on top of the modular service flag. Defaults to `true` for all merchants;
+    // when set to `false` for a specific org, the SDK is told to skip vaulting.
     let should_perform_sdk_vaulting =
         crate::core::payment_methods::utils::get_should_perform_sdk_vaulting(
             state,
-            &Dimensions::new()
-                .with_provider_merchant_id(platform.get_provider().get_provider_merchant_id()),
+            &Dimensions::new().with_organization_id(
+                platform
+                    .get_processor()
+                    .get_account()
+                    .organization_id
+                    .clone(),
+            ),
         )
         .await;
 

--- a/crates/router/src/core/superposition_sdk_config.rs
+++ b/crates/router/src/core/superposition_sdk_config.rs
@@ -447,10 +447,21 @@ async fn build_account_config(
         .with_provider_merchant_id(platform.get_provider().get_provider_merchant_id());
     let feature_config = crate::core::utils::get_feature_config(state, platform, &dimensions).await;
 
+    // Merchant level override on top of the modular service flag. Defaults to `true` for all
+    // merchants; when set to `false` for a specific merchant, the SDK is told to skip vaulting.
+    let should_perform_sdk_vaulting =
+        crate::core::payment_methods::utils::get_should_perform_sdk_vaulting(
+            state,
+            &Dimensions::new()
+                .with_provider_merchant_id(platform.get_provider().get_provider_merchant_id()),
+        )
+        .await;
+
     AccountConfig {
         profile: build_profile_account_config(
             business_profile,
             feature_config.is_payment_method_modular_allowed,
+            should_perform_sdk_vaulting,
         ),
     }
 }
@@ -459,6 +470,7 @@ async fn build_account_config(
 fn build_profile_account_config(
     business_profile: &domain::Profile,
     is_payment_method_modular_allowed: bool,
+    should_perform_sdk_vaulting: bool,
 ) -> ProfileAccountConfig {
     ProfileAccountConfig {
         collect_shipping_details_from_wallet_connector: business_profile
@@ -473,16 +485,24 @@ fn build_profile_account_config(
         always_collect_shipping_details_from_wallet_connector: business_profile
             .always_collect_shipping_details_from_wallet_connector
             .unwrap_or(false),
-        vaulting_action: resolve_vaulting_action(is_payment_method_modular_allowed),
+        vaulting_action: resolve_vaulting_action(
+            is_payment_method_modular_allowed,
+            should_perform_sdk_vaulting,
+        ),
     }
 }
 
 /// Determine whether the SDK should tokenize payment method details.
 ///
-/// Driven solely by whether the modular vaulting flow should be invoked: `Tokenize` when it
-/// should, `Skip` otherwise.
-fn resolve_vaulting_action(should_call_modular: bool) -> VaultingAction {
-    if should_call_modular {
+/// `should_call_modular` decides whether the modular vaulting flow is invoked at all.
+/// `should_perform_sdk_vaulting` is a merchant level override (default `true`) that can force the
+/// SDK to skip vaulting for specific merchants. Vaulting is `Tokenize` only when both are `true`;
+/// otherwise it is `Skip`.
+fn resolve_vaulting_action(
+    should_call_modular: bool,
+    should_perform_sdk_vaulting: bool,
+) -> VaultingAction {
+    if should_call_modular && should_perform_sdk_vaulting {
         VaultingAction::Tokenize
     } else {
         VaultingAction::Skip


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Adds a new org-level Superposition flag `should_perform_sdk_vaulting` that acts as an override on top of `should_call_pm_modular_service` for deciding the SDK's `vaulting_action` (surfaced in the account config / sdk_config).

Previously the SDK's `vaulting_action` was driven solely by `should_call_pm_modular_service`:

`should_call_modular = true` → Tokenize
`should_call_modular = false` → Skip
This PR introduces should_perform_sdk_vaulting as a kill-switch that lets us force Skip for specific orgs even when modular service is enabled:

Defaults to true for all orgs (no behavior change).
Set to false for a specific org → SDK is told to Skip vaulting.
Final resolution: vaulting_action = Tokenize only when should_call_modular && should_perform_sdk_vaulting; otherwise Skip.

The flag is scoped to the organization (matching should_call_pm_modular_service), keyed in the DB fallback as should_perform_sdk_vaulting_<org_id>.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
### Create a merchant account and enable it for the modular service
#### `/client`
```
curl --location --request GET 'http://localhost:8080/v1/sdk/configs/web/sdk_config.json' \
--header 'Authorization: cHJvZmlsZV9pZD1wcm9fODFpdGp3TmVQdHFHR2FPcVg3cmoscHVibGlzaGFibGVfa2V5PXBrX2Rldl9mN2I2NTVhNDhlMmY0MGY2YTIyZDVlMWYyM2IwMWU5ZixjbGllbnRfc2VjcmV0PXBheV9zUVFBbTB4V1VJYVBwYkNxc3c0UF9zZWNyZXRfMkpQNWRUUjVyOXduOUxmNmdGcGEsY3VzdG9tZXJfaWQ9MGFfY3VzXzAxOWYxN2VjOTkxYTcyNTE5N2Q2MjUxNDQ5ZjhkMzdhLGNsaWVudF9zZXNzaW9uX2lkPWNsaWVudF9zZXNzXzlWVUZzV3hYQkROVHVDNTFPck40LHBheW1lbnRfaWQ9cGF5X3NRUUFtMHhXVUlhUHBiQ3FzdzRQ' \
--header 'Content-Type: application/json' \
--data '
'
```
```
{
    "raw_configs": {..},
    "resolved_configs": null,
    "context_used": {
        "profile_id": "pro_81itjwNePtqGGaOqX7rj",
        "merchant_id": "merchant_1782812036",
        "organization_id": "org_b61MSgz92bR9CPXr5xuB",
        "connector": [
            "stripe"
        ]
    },
    "payment_methods": [..],
    "account_config": {
        "profile": {
            "collect_shipping_details_from_wallet_connector": false,
            "collect_billing_details_from_wallet_connector": false,
            "always_collect_billing_details_from_wallet_connector": false,
            "always_collect_shipping_details_from_wallet_connector": false,
            "vaulting_action": "tokenize"
        }
    }
}
```
### With modular also disabled should_perform_sdk_vaulting (it will be enabled by default)
```
curl --location --request GET 'http://localhost:8080/v1/sdk/configs/web/sdk_config.json' \
--header 'Authorization: cHJvZmlsZV9pZD1wcm9fODFpdGp3TmVQdHFHR2FPcVg3cmoscHVibGlzaGFibGVfa2V5PXBrX2Rldl9mN2I2NTVhNDhlMmY0MGY2YTIyZDVlMWYyM2IwMWU5ZixjbGllbnRfc2VjcmV0PXBheV9zUVFBbTB4V1VJYVBwYkNxc3c0UF9zZWNyZXRfMkpQNWRUUjVyOXduOUxmNmdGcGEsY3VzdG9tZXJfaWQ9MGFfY3VzXzAxOWYxN2VjOTkxYTcyNTE5N2Q2MjUxNDQ5ZjhkMzdhLGNsaWVudF9zZXNzaW9uX2lkPWNsaWVudF9zZXNzXzlWVUZzV3hYQkROVHVDNTFPck40LHBheW1lbnRfaWQ9cGF5X3NRUUFtMHhXVUlhUHBiQ3FzdzRQ' \
--header 'Content-Type: application/json' \
--data '
'
```
```
{
    "raw_configs": {..},
    "resolved_configs": null,
    "context_used": {
        "profile_id": "pro_81itjwNePtqGGaOqX7rj",
        "merchant_id": "merchant_1782812036",
        "organization_id": "org_b61MSgz92bR9CPXr5xuB",
        "connector": [
            "stripe"
        ]
    },
    "payment_methods": [..],
    "account_config": {
        "profile": {
            "collect_shipping_details_from_wallet_connector": false,
            "collect_billing_details_from_wallet_connector": false,
            "always_collect_billing_details_from_wallet_connector": false,
            "always_collect_shipping_details_from_wallet_connector": false,
            "vaulting_action": "skip"
        }
    }
}
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
