### PR TITLE
fix(connector): [fiuu] fix error propogation in webhook flow

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/fiuu.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu.rs
@@ -904,6 +904,10 @@ impl webhooks::IncomingWebhook for Fiuu {
         _context: Option<&webhooks::WebhookContext>,
     ) -> CustomResult<api_models::webhooks::IncomingWebhookEvent, errors::ConnectorError> {
         let header = utils::get_header_key_value("content-type", request.headers)?;
+        router_env::logger::info!(
+            connector = "fiuu",
+            webhook_content_type = %header,
+        );
         let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
             parse_and_log_keys_in_url_encoded_response::<FiuuWebhooksResponse>(request.body);
             serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)

--- a/crates/hyperswitch_connectors/src/connectors/fiuu.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu.rs
@@ -911,12 +911,12 @@ impl webhooks::IncomingWebhook for Fiuu {
         let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
             parse_and_log_keys_in_url_encoded_response::<FiuuWebhooksResponse>(request.body);
             serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
-                .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?
+                .change_context(errors::ConnectorError::WebhookResponseEncodingFailed)?
         } else {
             request
                 .body
                 .parse_struct("fiuu::FiuuWebhooksResponse")
-                .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?
+                .change_context(errors::ConnectorError::WebhookResponseEncodingFailed)?
         };
 
         match resource {

--- a/crates/hyperswitch_connectors/src/connectors/fiuu.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu.rs
@@ -904,10 +904,6 @@ impl webhooks::IncomingWebhook for Fiuu {
         _context: Option<&webhooks::WebhookContext>,
     ) -> CustomResult<api_models::webhooks::IncomingWebhookEvent, errors::ConnectorError> {
         let header = utils::get_header_key_value("content-type", request.headers)?;
-        router_env::logger::info!(
-            connector = "fiuu",
-            webhook_content_type = %header,
-        );
         let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
             parse_and_log_keys_in_url_encoded_response::<FiuuWebhooksResponse>(request.body);
             serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Improved error handling in Fiuu webhook flow by ensuring accurate error propagation and adding fallback logging to capture raw request bodies when decoding fails.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Payment Request:

```

{
    "amount": 100,
    "currency": "MYR",
    "amount_to_capture": 100,
    "confirm": true,
    "capture_method": "automatic",
    "authentication_type": "no_three_ds",
    "all_keys_required" : true,
    "customer": {
        "id": "customer123",
        "name": "John Doe",
        "email": "customer@gmail.com",
        "phone": "9999999999",
        "phone_country_code": "+1"
    },
    "customer_id": "customer123",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5105105105105100",
            "card_exp_month": "12",
            "card_exp_year": "2030",
            "card_holder_name": "Max Mustermann",
            "card_cvc": "444"
        }
    },
    //"payment_token":"<string>" ,
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "MY",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": "guest@example.com"
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "MY",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": "guest@example.com"
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "128.0.0.1"
    },
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "125.0.0.1",
            "user_agent": "amet irure esse"
        }
    },
    "payment_type": "normal",
    "request_incremental_authorization": false,
    "merchant_order_reference_id": "test_ord",
    "session_expiry": 900
}

```

Response:

```

{
    "payment_id": "pay_HrtQanJ7x4hvaDF3iVRl",
    "merchant_id": "merchant_1782815775",
    "status": "succeeded",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 100,
    "processor_merchant_id": "merchant_1782815775",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fdklZMzdHVm9QeXNaTnJJOTJTdzIscHVibGlzaGFibGVfa2V5PXBrX2Rldl9lMDMyM2E4YzgxMmQ0YjI5YjM2Mjk0YmU0ZTlkMjA0OSxjbGllbnRfc2VjcmV0PXBheV9IcnRRYW5KN3g0aHZhREYzaVZSbF9zZWNyZXRfUTE2OFh5ZlIxeUF2SHg4Yk9ESFksY3VzdG9tZXJfaWQ9Y3VzdG9tZXIxMjMsY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfcWZkMnpReXJRbUZweXVrV1FtTksscGF5bWVudF9pZD1wYXlfSHJ0UWFuSjd4NGh2YURGM2lWUmw=",
    "connector": "fiuu",
    "state_metadata": null,
    "client_secret": "pay_HrtQanJ7x4hvaDF3iVRl_secret_Q168XyfR1yAvHx8bODHY",
    "created": "2026-06-30T10:47:13.262Z",
    "modified_at": "2026-06-30T10:47:13.764Z",
    "connector_customer_id": null,
    "currency": "MYR",
    "customer_id": "customer123",
    "customer": {
        "id": "customer123",
        "name": "John Doe",
        "email": "customer@gmail.com",
        "phone": "9999999999",
        "phone_country_code": "+1",
        "customer_document_details": null
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "5100",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "510510",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "2030",
            "card_holder_name": "Max Mustermann",
            "payment_checks": null,
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "MY",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": "guest@example.com"
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "MY",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": "guest@example.com"
    },
    "order_details": null,
    "email": "customer@gmail.com",
    "name": "John Doe",
    "phone": "9999999999",
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "31505112",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_vIY37GVoPysZNrI92Sw2",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_VbR99QbcUDCY4YHnyT3w",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-06-30T11:02:13.262Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "128.0.0.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-06-30T10:47:13.764Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": "test_ord",
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}

```

Refund:

```

{
    "payment_id": "pay_HrtQanJ7x4hvaDF3iVRl",
    "amount": 100,
    "reason": "Customer returned product",
    "refund_type": "instant",
    "all_keys_required": true
}

```

Webhook:
Send malformed body - 

```

curl --location 'https://18e7-219-65-110-2.ngrok-free.app/webhooks/merchant_1782815775/fiuu' \
--header 'User-Agent: MOLPay-refund-callback_v1' \
--header 'Accept: */*' \
--header 'Content-Type: application/json' \
--header 'Newrelic: eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiMTQ3MDk3NCIsImFwIjoiODk0OTQ2NjgiLCJpZCI6IjdlMGNlMzQxMjg5ZDBlOWEiLCJ0ciI6ImU4YTY0MjE4NjdkNjA5MzMiLCJ0eCI6ImU4YTY0MjE4NjdkNjA5MzMiLCJwciI6MS4xOTkxMCwic2EiOnRydWUsInRpIjoxNzgyODE3ODAyMjE4fX0=' \
--header 'Traceparent: 00-0000000000000000e8a6421867d60933-7e0ce341289d0e9a-01' \
--header 'Tracestate: 1470974@nr=0-0-1470974-89494668-7e0ce341289d0e9a-e8a6421867d60933-1-1.199097-1782817802218' \
--header 'X-Forwarded-For: 52.220.41.253' \
--header 'X-Forwarded-Host: 18e7-219-65-110-2.ngrok-free.app' \
--header 'X-Forwarded-Proto: https' \
--header 'Accept-Encoding: gzip' \
--data '{
    "RefundType": "T",
    "MerchantID": "SB_zurichgdpp",
    "RefID": "ref_DzOT4traezE9vwReNz4l",
    "RefundID": "130387",
    "TxnID": "31505112",
    "Amount": "1.00",
    "Status": "00",
    "Signature": "2481afb5b139e857082995528ee3c251"
}'

```

<img width="1123" height="250" alt="Screenshot 2026-06-30 at 5 10 34 PM" src="https://github.com/user-attachments/assets/3bf5d330-29d2-456a-9a98-8a9213a5cd82" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
