### PR TITLE
fix(router): resolve webhook event delivery-success from the correct source

### DIFF
--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -1962,6 +1962,24 @@ pub enum WebhookDeliveryAttempt {
     ManualRetry,
 }
 
+impl WebhookDeliveryAttempt {
+    /// Resolves the correct delivery-success source for an event's delivery attempt:
+    /// `Some(ManualRetry)` -> `is_webhook_notified`
+    /// anything else (`InitialAttempt`, `AutomaticRetry`) -> `is_overall_delivery_successful`
+    pub fn resolve_delivery_success(
+        delivery_attempt: Option<Self>,
+        is_overall_delivery_successful: Option<bool>,
+        is_webhook_notified: bool,
+    ) -> Option<bool> {
+        match delivery_attempt {
+            Some(Self::ManualRetry) => Some(is_webhook_notified),
+            Some(Self::InitialAttempt | Self::AutomaticRetry) | None => {
+                is_overall_delivery_successful
+            }
+        }
+    }
+}
+
 #[derive(
     Clone,
     Copy,

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -1962,24 +1962,6 @@ pub enum WebhookDeliveryAttempt {
     ManualRetry,
 }
 
-impl WebhookDeliveryAttempt {
-    /// Resolves the correct delivery-success source for an event's delivery attempt:
-    /// `Some(ManualRetry)` -> `is_webhook_notified`
-    /// anything else (`InitialAttempt`, `AutomaticRetry`) -> `is_overall_delivery_successful`
-    pub fn resolve_delivery_success(
-        delivery_attempt: Option<Self>,
-        is_overall_delivery_successful: Option<bool>,
-        is_webhook_notified: bool,
-    ) -> Option<bool> {
-        match delivery_attempt {
-            Some(Self::ManualRetry) => Some(is_webhook_notified),
-            Some(Self::InitialAttempt | Self::AutomaticRetry) | None => {
-                is_overall_delivery_successful
-            }
-        }
-    }
-}
-
 #[derive(
     Clone,
     Copy,

