### PR TITLE
feat(analytics): expose connector event destination

### DIFF
--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -93,4 +93,10 @@ pub struct ConnectorEventsResult {
     #[serde(with = "common_utils::custom_serde::iso8601")]
     pub created_at: PrimitiveDateTime,
     pub method: Option<String>,
+    #[serde(default = "default_connector_event_destination")]
+    pub destination: common_enums::EventDestination,
+}
+
+fn default_connector_event_destination() -> common_enums::EventDestination {
+    common_enums::EventDestination::Connector
 }

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2938,7 +2938,7 @@ impl From<ExecutionMode> for EventExecutionMode {
     }
 }
 
-#[derive(Clone, Copy, Debug, serde::Serialize)]
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Where a connector event's call was sent.
 pub enum EventDestination {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds `destination` to connector event analytics responses so Control Center can distinguish calls sent directly to the connector from calls routed through Unified Connector Service.

- Deserializes `destination` from `connector_events_audit` / `connector_events_payout_audit` when the ClickHouse row contains the column.
- Defaults `destination` to `connector` when the column is absent. This keeps Prism connector event tables compatible, since they do not contain the column, and also avoids breaking older HS ClickHouse schemas during rollout.
- Keeps the existing `SELECT *` query path unchanged.

## Motivation and Context

Native connector event tables can contain `destination = connector` or `destination = unified_connector_service`. The analytics read API previously dropped this field, so downstream consumers could not tell where a connector-event request was sent.

This follows the same read-side area as #12899, which added the Prism connector-event endpoint.

## ClickHouse rollout shape

Sanitized DDL shape used for the ClickHouse rollout. Database names and sensitive Kafka details are intentionally omitted; only the table / materialized-view structure is relevant here.

<details>
<summary>ClickHouse DDL used for rollout</summary>

```sql
DROP TABLE IF EXISTS connector_events_mv;
DROP TABLE IF EXISTS connector_events_audit_mv;
DROP TABLE IF EXISTS connector_events_payout_audit_mv;
DROP TABLE IF EXISTS connector_events_parse_errors;
DROP TABLE IF EXISTS connector_events_queue;

ALTER TABLE connector_events
    ADD COLUMN IF NOT EXISTS `destination` LowCardinality(Nullable(String)),
    ADD COLUMN IF NOT EXISTS `execution_mode` LowCardinality(Nullable(String));

ALTER TABLE connector_events_audit
    ADD COLUMN IF NOT EXISTS `destination` LowCardinality(Nullable(String));

ALTER TABLE connector_events_payout_audit
    ADD COLUMN IF NOT EXISTS `destination` LowCardinality(Nullable(String));

CREATE TABLE IF NOT EXISTS connector_events_queue
(
    `tenant_id` String,
    `merchant_id` String,
    `payment_id` Nullable(String),
    `connector_name` LowCardinality(String),
    `request_id` String,
    `flow` LowCardinality(String),
    `request` String,
    `masked_response` Nullable(String),
    `error` Nullable(String),
    `status_code` UInt32,
    `created_at` DateTime64(3),
    `latency` UInt128,
    `method` LowCardinality(String),
    `refund_id` Nullable(String),
    `dispute_id` Nullable(String),
    `payout_id` Nullable(String),
    `destination` LowCardinality(Nullable(String)),
    `execution_mode` LowCardinality(Nullable(String))
)
ENGINE = Kafka
SETTINGS
    kafka_broker_list = '<masked>',
    kafka_topic_list = '<masked>',
    kafka_group_name = '<masked>',
    kafka_format = 'JSONEachRow',
    kafka_handle_error_mode = 'stream';

CREATE MATERIALIZED VIEW IF NOT EXISTS connector_events_mv
TO connector_events
AS
SELECT
    merchant_id,
    payment_id,
    connector_name,
    request_id,
    flow,
    request,
    masked_response AS response,
    masked_response,
    error,
    status_code,
    created_at,
    now64() AS inserted_at,
    latency,
    method,
    refund_id,
    dispute_id,
    payout_id,
    destination,
    execution_mode
FROM connector_events_queue
WHERE length(_error) = 0
  AND tenant_id = 'public';

CREATE MATERIALIZED VIEW IF NOT EXISTS connector_events_audit_mv
TO connector_events_audit
AS
SELECT
    merchant_id,
    payment_id,
    connector_name,
    request_id,
    flow,
    request,
    masked_response AS response,
    masked_response,
    error,
    status_code,
    created_at,
    now64() AS inserted_at,
    latency,
    method,
    refund_id,
    dispute_id,
    destination
FROM connector_events_queue
WHERE length(_error) = 0
  AND tenant_id = 'public'
  AND payment_id IS NOT NULL;

CREATE MATERIALIZED VIEW IF NOT EXISTS connector_events_payout_audit_mv
TO connector_events_payout_audit
AS
SELECT
    merchant_id,
    payout_id,
    connector_name,
    request_id,
    flow,
    request,
    masked_response AS response,
    masked_response,
    error,
    status_code,
    created_at,
    now64() AS inserted_at,
    latency,
    method,
    refund_id,
    dispute_id,
    destination
FROM connector_events_queue
WHERE length(_error) = 0
  AND tenant_id = 'public'
  AND payout_id IS NOT NULL;
```

</details>

## How did you test it?

- `cargo fmt --package analytics --package common_enums`
- `cargo check -p router`
- Ran local router with ClickHouse analytics enabled against local `pg`, `redis-standalone`, and `clickhouse-server`.
- Verified both ClickHouse schema states through the analytics endpoint:
  - Without `destination` column in `connector_events_audit`, `GET /analytics/v1/profile/connector_event_logs?payment_id=pay_destination_no_col_1` returned `destination: connector`.
  - After adding `destination` column and inserting a row with `destination = unified_connector_service`, `GET /analytics/v1/profile/connector_event_logs?payment_id=pay_destination_ucs_col_1` returned `destination: unified_connector_service`.

Screenshot 1: backward compatibility when ClickHouse does not have the column:

```bash
curl -sS 'http://localhost:8088/analytics/v1/profile/connector_event_logs?payment_id=pay_destination_no_col_1' \
  -H 'Authorization: Bearer <dashboard_jwt>' \
  -H 'x-profile-id: pro_mwSf0vcLJZeDYuchf56f' | jq .
```

<img width="1272" height="310" alt="image" src="https://github.com/user-attachments/assets/8f8fc122-653f-4e12-8a23-4ecab902d0d0" />

Response includes:

```json
"destination": "connector"
```

Screenshot 2: value is read from ClickHouse when the column exists:

```bash
curl -sS 'http://localhost:8088/analytics/v1/profile/connector_event_logs?payment_id=pay_destination_ucs_col_1' \
  -H 'Authorization: Bearer <dashboard_jwt>' \
  -H 'x-profile-id: pro_mwSf0vcLJZeDYuchf56f' | jq .
```

<img width="1042" height="316" alt="image" src="https://github.com/user-attachments/assets/ed2a760e-b669-41d8-8f52-1d423907fc20" />

Response includes:

```json
"destination": "unified_connector_service"
```

Note: `cargo check -p analytics` alone is not representative in this workspace because it does not activate a Redis backend feature; `cargo check -p router` passes with the default router feature set.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

## Tracking issue

Resolves juspay/hyperswitch-cloud#20251

