### PR TITLE
fix(trustpay): map CreateOrder shadow response to PreProcessingResponse

### DIFF
--- a/crates/router/src/core/payments/gateway/create_order_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_order_gateway.rs
@@ -29,6 +29,32 @@ use crate::{
 // PaymentGateway Implementation for domain::CreateOrder
 // =============================================================================
 
+/// TrustPay's HS-native connector transformer builds wallet (Apple/Google Pay) CreateOrder
+/// responses via the same helper it uses for the PreProcessing flow, so it always returns
+/// `PreProcessingResponse`, never `PaymentsCreateOrderResponse`. Mirror that here so the UCS
+/// shadow response matches HS's real response shape for trustpay specifically; every other
+/// connector keeps the generic `PaymentsCreateOrderResponse` mapping.
+fn apply_connector_native_response_shape(
+    connector: &str,
+    response: types::PaymentsResponseData,
+) -> types::PaymentsResponseData {
+    match (connector, response) {
+        (
+            "trustpay",
+            types::PaymentsResponseData::PaymentsCreateOrderResponse {
+                order_id,
+                session_token,
+            },
+        ) => types::PaymentsResponseData::PreProcessingResponse {
+            pre_processing_id: types::PreprocessingResponseId::ConnectorTransactionId(order_id),
+            connector_metadata: None,
+            session_token,
+            connector_response_reference_id: None,
+        },
+        (_, response) => response,
+    }
+}
+
 /// Implementation of PaymentGateway for api::CreateOrder flow
 #[async_trait]
 impl<RCD>
@@ -161,6 +187,10 @@ where
                 let router_data_response = match router_data_response {
                     Ok((response, status)) => {
                         router_data.status = status;
+                        let response = apply_connector_native_response_shape(
+                            router_data.connector.as_str(),
+                            response,
+                        );
                         Ok(response)
                     }
                     Err(err) => {
@@ -217,6 +247,59 @@ where
             ExecutionPath::Direct => Box::new(payment_gateway::DirectGateway),
             ExecutionPath::UnifiedConnectorService
             | ExecutionPath::ShadowUnifiedConnectorService => Box::new(Self),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trustpay_create_order_response_is_remapped_to_preprocessing_response() {
+        let response = types::PaymentsResponseData::PaymentsCreateOrderResponse {
+            order_id: "instance-123".to_string(),
+            session_token: None,
+        };
+
+        let remapped = apply_connector_native_response_shape("trustpay", response);
+
+        match remapped {
+            types::PaymentsResponseData::PreProcessingResponse {
+                pre_processing_id,
+                session_token,
+                connector_metadata,
+                connector_response_reference_id,
+            } => {
+                assert_eq!(
+                    pre_processing_id.get_string_repr().as_str(),
+                    "instance-123",
+                    "order_id must be preserved as the pre_processing_id"
+                );
+                assert!(session_token.is_none());
+                assert!(connector_metadata.is_none());
+                assert!(connector_response_reference_id.is_none());
+            }
+            other => panic!("expected PreProcessingResponse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn other_connectors_keep_the_generic_create_order_response() {
+        let response = types::PaymentsResponseData::PaymentsCreateOrderResponse {
+            order_id: "order-456".to_string(),
+            session_token: None,
+        };
+
+        let remapped = apply_connector_native_response_shape("razorpay", response.clone());
+
+        match remapped {
+            types::PaymentsResponseData::PaymentsCreateOrderResponse { order_id, .. } => {
+                assert_eq!(order_id, "order-456");
+            }
+            other => panic!(
+                "expected PaymentsCreateOrderResponse to pass through unchanged, got {other:?}"
+            ),
         }
     }
 }


### PR DESCRIPTION
## What

Shadow-validation diff on **trustpay / create_order** (wallet Apple Pay / Google Pay session
init): the UCS shadow leg's mapped `PaymentsResponseData` used a different enum variant than
HS's real response, producing `router.keyDiff:response.Ok.PaymentsCreateOrderResponse` (and the
mirror-image `router.keyDiff:response.Ok.PreProcessingResponse`) on every wallet-based trustpay
`CreateOrder` call.

## Root cause

- HS's **real** trustpay connector transformer
  (`crates/hyperswitch_connectors/src/connectors/trustpay/transformers.rs`,
  `get_apple_pay_session` / `get_google_pay_session`) builds the `CreateOrder` response through
  the *same* helper functions used for the `PreProcessing` flow, so it always returns
  `PaymentsResponseData::PreProcessingResponse { pre_processing_id, session_token, .. }` —
  **never** `PaymentsResponseData::PaymentsCreateOrderResponse`. This is a known, pre-existing
  quirk: `crates/router/src/core/payments/flows/authorize_flow.rs` already special-cases and
  accepts `PreProcessingResponse` from the `CreateOrder` flow with the comment *"Create Order
  response must always be PaymentsResponseData::PaymentsCreateOrderResponse only ... Some
  connector return PreProcessingResponse ... temporary fix for satisfying current connector side
  response handling"*.
- The UCS shadow leg's generic mapping
  (`crates/router/src/core/unified_connector_service/transformers.rs`,
  `ForeignTryFrom<(PaymentServiceCreateOrderResponse, AttemptStatus)>`) unconditionally builds
  `PaymentsResponseData::PaymentsCreateOrderResponse` for **every** connector's `CreateOrder`
  response — correct for connectors like Razorpay/Airwallex, but a structural mismatch for
  trustpay specifically, since HS's real trustpay path never returns that variant.

Confirmed by reading both sides of the transform directly (no field is missing from the gRPC
contract, no data is lost — the connector_order_id / session_token payload is identical on both
sides, only the outer enum variant tag differs). Not a proto or domain-layer gap.

## Fix

`crates/router/src/core/payments/gateway/create_order_gateway.rs`: after mapping the UCS
`CreateOrder` gRPC response into a `PaymentsResponseData`, add a connector-specific
post-processing step (`apply_connector_native_response_shape`) that re-shapes trustpay's
`PaymentsCreateOrderResponse` into `PreProcessingResponse` (preserving `order_id` as the
`ConnectorTransactionId` and passing `session_token` through unchanged), matching what HS's own
trustpay transformer actually returns. Every other connector's mapping is untouched.

## Verification

TrustPay sandbox credentials are not available in this environment (checked the shared creds
file and the repo's sample auth config — neither has a trustpay entry), and this diff only
manifests on a genuine wallet-init response from trustpay's sandbox, so a live shadow-call
repro wasn't possible here. Verified instead by:
- Reading the exact HS-native and UCS-shadow code paths that produce each side of the diff
  (cited above) to confirm the root cause precisely.
- Added targeted unit tests
  (`crates/router/src/core/payments/gateway/create_order_gateway.rs::tests`) exercising the new
  `apply_connector_native_response_shape` function directly: confirms trustpay's
  `PaymentsCreateOrderResponse` is remapped to `PreProcessingResponse` with the `order_id`
  preserved, and confirms all other connectors' responses pass through unchanged.
- `cargo build --bin router` succeeds; `cargo test -p router --lib create_order_gateway` passes.

## Category

HS→UCS response-mapping layer (`crates/router/src/core/unified_connector_service/*` /
`crates/router/src/core/payments/gateway/*`) — no proto or domain-model change needed.

Closes #13204
