### PR TITLE
fix(currency_conversion): return same-currency amounts unchanged

### DIFF
--- a/crates/currency_conversion/src/conversion.rs
+++ b/crates/currency_conversion/src/conversion.rs
@@ -14,6 +14,10 @@ pub fn convert(
     amount: i64,
 ) -> Result<Decimal, CurrencyConversionError> {
     let money_minor = Money::from_minor(amount, currency_match(from_currency));
+    if from_currency == to_currency {
+        return Ok(*money_minor.amount());
+    }
+
     let base_currency = ex_rates.base_currency;
     if to_currency == base_currency {
         ex_rates.forward_conversion(*money_minor.amount(), from_currency)
@@ -87,5 +91,29 @@ mod tests {
         let res =
             convert(&sample_rate, convert_from, convert_to, amount).expect("converted_currency");
         println!("The conversion from {amount} {convert_from} to {convert_to} is {res:?}");
+    }
+
+    #[test]
+    fn same_currency_conversion_returns_original_amount() {
+        use super::*;
+        let conversion: HashMap<Currency, CurrencyFactors> = HashMap::new();
+        let sample_rate = ExchangeRates::new(Currency::USD, conversion);
+
+        let res = convert(&sample_rate, Currency::INR, Currency::INR, 2000)
+            .expect("same_currency_conversion");
+
+        assert_eq!(res, Decimal::new(2000, 2));
+    }
+
+    #[test]
+    fn same_base_currency_conversion_returns_original_amount() {
+        use super::*;
+        let conversion: HashMap<Currency, CurrencyFactors> = HashMap::new();
+        let sample_rate = ExchangeRates::new(Currency::USD, conversion);
+
+        let res = convert(&sample_rate, Currency::USD, Currency::USD, 2000)
+            .expect("same_base_currency_conversion");
+
+        assert_eq!(res, Decimal::new(2000, 2));
     }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Return the original amount from `currency_conversion::convert` when the source and target currencies are the same. This avoids unnecessarily routing an identity conversion through the base currency and requiring exchange-rate entries for a no-op conversion.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Fixes #9280.

Before this change, `convert` attempted forward/backward conversion even when `from_currency == to_currency` and the currency differed from the exchange-rate base currency. Same-currency conversion should preserve the input amount after the existing minor-unit normalization.

## How did you test it?

- `git diff --check origin/main...HEAD`
- `cargo +nightly fmt --all --check`
- `cargo check -p currency_conversion --lib`
- `LDFLAGS="-L/opt/homebrew/opt/libpq/lib" CPPFLAGS="-I/opt/homebrew/opt/libpq/include" LIBRARY_PATH="/opt/homebrew/opt/libpq/lib" cargo test -p currency_conversion --lib`
- `LDFLAGS="-L/opt/homebrew/opt/libpq/lib" CPPFLAGS="-I/opt/homebrew/opt/libpq/include" LIBRARY_PATH="/opt/homebrew/opt/libpq/lib" cargo clippy -p currency_conversion --lib -- -D warnings`

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible