### PR TITLE
feat(adyen/repeat_payment): map network_txn_link_id from UCS RepeatPayment response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "log 0.4.27",
  "prettyplease",
  "proc-macro2",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e49eef2ba197c3cd0edd632181d1f4c346dcc0e7#e49eef2ba197c3cd0edd632181d1f4c346dcc0e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3982,7 +3982,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e49eef2ba197c3cd0edd632181d1f4c346dcc0e7#e49eef2ba197c3cd0edd632181d1f4c346dcc0e7"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -6836,7 +6836,7 @@ dependencies = [
  "regex-cache",
  "serde",
  "serde_derive",
- "strum 0.26.3",
+ "strum 0.25.0",
  "thiserror 1.0.69",
 ]
 
@@ -7157,8 +7157,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.11.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log 0.4.27",
  "multimap",
  "petgraph",
@@ -7179,7 +7179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7192,7 +7192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e49eef2ba197c3cd0edd632181d1f4c346dcc0e7#e49eef2ba197c3cd0edd632181d1f4c346dcc0e7"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11012,7 +11012,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e49eef2ba197c3cd0edd632181d1f4c346dcc0e7#e49eef2ba197c3cd0edd632181d1f4c346dcc0e7"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11028,7 +11028,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e49eef2ba197c3cd0edd632181d1f4c346dcc0e7#e49eef2ba197c3cd0edd632181d1f4c346dcc0e7"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e49eef2ba197c3cd0edd632181d1f4c346dcc0e7#e49eef2ba197c3cd0edd632181d1f4c346dcc0e7"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -82,7 +82,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e49eef2ba197c3cd0edd632181d1f4c346dcc0e7", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.114.0", optional = true}
 superposition_types = "0.114.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e49eef2ba197c3cd0edd632181d1f4c346dcc0e7", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -970,6 +970,12 @@ impl ForeignTryFrom<payments_grpc::RedirectForm> for RedirectForm {
                 )
                 .into(),
             ),
+            Some(payments_grpc::redirect_form::FormType::HostedIframe(_)) => Err(
+                UnifiedConnectorServiceError::RequestEncodingFailedWithReason(
+                    "Hosted iframe form type is not implemented".to_string(),
+                )
+                .into(),
+            ),
             Some(payments_grpc::redirect_form::FormType::Braintree(braintree)) => {
                 Ok(Self::Braintree {
                     client_token: braintree.client_token,

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e49eef2ba197c3cd0edd632181d1f4c346dcc0e7", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "e49eef2ba197c3cd0edd632181d1f4c346dcc0e7", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -5767,7 +5767,9 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                                         ),
                                         initial_billing_amount: None,
                                         external_subscription_id: None,
-                                        mandate_status: payments_grpc::MandateStatus::Unspecified as i32,
+                                        mandate_status: i32::from(
+                                            payments_grpc::MandateStatus::Unspecified,
+                                        ),
                                         next_billing_date: None,
                                         billing_cycle: None,
                                         description: None,
@@ -5809,7 +5811,9 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                                             ),
                                             initial_billing_amount: None,
                                             external_subscription_id: None,
-                                            mandate_status: payments_grpc::MandateStatus::Unspecified as i32,
+                                            mandate_status: i32::from(
+                                                payments_grpc::MandateStatus::Unspecified,
+                                            ),
                                             next_billing_date: None,
                                             billing_cycle: None,
                                             description: None,

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1008,6 +1008,7 @@ impl
 
         Ok(Self {
             merchant_order_id: Some(router_data.connector_request_reference_id.clone()),
+            webhook_url: None, // PaymentsAuthenticateData does not carry a webhook_url
             amount: router_data
                 .request
                 .minor_amount
@@ -1197,6 +1198,7 @@ impl
             .map(|s| s.into());
 
         Ok(Self {
+            merchant_transaction_id: Some(router_data.connector_request_reference_id.clone()),
             merchant_order_id: Some(router_data.connector_request_reference_id.clone()),
             amount: Some(payments_grpc::Money {
                 minor_amount: router_data.request.minor_amount.get_amount_as_i64(),
@@ -3080,7 +3082,7 @@ impl
                     mandate_reference: Box::new(response.mandate_reference.map(hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from).transpose()?),
                     connector_metadata,
                     network_txn_id: response.network_transaction_id.clone(),
-                    network_txn_link_id: None,
+                    network_txn_link_id: response.network_txn_link_id.clone(),
                     connector_response_reference_id: response.merchant_charge_id.clone(),
                     incremental_authorization_allowed: response.incremental_authorization_allowed,
                     authentication_data: None,
@@ -5763,6 +5765,12 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                                                 dt.assume_utc().unix_timestamp()
                                             },
                                         ),
+                                        initial_billing_amount: None,
+                                        external_subscription_id: None,
+                                        mandate_status: payments_grpc::MandateStatus::Unspecified as i32,
+                                        next_billing_date: None,
+                                        billing_cycle: None,
+                                        description: None,
                                     },
                                 ),
                             ),
@@ -5799,6 +5807,12 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                                                     dt.assume_utc().unix_timestamp()
                                                 },
                                             ),
+                                            initial_billing_amount: None,
+                                            external_subscription_id: None,
+                                            mandate_status: payments_grpc::MandateStatus::Unspecified as i32,
+                                            next_billing_date: None,
+                                            billing_cycle: None,
+                                            description: None,
                                         },
                                     ),
                                 )


### PR DESCRIPTION
## Summary
- Maps the new `network_txn_link_id` field on `RecurringPaymentServiceChargeResponse` into `PaymentsResponseData::TransactionResponse.network_txn_link_id` for the RepeatPayment/UCS charge response handler (`crates/router/src/core/unified_connector_service/transformers.rs`).
- Bumps the pinned `connector-service` dependency (`unified-connector-service-client` / `unified-connector-service-cards`) from `tag = "2026.07.02.1"` to `rev = "e49eef2ba197c3cd0edd632181d1f4c346dcc0e7"` (head of connector-service PR juspay/hyperswitch-prism#1839) across the three Cargo.tomls, so the generated proto types include the new field.
- **Depends on connector-service PR #1839** — the `rev` pin above is interim; once #1839 merges to `main`, this pin should move to a `tag`/main commit rather than staying on a raw `rev`.
- The rev bump also pulled in unrelated proto/domain drift accumulated on connector-service `main` since the previous tag; fixed the resulting compile breaks minimally:
  - `PaymentMethodAuthenticationServiceAuthenticateRequest` gained a `webhook_url` field (set to `None`, mirroring the existing `CompleteAuthorize` precedent — `PaymentsAuthenticateData` has no webhook URL).
  - `PaymentMethodAuthenticationServicePreAuthenticateRequest` gained a `merchant_transaction_id` field (set from `connector_request_reference_id`, same value already used for `merchant_order_id` elsewhere in this file).
  - `MandateAmountData` gained 6 subscription-related fields (`initial_billing_amount`, `external_subscription_id`, `mandate_status`, `next_billing_date`, `billing_cycle`, `description`); set to `None`/`Unspecified` since none of that data exists on the plain mandate-amount path.
  - `redirect_form::FormType` gained a `HostedIframe` variant; added a not-implemented arm mirroring the existing `Uri` arm (HS's `RedirectForm` domain enum has no hosted-iframe representation yet).

## Root cause
Detected via HS↔UCS shadow-validation diff on adyen `repeat_payment`: `router.typeDiff:response.Ok.TransactionResponse.network_txn_link_id` (hyperswitch: string, ucs: null). Verified that adyen's repeat-payment connector-integration code in connector-service already parses `additionalData.transactionLinkId` into the domain response; the value was only lost because (a) the proto response message had no slot for it and (b) HS's mapping hardcoded `None`.

Closes #13191

## Test plan
- [x] `cargo build` (default v1 features)
- [ ] `cargo build --no-default-features --features "release,v2,redis-rs"`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [x] Verified locally: adyen repeat_payment shadow-validation diff on `network_txn_link_id` disappears (typeDiff empty) after this fix + connector-service PR #1839.
