### PR TITLE
fix(connector-template): template connector enum and mark Stripe error strings as placeholders

### DIFF
--- a/connector-template/test.rs
+++ b/connector-template/test.rs
@@ -15,7 +15,7 @@ impl utils::Connector for {{project-name | downcase | pascal_case}}Test {
         use router::connector::{{project-name | downcase | pascal_case}};
         utils::construct_connector_data_old(
             Box::new({{project-name | downcase | pascal_case}}::new()),
-            types::Connector::Plaid,
+            types::Connector::{{project-name | downcase | pascal_case}},
             api::GetToken::Connector,
             None,
         )
@@ -300,6 +300,7 @@ async fn should_fail_payment_for_incorrect_cvc() {
         .unwrap();
     assert_eq!(
         response.response.unwrap_err().message,
+        // TODO({{project-name | downcase}}): replace with your connector's actual error message
         "Your card's security code is invalid.".to_string(),
     );
 }
@@ -322,6 +323,7 @@ async fn should_fail_payment_for_invalid_exp_month() {
         .unwrap();
     assert_eq!(
         response.response.unwrap_err().message,
+        // TODO({{project-name | downcase}}): replace with your connector's actual error message
         "Your card's expiration month is invalid.".to_string(),
     );
 }
@@ -344,6 +346,7 @@ async fn should_fail_payment_for_incorrect_expiry_year() {
         .unwrap();
     assert_eq!(
         response.response.unwrap_err().message,
+        // TODO({{project-name | downcase}}): replace with your connector's actual error message
         "Your card's expiration year is invalid.".to_string(),
     );
 }
@@ -361,6 +364,7 @@ async fn should_fail_void_payment_for_auto_capture() {
         .unwrap();
     assert_eq!(
         void_response.response.unwrap_err().message,
+        // TODO({{project-name | downcase}}): replace with your connector's actual error message
         "You cannot cancel this PaymentIntent because it has a status of succeeded."
     );
 }
@@ -374,6 +378,7 @@ async fn should_fail_capture_for_invalid_payment() {
         .unwrap();
     assert_eq!(
         capture_response.response.unwrap_err().message,
+        // TODO({{project-name | downcase}}): replace with your connector's actual error message
         String::from("No such payment_intent: '123456789'")
     );
 }
@@ -394,6 +399,7 @@ async fn should_fail_for_refund_amount_higher_than_payment_amount() {
         .unwrap();
     assert_eq!(
         response.response.unwrap_err().message,
+        // TODO({{project-name | downcase}}): replace with your connector's actual error message
         "Refund amount (₹1.50) is greater than charge amount (₹1.00)",
     );
 }


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description

`connector-template/test.rs` is the scaffold consumed by `cargo generate` (via `scripts/add_connector.sh`) when adding a new connector. Only the `{{project-name | downcase | pascal_case}}` placeholder was substituted during generation; two values were left hardcoded and survived generation, producing a misleading test file for every new connector:

1. **`connector-template/test.rs:18`** — the test's `get_data()` hardcoded `types::Connector::Plaid`, so every generated connector's test pointed at `Plaid` instead of itself.
2. **Negative-test error strings (~lines 303–397)** — Stripe's actual API error messages (`"Your card's security code is invalid."`, `"No such payment_intent: '123456789'"`, `"Refund amount (₹1.50)…"`, etc.) were asserted verbatim. Each connector returns different error text, so these assertions fail until manually rewritten.

## Changes

- **Option A** — Template the connector enum:
  ```rust
  types::Connector::{{project-name | downcase | pascal_case}},
  ```
  `cargo generate` now resolves it to the new connector's variant automatically. This reuses the **exact** placeholder expression already used 4× elsewhere in the same file (struct, `impl`, `use`, `Box::new`), so it renders identically.
- **Option B** — Add `// TODO({{project-name | downcase}}): replace with your connector's actual error message` markers above each Stripe-specific negative-test assertion, so authors know these strings must be swapped.

## Verification

`connector-template/test.rs` contains `{{…}}` liquid placeholders (invalid Rust until generated), so it is **not** part of the compiled workspace — `cargo c` does not touch it. Correctness of the new enum placeholder is guaranteed by equivalence with the four existing, already-proven uses of the same expression in this file. No behavioural change to any compiled crate.

## Motivation and Context

Closes #13185

## Checklist
- [x] I formatted the code (no compiled crate touched; template-only change)
- [x] I reviewed the diff — only `connector-template/test.rs` changed (7 insertions, 1 deletion)