### PR TITLE
fix(connector): [Cybersource] allow connector creation without metadata

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -117,11 +117,15 @@ pub struct CybersourceConnectorMetadataObject {
 impl TryFrom<&Option<pii::SecretSerdeValue>> for CybersourceConnectorMetadataObject {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(meta_data: &Option<pii::SecretSerdeValue>) -> Result<Self, Self::Error> {
-        let metadata = utils::to_connector_meta_from_secret::<Self>(meta_data.clone())
-            .change_context(errors::ConnectorError::InvalidConnectorConfig {
-                config: "metadata",
-            })?;
-        Ok(metadata)
+        // Cybersource metadata is optional (all fields are optional), so treat an absent
+        // metadata object as the default rather than a missing required field.
+        match meta_data {
+            Some(_) => utils::to_connector_meta_from_secret::<Self>(meta_data.clone())
+                .change_context(errors::ConnectorError::InvalidConnectorConfig {
+                    config: "metadata",
+                }),
+            None => Ok(Self::default()),
+        }
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Creating a Cybersource connector via the API without a `connector_meta_data` field fails with `IR_06 - "The metadata is invalid"`, even though Cybersource metadata is entirely optional.

`CybersourceConnectorMetadataObject` has only optional fields and derives `Default`:

```rust
#[derive(Debug, Default, Serialize, Deserialize)]
pub struct CybersourceConnectorMetadataObject {
    pub disable_avs: Option<bool>,
    pub disable_cvn: Option<bool>,
}
```

However, its `TryFrom<&Option<SecretSerdeValue>>` impl routed through `to_connector_meta_from_secret`, which treats an absent (`None`) metadata as a `MissingRequiredField`. That error is then `change_context`'d to `InvalidConnectorConfig { config: "metadata" }` and surfaced to the caller as `IR_06 - "The metadata is invalid"`.

This PR makes the Cybersource metadata `TryFrom` return `Self::default()` (both fields `None`) when metadata is absent, while still validating strictly when a metadata object is supplied (a malformed object still errors). This makes "no metadata sent" behave identically to sending an empty `{}` object.

The change is scoped to Cybersource only — it is not pushed into the shared `to_connector_meta_from_secret` helper — because other connectors (e.g. Coingate, Calida) have genuinely mandatory metadata fields that must keep failing on `None`.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Merchants integrating Cybersource without configuring AVS/CVN overrides were forced to send a placeholder `metadata: {}` in the create-connector request to work around `IR_06`. Since neither `disable_avs` nor `disable_cvn` is required, Hyperswitch should accept connector creation with no metadata at all.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually via the create Merchant Connector Account API against Cybersource:

1. `POST /account/{merchant_id}/connectors` with a valid Cybersource `connector_account_details` and no `metadata` field → previously returned `IR_06`, now succeeds (200) with the connector created.
2. Same request with `"metadata": {}` → succeeds (unchanged).
3. Same request with valid `"metadata": {"disable_avs": true}` → succeeds and the value is persisted (unchanged).
4. Same request with malformed `"metadata": {"disable_avs": "yes"}` → still rejected with `IR_06` (strict validation preserved).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
