### PR TITLE
fix(router): Add config to close idle DB connections

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1174,9 +1174,12 @@ password = "db_pass"      # Analytics DB Password
 host = "localhost"        # Analytics DB Host
 port = 5432               # Analytics DB Port
 dbname = "hyperswitch_db" # Name of Database
-pool_size = 5             # Number of connections to keep open
+max_pool_size = 5         # Maximum number of connections in the pool
+min_idle_pool_size = 2    # Minimum number of idle connections to maintain in the pool
 connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
+idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
+max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
 
 # Config for KV setup
 [kv_config]

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -52,9 +52,12 @@ password = "db_pass"      # DB Password. Use base-64 encoded kms encrypted value
 host = "localhost"        # DB Host
 port = 5432               # DB Port
 dbname = "hyperswitch_db" # Name of Database
-pool_size = 5             # Number of connections to keep open
+max_pool_size = 5         # Maximum number of connections in the pool
+min_idle_pool_size = 2    # Minimum number of idle connections to maintain in the pool
 connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
+idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
+max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
 
 # Replica SQL data store credentials
 [replica_database]
@@ -63,9 +66,12 @@ password = "db_pass"      # DB Password. Use base-64 encoded kms encrypted value
 host = "localhost"        # DB Host
 port = 5432               # DB Port
 dbname = "hyperswitch_db" # Name of Database
-pool_size = 5             # Number of connections to keep open
+max_pool_size = 5         # Maximum number of connections in the pool
+min_idle_pool_size = 2    # Minimum number of idle connections to maintain in the pool
 connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
+idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
+max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
 
 # Redis credentials
 [redis]

--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -22,9 +22,12 @@ password = "db_pass"      # Analytics DB Password
 host = "localhost"        # Analytics DB Host
 port = 5432               # Analytics DB Port
 dbname = "hyperswitch_db" # Name of Database
-pool_size = 5             # Number of connections to keep open
+max_pool_size = 5         # Maximum number of connections in the pool
+min_idle_pool_size = 2    # Minimum number of idle connections to maintain in the pool
 connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
+idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
+max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
 
 [api_keys]
 hash_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" # API key hashing key.

--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -177,9 +177,12 @@ password = "db_pass"      # DB Password. Use base-64 encoded kms encrypted value
 host = "localhost"        # DB Host
 port = 5432               # DB Port
 dbname = "hyperswitch_db" # Name of Database
-pool_size = 5             # Number of connections to keep open
+max_pool_size = 5         # Maximum number of connections in the pool
+min_idle_pool_size = 2    # Minimum number of idle connections to maintain in the pool
 connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
+idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
+max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
 
 [generic_link]
 [generic_link.payment_method_collect]
@@ -248,9 +251,12 @@ password = "db_pass"      # DB Password. Use base-64 encoded kms encrypted value
 host = "localhost"        # DB Host
 port = 5432               # DB Port
 dbname = "hyperswitch_db" # Name of Database
-pool_size = 5             # Number of connections to keep open
+max_pool_size = 5          # Maximum number of connections in the pool
+min_idle_pool_size = 2    # Minimum number of idle connections to maintain in the pool
 connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
+idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
+max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
 
 [report_download_config]
 dispute_function = "report_download_config_dispute_function" # Config to download dispute report

--- a/config/development.toml
+++ b/config/development.toml
@@ -1377,9 +1377,12 @@ password = "db_pass"
 host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"
-pool_size = 5
+max_pool_size = 5
+min_idle_pool_size = 2
 connection_timeout = 10
 queue_strategy = "Fifo"
+idle_timeout = 300
+max_lifetime = 1800
 
 [connector_onboarding.paypal]
 client_id = ""

--- a/config/development.toml
+++ b/config/development.toml
@@ -25,9 +25,11 @@ password = "db_pass"
 host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"
-pool_size = 5
+max_pool_size = 5
+min_idle_pool_size = 2
 connection_timeout = 10
-min_idle = 2
+idle_timeout = 300
+max_lifetime = 1800
 
 [replica_database]
 username = "db_user"
@@ -35,8 +37,11 @@ password = "db_pass"
 host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"
-pool_size = 5
+max_pool_size = 5
+min_idle_pool_size = 2
 connection_timeout = 10
+idle_timeout = 300
+max_lifetime = 1800
 
 [redis]
 host = "127.0.0.1"

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -32,7 +32,10 @@ password = "db_pass"
 host = "pg"
 port = 5432
 dbname = "hyperswitch_db"
