### PR TITLE
fix(stripe): require amount for single-use mandates

### DIFF
--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -884,3 +884,29 @@ impl ErrorSwitch<StripeErrorCode> for CustomersErrorResponse {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_mandate_amount_serializes_as_stripe_parameter_error() {
+        let stripe_error = StripeErrorCode::from(errors::ApiErrorResponse::MissingRequiredField {
+            field_name: "mandate_data.amount",
+        });
+
+        let serialized = stripe_error.to_string();
+        let body: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Stripe error response should be valid JSON");
+
+        assert_eq!(body["error"]["code"], "parameter_missing", "{serialized}");
+        assert_eq!(
+            body["error"]["message"], "Missing required param: mandate_data.amount.",
+            "{serialized}"
+        );
+        assert_eq!(
+            body["error"]["type"], "invalid_request_error",
+            "{serialized}"
+        );
+    }
+}

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -744,19 +744,34 @@ impl ForeignTryFrom<(Option<MandateData>, Option<String>)> for Option<payments::
                     },
                 )
             })?;
-        let mandate_data = mandate_data.map(|mandate| payments::MandateData {
-            mandate_type: match mandate.mandate_type {
-                Some(item) => match item {
-                    StripeMandateType::SingleUse => Some(payments::MandateType::SingleUse(
-                        payments::MandateAmountData {
-                            amount: MinorUnit::new(mandate.amount.unwrap_or_default()),
-                            currency,
-                            start_date: mandate.start_date,
-                            end_date: mandate.end_date,
-                            metadata: None,
-                        },
-                    )),
-                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(Some(
+        let mandate_data = match mandate_data {
+            Some(mandate) => Some(payments::MandateData {
+                mandate_type: match mandate.mandate_type {
+                    Some(item) => match item {
+                        StripeMandateType::SingleUse => Some(payments::MandateType::SingleUse(
+                            payments::MandateAmountData {
+                                amount: MinorUnit::new(mandate.amount.ok_or(
+                                    errors::ApiErrorResponse::MissingRequiredField {
+                                        field_name: "mandate_data.amount",
+                                    },
+                                )?),
+                                currency,
+                                start_date: mandate.start_date,
+                                end_date: mandate.end_date,
+                                metadata: None,
+                            },
+                        )),
+                        StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(Some(
+                            payments::MandateAmountData {
+                                amount: MinorUnit::new(mandate.amount.unwrap_or_default()),
+                                currency,
+                                start_date: mandate.start_date,
+                                end_date: mandate.end_date,
+                                metadata: None,
+                            },
+                        ))),
+                    },
+                    None => Some(payments::MandateType::MultiUse(Some(
                         payments::MandateAmountData {
                             amount: MinorUnit::new(mandate.amount.unwrap_or_default()),
                             currency,
@@ -766,28 +781,20 @@ impl ForeignTryFrom<(Option<MandateData>, Option<String>)> for Option<payments::
                         },
                     ))),
                 },
-                None => Some(payments::MandateType::MultiUse(Some(
-                    payments::MandateAmountData {
-                        amount: MinorUnit::new(mandate.amount.unwrap_or_default()),
-                        currency,
-                        start_date: mandate.start_date,
-                        end_date: mandate.end_date,
-                        metadata: None,
-                    },
-                ))),
-            },
-            customer_acceptance: Some(common_payments_types::CustomerAcceptance {
-                acceptance_type: common_payments_types::AcceptanceType::Online,
-                accepted_at: mandate.customer_acceptance.accepted_at,
-                online: mandate.customer_acceptance.online.map(|online| {
-                    common_payments_types::OnlineMandate {
-                        ip_address: Some(online.ip_address),
-                        user_agent: online.user_agent,
-                    }
+                customer_acceptance: Some(common_payments_types::CustomerAcceptance {
+                    acceptance_type: common_payments_types::AcceptanceType::Online,
+                    accepted_at: mandate.customer_acceptance.accepted_at,
+                    online: mandate.customer_acceptance.online.map(|online| {
+                        common_payments_types::OnlineMandate {
+                            ip_address: Some(online.ip_address),
+                            user_agent: online.user_agent,
+                        }
+                    }),
                 }),
+                update_mandate_id: None,
             }),
-            update_mandate_id: None,
-        });
+            None => None,
+        };
         Ok(mandate_data)
     }
 }
@@ -1012,5 +1019,64 @@ fn get_pmd_based_on_payment_method_type(
             ))
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stripe_mandate_data(mandate_type: StripeMandateType, amount: Option<i64>) -> MandateData {
+        MandateData {
+            customer_acceptance: CustomerAcceptance::default(),
+            mandate_type: Some(mandate_type),
+            amount,
+            start_date: None,
+            end_date: None,
+        }
+    }
+
+    #[test]
+    fn rejects_single_use_mandate_without_amount() {
+        let error = <Option<payments::MandateData> as ForeignTryFrom<(
+            Option<MandateData>,
+            Option<String>,
+        )>>::foreign_try_from((
+            Some(stripe_mandate_data(StripeMandateType::SingleUse, None)),
+            Some("usd".to_string()),
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            error.current_context(),
+            errors::ApiErrorResponse::MissingRequiredField { field_name }
+                if *field_name == "mandate_data.amount"
+        ));
+    }
+
+    #[test]
+    fn preserves_single_use_mandate_amount_when_present() {
+        let mandate_data = <Option<payments::MandateData> as ForeignTryFrom<(
+            Option<MandateData>,
+            Option<String>,
+        )>>::foreign_try_from((
+            Some(stripe_mandate_data(
+                StripeMandateType::SingleUse,
+                Some(6540),
+            )),
+            Some("usd".to_string()),
+        ))
+        .unwrap()
+        .unwrap();
+
+        let payments::MandateType::SingleUse(amount_data) = mandate_data
+            .mandate_type
+            .expect("mandate type should be set")
+        else {
+            panic!("expected single use mandate data");
+        };
+
+        assert_eq!(amount_data.amount, MinorUnit::new(6540));
+        assert_eq!(amount_data.currency, api_enums::Currency::USD);
     }
 }


### PR DESCRIPTION
## Summary
- Require `mandate_data.amount` for Stripe-compatible `single_use` mandates instead of silently defaulting to zero
- Preserve existing default behavior for `multi_use` and omitted mandate type paths
- Add focused unit coverage for missing amount rejection and amount preservation

Closes #13181

## Testing
- `git diff --check`
- `cargo +nightly fmt --all -- --check`
- `LIBRARY_PATH=/opt/homebrew/opt/libpq/lib PKG_CONFIG_PATH=/opt/homebrew/opt/libpq/lib/pkgconfig PATH=/opt/homebrew/opt/libpq/bin:$PATH cargo test -p router --lib single_use_mandate -- --nocapture`

## Notes
- Focused conversion coverage was run locally; no full router suite or end-to-end HTTP error serialization check was run locally.