### PR TITLE
fix(ucs): stop re-deriving minor_amount_captured for checkout repeat_payment shadow mapping

### DIFF
--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -217,9 +217,6 @@ where
                     router_data.response = router_data_response;
 
                     router_data.amount_captured = recurring_payment_charge_response.captured_amount;
-                    router_data.minor_amount_captured = recurring_payment_charge_response
-                        .captured_amount
-                        .map(MinorUnit::new);
                     if return_raw_connector_response.unwrap_or(false) {
                         router_data.raw_connector_response = recurring_payment_charge_response
                             .raw_connector_response


### PR DESCRIPTION
Closes #13187

## Problem

UCS shadow-validation diff: `router.typeDiff:minor_amount_captured` on `checkout` / `repeat_payment` (MIT/recurring charge), `{hyperswitch: null, ucs: number}`, for auto-captured payments.

## Root cause

`crates/router/src/core/payments/gateway/authorize_gateway.rs`'s `RepeatPayment`/`Charge` response-mapping branch unconditionally re-derived `router_data.minor_amount_captured` from the UCS gRPC response's `captured_amount`:

```rust
router_data.amount_captured = recurring_payment_charge_response.captured_amount;
router_data.minor_amount_captured = recurring_payment_charge_response
    .captured_amount
    .map(MinorUnit::new);
```

No native HS connector transformer (checkout included) ever sets `minor_amount_captured` at this stage of the response — only the deprecated `amount_captured` (`i64`) field is populated by connector transformers. So the native path always leaves `minor_amount_captured` unset here, while the UCS-shadow path derived a `Some(..)` value whenever the connector returned a captured amount, producing a false divergence. Same bug class as the paypal/capture `minor_amount_captured` family (#12902/#12980), just in the repeat-payment gateway mapping rather than the capture gateway mapping.

## Fix

Remove the incorrect re-derivation so the shadow path matches native behavior (leaves `minor_amount_captured` unset here); `amount_captured` (the field connectors actually populate) is unaffected.

## Verification (local HS↔UCS shadow stack)

Repro: CIT (checkout card, `off_session` + `customer_acceptance`) to store a mandate, then an MIT repeat payment (`automatic` capture) against it, with the merchant enrolled in the UCS shadow rollout for `checkout`/`card`/`Authorize` (repeat_payment reuses the `Authorize` HS flow with `is_mit_payment`).

- Before fix: `comparison_results.typeDiff = {"minor_amount_captured": {"hyperswitch": "null", "ucs": "number"}}`, with `hyperswitch_data.minor_amount_captured = null` vs `unified_connector_service_data.minor_amount_captured = 100000` (both `amount_captured` = 100000, matching).
- After fix: `comparison_results = null` (no diff at all); both sides now report `minor_amount_captured = null`, `amount_captured = 100000`.

## Category

L2 — HS→UCS shadow-mapping gateway code (`core/payments/gateway/authorize_gateway.rs`), not a connector transformer, not a proto change (no UCS PR needed — the UCS-side `captured_amount` computation for checkout was already correct/faithful to native).