-pool_size = 5
+max_pool_size = 5
+min_idle_pool_size = 2
+idle_timeout = 300
+max_lifetime = 1800
 
 [forex_api]
 api_key = ""
@@ -47,7 +50,10 @@ password = "db_pass"
 host = "pg"
 port = 5432
 dbname = "hyperswitch_db"
-pool_size = 5
+max_pool_size = 5
+min_idle_pool_size = 2
+idle_timeout = 300
+max_lifetime = 1800
 
 [secrets]
 admin_api_key = "test_admin"

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -1201,9 +1201,12 @@ password = "db_pass"
 host = "pg"
 port = 5432
 dbname = "hyperswitch_db"
-pool_size = 5
+max_pool_size = 5
+min_idle_pool_size = 2
 connection_timeout = 10
 queue_strategy = "Fifo"
+idle_timeout = 300
+max_lifetime = 1800
 
 [kv_config]
 ttl = 900         # 15 * 60 seconds

--- a/crates/analytics/src/sqlx.rs
+++ b/crates/analytics/src/sqlx.rs
@@ -59,7 +59,7 @@ impl SqlxClient {
         let database_url = conf.get_database_url(schema);
         #[allow(clippy::expect_used)]
         let pool = PgPoolOptions::new()
-            .max_connections(conf.pool_size)
+            .max_connections(conf.max_pool_size)
             .acquire_timeout(std::time::Duration::from_secs(conf.connection_timeout))
             .connect_lazy(&database_url)
             .expect("SQLX Pool Creation failed");

--- a/crates/analytics/src/sqlx.rs
+++ b/crates/analytics/src/sqlx.rs
@@ -60,7 +60,10 @@ impl SqlxClient {
         #[allow(clippy::expect_used)]
         let pool = PgPoolOptions::new()
             .max_connections(conf.max_pool_size)
+            .min_connections(conf.min_idle_pool_size)
             .acquire_timeout(std::time::Duration::from_secs(conf.connection_timeout))
+            .max_lifetime(std::time::Duration::from_secs(conf.max_lifetime))
+            .idle_timeout(std::time::Duration::from_secs(conf.idle_timeout))
             .connect_lazy(&database_url)
             .expect("SQLX Pool Creation failed");
         Self { pool }

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -42,11 +42,12 @@ impl Default for super::settings::Database {
             host: "localhost".into(),
             port: 5432,
             dbname: String::new(),
-            pool_size: 5,
+            max_pool_size: 5,
             connection_timeout: 10,
             queue_strategy: Default::default(),
-            min_idle: None,
-            max_lifetime: None,
+            min_idle_pool_size: 2,
+            max_lifetime: 1800,
+            idle_timeout: 300,
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -865,9 +865,11 @@ pub struct Database {
     pub host: String,
     pub port: u16,
     pub dbname: String,
+    #[serde(alias = "pool_size")]
     pub max_pool_size: u32,
     pub connection_timeout: u64,
     pub queue_strategy: QueueStrategy,
+    #[serde(alias = "min_idle")]
     pub min_idle_pool_size: u32,
     pub max_lifetime: u64,
     pub idle_timeout: u64,

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -865,11 +865,12 @@ pub struct Database {
     pub host: String,
     pub port: u16,
     pub dbname: String,
-    pub pool_size: u32,
+    pub max_pool_size: u32,
     pub connection_timeout: u64,
     pub queue_strategy: QueueStrategy,
-    pub min_idle: Option<u32>,
-    pub max_lifetime: Option<u64>,
+    pub min_idle_pool_size: u32,
+    pub max_lifetime: u64,
+    pub idle_timeout: u64,
 }
 
 impl From<Database> for storage_impl::config::Database {
@@ -880,11 +881,12 @@ impl From<Database> for storage_impl::config::Database {
             host: val.host,
             port: val.port,
             dbname: val.dbname,
-            pool_size: val.pool_size,
+            max_pool_size: val.max_pool_size,
             connection_timeout: val.connection_timeout,
             queue_strategy: val.queue_strategy,
-            min_idle: val.min_idle,
+            min_idle_pool_size: val.min_idle_pool_size,
             max_lifetime: val.max_lifetime,
+            idle_timeout: val.idle_timeout,
         }
     }
 }

--- a/crates/storage_impl/src/config.rs
+++ b/crates/storage_impl/src/config.rs
@@ -11,11 +11,12 @@ pub struct Database {
     pub host: String,
     pub port: u16,
     pub dbname: String,
-    pub pool_size: u32,
+    pub max_pool_size: u32,
     pub connection_timeout: u64,
     pub queue_strategy: QueueStrategy,
-    pub min_idle: Option<u32>,
-    pub max_lifetime: Option<u64>,
+    pub min_idle_pool_size: u32,
+    pub max_lifetime: u64,
+    pub idle_timeout: u64,
 }
 
 impl DbConnectionParams for Database {
@@ -61,11 +62,12 @@ impl Default for Database {
             host: "localhost".into(),
             port: 5432,
             dbname: String::new(),
-            pool_size: 5,
+            max_pool_size: 5,
             connection_timeout: 10,
             queue_strategy: QueueStrategy::default(),
-            min_idle: None,
-            max_lifetime: None,
+            min_idle_pool_size: 2,
+            max_lifetime: 1800,
+            idle_timeout: 300,
         }
     }
 }

--- a/crates/storage_impl/src/config.rs
+++ b/crates/storage_impl/src/config.rs
@@ -11,12 +11,28 @@ pub struct Database {
     pub host: String,
     pub port: u16,
     pub dbname: String,
+    #[serde(alias = "pool_size")]
     pub max_pool_size: u32,
     pub connection_timeout: u64,
     pub queue_strategy: QueueStrategy,
+    #[serde(alias = "min_idle", default = "default_min_idle_pool_size")]
     pub min_idle_pool_size: u32,
+    #[serde(default = "default_max_lifetime")]
     pub max_lifetime: u64,
+    #[serde(default = "default_idle_timeout")]
     pub idle_timeout: u64,
+}
+
+const fn default_min_idle_pool_size() -> u32 {
+    2
+}
+
+const fn default_max_lifetime() -> u64 {
+    1800
+}
+
+const fn default_idle_timeout() -> u64 {
+    300
 }
 
 impl DbConnectionParams for Database {
@@ -65,9 +81,9 @@ impl Default for Database {
             max_pool_size: 5,
             connection_timeout: 10,
             queue_strategy: QueueStrategy::default(),
-            min_idle_pool_size: 2,
-            max_lifetime: 1800,
-            idle_timeout: 300,
+            min_idle_pool_size: default_min_idle_pool_size(),
+            max_lifetime: default_max_lifetime(),
+            idle_timeout: default_idle_timeout(),
         }
     }
 }

--- a/crates/storage_impl/src/database/store.rs
+++ b/crates/storage_impl/src/database/store.rs
@@ -151,11 +151,12 @@ pub async fn diesel_make_pg_pool(
     let database_url = database.get_database_url(schema);
     let manager = async_bb8_diesel::ConnectionManager::<PgConnection>::new(database_url);
     let mut pool = bb8::Pool::builder()
-        .max_size(database.pool_size)
-        .min_idle(database.min_idle)
+        .max_size(database.max_pool_size)
+        .min_idle(Some(database.min_idle_pool_size))
         .queue_strategy(database.queue_strategy.into())
         .connection_timeout(std::time::Duration::from_secs(database.connection_timeout))
-        .max_lifetime(database.max_lifetime.map(std::time::Duration::from_secs));
+        .max_lifetime(std::time::Duration::from_secs(database.max_lifetime))
+        .idle_timeout(std::time::Duration::from_secs(database.idle_timeout));
 
     if test_transaction {
         pool = pool.connection_customizer(Box::new(TestTransaction));

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -871,8 +871,11 @@ password = "db_pass"
 host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"
-pool_size = 5
+max_pool_size = 5
 connection_timeout = 10
+min_idle_pool_size = 2
+idle_timeout = 300
+max_lifetime = 1800
 
 [kv_config]
 ttl = 300 # 5 * 60 seconds

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -19,8 +19,11 @@ password = "postgres"
 host = "db"
 port = 5432
 dbname = "loadtest_router"
-pool_size = 20
+max_pool_size = 20
 connection_timeout = 10
+min_idle_pool_size = 2
+idle_timeout = 300
+max_lifetime = 1800
 
 [server]
 host = "0.0.0.0"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
We did not have the DB pool config to close idle connections. This could lead to stale connections in long running pods. Added the config.

- Added `min_idle_pool_size` and `idle_timeout` to the config
- Renamed `pool_size` to `max_pool_size` to enhance clarity

Relevant docs: https://docs.rs/bb8/latest/bb8/struct.Builder.html

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
