### PR TITLE
fix(cybersource): populate original_payment_authorized_amount for UCS repeat_payment (shadow diff #17471)

### DIFF
--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2349,6 +2349,27 @@ impl
         let auth_type = payments_grpc::AuthenticationType::foreign_try_from(router_data.auth_type)
             .attach_printable("Failed to convert authentication type")?;
 
+        // Original authorized amount from the initial (CIT) payment, required by connectors
+        // (e.g. Cybersource MIT authorizationOptions.merchantInitiatedTransaction) to build the
+        // stored-credential request. Mirrors the Direct gateway, which reads the same
+        // `recurring_mandate_payment_data` off RouterData; omitting it left UCS emitting null.
+        let original_payment_authorized_amount = router_data
+            .recurring_mandate_payment_data
+            .as_ref()
+            .and_then(|recurring_mandate_payment_data| {
+                recurring_mandate_payment_data
+                    .original_payment_authorized_amount
+                    .zip(recurring_mandate_payment_data.original_payment_authorized_currency)
+            })
+            .map(|(minor_amount, original_currency)| {
+                payments_grpc::Currency::foreign_try_from(original_currency).map(|currency| {
+                    payments_grpc::Money {
+                        minor_amount,
+                        currency: currency.into(),
+                    }
+                })
+            })
+            .transpose()?;
         Ok(Self {
             split_payments: router_data
                 .request
@@ -2362,7 +2383,7 @@ impl
                 minor_amount: router_data.request.minor_amount.get_amount_as_i64(),
                 currency: currency.into(),
             }),
-            original_payment_authorized_amount: None,
+            original_payment_authorized_amount,
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             metadata: router_data
                 .request


### PR DESCRIPTION
## What

Paired hyperswitch-side fix for shadow-validation request_diff **#17471**
(`prod` / flowbird / **cybersource** / **repeat_payment**).

The UCS client built `RecurringPaymentServiceChargeRequest` with
`original_payment_authorized_amount: None`, so the shadow UCS leg omitted the Cybersource MIT
`processingInformation.authorizationOptions.merchantInitiatedTransaction.originalAuthorizedAmount`
that the Direct gateway sends (as a string).

This populates the proto field from `router_data.recurring_mandate_payment_data` — the same
`RouterData` source the Direct gateway reads (`hyperswitch_connectors/.../cybersource/transformers.rs`,
ConnectorMandateId arm) — mapping the original amount + currency into the existing proto `Money` field:

```rust
let original_payment_authorized_amount = router_data
    .recurring_mandate_payment_data
    .as_ref()
    .and_then(|d| d.original_payment_authorized_amount.zip(d.original_payment_authorized_currency))
    .map(|(minor_amount, original_currency)| {
        payments_grpc::Currency::foreign_try_from(original_currency)
            .map(|currency| payments_grpc::Money { minor_amount, currency: currency.into() })
    })
    .transpose()?;
```

**No proto change / no rev-pin** — `original_payment_authorized_amount` (field 23) already exists in
the pinned connector-service proto (`tag = 2026.07.02.1`); only the client mapping was missing. So
this is a normal PR, not a draft.

## Root cause (RCA)

- Live prod request `019f17b7-a5d0-76e1-b2e1-cbc78384f95b` (2026-06-30T08:48:59Z), 2.60 EUR, flowbird,
  `pay_SNJf2ptr0y2HCCcAZY47`, off-session recurring MIT.
- mitm-proxy captured HS leg **1109 bytes** vs UCS leg **1024 bytes** — the byte gap is the omitted MIT
  `authorizationOptions` fields.

### Before
```
body.typeDiff.processingInformation.authorizationOptions.merchantInitiatedTransaction.originalAuthorizedAmount = {"hyperswitch":"string","ucs":"null"}
```

### After
- UCS leg now sends `original_payment_authorized_amount` in the proto request; prism's cybersource
  transformer already consumes it and emits `merchantInitiatedTransaction.originalAuthorizedAmount`,
  byte-matching Direct.
- The companion `authorizationOptions.initiator = null` facet is fixed in prism PR
  juspay/hyperswitch-prism#1805.

## Verification
- `cargo build -p router` → exit 0 (compiles against pinned connector-service `tag = 2026.07.02.1`).
- Code parity: mapping mirrors the Direct gateway's read of `recurring_mandate_payment_data`.

No creds; `config/development.toml` excluded.
