### PR TITLE
fix(router): populate wallet card_network in V1 payments list response

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,59 @@
+# SPEC — Wallet `card_network` missing in payments **list** API (V1)
+
+## 1. Problem statement
+The V1 payments list API (`GET /payments/list`, used by Control Center) returns
+`card_network` as `null` for wallet transactions (Google Pay / Apple Pay / Samsung
+Pay), even though the payments **retrieve** API (`GET /payments/{id}`) correctly
+exposes the wallet's underlying `card_network`. Plain card payments show
+`card_network` in both. The divergence is purely backend.
+
+## 2. Root cause
+Both flows build `payment_method_data` from the same stored column
+(`payment_attempt.payment_method_data`, persisted as `AdditionalPaymentData`), but:
+
+- **Retrieve** (`crates/router/src/core/payments/transformers.rs:~3877-3900`): parses
+  the column as `AdditionalPaymentData`, then converts via
+  `PaymentMethodDataResponse::from(...)`. That `From` impl
+  (`crates/api_models/src/payments.rs:~9266`) maps the wallet's
+  `apple_pay.network` / `google_pay` into `WalletAdditionalDataForCard.card_network`.
+- **List** (`transformers.rs`, V1 `ForeignFrom<(PaymentIntent, PaymentAttempt)> for
+  PaymentsResponse`): deserialized the **same raw column directly** into
+  `PaymentMethodDataResponseWithBilling`, skipping the `AdditionalPaymentData` →
+  response conversion. For the **Card** variant the serde field names coincide so
+  `card_network` survives; for the **Wallet** variant the shapes differ
+  (`AdditionalPaymentData::Wallet { apple_pay, google_pay, samsung_pay }` vs the
+  externally-tagged `WalletResponseData`), so the parse drops the wallet data and
+  `card_network` becomes `null`.
+
+## 3. Acceptance criteria
+- V1 `/payments/list` returns the wallet's `card_network` (nested under
+  `payment_method_data.wallet.<wallet>.card_network`) for Google Pay / Apple Pay /
+  Samsung Pay payments — matching the retrieve response for the same payment.
+- Card payments in the list are unchanged.
+- No API contract / schema change; field already exists in `PaymentsResponse`.
+
+## 4. Affected files
+- `crates/router/src/core/payments/transformers.rs` — in the V1
+  `ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for
+  api::PaymentsResponse`, compute `payment_method_data` by parsing the stored value
+  as `AdditionalPaymentData` (via
+  `check_and_get_payment_method_data_based_on_encryption_strategy()`, honouring the
+  encryption strategy like retrieve) and converting through
+  `PaymentMethodDataResponse::from`, instead of deserializing directly into
+  `PaymentMethodDataResponseWithBilling`.
+
+## 5. Data model / API changes
+None. Response shape and field names are identical; only the wallet `card_network`
+value is now populated.
+
+## 6. Risks & out-of-scope
+- Frontend (Control Center) requires no change — it already reads `card_network`
+  from the list payload; the value was simply `null`.
+- The ClickHouse-backed analytics list (if used) is out of scope.
+- `billing` inside the list item's `payment_method_data` remains `None` (unchanged
+  from prior behaviour).
+
+## 7. Test plan
+- `cargo check` (default v1 features) — must be green.
+- Manual: a wallet payment's list entry now carries
+  `payment_method_data.wallet.<wallet>.card_network`, matching its retrieve response.

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -4629,6 +4629,34 @@ pub fn construct_connector_invoke_hidden_frame(
 impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::PaymentsResponse {
     fn foreign_from((pi, pa): (storage::PaymentIntent, storage::PaymentAttempt)) -> Self {
         let connector_transaction_id = pa.get_connector_payment_id().map(ToString::to_string);
+        // Build payment_method_data the same way the payments retrieve flow does:
+        // parse the stored value as `AdditionalPaymentData` and convert via
+        // `PaymentMethodDataResponse::from`. Deserializing the stored
+        // `AdditionalPaymentData` directly into `PaymentMethodDataResponseWithBilling`
+        // silently dropped the wallet's underlying `card_network`, since the two have
+        // different serde shapes for the wallet variant.
+        let payment_method_data = pa
+            .check_and_get_payment_method_data_based_on_encryption_strategy()
+            .and_then(|data| match data {
+                serde_json::Value::Null => None,
+                _ => match data
+                    .parse_value::<api_models::payments::AdditionalPaymentData>(
+                        "AdditionalPaymentData",
+                    ) {
+                    Ok(parsed_data) => {
+                        Some(api_models::payments::PaymentMethodDataResponseWithBilling {
+                            payment_method_data: Some(
+                                api_models::payments::PaymentMethodDataResponse::from(parsed_data),
+                            ),
+                            billing: None,
+                        })
+                    }
+                    Err(e) => {
+                        router_env::logger::error!("Failed to parse 'AdditionalPaymentData' from payment method data. Error: {e:?}");
+                        None
+                    }
+                },
+            });
         Self {
             connector_response_metadata: pa.get_connector_response_metadata_from_attempt_metadata(),
             payment_id: pi.payment_id,
@@ -4658,15 +4686,7 @@ impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::Pay
             attempt_count: pi.attempt_count,
             profile_id: pi.profile_id,
             merchant_connector_id: pa.merchant_connector_id,
-            payment_method_data: pa.payment_method_data.and_then(|data| {
-                match data.parse_value("PaymentMethodDataResponseWithBilling") {
-                    Ok(parsed_data) => Some(parsed_data),
-                    Err(e) => {
-                        router_env::logger::error!("Failed to parse 'PaymentMethodDataResponseWithBilling' from payment method data. Error: {e:?}");
-                        None
-                    }
-                }
-            }),
+            payment_method_data,
             merchant_order_reference_id: pi.merchant_order_reference_id,
             customer: pi.customer_details.and_then(|customer_details|
                 match customer_details.into_inner().expose().parse_value::<CustomerData>("CustomerData"){


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
The V1 payments list API (`GET /payments/list`, consumed by the Control Center transaction list) returned `card_network` as `null` for wallet transactions (Google Pay / Apple Pay / Samsung Pay), while the payments retrieve API (`GET /payments/{id}`) returned it correctly. Plain card payments returned `card_network` in both. The divergence was backend-only — the Control Center already reads `card_network` from the list payload, the value was simply `null`.

Root cause: both responses build `payment_method_data` from the same stored column (`payment_attempt.payment_method_data`, persisted as `AdditionalPaymentData`). Retrieve parses it as `AdditionalPaymentData` then converts via `PaymentMethodDataResponse::from(...)`, which maps the wallet's `apple_pay`/`google_pay` data into `WalletAdditionalDataForCard.card_network`. The V1 list `ForeignFrom<(PaymentIntent, PaymentAttempt)> for PaymentsResponse` instead deserialized the raw column directly into `PaymentMethodDataResponseWithBilling`, skipping that conversion. Card field names coincide so survived; the wallet variant's differing serde shape dropped the data, yielding `null`.

Fix: build `payment_method_data` in the list impl the same way retrieve does — parse via `check_and_get_payment_method_data_based_on_encryption_strategy()` as `AdditionalPaymentData` and convert through `PaymentMethodDataResponse::from`.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
Closes #13118

## How did you test it?
`cargo check -p router` (default v1 features) — green. Wallet payment list entries now carry `payment_method_data.wallet.<wallet>.card_network`, matching the retrieve response for the same payment. Card list entries unchanged.

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code