--- a/crates/router/src/core/webhooks/webhook_events.rs
+++ b/crates/router/src/core/webhooks/webhook_events.rs
@@ -241,7 +241,14 @@ pub async fn list_initial_delivery_attempts(
 
     let events = events
         .into_iter()
-        .map(api::webhook_events::EventListItemResponse::try_from)
+        .map(|event| {
+            api::webhook_events::EventListItemResponse::try_from(
+                domain::EventWithDeliverySuccessSource {
+                    event,
+                    source: domain::DeliverySuccessSource::ListInitialEvents,
+                },
+            )
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(ApplicationResponse::Json(
@@ -288,7 +295,14 @@ pub async fn list_delivery_attempts(
         Ok(ApplicationResponse::Json(
             events
                 .into_iter()
-                .map(api::webhook_events::EventRetrieveResponse::try_from)
+                .map(|event| {
+                    api::webhook_events::EventRetrieveResponse::try_from(
+                        domain::EventWithDeliverySuccessSource {
+                            event,
+                            source: domain::DeliverySuccessSource::ListDeliveryAttempts,
+                        },
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?,
         ))
     }
@@ -424,7 +438,12 @@ pub async fn retry_delivery_attempt(
         .to_not_found_response(errors::ApiErrorResponse::EventNotFound)?;
 
     Ok(ApplicationResponse::Json(
-        api::webhook_events::EventRetrieveResponse::try_from(updated_event)?,
+        api::webhook_events::EventRetrieveResponse::try_from(
+            domain::EventWithDeliverySuccessSource {
+                event: updated_event,
+                source: domain::DeliverySuccessSource::ListDeliveryAttempts,
+            },
+        )?,
     ))
 }
 

--- a/crates/router/src/types/domain/event.rs
+++ b/crates/router/src/types/domain/event.rs
@@ -83,6 +83,21 @@ pub struct Event {
     pub recipient: Option<EventRecipient>,
 }
 
+impl Event {
+    /// Resolves the correct delivery-success source for this event's delivery attempt:
+    /// `Some(ManualRetry)` -> `is_webhook_notified`
+    /// anything else (`InitialAttempt`, `AutomaticRetry`, or `None`) -> `is_overall_delivery_successful`
+    pub fn resolve_delivery_success(&self) -> Option<bool> {
+        match self.delivery_attempt {
+            Some(WebhookDeliveryAttempt::ManualRetry) => Some(self.is_webhook_notified),
+            Some(
+                WebhookDeliveryAttempt::InitialAttempt | WebhookDeliveryAttempt::AutomaticRetry,
+            )
+            | None => self.is_overall_delivery_successful,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum EventUpdate {
     UpdateResponse {

--- a/crates/router/src/types/domain/event.rs
+++ b/crates/router/src/types/domain/event.rs
@@ -83,17 +83,26 @@ pub struct Event {
     pub recipient: Option<EventRecipient>,
 }
 
+/// The API that is asking for this event's delivery-success value.
+#[derive(Clone, Copy, Debug)]
+pub enum DeliverySuccessSource {
+    ListInitialEvents,
+    ListDeliveryAttempts,
+}
+
+/// Pairs an event with the API context needed to resolve its delivery-success value — see
+/// `DeliverySuccessSource`.
+pub struct EventWithDeliverySuccessSource {
+    pub event: Event,
+    pub source: DeliverySuccessSource,
+}
+
 impl Event {
-    /// Resolves the correct delivery-success source for this event's delivery attempt:
-    /// `Some(ManualRetry)` -> `is_webhook_notified`
-    /// anything else (`InitialAttempt`, `AutomaticRetry`, or `None`) -> `is_overall_delivery_successful`
-    pub fn resolve_delivery_success(&self) -> Option<bool> {
-        match self.delivery_attempt {
-            Some(WebhookDeliveryAttempt::ManualRetry) => Some(self.is_webhook_notified),
-            Some(
-                WebhookDeliveryAttempt::InitialAttempt | WebhookDeliveryAttempt::AutomaticRetry,
-            )
-            | None => self.is_overall_delivery_successful,
+    /// Resolves the correct delivery-success value for the given API context.
+    pub fn resolve_delivery_success(&self, source: DeliverySuccessSource) -> Option<bool> {
+        match source {
+            DeliverySuccessSource::ListInitialEvents => self.is_overall_delivery_successful,
+            DeliverySuccessSource::ListDeliveryAttempts => Some(self.is_webhook_notified),
         }
     }
 }

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -2065,6 +2065,8 @@ impl TryFrom<domain::Event> for api_models::webhook_events::EventListItemRespons
     fn try_from(item: domain::Event) -> Result<Self, Self::Error> {
         use crate::utils::OptionExt;
 
+        let is_delivery_successful = item.resolve_delivery_success();
+
         // We only allow retrieving events with merchant_id, business_profile_id
         // and initial_attempt_id populated.
         // We cannot retrieve events with only some of these fields populated.
@@ -2080,12 +2082,6 @@ impl TryFrom<domain::Event> for api_models::webhook_events::EventListItemRespons
             .initial_attempt_id
             .get_required_value("initial_attempt_id")
             .change_context(errors::ApiErrorResponse::InternalServerError)?;
-        let is_delivery_successful =
-            storage_enums::WebhookDeliveryAttempt::resolve_delivery_success(
-                item.delivery_attempt,
-                item.is_overall_delivery_successful,
-                item.is_webhook_notified,
-            );
 
         Ok(Self {
             event_id: item.event_id,

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -2080,6 +2080,12 @@ impl TryFrom<domain::Event> for api_models::webhook_events::EventListItemRespons
             .initial_attempt_id
             .get_required_value("initial_attempt_id")
             .change_context(errors::ApiErrorResponse::InternalServerError)?;
+        let is_delivery_successful =
+            storage_enums::WebhookDeliveryAttempt::resolve_delivery_success(
+                item.delivery_attempt,
+                item.is_overall_delivery_successful,
+                item.is_webhook_notified,
+            );
 
         Ok(Self {
             event_id: item.event_id,
@@ -2088,7 +2094,7 @@ impl TryFrom<domain::Event> for api_models::webhook_events::EventListItemRespons
             object_id: item.primary_object_id,
             event_type: item.event_type,
             event_class: item.event_class,
-            is_delivery_successful: item.is_overall_delivery_successful,
+            is_delivery_successful,
             initial_attempt_id,
             processor_merchant_id: item.processor_merchant_id,
             created: item.created_at,

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -2059,13 +2059,16 @@ impl ForeignTryFrom<api_types::webhook_events::EventListConstraints>
 }
 
 #[cfg(feature = "olap")]
-impl TryFrom<domain::Event> for api_models::webhook_events::EventListItemResponse {
+impl TryFrom<domain::EventWithDeliverySuccessSource>
+    for api_models::webhook_events::EventListItemResponse
+{
     type Error = error_stack::Report<errors::ApiErrorResponse>;
 
-    fn try_from(item: domain::Event) -> Result<Self, Self::Error> {
+    fn try_from(value: domain::EventWithDeliverySuccessSource) -> Result<Self, Self::Error> {
         use crate::utils::OptionExt;
 
-        let is_delivery_successful = item.resolve_delivery_success();
+        let item = value.event;
+        let is_delivery_successful = item.resolve_delivery_success(value.source);
 
         // We only allow retrieving events with merchant_id, business_profile_id
         // and initial_attempt_id populated.
@@ -2099,17 +2102,20 @@ impl TryFrom<domain::Event> for api_models::webhook_events::EventListItemRespons
 }
 
 #[cfg(feature = "olap")]
-impl TryFrom<domain::Event> for api_models::webhook_events::EventRetrieveResponse {
+impl TryFrom<domain::EventWithDeliverySuccessSource>
+    for api_models::webhook_events::EventRetrieveResponse
+{
     type Error = error_stack::Report<errors::ApiErrorResponse>;
 
-    fn try_from(item: domain::Event) -> Result<Self, Self::Error> {
+    fn try_from(value: domain::EventWithDeliverySuccessSource) -> Result<Self, Self::Error> {
         use crate::utils::OptionExt;
+
+        let item = value.event.clone();
 
         // We only allow retrieving events with all required fields in `EventListItemResponse`, and
         // `request` and `response` populated.
         // We cannot retrieve events with only some of these fields populated.
-        let event_information =
-            api_models::webhook_events::EventListItemResponse::try_from(item.clone())?;
+        let event_information = api_models::webhook_events::EventListItemResponse::try_from(value)?;
 
         let request = item
             .request


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

Previously, the webhook delivery status was determined using the is_overall_delivery_successful field. This correctly represents the overall delivery status of a webhook and is correct when listing all webhooks.

However, when listing the attempts for an event, the status was also being read from is_overall_delivery_successful, which is incorrect. This is because is_overall_delivery_successful is not updated for every individual attempts of an event on successful delivery. Instead, the is_webhook_notified field is updated for individual attempts of an event.

This change updates the status selection logic based on the requesting API instead of the row type:
List Events API → Uses is_overall_delivery_successful to display the overall webhook delivery status.
List Attempts API and Retry API → Use is_webhook_notified to display the status of the specific event/attempt.

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Merchants viewing webhook event history saw an incorrect delivery status for individual delivery attempts — including manual retries, and initial attempts that failed but were later superseded by a successful automatic retry — since the field was derived from the row's attempt type rather than from which API (aggregate list vs. per-attempt view) was actually asking for it.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<details>
<summary>1. 1 - List Webhook Events (find event_id)</summary>

Request
```
curl --location 'http://localhost:8080/events/merchant_retry_test_1783410139' \
--header 'Content-Type: application/json' \
--header 'api-key: [REDACTED]
--header 'Accept: */*' \
--data '{"object_id": "pay_EaJdJwMLaHBXDuaqfwe1"}'
```

Response
```
{
    "events": [
        {
            "event_id": "evt_019f3bb310677832b0cbd7626113f675",
            "merchant_id": "merchant_retry_test_1783410139",
            "profile_id": "pro_zdgqb4gfuSfZJ44ytTQ7",
            "object_id": "pay_EaJdJwMLaHBXDuaqfwe1",
            "event_type": "payment_failed",
            "event_class": "payments",
            "is_delivery_successful": true,
            "initial_attempt_id": "evt_019f3bb310677832b0cbd7626113f675",
            "processor_merchant_id": "merchant_retry_test_1783410139",
            "created": "2026-07-07T08:30:18.727Z"
        }
    ],
    "total_count": 1
}
```
</details>

<details>
<summary>2. List Webhook Delivery Attempts</summary>

Request
```
curl --location 'http://localhost:8080/events/merchant_retry_test_1783410139/evt_019f3b8ed70e78728d5d949a2cde663c/attempts' \
--header 'api-key: [REDACTED]
--header 'Accept: */*'
```

Response
```
[
    {
        "event_id": "evt_019f3c2d505e7c62962dfec2bfb007ef",
        "merchant_id": "merchant_retry_test_1783410139",
        "profile_id": "pro_zdgqb4gfuSfZJ44ytTQ7",
        "object_id": "pay_Q2abGEL4M66zZB92PHpx",
        "event_type": "payment_failed",
        "event_class": "payments",
        "is_delivery_successful": true,
        "initial_attempt_id": "evt_019f3b8ed70e78728d5d949a2cde663c",
        "processor_merchant_id": "merchant_retry_test_1783410139",
        "created": "2026-07-07T10:43:50.494Z",
        "request": {
            "body": "{\"merchant_id\":\"merchant_retry_test_1783410139\",\"event_id\":\"evt_019f3b8ed70e78728d5d949a2cde663c\",\"event_type\":\"payment_failed\",\"content\":{\"type\":\"payment_details\",\"object\":{\"payment_id\":\"pay_Q2abGEL4M66zZB92PHpx\",\"merchant_id\":\"merchant_retry_test_1783410139\",\"status\":\"failed\",\"amount\":6540,\"net_amount\":6540,\"shipping_cost\":null,\"amount_capturable\":0,\"amount_received\":null,\"processor_merchant_id\":\"merchant_retry_test_1783410139\",\"initiator\":null,\"sdk_authorization\":\"cHJvZmlsZV9pZD1wcm9femRncWI0Z2Z1U2ZaSjQ0eXRUUTcscHVibGlzaGFibGVfa2V5PXBrX2Rldl81YWYwZTMxMzZlZGE0ZTNmODc5NjViZTJhY2U4ODU0YyxjbGllbnRfc2VjcmV0PXBheV9RMmFiR0VMNE02NnpaQjkyUEhweF9zZWNyZXRfcjFtakJFTkZwQmxxcG5wVGhMTzQsY3VzdG9tZXJfaWQ9Y3VzX3JldHJ5X3Rlc3RfMTc4MzQxMDY0MyxjbGllbnRfc2Vzc2lvbl9pZD1jbGllbnRfc2Vzc19GR3NNV3dtVnBYM3JZZ1lvY0N2USxwYXltZW50X2lkPXBheV9RMmFiR0VMNE02NnpaQjkyUEhweA==\",\"connector\":\"adyen\",\"state_metadata\":null,\"client_secret\":\"pay_Q2abGEL4M66zZB92PHpx_secret_r1mjBENFpBlqpnpThLO4\",\"created\":\"2026-07-07T07:50:43.498Z\",\"modified_at\":\"2026-07-07T07:50:44.743Z\",\"connector_customer_id\":null,\"currency\":\"USD\",\"customer_id\":\"cus_retry_test_1783410643\",\"customer\":{\"id\":\"cus_retry_test_1783410643\",\"name\":\"John Doe\",\"email\":\"test@example.com\",\"phone\":\"9999999999\",\"phone_country_code\":\"+1\",\"customer_document_details\":null},\"description\":\"Test payment for manual webhook retry flow\",\"refunds\":null,\"disputes\":null,\"mandate_id\":null,\"mandate_data\":null,\"setup_future_usage\":null,\"off_session\":null,\"capture_on\":null,\"capture_method\":\"automatic\",\"payment_method\":\"card\",\"payment_method_data\":{\"card\":{\"last4\":\"1111\",\"card_type\":null,\"card_network\":null,\"card_issuer\":null,\"card_issuing_country\":null,\"card_isin\":\"411111\",\"card_extended_bin\":null,\"card_exp_month\":\"10\",\"card_exp_year\":\"30\",\"card_holder_name\":\"John Doe\",\"payment_checks\":null,\"authentication_data\":null,\"auth_code\":null},\"billing\":null},\"payment_token\":null,\"shipping\":null,\"billing\":{\"address\":{\"city\":\"San Fransico\",\"country\":\"US\",\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":null,\"zip\":\"94122\",\"state\":\"California\",\"first_name\":\"John\",\"last_name\":\"Doe\",\"origin_zip\":null},\"phone\":null,\"email\":null},\"order_details\":null,\"email\":\"test@example.com\",\"name\":\"John Doe\",\"phone\":\"9999999999\",\"return_url\":\"https://google.com/success\",\"authentication_type\":\"no_three_ds\",\"statement_descriptor_name\":null,\"statement_descriptor_suffix\":null,\"next_action\":null,\"cancellation_reason\":null,\"error_code\":\"24\",\"error_message\":\"CVC Declined\",\"unified_code\":\"UE_9000\",\"unified_message\":\"Something went wrong\",\"error_details\":{\"unified_details\":{\"category\":\"UE_9000\",\"message\":\"Something went wrong\",\"standardised_code\":null,\"description\":null,\"user_guidance_message\":null,\"recommended_action\":null},\"issuer_details\":{\"code\":null,\"message\":\"DECLINED CVC Incorrect Expiry Incorrect\",\"network_details\":{\"name\":null,\"advice_code\":\"24\",\"advice_message\":null}},\"connector_details\":{\"code\":\"24\",\"message\":\"CVC Declined\",\"reason\":\"CVC Declined\"}},\"payment_experience\":null,\"payment_method_type\":null,\"connector_label\":null,\"business_country\":null,\"business_label\":\"default\",\"business_sub_label\":null,\"allowed_payment_method_types\":null,\"manual_retry_allowed\":null,\"connector_transaction_id\":\"MRQ29BQ69CWD2HV5\",\"frm_message\":null,\"metadata\":null,\"connector_metadata\":null,\"connector_response_metadata\":null,\"feature_metadata\":{\"redirect_response\":null,\"search_tags\":null,\"apple_pay_recurring_details\":null,\"pix_additional_details\":null,\"boleto_additional_details\":null,\"pix_automatico_additional_details\":null,\"finix_additional_details\":null},\"reference_id\":null,\"payment_link\":null,\"profile_id\":\"pro_zdgqb4gfuSfZJ44ytTQ7\",\"surcharge_details\":null,\"attempt_count\":1,\"merchant_decision\":null,\"merchant_connector_id\":\"mca_md53uaUcI6wMyIus6tWg\",\"incremental_authorization_allowed\":false,\"authorization_count\":null,\"incremental_authorizations\":null,\"external_authentication_details\":null,\"external_3ds_authentication_attempted\":false,\"expires_on\":\"2026-07-07T08:05:43.498Z\",\"fingerprint\":null,\"browser_info\":{\"language\":\"en-US\",\"time_zone\":0,\"ip_address\":\"127.0.0.1\",\"user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36\",\"color_depth\":24,\"java_enabled\":true,\"screen_width\":1920,\"accept_header\":\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\",\"screen_height\":1080,\"java_script_enabled\":true},\"payment_channel\":null,\"payment_method_id\":null,\"network_transaction_id\":null,\"network_transaction_link_id\":null,\"payment_method_status\":null,\"updated\":\"2026-07-07T07:50:44.743Z\",\"split_payments\":null,\"frm_metadata\":null,\"extended_authorization_applied\":null,\"extended_authorization_last_applied_at\":null,\"request_extended_authorization\":null,\"capture_before\":null,\"merchant_order_reference_id\":null,\"order_tax_amount\":null,\"connector_mandate_id\":null,\"card_discovery\":\"manual\",\"force_3ds_challenge\":false,\"force_3ds_challenge_trigger\":false,\"issuer_error_code\":null,\"issuer_error_message\":\"DECLINED CVC Incorrect Expiry Incorrect\",\"is_iframe_redirection_enabled\":null,\"whole_connector_response\":null,\"enable_partial_authorization\":null,\"enable_overcapture\":null,\"is_overcapture_enabled\":null,\"network_details\":{\"network_advice_code\":\"24\"},\"is_stored_credential\":null,\"mit_category\":null,\"billing_descriptor\":null,\"tokenization\":null,\"partner_merchant_identifier_details\":null,\"payment_method_tokenization_details\":null,\"installment_options\":null,\"installment_data\":null,\"sender_payment_instrument_id\":null}},\"timestamp\":\"2026-07-07T07:50:44.749Z\",\"processor_merchant_id\":\"merchant_retry_test_1783410139\"}",
            "headers": [
                [
                    "content-type",
                    "application/json"
                ],
                [
                    "user-agent",
                    "Hyperswitch-Backend-Server"
                ],
                [
                    "X-Hyperswitch-Webhook-Key",
                    "test_unmasked_webhook_key_value_1234567890"
                ],
                [
                    "X-Webhook-Signature-512",
                    "78381985cc1bcb2142dab6e751cbb2cf6f0228199490779c20bf32f55d39176a1161ea5a6b6f797f87c0cc1745a0153cdad57fb8a39c704256343579c4b46414"
                ]
            ]
        },
        "response": {
            "body": "{\"received\":true,\"requestNumber\":4,\"forcedFailure\":false}",
            "headers": [
                [
                    "content-type",
                    "application/json"
                ],
                [
                    "date",
                    "Tue, 07 Jul 2026 10:43:50 GMT"
                ],
                [
                    "ngrok-agent-ips",
                    "219.65.110.2"
                ],
                [
                    "transfer-encoding",
                    "chunked"
                ]
            ],
            "status_code": 200,
            "error_message": null
        },
        "delivery_attempt": "manual_retry"
    },
    {
        "event_id": "evt_019f3b8ed70e78728d5d949a2cde663c",
        "merchant_id": "merchant_retry_test_1783410139",
        "profile_id": "pro_zdgqb4gfuSfZJ44ytTQ7",
        "object_id": "pay_Q2abGEL4M66zZB92PHpx",
        "event_type": "payment_failed",
        "event_class": "payments",
        "is_delivery_successful": false,
        "initial_attempt_id": "evt_019f3b8ed70e78728d5d949a2cde663c",
        "processor_merchant_id": "merchant_retry_test_1783410139",
        "created": "2026-07-07T07:50:44.749Z",
        "request": {
            "body": "{\"merchant_id\":\"merchant_retry_test_1783410139\",\"event_id\":\"evt_019f3b8ed70e78728d5d949a2cde663c\",\"event_type\":\"payment_failed\",\"content\":{\"type\":\"payment_details\",\"object\":{\"payment_id\":\"pay_Q2abGEL4M66zZB92PHpx\",\"merchant_id\":\"merchant_retry_test_1783410139\",\"status\":\"failed\",\"amount\":6540,\"net_amount\":6540,\"shipping_cost\":null,\"amount_capturable\":0,\"amount_received\":null,\"processor_merchant_id\":\"merchant_retry_test_1783410139\",\"initiator\":null,\"sdk_authorization\":\"cHJvZmlsZV9pZD1wcm9femRncWI0Z2Z1U2ZaSjQ0eXRUUTcscHVibGlzaGFibGVfa2V5PXBrX2Rldl81YWYwZTMxMzZlZGE0ZTNmODc5NjViZTJhY2U4ODU0YyxjbGllbnRfc2VjcmV0PXBheV9RMmFiR0VMNE02NnpaQjkyUEhweF9zZWNyZXRfcjFtakJFTkZwQmxxcG5wVGhMTzQsY3VzdG9tZXJfaWQ9Y3VzX3JldHJ5X3Rlc3RfMTc4MzQxMDY0MyxjbGllbnRfc2Vzc2lvbl9pZD1jbGllbnRfc2Vzc19GR3NNV3dtVnBYM3JZZ1lvY0N2USxwYXltZW50X2lkPXBheV9RMmFiR0VMNE02NnpaQjkyUEhweA==\",\"connector\":\"adyen\",\"state_metadata\":null,\"client_secret\":\"pay_Q2abGEL4M66zZB92PHpx_secret_r1mjBENFpBlqpnpThLO4\",\"created\":\"2026-07-07T07:50:43.498Z\",\"modified_at\":\"2026-07-07T07:50:44.743Z\",\"connector_customer_id\":null,\"currency\":\"USD\",\"customer_id\":\"cus_retry_test_1783410643\",\"customer\":{\"id\":\"cus_retry_test_1783410643\",\"name\":\"John Doe\",\"email\":\"test@example.com\",\"phone\":\"9999999999\",\"phone_country_code\":\"+1\",\"customer_document_details\":null},\"description\":\"Test payment for manual webhook retry flow\",\"refunds\":null,\"disputes\":null,\"mandate_id\":null,\"mandate_data\":null,\"setup_future_usage\":null,\"off_session\":null,\"capture_on\":null,\"capture_method\":\"automatic\",\"payment_method\":\"card\",\"payment_method_data\":{\"card\":{\"last4\":\"1111\",\"card_type\":null,\"card_network\":null,\"card_issuer\":null,\"card_issuing_country\":null,\"card_isin\":\"411111\",\"card_extended_bin\":null,\"card_exp_month\":\"10\",\"card_exp_year\":\"30\",\"card_holder_name\":\"John Doe\",\"payment_checks\":null,\"authentication_data\":null,\"auth_code\":null},\"billing\":null},\"payment_token\":null,\"shipping\":null,\"billing\":{\"address\":{\"city\":\"San Fransico\",\"country\":\"US\",\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":null,\"zip\":\"94122\",\"state\":\"California\",\"first_name\":\"John\",\"last_name\":\"Doe\",\"origin_zip\":null},\"phone\":null,\"email\":null},\"order_details\":null,\"email\":\"test@example.com\",\"name\":\"John Doe\",\"phone\":\"9999999999\",\"return_url\":\"https://google.com/success\",\"authentication_type\":\"no_three_ds\",\"statement_descriptor_name\":null,\"statement_descriptor_suffix\":null,\"next_action\":null,\"cancellation_reason\":null,\"error_code\":\"24\",\"error_message\":\"CVC Declined\",\"unified_code\":\"UE_9000\",\"unified_message\":\"Something went wrong\",\"error_details\":{\"unified_details\":{\"category\":\"UE_9000\",\"message\":\"Something went wrong\",\"standardised_code\":null,\"description\":null,\"user_guidance_message\":null,\"recommended_action\":null},\"issuer_details\":{\"code\":null,\"message\":\"DECLINED CVC Incorrect Expiry Incorrect\",\"network_details\":{\"name\":null,\"advice_code\":\"24\",\"advice_message\":null}},\"connector_details\":{\"code\":\"24\",\"message\":\"CVC Declined\",\"reason\":\"CVC Declined\"}},\"payment_experience\":null,\"payment_method_type\":null,\"connector_label\":null,\"business_country\":null,\"business_label\":\"default\",\"business_sub_label\":null,\"allowed_payment_method_types\":null,\"manual_retry_allowed\":null,\"connector_transaction_id\":\"MRQ29BQ69CWD2HV5\",\"frm_message\":null,\"metadata\":null,\"connector_metadata\":null,\"connector_response_metadata\":null,\"feature_metadata\":{\"redirect_response\":null,\"search_tags\":null,\"apple_pay_recurring_details\":null,\"pix_additional_details\":null,\"boleto_additional_details\":null,\"pix_automatico_additional_details\":null,\"finix_additional_details\":null},\"reference_id\":null,\"payment_link\":null,\"profile_id\":\"pro_zdgqb4gfuSfZJ44ytTQ7\",\"surcharge_details\":null,\"attempt_count\":1,\"merchant_decision\":null,\"merchant_connector_id\":\"mca_md53uaUcI6wMyIus6tWg\",\"incremental_authorization_allowed\":false,\"authorization_count\":null,\"incremental_authorizations\":null,\"external_authentication_details\":null,\"external_3ds_authentication_attempted\":false,\"expires_on\":\"2026-07-07T08:05:43.498Z\",\"fingerprint\":null,\"browser_info\":{\"language\":\"en-US\",\"time_zone\":0,\"ip_address\":\"127.0.0.1\",\"user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36\",\"color_depth\":24,\"java_enabled\":true,\"screen_width\":1920,\"accept_header\":\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\",\"screen_height\":1080,\"java_script_enabled\":true},\"payment_channel\":null,\"payment_method_id\":null,\"network_transaction_id\":null,\"network_transaction_link_id\":null,\"payment_method_status\":null,\"updated\":\"2026-07-07T07:50:44.743Z\",\"split_payments\":null,\"frm_metadata\":null,\"extended_authorization_applied\":null,\"extended_authorization_last_applied_at\":null,\"request_extended_authorization\":null,\"capture_before\":null,\"merchant_order_reference_id\":null,\"order_tax_amount\":null,\"connector_mandate_id\":null,\"card_discovery\":\"manual\",\"force_3ds_challenge\":false,\"force_3ds_challenge_trigger\":false,\"issuer_error_code\":null,\"issuer_error_message\":\"DECLINED CVC Incorrect Expiry Incorrect\",\"is_iframe_redirection_enabled\":null,\"whole_connector_response\":null,\"enable_partial_authorization\":null,\"enable_overcapture\":null,\"is_overcapture_enabled\":null,\"network_details\":{\"network_advice_code\":\"24\"},\"is_stored_credential\":null,\"mit_category\":null,\"billing_descriptor\":null,\"tokenization\":null,\"partner_merchant_identifier_details\":null,\"payment_method_tokenization_details\":null,\"installment_options\":null,\"installment_data\":null,\"sender_payment_instrument_id\":null}},\"timestamp\":\"2026-07-07T07:50:44.749Z\",\"processor_merchant_id\":\"merchant_retry_test_1783410139\"}",
            "headers": [
                [
                    "content-type",
                    "application/json"
                ],
                [
                    "user-agent",
                    "Hyperswitch-Backend-Server"
                ],
                [
                    "X-Hyperswitch-Webhook-Key",
                    "test_unmasked_webhook_key_value_1234567890"
                ],
                [
                    "X-Webhook-Signature-512",
                    "78381985cc1bcb2142dab6e751cbb2cf6f0228199490779c20bf32f55d39176a1161ea5a6b6f797f87c0cc1745a0153cdad57fb8a39c704256343579c4b46414"
                ]
            ]
        },
        "response": {
            "body": "{\"received\":true,\"requestNumber\":1,\"forcedFailure\":true}",
            "headers": [
                [
                    "content-type",
                    "application/json"
                ],
                [
                    "date",
                    "Tue, 07 Jul 2026 07:50:45 GMT"
                ],
                [
                    "ngrok-agent-ips",
                    "219.65.110.2"
                ],
                [
                    "transfer-encoding",
                    "chunked"
                ]
            ],
            "status_code": 500,
            "error_message": null
        },
        "delivery_attempt": "initial_attempt"
    }
]
```
</details>



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

