### PR TITLE
fix(connector): [chargebee] fix chargebee webhook deserialization issue

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -628,7 +628,6 @@ impl ChargebeeInvoiceBody {
         let webhook_body = body
             .parse_struct::<Self>("ChargebeeInvoiceBody")
             .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
-        println!("Webhook Body: {:?}", webhook_body);
         Ok(webhook_body)
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -496,8 +496,72 @@ pub struct ChargebeePaymentMethodDetails {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ChargebeeCardDetails {
     funding_type: ChargebeeFundingType,
-    brand: common_enums::CardNetwork,
+    brand: ChargebeeCardBrand,
     iin: String,
+}
+
+// Chargebee sends card brand values in lowercase snake_case (e.g. `visa`, `mastercard`,
+// `american_express`), which don't match `common_enums::CardNetwork`'s serde representation.
+// We deserialize into this connector-local enum so parsing never fails, then map the brands that
+// have a `CardNetwork` equivalent. Brands with no equivalent (regional networks, `other`, and any
+// future value caught by `#[serde(other)]`) map to `None`.
+// Reference: https://apidocs.chargebee.com/docs/api/transactions (payment_method_details -> card -> brand)
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ChargebeeCardBrand {
+    Visa,
+    Mastercard,
+    AmericanExpress,
+    Discover,
+    Jcb,
+    DinersClub,
+    Bancontact,
+    CmrFalabella,
+    TarjetaNaranja,
+    Nativa,
+    Cencosud,
+    Cabal,
+    Argencard,
+    Elo,
+    Hipercard,
+    Carnet,
+    #[serde(rename = "rupay")]
+    RuPay,
+    Maestro,
+    Dankort,
+    CartesBancaires,
+    Mada,
+    #[serde(other)]
+    Other,
+}
+
+impl ChargebeeCardBrand {
+    fn to_card_network(&self) -> Option<common_enums::CardNetwork> {
+        match self {
+            Self::Visa => Some(common_enums::CardNetwork::Visa),
+            Self::Mastercard => Some(common_enums::CardNetwork::Mastercard),
+            Self::AmericanExpress => Some(common_enums::CardNetwork::AmericanExpress),
+            Self::Discover => Some(common_enums::CardNetwork::Discover),
+            Self::Jcb => Some(common_enums::CardNetwork::JCB),
+            Self::DinersClub => Some(common_enums::CardNetwork::DinersClub),
+            Self::RuPay => Some(common_enums::CardNetwork::RuPay),
+            Self::Maestro => Some(common_enums::CardNetwork::Maestro),
+            Self::CartesBancaires => Some(common_enums::CardNetwork::CartesBancaires),
+            Self::Bancontact
+            | Self::CmrFalabella
+            | Self::TarjetaNaranja
+            | Self::Nativa
+            | Self::Cencosud
+            | Self::Cabal
+            | Self::Argencard
+            | Self::Elo
+            | Self::Hipercard
+            | Self::Carnet
+            | Self::Dankort
+            | Self::Mada
+            | Self::Other => None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -570,6 +634,7 @@ impl ChargebeeInvoiceBody {
         let webhook_body = body
             .parse_struct::<Self>("ChargebeeInvoiceBody")
             .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
+        println!("Webhook Body: {:?}", webhook_body);
         Ok(webhook_body)
     }
 }
@@ -707,7 +772,7 @@ impl TryFrom<ChargebeeWebhookBody> for revenue_recovery::RevenueRecoveryAttemptD
             charge_id: None,
             // Need to populate these card info field
             card_info: api_models::payments::AdditionalCardInfo {
-                card_network: Some(payment_method_details.card.brand),
+                card_network: payment_method_details.card.brand.to_card_network(),
                 card_isin: Some(payment_method_details.card.iin),
                 card_issuer: None,
                 card_type: None,

--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -500,12 +500,6 @@ pub struct ChargebeeCardDetails {
     iin: String,
 }
 
-// Chargebee sends card brand values in lowercase snake_case (e.g. `visa`, `mastercard`,
-// `american_express`), which don't match `common_enums::CardNetwork`'s serde representation.
-// We deserialize into this connector-local enum so parsing never fails, then map the brands that
-// have a `CardNetwork` equivalent. Brands with no equivalent (regional networks, `other`, and any
-// future value caught by `#[serde(other)]`) map to `None`.
-// Reference: https://apidocs.chargebee.com/docs/api/transactions (payment_method_details -> card -> brand)
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ChargebeeCardBrand {

--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -500,60 +500,49 @@ pub struct ChargebeeCardDetails {
     iin: String,
 }
 
+// Chargebee sends card brand values in lowercase snake_case (e.g. `visa`, `mastercard`,
+// `american_express`), which don't match `common_enums::CardNetwork`'s serde representation.
+// We deserialize into this connector-local enum, which mirrors the networks defined in
+// `CardNetwork`, and map it over via `From`.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ChargebeeCardBrand {
     Visa,
     Mastercard,
     AmericanExpress,
-    Discover,
     Jcb,
     DinersClub,
-    Bancontact,
-    CmrFalabella,
-    TarjetaNaranja,
-    Nativa,
-    Cencosud,
-    Cabal,
-    Argencard,
-    Elo,
-    Hipercard,
-    Carnet,
+    Discover,
+    CartesBancaires,
+    UnionPay,
+    Interac,
     #[serde(rename = "rupay")]
     RuPay,
     Maestro,
-    Dankort,
-    CartesBancaires,
-    Mada,
-    #[serde(other)]
-    Other,
+    Star,
+    Pulse,
+    Accel,
+    Nyce,
 }
 
-impl ChargebeeCardBrand {
-    fn to_card_network(&self) -> Option<common_enums::CardNetwork> {
-        match self {
-            Self::Visa => Some(common_enums::CardNetwork::Visa),
-            Self::Mastercard => Some(common_enums::CardNetwork::Mastercard),
-            Self::AmericanExpress => Some(common_enums::CardNetwork::AmericanExpress),
-            Self::Discover => Some(common_enums::CardNetwork::Discover),
-            Self::Jcb => Some(common_enums::CardNetwork::JCB),
-            Self::DinersClub => Some(common_enums::CardNetwork::DinersClub),
-            Self::RuPay => Some(common_enums::CardNetwork::RuPay),
-            Self::Maestro => Some(common_enums::CardNetwork::Maestro),
-            Self::CartesBancaires => Some(common_enums::CardNetwork::CartesBancaires),
-            Self::Bancontact
-            | Self::CmrFalabella
-            | Self::TarjetaNaranja
-            | Self::Nativa
-            | Self::Cencosud
-            | Self::Cabal
-            | Self::Argencard
-            | Self::Elo
-            | Self::Hipercard
-            | Self::Carnet
-            | Self::Dankort
-            | Self::Mada
-            | Self::Other => None,
+impl From<ChargebeeCardBrand> for common_enums::CardNetwork {
+    fn from(brand: ChargebeeCardBrand) -> Self {
+        match brand {
+            ChargebeeCardBrand::Visa => Self::Visa,
+            ChargebeeCardBrand::Mastercard => Self::Mastercard,
+            ChargebeeCardBrand::AmericanExpress => Self::AmericanExpress,
+            ChargebeeCardBrand::Jcb => Self::JCB,
+            ChargebeeCardBrand::DinersClub => Self::DinersClub,
+            ChargebeeCardBrand::Discover => Self::Discover,
+            ChargebeeCardBrand::CartesBancaires => Self::CartesBancaires,
+            ChargebeeCardBrand::UnionPay => Self::UnionPay,
+            ChargebeeCardBrand::Interac => Self::Interac,
+            ChargebeeCardBrand::RuPay => Self::RuPay,
+            ChargebeeCardBrand::Maestro => Self::Maestro,
+            ChargebeeCardBrand::Star => Self::Star,
+            ChargebeeCardBrand::Pulse => Self::Pulse,
+            ChargebeeCardBrand::Accel => Self::Accel,
+            ChargebeeCardBrand::Nyce => Self::Nyce,
         }
     }
 }
@@ -765,7 +754,7 @@ impl TryFrom<ChargebeeWebhookBody> for revenue_recovery::RevenueRecoveryAttemptD
             charge_id: None,
             // Need to populate these card info field
             card_info: api_models::payments::AdditionalCardInfo {
-                card_network: payment_method_details.card.brand.to_card_network(),
+                card_network: Some(payment_method_details.card.brand.into()),
                 card_isin: Some(payment_method_details.card.iin),
                 card_issuer: None,
                 card_type: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Webhook deserialization was failing for Chargebee because it sends card network values in `snake_case` (for example, `"visa"`), while our `CardNetwork` enum did not accept those values during deserialization.

This change adds support for deserializing `snake_case` card network values, allowing values such as `"visa"` to correctly map to `CardNetwork::Visa`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
follow the steps mentioned in pr #7236 to test this.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
