### PR TITLE
fix(connector): [Adyen] handle empty webhook requests

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyen.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen.rs
@@ -2115,6 +2115,10 @@ impl IncomingWebhook for Adyen {
         request: &IncomingWebhookRequestDetails<'_>,
         _context: Option<&WebhookContext>,
     ) -> CustomResult<api_models::webhooks::IncomingWebhookEvent, errors::ConnectorError> {
+        if request.body.is_empty(){
+            return Ok(api_models::webhooks::IncomingWebhookEvent::EndpointVerification);
+        }
+
         let notif = get_webhook_object_from_body(request.body)
             .change_context(errors::ConnectorError::WebhookResponseEncodingFailed)?;
 

--- a/crates/hyperswitch_connectors/src/connectors/adyen.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen.rs
@@ -2115,7 +2115,7 @@ impl IncomingWebhook for Adyen {
         request: &IncomingWebhookRequestDetails<'_>,
         _context: Option<&WebhookContext>,
     ) -> CustomResult<api_models::webhooks::IncomingWebhookEvent, errors::ConnectorError> {
-        if request.body.is_empty(){
+        if request.body.is_empty() {
             return Ok(api_models::webhooks::IncomingWebhookEvent::EndpointVerification);
         }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the Adyen incoming webhook handler to treat empty webhook request bodies.

Earlier when webhook with no request was received, we were throwing a 5xx : 
```

{"error":{"type":"server_not_available","code":"HE_00","message":"Something went wrong"}}
├╴at crates/router/src/core/webhooks/gateway.rs:225:14
├╴Could not find event type in incoming webhook body
│
├─:arrow_forward: Could not respond to the incoming webhook event
│   ╰╴at crates/hyperswitch_connectors/src/connectors/adyen.rs:2100:14
│
├─:arrow_forward: Failed to parse struct: AdyenIncomingWebhook
│   ├╴at crates/hyperswitch_connectors/src/connectors/adyen.rs:1954:57
│   ╰╴Unable to parse AdyenIncomingWebhook from &[u8] "**"
│
╰─:arrow_forward: EOF while parsing a value at line 1 column 0
╰╴at crates/hyperswitch_connectors/src/connectors/adyen.rs:1954:57

```

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Webhook:

```

curl --location 'http://localhost:8080/webhooks/merchant_1783066139/adyen' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_LnmCOaHjL5Umf7iLjrEKM4Gesxs8X2aZnjQah8Ny7AYsq6hBKxWidmovHW9ue9lf' \
--data '
'

```

Response:

```
[accepted]
```

<img width="1123" height="250" alt="Screenshot 2026-07-03 at 2 57 43 PM" src="https://github.com/user-attachments/assets/6efa4be1-6ccc-4052-b569-799d05642e46" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
