### PR TITLE
fix(router): fix null recipient filtering and prevent unconfigured delivery

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -21264,6 +21264,14 @@
             "type": "boolean",
             "description": "Filter all events by `is_overall_delivery_successful` field of the event.",
             "nullable": true
+          },
+          "recipient": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EventRecipient"
+              }
+            ],
+            "nullable": true
           }
         }
       },
@@ -21335,6 +21343,13 @@
             "example": "2022-09-10T10:11:12Z"
           }
         }
+      },
+      "EventRecipient": {
+        "type": "string",
+        "enum": [
+          "merchant",
+          "connector"
+        ]
       },
       "EventRetrieveResponse": {
         "allOf": [

--- a/crates/api_models/src/webhook_events.rs
+++ b/crates/api_models/src/webhook_events.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use common_enums::{EventClass, EventType, WebhookDeliveryAttempt};
+use common_enums::{EventClass, EventRecipient, EventType, WebhookDeliveryAttempt};
 use hyperswitch_masking::Secret;
 use serde::{Deserialize, Serialize};
 use time::PrimitiveDateTime;
@@ -41,6 +41,8 @@ pub struct EventListConstraints {
     pub event_types: Option<HashSet<EventType>>,
     /// Filter all events by `is_overall_delivery_successful` field of the event.
     pub is_delivered: Option<bool>,
+    /// Filter all events by the recipient of the webhook.
+    pub recipient: Option<EventRecipient>,
 }
 
 #[derive(Debug)]
@@ -53,9 +55,11 @@ pub enum EventListConstraintsInternal {
         event_classes: Option<HashSet<EventClass>>,
         event_types: Option<HashSet<EventType>>,
         is_delivered: Option<bool>,
+        recipient: Option<EventRecipient>,
     },
     ObjectIdFilter {
         object_id: String,
+        recipient: Option<EventRecipient>,
     },
     EventIdFilter {
         event_id: String,

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -1760,6 +1760,7 @@ impl Currency {
     serde::Serialize,
     strum::Display,
     strum::EnumString,
+    ToSchema,
 )]
 #[router_derive::diesel_enum(storage_type = "text")]
 #[serde(rename_all = "snake_case")]

--- a/crates/diesel_models/src/query/events.rs
+++ b/crates/diesel_models/src/query/events.rs
@@ -101,9 +101,7 @@ impl Event {
             .order(dsl::created_at.desc())
             .into_boxed();
 
-        if let Some(recipient) = event_recipient {
-            query = query.filter(dsl::recipient.eq(recipient.to_string()));
-        };
+        query = Self::apply_event_recipient(query, event_recipient);
 
         logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
 
@@ -190,9 +188,7 @@ impl Event {
             .order(dsl::created_at.desc())
             .into_boxed();
 
-        if let Some(recipient) = event_recipient {
-            query = query.filter(dsl::recipient.eq(recipient.to_string()));
-        };
+        query = Self::apply_event_recipient(query, event_recipient);
 
         logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
 
@@ -230,9 +226,7 @@ impl Event {
             .order(dsl::created_at.desc())
             .into_boxed();
 
-        if let Some(recipient) = recipient {
-            query = query.filter(dsl::recipient.eq(recipient.to_string()));
-        }
+        query = Self::apply_event_recipient(query, recipient);
 
         if let Some(profile_id) = profile_id {
             query = query.filter(dsl::business_profile_id.eq(profile_id));
@@ -323,9 +317,7 @@ impl Event {
             .order(dsl::created_at.desc())
             .into_boxed();
 
-        if let Some(recipient) = event_recipient {
-            query = query.filter(dsl::recipient.eq(recipient.to_string()));
-        };
+        query = Self::apply_event_recipient(query, event_recipient);
 
         logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
 
@@ -352,9 +344,7 @@ impl Event {
             .order(dsl::created_at.desc())
             .into_boxed();
 
-        if let Some(recipient) = event_recipient {
-            query = query.filter(dsl::recipient.eq(recipient.to_string()));
-        };
+        query = Self::apply_event_recipient(query, event_recipient);
 
         logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
 
@@ -520,6 +510,13 @@ impl Event {
             diesel::dsl::Eq<dsl::recipient, String>,
             Output = T,
         >,
+        T: diesel::query_dsl::methods::FilterDsl<
+            diesel::dsl::Or<
+                diesel::dsl::Eq<dsl::recipient, String>,
+                diesel::dsl::IsNull<dsl::recipient>,
+            >,
+            Output = T,
+        >,
     {
         if let Some(profile_id) = profile_id {
             query = query.filter(dsl::business_profile_id.eq(profile_id));
@@ -545,8 +542,43 @@ impl Event {
             query = query.filter(dsl::is_overall_delivery_successful.eq(is_delivered));
         }
 
-        if let Some(recipient) = event_recipient {
-            query = query.filter(dsl::recipient.eq(recipient.to_string()));
+        query = Self::apply_event_recipient(query, event_recipient);
+
+        query
+    }
+
+    fn apply_event_recipient<T>(
+        mut query: T,
+        event_recipient: Option<common_enums::EventRecipient>,
+    ) -> T
+    where
+        T: diesel::query_dsl::methods::FilterDsl<
+            diesel::dsl::Eq<dsl::recipient, String>,
+            Output = T,
+        >,
+        T: diesel::query_dsl::methods::FilterDsl<
+            diesel::dsl::Or<
+                diesel::dsl::Eq<dsl::recipient, String>,
+                diesel::dsl::IsNull<dsl::recipient>,
+            >,
+            Output = T,
+        >,
+    {
+        match event_recipient {
+            Some(common_enums::EventRecipient::Merchant) => {
+                query = query.filter(
+                    dsl::recipient
+                        .eq(common_enums::EventRecipient::Merchant.to_string())
+                        .or(
+                            dsl::recipient.is_null(), // Treat NULL recipient as Merchant for backward compatibility
+                        ),
+                );
+            }
+            Some(common_enums::EventRecipient::Connector) => {
+                query = query
+                    .filter(dsl::recipient.eq(common_enums::EventRecipient::Connector.to_string()));
+            }
+            None => {}
         }
 
         query

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -900,6 +900,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::webhooks::OutgoingWebhookContent,
         api_models::enums::EventClass,
         api_models::enums::EventType,
+        api_models::enums::EventRecipient,
         api_models::enums::DecoupledAuthenticationType,
         api_models::enums::Tokenization,
         api_models::enums::AuthenticationStatus,

--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -245,6 +245,7 @@ async fn insert_event_and_spawn_webhook_delivery(
                 "merchant webhook URL \
                  could not be obtained; skipping outgoing webhooks for event"
             );
+            return Ok(());
         }
     };
 

--- a/crates/router/src/core/webhooks/webhook_events.rs
+++ b/crates/router/src/core/webhooks/webhook_events.rs
@@ -55,14 +55,17 @@ pub async fn list_initial_delivery_attempts(
         (now.date() - time::Duration::days(INITIAL_DELIVERY_ATTEMPTS_LIST_MAX_DAYS)).midnight();
 
     let (events, total_count) = match constraints {
-        api_models::webhook_events::EventListConstraintsInternal::ObjectIdFilter { object_id } => {
+        api_models::webhook_events::EventListConstraintsInternal::ObjectIdFilter {
+            object_id,
+            recipient,
+        } => {
             let events = store
                 .list_initial_events_by_initiator_merchant_id_primary_object_id(
                     &merchant_id,
                     object_id.as_str(),
                     profile_id.clone(),
                     &key_store,
-                    Some(common_enums::EventRecipient::Merchant),
+                    recipient,
                 )
                 .await
                 .change_context(errors::ApiErrorResponse::InternalServerError)
@@ -113,6 +116,7 @@ pub async fn list_initial_delivery_attempts(
             event_classes,
             event_types,
             is_delivered,
+            recipient,
         } => {
             let limit = match limit {
                 Some(limit) if  limit <= INITIAL_DELIVERY_ATTEMPTS_LIST_MAX_LIMIT => Ok(Some(limit)),
@@ -178,7 +182,7 @@ pub async fn list_initial_delivery_attempts(
                             event_types.clone(),
                             is_delivered,
                             &key_store,
-                            Some(common_enums::EventRecipient::Merchant),
+                            recipient,
                         )
                         .await
                 }
@@ -193,7 +197,7 @@ pub async fn list_initial_delivery_attempts(
                             event_types.clone(),
                             is_delivered,
                             &key_store,
-                            Some(common_enums::EventRecipient::Merchant),
+                            recipient,
                         )
                         .await
                 }
@@ -210,7 +214,7 @@ pub async fn list_initial_delivery_attempts(
                             created_before,
                             event_types,
                             is_delivered,
-                            Some(common_enums::EventRecipient::Merchant),
+                            recipient,
                         )
                         .await
                 }
@@ -223,7 +227,7 @@ pub async fn list_initial_delivery_attempts(
                             created_before,
                             event_types,
                             is_delivered,
-                            Some(common_enums::EventRecipient::Merchant),
+                            recipient,
                         )
                         .await
                 }
@@ -269,7 +273,7 @@ pub async fn list_delivery_attempts(
             &initial_attempt_id,
             &merchant_id,
             &key_store,
-            Some(common_enums::EventRecipient::Merchant),
+            None,
         )
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -2032,7 +2032,10 @@ impl ForeignTryFrom<api_types::webhook_events::EventListConstraints>
         }
 
         match (item.object_id.clone(), item.event_id.clone()) {
-            (Some(object_id), None) => Ok(Self::ObjectIdFilter { object_id }),
+            (Some(object_id), None) => Ok(Self::ObjectIdFilter {
+                object_id,
+                recipient: item.recipient,
+            }),
 
             (None, Some(event_id)) => Ok(Self::EventIdFilter { event_id }),
 
@@ -2044,6 +2047,7 @@ impl ForeignTryFrom<api_types::webhook_events::EventListConstraints>
                 event_classes: item.event_classes,
                 event_types: item.event_types,
                 is_delivered: item.is_delivered,
+                recipient: item.recipient,
             }),
 
             (Some(_), Some(_)) => Err(report!(errors::ApiErrorResponse::PreconditionFailed {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes two issues:

1. While listing outgoing webhooks, we added a filter for recipient = merchant. However, older records did not contain the recipient field, resulting in a null value. As a result, those earlier records were not fetched.
2. Whenever a payment was created, we attempted to send an outgoing webhook even if the merchant had not configured any webhook endpoint. This PR prevents those unnecessary webhook attempts.

Hotfix for https://github.com/juspay/hyperswitch/pull/13141

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Create a payment for merchant where endpoint is not configured for outgoing webhook

```
{
    "payment_id": "pay_fEOqU87Mmeucl2iwLZ5F",
    "merchant_id": "postman_merchant_GHAction_7a2a0d1c-821a-4e87-8004-92c34571acbf",
    "status": "succeeded",
    "amount": 10900,
    "net_amount": 10900,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 10900,
    "processor_merchant_id": "postman_merchant_GHAction_7a2a0d1c-821a-4e87-8004-92c34571acbf",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fUnFUQ1NuVFZLckxDUTF3Umd6RXEscHVibGlzaGFibGVfa2V5PXBrX2Rldl8wZjM3ZDFhZDVlMzk0N2E2OWM2ZmViNWFiN2Y3MzY5MSxjbGllbnRfc2VjcmV0PXBheV9mRU9xVTg3TW1ldWNsMml3TFo1Rl9zZWNyZXRfS1VmUFJRUVA5d2VIeTV1OUtNTHcsY3VzdG9tZXJfaWQ9R2VvcmdlXzE3MzQsY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfVmZsd1plN096c1dlSk1pRkd4RUYscGF5bWVudF9pZD1wYXlfZkVPcVU4N01tZXVjbDJpd0xaNUY=",
    "connector": "stripe",
    "state_metadata": null,
    "client_secret": "pay_fEOqU87Mmeucl2iwLZ5F_secret_KUfPRQQP9weHy5u9KMLw",
    "created": "2026-07-02T07:51:19.113Z",
    "modified_at": "2026-07-02T07:51:22.569Z",
    "connector_customer_id": "cus_UoHydOQZsT8woe",
    "currency": "USD",
    "customer_id": "George_1734",
    "customer": {
        "id": "George_1734",
        "name": null,
        "email": "hello@123.com",
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": "vantiv payment",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "0259",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "400000",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "30",
            "card_holder_name": "joseph Doe",
            "payment_checks": {
                "cvc_check": "pass",
                "address_line1_check": "pass",
                "address_postal_code_check": "pass"
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "North Carolina South",
            "first_name": "박성준",
            "last_name": "박성준",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "hello@123.com",
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "pi_3TofP2D5R7gDAGff1kGsiJtN",
    "frm_message": null,
    "metadata": {
        "processing_account_id": "acct_3eoxafCHioIB3jNMKJev4"
    },
    "connector_metadata": {
        "apple_pay": null,
        "airwallex": null,
        "noon": {
            "order_category": "pay"
        },
        "braintree": null,
        "adyen": null,
        "peachpayments": null,
        "santander": null
    },
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "pi_3TofP2D5R7gDAGff1kGsiJtN",
    "payment_link": null,
    "profile_id": "pro_RqTCSnTVKrLCQ1wRgzEq",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_m3Y2DgODmQaSK38MaCwW",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-07-02T08:06:19.113Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": "548497118106811",
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-07-02T07:51:22.569Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": false,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": false,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

Event not created
<img width="1504" height="226" alt="Screenshot 2026-07-02 at 1 21 40 PM" src="https://github.com/user-attachments/assets/a2448d0e-c887-4d17-a8b3-6df56752175a" />


List events, include events where the

List events without recipient 

```
curl --location 'http://localhost:8080/events/postman_merchant_GHAction_12' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{


  "event_classes": [
    "payments",
    "refunds"
  ],
  "event_types": [
    "payment_succeeded"
  ],

  "limit": 5,

  "offset": 0


}'
```

Response - expected to return all the events 


```
{
    "events": [
        {
            "event_id": "evt_019f22a12f5b7d40ba21185e41d3986e",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_pxyLYKqKnGGk4BnBQD7R",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f22a12f5b7d40ba21185e41d3986e",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:40:16.603Z"
        },
        {
            "event_id": "evt_019f22a0e6b570008921a705b36470c9",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_cpFy0gFml39ThzHDIdSe",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f22a0e6b570008921a705b36470c9",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:39:58.005Z"
        },
        {
            "event_id": "evt_019f22a04d9b7b438d8e074cf5502eac",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_WSJhjNshvzIuZf5CA0zr",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f22a04d9b7b438d8e074cf5502eac",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:39:18.811Z"
        },
        {
            "event_id": "evt_019f2299a83e7f10b88fe1105b7ee34a",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_QyJQ4cCGyHJS3FT3H1wl",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f2299a83e7f10b88fe1105b7ee34a",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:32:03.262Z"
        },
        {
            "event_id": "evt_019f229915477a40a756d666ecb5a941",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_kT0fT21cn69aqbiqyVLg",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f229915477a40a756d666ecb5a941",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:31:25.639Z"
        }
    ],
    "total_count": 6
}
```

List events with recipient merchant 

```
curl --location 'http://localhost:8080/events/postman_merchant_GHAction_12' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{


  "event_classes": [
    "payments",
    "refunds"
  ],
  "event_types": [
    "payment_succeeded"
  ],

  "limit": 5,

  "offset": 0,

"recipient": "merchant"
}'
```

Response

Returns all except events sent to connector  
```

{
    "events": [
        {
            "event_id": "evt_019f22a12f5b7d40ba21185e41d3986e",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_pxyLYKqKnGGk4BnBQD7R",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f22a12f5b7d40ba21185e41d3986e",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:40:16.603Z"
        },
        {
            "event_id": "evt_019f22a0e6b570008921a705b36470c9",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_cpFy0gFml39ThzHDIdSe",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f22a0e6b570008921a705b36470c9",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:39:58.005Z"
        },
        {
            "event_id": "evt_019f22a04d9b7b438d8e074cf5502eac",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_WSJhjNshvzIuZf5CA0zr",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f22a04d9b7b438d8e074cf5502eac",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:39:18.811Z"
        },
        {
            "event_id": "evt_019f2299a83e7f10b88fe1105b7ee34a",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_QyJQ4cCGyHJS3FT3H1wl",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f2299a83e7f10b88fe1105b7ee34a",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:32:03.262Z"
        },
        {
            "event_id": "evt_019f229915477a40a756d666ecb5a941",
            "merchant_id": "postman_merchant_GHAction_12",
            "profile_id": "pro_P3wQRMSFPRbPKR4UuHnK",
            "object_id": "pay_kT0fT21cn69aqbiqyVLg",
            "event_type": "payment_succeeded",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f229915477a40a756d666ecb5a941",
            "processor_merchant_id": "postman_merchant_GHAction_12",
            "created": "2026-07-02T11:31:25.639Z"
        }
    ],
    "total_count": 6
}

```

List events for connectors 

```
curl --location 'http://localhost:8080/events/postman_merchant_GHAction_12' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{


  "event_classes": [
    "payments",
    "refunds"
  ],
  "event_types": [
    "payment_succeeded"
  ],

  "limit": 5,

  "offset": 0,

"recipient": "connector"
}'
```

Response

```
{
    "events": [],
    "total_count": 0
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
