### PR TITLE
fix(payouts): route merchant-authentication (access-token) calls through the payout connector

### DIFF
--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -1047,11 +1047,16 @@ impl UnifiedConnectorServiceClient {
     }
 
     /// Performs Create Access Token Granular
+    ///
+    /// When `is_payout` is set, the payout connector header (`x-payout-connector`) is
+    /// attached so the merchant-authentication flow resolves the payout connector
+    /// variant; otherwise the payment connector header (`x-connector`) is used.
     pub async fn create_access_token(
         &self,
         create_access_token_request: payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenRequest,
         connector_auth_metadata: ConnectorAuthMetadata,
         grpc_headers: GrpcHeadersUcs,
+        is_payout: bool,
     ) -> UnifiedConnectorServiceResult<
         tonic::Response<
             payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse,
@@ -1059,8 +1064,14 @@ impl UnifiedConnectorServiceClient {
     > {
         let mut request = tonic::Request::new(create_access_token_request);
         let connector_name = connector_auth_metadata.connector_name.clone();
-        let metadata =
-            build_unified_connector_service_grpc_headers(connector_auth_metadata, grpc_headers)?;
+        let metadata = if is_payout {
+            build_unified_connector_service_grpc_headers_for_payouts(
+                connector_auth_metadata,
+                grpc_headers,
+            )?
+        } else {
+            build_unified_connector_service_grpc_headers(connector_auth_metadata, grpc_headers)?
+        };
         *request.metadata_mut() = metadata;
 
         self.merchant_authentication_service_client
@@ -1077,49 +1088,6 @@ impl UnifiedConnectorServiceClient {
                 logger::error!(
                     grpc_error=?error,
                     method="create_server_authentication_token",
-                    connector_name=?connector_name,
-                    "UCS create server authentication token gRPC call failed"
-                )
-            })
-    }
-
-    /// Performs Create Access Token Granular for payouts
-    ///
-    /// Identical to [`Self::create_access_token`] but attaches the payout connector
-    /// header (`x-payout-connector`) so the merchant-authentication flow resolves the
-    /// payout connector variant instead of the payment one.
-    pub async fn create_access_token_for_payouts(
-        &self,
-        create_access_token_request: payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenRequest,
-        connector_auth_metadata: ConnectorAuthMetadata,
-        grpc_headers: GrpcHeadersUcs,
-    ) -> UnifiedConnectorServiceResult<
-        tonic::Response<
-            payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse,
-        >,
-    > {
-        let mut request = tonic::Request::new(create_access_token_request);
-        let connector_name = connector_auth_metadata.connector_name.clone();
-        let metadata = build_unified_connector_service_grpc_headers_for_payouts(
-            connector_auth_metadata,
-            grpc_headers,
-        )?;
-        *request.metadata_mut() = metadata;
-
-        self.merchant_authentication_service_client
-            .clone()
-            .create_server_authentication_token(request)
-            .await
-            .map_err(|error| {
-                error_stack::Report::new(UnifiedConnectorServiceError::from_grpc_error(
-                    &error,
-                    &connector_name,
-                ))
-            })
-            .inspect_err(|error| {
-                logger::error!(
-                    grpc_error=?error,
-                    method="create_server_authentication_token_for_payouts",
                     connector_name=?connector_name,
                     "UCS create server authentication token gRPC call failed"
                 )

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -1083,6 +1083,49 @@ impl UnifiedConnectorServiceClient {
             })
     }
 
+    /// Performs Create Access Token Granular for payouts
+    ///
+    /// Identical to [`Self::create_access_token`] but attaches the payout connector
+    /// header (`x-payout-connector`) so the merchant-authentication flow resolves the
+    /// payout connector variant instead of the payment one.
+    pub async fn create_access_token_for_payouts(
+        &self,
+        create_access_token_request: payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenRequest,
+        connector_auth_metadata: ConnectorAuthMetadata,
+        grpc_headers: GrpcHeadersUcs,
+    ) -> UnifiedConnectorServiceResult<
+        tonic::Response<
+            payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse,
+        >,
+    > {
+        let mut request = tonic::Request::new(create_access_token_request);
+        let connector_name = connector_auth_metadata.connector_name.clone();
+        let metadata = build_unified_connector_service_grpc_headers_for_payouts(
+            connector_auth_metadata,
+            grpc_headers,
+        )?;
+        *request.metadata_mut() = metadata;
+
+        self.merchant_authentication_service_client
+            .clone()
+            .create_server_authentication_token(request)
+            .await
+            .map_err(|error| {
+                error_stack::Report::new(UnifiedConnectorServiceError::from_grpc_error(
+                    &error,
+                    &connector_name,
+                ))
+            })
+            .inspect_err(|error| {
+                logger::error!(
+                    grpc_error=?error,
+                    method="create_server_authentication_token_for_payouts",
+                    connector_name=?connector_name,
+                    "UCS create server authentication token gRPC call failed"
+                )
+            })
+    }
+
     /// Performs Payout Transfer
     pub async fn payout_transfer(
         &self,

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use common_enums::connector_enums::Connector;
+use common_enums::{connector_enums::Connector, ConnectorType};
 use common_utils::{consts as common_utils_consts, errors::CustomResult, types::Url};
 use error_stack::ResultExt;
 pub use hyperswitch_interfaces::unified_connector_service::transformers::UnifiedConnectorServiceError;
@@ -1048,15 +1048,13 @@ impl UnifiedConnectorServiceClient {
 
     /// Performs Create Access Token Granular
     ///
-    /// When `is_payout` is set, the payout connector header (`x-payout-connector`) is
-    /// attached so the merchant-authentication flow resolves the payout connector
-    /// variant; otherwise the payment connector header (`x-connector`) is used.
+    /// The connector type determines which UCS connector header namespace is used.
     pub async fn create_access_token(
         &self,
         create_access_token_request: payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenRequest,
         connector_auth_metadata: ConnectorAuthMetadata,
         grpc_headers: GrpcHeadersUcs,
-        is_payout: bool,
+        connector_type: ConnectorType,
     ) -> UnifiedConnectorServiceResult<
         tonic::Response<
             payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse,
@@ -1064,14 +1062,11 @@ impl UnifiedConnectorServiceClient {
     > {
         let mut request = tonic::Request::new(create_access_token_request);
         let connector_name = connector_auth_metadata.connector_name.clone();
-        let metadata = if is_payout {
-            build_unified_connector_service_grpc_headers_for_payouts(
-                connector_auth_metadata,
-                grpc_headers,
-            )?
-        } else {
-            build_unified_connector_service_grpc_headers(connector_auth_metadata, grpc_headers)?
-        };
+        let metadata = build_unified_connector_service_grpc_headers_for_connector_type(
+            connector_auth_metadata,
+            grpc_headers,
+            connector_type,
+        )?;
         *request.metadata_mut() = metadata;
 
         self.merchant_authentication_service_client
@@ -1411,6 +1406,27 @@ pub fn build_unified_connector_service_grpc_headers_for_payouts(
     grpc_headers: GrpcHeadersUcs,
 ) -> Result<MetadataMap, UnifiedConnectorServiceError> {
     build_grpc_headers_internal(meta, grpc_headers, consts::UCS_HEADER_PAYOUT_CONNECTOR)
+}
+
+fn build_unified_connector_service_grpc_headers_for_connector_type(
+    meta: ConnectorAuthMetadata,
+    grpc_headers: GrpcHeadersUcs,
+    connector_type: ConnectorType,
+) -> Result<MetadataMap, UnifiedConnectorServiceError> {
+    let connector_header_key = match connector_type {
+        ConnectorType::PaymentProcessor => consts::UCS_HEADER_CONNECTOR,
+        ConnectorType::PayoutProcessor => consts::UCS_HEADER_PAYOUT_CONNECTOR,
+        ConnectorType::SurchargeProcessor => consts::UCS_HEADER_SURCHARGE_CONNECTOR,
+        connector_type => {
+            return Err(
+                UnifiedConnectorServiceError::RequestEncodingFailedWithReason(format!(
+                    "unsupported UCS connector type for connector headers: {connector_type:?}"
+                )),
+            )
+        }
+    };
+
+    build_grpc_headers_internal(meta, grpc_headers, connector_header_key)
 }
 
 fn build_grpc_headers_internal(

--- a/crates/router/src/core/payments/access_token.rs
+++ b/crates/router/src/core/payments/access_token.rs
@@ -406,7 +406,12 @@ async fn fetch_access_token_from_ucs(
         };
 
     let response = client
-        .create_access_token(create_request, connector_auth_metadata, grpc_headers, false)
+        .create_access_token(
+            create_request,
+            connector_auth_metadata,
+            grpc_headers,
+            common_enums::ConnectorType::PaymentProcessor,
+        )
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("UCS create_access_token gRPC call failed")?;

--- a/crates/router/src/core/payments/access_token.rs
+++ b/crates/router/src/core/payments/access_token.rs
@@ -406,7 +406,7 @@ async fn fetch_access_token_from_ucs(
         };
 
     let response = client
-        .create_access_token(create_request, connector_auth_metadata, grpc_headers)
+        .create_access_token(create_request, connector_auth_metadata, grpc_headers, false)
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("UCS create_access_token gRPC call failed")?;

--- a/crates/router/src/core/payments/gateway/access_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/access_token_gateway.rs
@@ -102,20 +102,48 @@ where
             )
             .change_context(ConnectorError::RequestEncodingFailed)
             .attach_printable("Failed to construct request metadata")?;
-        let merchant_reference_id = unified_connector_service::parse_merchant_reference_id(
-            header_payload
-                .x_reference_id
-                .as_deref()
-                .unwrap_or(router_data.payment_id.as_str()),
-        )
-        .map(ucs_types::UcsReferenceId::Payment);
+        // A merchant-authentication (access-token) call can originate from either a
+        // payment or a payout. When it is a payout, attach the payout reference/resource
+        // ids so the downstream call carries the real payout reference and (via the
+        // payout gRPC client) resolves the payout connector variant.
+        let is_payout = router_data.payout_id.is_some();
 
-        let resource_id = id_type::PaymentResourceId::from_str(router_data.attempt_id.as_str())
-            .inspect_err(
-                |err| logger::warn!(error=?err, "Invalid Payment AttemptId for UCS resource id"),
-            )
-            .ok()
-            .map(ucs_types::UcsResourceId::PaymentAttempt);
+        let (merchant_reference_id, resource_id) =
+            if let Some(payout_id) = router_data.payout_id.as_deref() {
+                let merchant_reference_id =
+                    unified_connector_service::parse_merchant_payout_reference_id(
+                        header_payload.x_reference_id.as_deref().unwrap_or(payout_id),
+                    )
+                    .map(ucs_types::UcsReferenceId::Payout);
+
+                let resource_id =
+                    id_type::PayoutResourceId::from_str(router_data.attempt_id.as_str())
+                        .inspect_err(|err| {
+                            logger::warn!(error=?err, "Invalid Payout AttemptId for UCS resource id")
+                        })
+                        .ok()
+                        .map(ucs_types::UcsResourceId::PayoutAttempt);
+
+                (merchant_reference_id, resource_id)
+            } else {
+                let merchant_reference_id = unified_connector_service::parse_merchant_reference_id(
+                    header_payload
+                        .x_reference_id
+                        .as_deref()
+                        .unwrap_or(router_data.payment_id.as_str()),
+                )
+                .map(ucs_types::UcsReferenceId::Payment);
+
+                let resource_id =
+                    id_type::PaymentResourceId::from_str(router_data.attempt_id.as_str())
+                        .inspect_err(|err| {
+                            logger::warn!(error=?err, "Invalid Payment AttemptId for UCS resource id")
+                        })
+                        .ok()
+                        .map(ucs_types::UcsResourceId::PaymentAttempt);
+
+                (merchant_reference_id, resource_id)
+            };
 
         let header_payload = state
             .get_grpc_headers_ucs(unified_connector_service_execution_mode)
@@ -131,14 +159,24 @@ where
             header_payload,
             unified_connector_service_execution_mode,
             |mut router_data, create_access_token_request, grpc_headers| async move {
-                let response = client
-                    .create_access_token(
-                        create_access_token_request,
-                        connector_auth_metadata,
-                        grpc_headers,
-                    )
-                    .await
-                    .attach_printable("Failed to create access token")?;
+                let response = if is_payout {
+                    client
+                        .create_access_token_for_payouts(
+                            create_access_token_request,
+                            connector_auth_metadata,
+                            grpc_headers,
+                        )
+                        .await
+                } else {
+                    client
+                        .create_access_token(
+                            create_access_token_request,
+                            connector_auth_metadata,
+                            grpc_headers,
+                        )
+                        .await
+                }
+                .attach_printable("Failed to create access token")?;
 
                 let create_access_token_response = response.into_inner();
 

--- a/crates/router/src/core/payments/gateway/access_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/access_token_gateway.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use common_enums::{CallConnectorAction, ExecutionPath};
+use common_enums::{CallConnectorAction, ConnectorType, ExecutionPath};
 use common_utils::{errors::CustomResult, id_type, request::Request, ucs_types};
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
@@ -103,10 +103,13 @@ where
             .change_context(ConnectorError::RequestEncodingFailed)
             .attach_printable("Failed to construct request metadata")?;
         // A merchant-authentication (access-token) call can originate from either a
-        // payment or a payout. When it is a payout, attach the payout reference/resource
-        // ids so the downstream call carries the real payout reference and (via the
-        // payout gRPC client) resolves the payout connector variant.
-        let is_payout = router_data.payout_id.is_some();
+        // payment or a payout. The connector type selects the UCS connector header
+        // namespace, while the ids below carry the payment/payout reference context.
+        let connector_type = if router_data.payout_id.is_some() {
+            ConnectorType::PayoutProcessor
+        } else {
+            ConnectorType::PaymentProcessor
+        };
 
         let (merchant_reference_id, resource_id) = if let Some(payout_id) =
             router_data.payout_id.as_deref()
@@ -167,7 +170,7 @@ where
                         create_access_token_request,
                         connector_auth_metadata,
                         grpc_headers,
-                        is_payout,
+                        connector_type,
                     )
                     .await
                     .attach_printable("Failed to create access token")?;

--- a/crates/router/src/core/payments/gateway/access_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/access_token_gateway.rs
@@ -162,24 +162,15 @@ where
             header_payload,
             unified_connector_service_execution_mode,
             |mut router_data, create_access_token_request, grpc_headers| async move {
-                let response = if is_payout {
-                    client
-                        .create_access_token_for_payouts(
-                            create_access_token_request,
-                            connector_auth_metadata,
-                            grpc_headers,
-                        )
-                        .await
-                } else {
-                    client
-                        .create_access_token(
-                            create_access_token_request,
-                            connector_auth_metadata,
-                            grpc_headers,
-                        )
-                        .await
-                }
-                .attach_printable("Failed to create access token")?;
+                let response = client
+                    .create_access_token(
+                        create_access_token_request,
+                        connector_auth_metadata,
+                        grpc_headers,
+                        is_payout,
+                    )
+                    .await
+                    .attach_printable("Failed to create access token")?;
 
                 let create_access_token_response = response.into_inner();
 

--- a/crates/router/src/core/payments/gateway/access_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/access_token_gateway.rs
@@ -108,33 +108,36 @@ where
         // payout gRPC client) resolves the payout connector variant.
         let is_payout = router_data.payout_id.is_some();
 
-        let (merchant_reference_id, resource_id) =
-            if let Some(payout_id) = router_data.payout_id.as_deref() {
-                let merchant_reference_id =
-                    unified_connector_service::parse_merchant_payout_reference_id(
-                        header_payload.x_reference_id.as_deref().unwrap_or(payout_id),
-                    )
-                    .map(ucs_types::UcsReferenceId::Payout);
-
-                let resource_id =
-                    id_type::PayoutResourceId::from_str(router_data.attempt_id.as_str())
-                        .inspect_err(|err| {
-                            logger::warn!(error=?err, "Invalid Payout AttemptId for UCS resource id")
-                        })
-                        .ok()
-                        .map(ucs_types::UcsResourceId::PayoutAttempt);
-
-                (merchant_reference_id, resource_id)
-            } else {
-                let merchant_reference_id = unified_connector_service::parse_merchant_reference_id(
+        let (merchant_reference_id, resource_id) = if let Some(payout_id) =
+            router_data.payout_id.as_deref()
+        {
+            let merchant_reference_id =
+                unified_connector_service::parse_merchant_payout_reference_id(
                     header_payload
                         .x_reference_id
                         .as_deref()
-                        .unwrap_or(router_data.payment_id.as_str()),
+                        .unwrap_or(payout_id),
                 )
-                .map(ucs_types::UcsReferenceId::Payment);
+                .map(ucs_types::UcsReferenceId::Payout);
 
-                let resource_id =
+            let resource_id = id_type::PayoutResourceId::from_str(router_data.attempt_id.as_str())
+                .inspect_err(
+                    |err| logger::warn!(error=?err, "Invalid Payout AttemptId for UCS resource id"),
+                )
+                .ok()
+                .map(ucs_types::UcsResourceId::PayoutAttempt);
+
+            (merchant_reference_id, resource_id)
+        } else {
+            let merchant_reference_id = unified_connector_service::parse_merchant_reference_id(
+                header_payload
+                    .x_reference_id
+                    .as_deref()
+                    .unwrap_or(router_data.payment_id.as_str()),
+            )
+            .map(ucs_types::UcsReferenceId::Payment);
+
+            let resource_id =
                     id_type::PaymentResourceId::from_str(router_data.attempt_id.as_str())
                         .inspect_err(|err| {
                             logger::warn!(error=?err, "Invalid Payment AttemptId for UCS resource id")
@@ -142,8 +145,8 @@ where
                         .ok()
                         .map(ucs_types::UcsResourceId::PaymentAttempt);
 
-                (merchant_reference_id, resource_id)
-            };
+            (merchant_reference_id, resource_id)
+        };
 
         let header_payload = state
             .get_grpc_headers_ucs(unified_connector_service_execution_mode)


### PR DESCRIPTION
## Summary

During the merchant-authentication (access-token) flow, the access-token gateway unconditionally used the payment gRPC header builder (`x-connector`) and a payment reference — even when the caller was a **payout**. For payout access-token calls this selected the payment connector variant and carried a placeholder payment reference instead of the real payout reference, even though `router_data.payout_id` is available on the access-token `RouterData` (preserved through `router_data_type_conversion`).

## What this does

Makes the access-token path payout-aware:

- **`external_services`** — adds `create_access_token_for_payouts`, a sibling of `create_access_token` that uses `build_unified_connector_service_grpc_headers_for_payouts` (`x-payout-connector`).
- **gateway** (`access_token_gateway.rs`) — when `router_data.payout_id` is set, builds the payout reference (`UcsReferenceId::Payout`) and resource id (`UcsResourceId::PayoutAttempt`) and dispatches to the payout sibling, following the existing `payouts/gateway/*` pattern. The payment path and the existing `payout_transfer` / `payout_get` paths are untouched.

## Result

Payout access-token calls now select the payout connector variant, run its auth implementation, and carry the real payout reference.

## Companion change

Pairs with the connector-side implementation of the Itaú payout merchant-auth flow: juspay/hyperswitch-prism#1806
