### PR TITLE
refactor(connector): [Authorizedotnet] gracefully handle unknown response enum variants and missing optional fields

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet.rs
@@ -223,40 +223,71 @@ impl ConnectorIntegration<CreateConnectorCustomer, ConnectorCustomerData, Paymen
         res: Response,
         event_builder: Option<&mut ConnectorEvent>,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        if res.response.is_empty() {
+            return Ok(ErrorResponse {
+                status_code: res.status_code,
+                code: consts::NO_ERROR_CODE.to_string(),
+                message: consts::NO_ERROR_MESSAGE.to_string(),
+                reason: None,
+                attempt_status: None,
+                connector_transaction_id: None,
+                connector_response_reference_id: None,
+                network_advice_code: None,
+                network_decline_code: None,
+                network_error_message: None,
+                connector_metadata: None,
+            });
+        }
+
         use bytes::Buf;
         // Handle the case where response bytes contains U+FEFF (BOM) character sent by connector
         let encoding = encoding_rs::UTF_8;
         let intermediate_response = encoding.decode_with_bom_removal(res.response.chunk());
         let intermediate_response =
             bytes::Bytes::copy_from_slice(intermediate_response.0.as_bytes());
-        let response: authorizedotnet::AuthorizedotnetErrorResponse = intermediate_response
-            .parse_struct("AuthorizedotnetErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        let response: Result<
+            authorizedotnet::AuthorizedotnetErrorResponse,
+            error_stack::Report<common_utils::errors::ParsingError>,
+        > = intermediate_response.parse_struct("AuthorizedotnetErrorResponse");
 
-        event_builder.map(|i| i.set_error_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
+        match response {
+            Ok(response) => {
+                event_builder.map(|i| i.set_error_response_body(&response));
+                router_env::logger::info!(connector_response=?response);
 
-        Ok(ErrorResponse {
-            status_code: res.status_code,
-            code: response
-                .error
-                .code
-                .clone()
-                .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
-            message: response
-                .error
-                .message
-                .clone()
-                .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-            reason: response.error.message,
-            attempt_status: None,
-            connector_transaction_id: None,
-            connector_response_reference_id: None,
-            network_advice_code: None,
-            network_decline_code: None,
-            network_error_message: None,
-            connector_metadata: None,
-        })
+                Ok(ErrorResponse {
+                    status_code: res.status_code,
+                    code: response
+                        .error
+                        .code
+                        .clone()
+                        .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
+                    message: response
+                        .error
+                        .message
+                        .clone()
+                        .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
+                    reason: response.error.message,
+                    attempt_status: None,
+                    connector_transaction_id: None,
+                    connector_response_reference_id: None,
+                    network_advice_code: None,
+                    network_decline_code: None,
+                    network_error_message: None,
+                    connector_metadata: None,
+                })
+            }
+            Err(error_msg) => {
+                event_builder.map(|event| {
+                    event.set_error(serde_json::json!({
+                        "error": res.response.escape_ascii().to_string(),
+                        "status_code": res.status_code,
+                    }))
+                });
+                router_env::logger::error!(deserialization_error =? error_msg);
+                crate::utils::handle_json_response_deserialization_failure(res, "authorizedotnet")
+            }
+        }
     }
 }
 
@@ -1055,6 +1086,9 @@ impl webhooks::IncomingWebhook for Authorizedotnet {
                     ),
                 ))
             }
+            authorizedotnet::AuthorizedotnetWebhookEvent::Unknown => {
+                Err(errors::ConnectorError::WebhookBodyDecodingFailed.into())
+            }
         }
     }
 
@@ -1063,6 +1097,10 @@ impl webhooks::IncomingWebhook for Authorizedotnet {
         request: &webhooks::IncomingWebhookRequestDetails<'_>,
         _context: Option<&webhooks::WebhookContext>,
     ) -> CustomResult<api_models::webhooks::IncomingWebhookEvent, errors::ConnectorError> {
+        if request.body.is_empty() {
+            return Ok(api_models::webhooks::IncomingWebhookEvent::EndpointVerification);
+        }
+
         let details: authorizedotnet::AuthorizedotnetWebhookEventType = request
             .body
             .parse_struct("AuthorizedotnetWebhookEventType")
@@ -1090,74 +1128,106 @@ impl webhooks::IncomingWebhook for Authorizedotnet {
 
 #[inline]
 fn get_error_response(
-    Response {
-        response,
-        status_code,
-        ..
-    }: Response,
+    res: Response,
     event_builder: Option<&mut ConnectorEvent>,
 ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-    let response: authorizedotnet::AuthorizedotnetPaymentsResponse = response
-        .parse_struct("AuthorizedotnetPaymentsResponse")
-        .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+    if res.response.is_empty() {
+        return Ok(ErrorResponse {
+            status_code: res.status_code,
+            code: consts::NO_ERROR_CODE.to_string(),
+            message: consts::NO_ERROR_MESSAGE.to_string(),
+            reason: None,
+            attempt_status: None,
+            connector_transaction_id: None,
+            connector_response_reference_id: None,
+            network_advice_code: None,
+            network_decline_code: None,
+            network_error_message: None,
+            connector_metadata: None,
+        });
+    }
 
-    event_builder.map(|i| i.set_error_response_body(&response));
-    router_env::logger::info!(connector_response=?response);
+    let response: Result<
+        authorizedotnet::AuthorizedotnetPaymentsResponse,
+        error_stack::Report<common_utils::errors::ParsingError>,
+    > = res.response.parse_struct("AuthorizedotnetPaymentsResponse");
 
-    match response.transaction_response {
-        Some(authorizedotnet::TransactionResponse::AuthorizedotnetTransactionResponse(
-            payment_response,
-        )) => Ok(payment_response
-            .errors
-            .and_then(|errors| {
-                errors.into_iter().next().map(|error| ErrorResponse {
-                    code: error.error_code,
-                    message: error.error_text.to_owned(),
-                    reason: Some(error.error_text),
-                    status_code,
-                    attempt_status: None,
-                    connector_transaction_id: None,
-                    connector_response_reference_id: None,
-                    network_advice_code: None,
-                    network_decline_code: None,
-                    network_error_message: None,
-                    connector_metadata: None,
-                })
-            })
-            .unwrap_or_else(|| ErrorResponse {
-                code: consts::NO_ERROR_CODE.to_string(), // authorizedotnet sends 200 in case of bad request so this are hard coded to NO_ERROR_CODE and NO_ERROR_MESSAGE
-                message: consts::NO_ERROR_MESSAGE.to_string(),
-                reason: None,
-                status_code,
-                attempt_status: None,
-                connector_transaction_id: None,
-                connector_response_reference_id: None,
-                network_advice_code: None,
-                network_decline_code: None,
-                network_error_message: None,
-                connector_metadata: None,
-            })),
-        Some(authorizedotnet::TransactionResponse::AuthorizedotnetTransactionResponseError(_))
-        | None => {
-            let message = &response
-                .messages
-                .message
-                .first()
-                .ok_or(errors::ConnectorError::ResponseDeserializationFailed)?
-                .text;
-            Ok(ErrorResponse {
-                code: consts::NO_ERROR_CODE.to_string(),
-                message: message.to_string(),
-                reason: Some(message.to_string()),
-                status_code,
-                attempt_status: None,
-                connector_transaction_id: None,
-                connector_response_reference_id: None,
-                network_advice_code: None,
-                network_decline_code: None,
-                network_error_message: None,
-                connector_metadata: None,
-            })
+    match response {
+        Ok(response) => {
+            event_builder.map(|i| i.set_error_response_body(&response));
+            router_env::logger::info!(connector_response=?response);
+
+            let status_code = res.status_code;
+            match response.transaction_response {
+                Some(authorizedotnet::TransactionResponse::AuthorizedotnetTransactionResponse(
+                    payment_response,
+                )) => Ok(payment_response
+                    .errors
+                    .and_then(|errors| {
+                        errors.into_iter().next().map(|error| ErrorResponse {
+                            code: error.error_code,
+                            message: error.error_text.to_owned(),
+                            reason: Some(error.error_text),
+                            status_code,
+                            attempt_status: None,
+                            connector_transaction_id: None,
+                            connector_response_reference_id: None,
+                            network_advice_code: None,
+                            network_decline_code: None,
+                            network_error_message: None,
+                            connector_metadata: None,
+                        })
+                    })
+                    .unwrap_or_else(|| ErrorResponse {
+                        code: consts::NO_ERROR_CODE.to_string(), // authorizedotnet sends 200 in case of bad request so this are hard coded to NO_ERROR_CODE and NO_ERROR_MESSAGE
+                        message: consts::NO_ERROR_MESSAGE.to_string(),
+                        reason: None,
+                        status_code,
+                        attempt_status: None,
+                        connector_transaction_id: None,
+                        connector_response_reference_id: None,
+                        network_advice_code: None,
+                        network_decline_code: None,
+                        network_error_message: None,
+                        connector_metadata: None,
+                    })),
+                Some(
+                    authorizedotnet::TransactionResponse::AuthorizedotnetTransactionResponseError(
+                        _,
+                    ),
+                )
+                | None => {
+                    let message = response
+                        .messages
+                        .message
+                        .first()
+                        .map(|msg| msg.text.clone())
+                        .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string());
+                    Ok(ErrorResponse {
+                        code: consts::NO_ERROR_CODE.to_string(),
+                        message: message.clone(),
+                        reason: Some(message),
+                        status_code,
+                        attempt_status: None,
+                        connector_transaction_id: None,
+                        connector_response_reference_id: None,
+                        network_advice_code: None,
+                        network_decline_code: None,
+                        network_error_message: None,
+                        connector_metadata: None,
+                    })
+                }
+            }
+        }
+        Err(error_msg) => {
+            event_builder.map(|event| {
+                event.set_error(serde_json::json!({
+                    "error": res.response.escape_ascii().to_string(),
+                    "status_code": res.status_code,
+                }))
+            });
+            router_env::logger::error!(deserialization_error =? error_msg);
+            crate::utils::handle_json_response_deserialization_failure(res, "authorizedotnet")
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -654,7 +654,8 @@ impl<F, T> TryFrom<ResponseRouterData<F, AuthorizedotnetCustomerResponse, T, Pay
                     .into(),
                 ),
             },
-            ResultCode::Error => {
+
+            ResultCode::Error | ResultCode::Unknown => {
                 let error_message = item.response.messages.message.first();
                 if let Some(connector_customer_id) =
                     error_message.and_then(|error| extract_customer_id(&error.text))
@@ -1391,6 +1392,8 @@ pub enum AuthorizedotnetPaymentStatus {
     HeldForReview,
     #[serde(rename = "5")]
     RequiresAction,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, Serialize)]
@@ -1403,10 +1406,12 @@ pub enum AuthorizedotnetRefundStatus {
     Error,
     #[serde(rename = "4")]
     HeldForReview,
+    #[serde(other)]
+    Unknown,
 }
 
 fn get_payment_status(
-    (item, auto_capture): (AuthorizedotnetPaymentStatus, bool),
+    (item, auto_capture, prev_status): (AuthorizedotnetPaymentStatus, bool, enums::AttemptStatus),
 ) -> enums::AttemptStatus {
     match item {
         AuthorizedotnetPaymentStatus::Approved => {
@@ -1421,6 +1426,13 @@ fn get_payment_status(
         }
         AuthorizedotnetPaymentStatus::RequiresAction => enums::AttemptStatus::AuthenticationPending,
         AuthorizedotnetPaymentStatus::HeldForReview => enums::AttemptStatus::Unresolved,
+        AuthorizedotnetPaymentStatus::Unknown => {
+            router_env::logger::warn!(
+                "Unknown authorizedotnet payment status received; retaining previous status {:?}",
+                prev_status
+            );
+            prev_status
+        }
     }
 }
 
@@ -1435,6 +1447,8 @@ enum ResultCode {
     #[default]
     Ok,
     Error,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, PartialEq, Serialize)]
@@ -1508,7 +1522,7 @@ pub struct AuthorizedotnetPaymentsResponse {
 pub struct AuthorizedotnetNonZeroMandateResponse {
     customer_profile_id: Option<String>,
     customer_payment_profile_id_list: Option<Vec<String>>,
-    pub messages: ResponseMessages,
+    pub messages: Option<ResponseMessages>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1539,16 +1553,26 @@ pub enum AuthorizedotnetVoidStatus {
     Error,
     #[serde(rename = "4")]
     HeldForReview,
+    #[serde(other)]
+    Unknown,
 }
 
-impl From<AuthorizedotnetVoidStatus> for enums::AttemptStatus {
-    fn from(item: AuthorizedotnetVoidStatus) -> Self {
-        match item {
-            AuthorizedotnetVoidStatus::Approved => Self::Voided,
-            AuthorizedotnetVoidStatus::Declined | AuthorizedotnetVoidStatus::Error => {
-                Self::VoidFailed
-            }
-            AuthorizedotnetVoidStatus::HeldForReview => Self::VoidInitiated,
+fn get_void_status(
+    item: AuthorizedotnetVoidStatus,
+    prev_status: enums::AttemptStatus,
+) -> enums::AttemptStatus {
+    match item {
+        AuthorizedotnetVoidStatus::Approved => enums::AttemptStatus::Voided,
+        AuthorizedotnetVoidStatus::Declined | AuthorizedotnetVoidStatus::Error => {
+            enums::AttemptStatus::VoidFailed
+        }
+        AuthorizedotnetVoidStatus::HeldForReview => enums::AttemptStatus::VoidInitiated,
+        AuthorizedotnetVoidStatus::Unknown => {
+            router_env::logger::warn!(
+                "Unknown authorizedotnet void status received; retaining previous status {:?}",
+                prev_status
+            );
+            prev_status
         }
     }
 }
@@ -1609,11 +1633,13 @@ impl<F, T>
             bool,
         ),
     ) -> Result<Self, Self::Error> {
+        let prev_status = item.data.status;
         match &item.response.transaction_response {
             Some(TransactionResponse::AuthorizedotnetTransactionResponse(transaction_response)) => {
                 let status = get_payment_status((
                     transaction_response.response_code.clone(),
                     is_auto_capture,
+                    prev_status,
                 ));
                 let error = transaction_response.errors.as_ref().and_then(|errors| {
                     errors.iter().next().map(|error| ErrorResponse {
@@ -1719,9 +1745,11 @@ impl<F, T> TryFrom<ResponseRouterData<F, AuthorizedotnetVoidResponse, T, Payment
     fn try_from(
         item: ResponseRouterData<F, AuthorizedotnetVoidResponse, T, PaymentsResponseData>,
     ) -> Result<Self, Self::Error> {
+        let prev_status = item.data.status;
         match &item.response.transaction_response {
             Some(transaction_response) => {
-                let status = enums::AttemptStatus::from(transaction_response.response_code.clone());
+                let status =
+                    get_void_status(transaction_response.response_code.clone(), prev_status);
                 let error = transaction_response.errors.as_ref().and_then(|errors| {
                     errors.iter().next().map(|error| ErrorResponse {
                         code: error.error_code.clone(),
@@ -1875,15 +1903,23 @@ fn get_refund_metadata(
         .into()),
     }
 }
-impl From<AuthorizedotnetRefundStatus> for enums::RefundStatus {
-    fn from(item: AuthorizedotnetRefundStatus) -> Self {
-        match item {
-            AuthorizedotnetRefundStatus::Declined | AuthorizedotnetRefundStatus::Error => {
-                Self::Failure
-            }
-            AuthorizedotnetRefundStatus::Approved | AuthorizedotnetRefundStatus::HeldForReview => {
-                Self::Pending
-            }
+fn get_refund_status(
+    item: AuthorizedotnetRefundStatus,
+    prev_status: enums::RefundStatus,
+) -> enums::RefundStatus {
+    match item {
+        AuthorizedotnetRefundStatus::Declined | AuthorizedotnetRefundStatus::Error => {
+            enums::RefundStatus::Failure
+        }
+        AuthorizedotnetRefundStatus::Approved | AuthorizedotnetRefundStatus::HeldForReview => {
+            enums::RefundStatus::Pending
+        }
+        AuthorizedotnetRefundStatus::Unknown => {
+            router_env::logger::warn!(
+                "Unknown authorizedotnet refund status received; retaining previous status {:?}",
+                prev_status
+            );
+            prev_status
         }
     }
 }
@@ -1902,8 +1938,12 @@ impl<F> TryFrom<RefundsResponseRouterData<F, AuthorizedotnetRefundResponse>>
     fn try_from(
         item: RefundsResponseRouterData<F, AuthorizedotnetRefundResponse>,
     ) -> Result<Self, Self::Error> {
+        let prev_refund_status = item.data.request.refund_status;
         let transaction_response = &item.response.transaction_response;
-        let refund_status = enums::RefundStatus::from(transaction_response.response_code.clone());
+        let refund_status = get_refund_status(
+            transaction_response.response_code.clone(),
+            prev_refund_status,
+        );
         let error = transaction_response.errors.clone().and_then(|errors| {
             errors.first().map(|error| ErrorResponse {
                 code: error.error_code.clone(),
@@ -2006,6 +2046,8 @@ pub enum SyncStatus {
     FDSPendingReview,
     #[serde(rename = "FDSAuthorizedPendingReview")]
     FDSAuthorizedPendingReview,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -2016,6 +2058,8 @@ pub enum RSyncStatus {
     Declined,
     GeneralError,
     Voided,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -2046,35 +2090,51 @@ pub struct AuthorizedotnetRSyncResponse {
     messages: ResponseMessages,
 }
 
-impl From<SyncStatus> for enums::AttemptStatus {
-    fn from(transaction_status: SyncStatus) -> Self {
-        match transaction_status {
-            SyncStatus::SettledSuccessfully | SyncStatus::CapturedPendingSettlement => {
-                Self::Charged
-            }
-            SyncStatus::AuthorizedPendingCapture => Self::Authorized,
-            SyncStatus::Declined => Self::AuthenticationFailed,
-            SyncStatus::Voided => Self::Voided,
-            SyncStatus::CouldNotVoid => Self::VoidFailed,
-            SyncStatus::GeneralError => Self::Failure,
-            SyncStatus::RefundSettledSuccessfully | SyncStatus::RefundPendingSettlement => {
-                Self::Charged
-            }
-            SyncStatus::FDSPendingReview | SyncStatus::FDSAuthorizedPendingReview => {
-                Self::Unresolved
-            }
+fn get_sync_attempt_status(
+    transaction_status: SyncStatus,
+    prev_status: enums::AttemptStatus,
+) -> enums::AttemptStatus {
+    match transaction_status {
+        SyncStatus::SettledSuccessfully | SyncStatus::CapturedPendingSettlement => {
+            enums::AttemptStatus::Charged
+        }
+        SyncStatus::AuthorizedPendingCapture => enums::AttemptStatus::Authorized,
+        SyncStatus::Declined => enums::AttemptStatus::AuthenticationFailed,
+        SyncStatus::Voided => enums::AttemptStatus::Voided,
+        SyncStatus::CouldNotVoid => enums::AttemptStatus::VoidFailed,
+        SyncStatus::GeneralError => enums::AttemptStatus::Failure,
+        SyncStatus::RefundSettledSuccessfully | SyncStatus::RefundPendingSettlement => {
+            enums::AttemptStatus::Charged
+        }
+        SyncStatus::FDSPendingReview | SyncStatus::FDSAuthorizedPendingReview => {
+            enums::AttemptStatus::Unresolved
+        }
+        SyncStatus::Unknown => {
+            router_env::logger::warn!(
+                "Unknown authorizedotnet sync status received; retaining previous status {:?}",
+                prev_status
+            );
+            prev_status
         }
     }
 }
 
-impl From<RSyncStatus> for enums::RefundStatus {
-    fn from(transaction_status: RSyncStatus) -> Self {
-        match transaction_status {
-            RSyncStatus::RefundSettledSuccessfully => Self::Success,
-            RSyncStatus::RefundPendingSettlement => Self::Pending,
-            RSyncStatus::Declined | RSyncStatus::GeneralError | RSyncStatus::Voided => {
-                Self::Failure
-            }
+fn get_rsync_refund_status(
+    transaction_status: RSyncStatus,
+    prev_status: enums::RefundStatus,
+) -> enums::RefundStatus {
+    match transaction_status {
+        RSyncStatus::RefundSettledSuccessfully => enums::RefundStatus::Success,
+        RSyncStatus::RefundPendingSettlement => enums::RefundStatus::Pending,
+        RSyncStatus::Declined | RSyncStatus::GeneralError | RSyncStatus::Voided => {
+            enums::RefundStatus::Failure
+        }
+        RSyncStatus::Unknown => {
+            router_env::logger::warn!(
+                "Unknown authorizedotnet rsync status received; retaining previous status {:?}",
+                prev_status
+            );
+            prev_status
         }
     }
 }
@@ -2087,9 +2147,11 @@ impl TryFrom<RefundsResponseRouterData<RSync, AuthorizedotnetRSyncResponse>>
     fn try_from(
         item: RefundsResponseRouterData<RSync, AuthorizedotnetRSyncResponse>,
     ) -> Result<Self, Self::Error> {
+        let prev_refund_status = item.data.request.refund_status;
         match item.response.transaction {
             Some(transaction) => {
-                let refund_status = enums::RefundStatus::from(transaction.transaction_status);
+                let refund_status =
+                    get_rsync_refund_status(transaction.transaction_status, prev_refund_status);
                 Ok(Self {
                     response: Ok(RefundsResponseData {
                         connector_refund_id: transaction.transaction_id,
@@ -2114,9 +2176,11 @@ impl<F, Req> TryFrom<ResponseRouterData<F, AuthorizedotnetSyncResponse, Req, Pay
     fn try_from(
         item: ResponseRouterData<F, AuthorizedotnetSyncResponse, Req, PaymentsResponseData>,
     ) -> Result<Self, Self::Error> {
+        let prev_status = item.data.status;
         match item.response.transaction {
             Some(transaction) => {
-                let payment_status = enums::AttemptStatus::from(transaction.transaction_status);
+                let payment_status =
+                    get_sync_attempt_status(transaction.transaction_status, prev_status);
                 Ok(Self {
                     response: Ok(PaymentsResponseData::TransactionResponse {
                         resource_id: ResponseId::ConnectorTransactionId(
@@ -2235,7 +2299,7 @@ fn get_err_response(
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthorizedotnetWebhookObjectId {
-    pub webhook_id: String,
+    pub webhook_id: Option<String>,
     pub event_type: AuthorizedotnetWebhookEvent,
     pub payload: AuthorizedotnetWebhookPayload,
 }
@@ -2265,6 +2329,8 @@ pub enum AuthorizedotnetWebhookEvent {
     VoidCreated,
     #[serde(rename = "net.authorize.payment.refund.created")]
     RefundCreated,
+    #[serde(other)]
+    Unknown,
 }
 ///Including Unknown to map unknown webhook events
 #[derive(Debug, Deserialize)]
@@ -2299,16 +2365,20 @@ impl From<AuthorizedotnetIncomingWebhookEventType> for IncomingWebhookEvent {
     }
 }
 
-impl From<AuthorizedotnetWebhookEvent> for SyncStatus {
+impl TryFrom<AuthorizedotnetWebhookEvent> for SyncStatus {
+    type Error = error_stack::Report<errors::ConnectorError>;
     // status mapping reference https://developer.authorize.net/api/reference/features/webhooks.html#Event_Types_and_Payloads
-    fn from(event_type: AuthorizedotnetWebhookEvent) -> Self {
+    fn try_from(event_type: AuthorizedotnetWebhookEvent) -> Result<Self, Self::Error> {
         match event_type {
-            AuthorizedotnetWebhookEvent::AuthorizationCreated => Self::AuthorizedPendingCapture,
+            AuthorizedotnetWebhookEvent::AuthorizationCreated => Ok(Self::AuthorizedPendingCapture),
             AuthorizedotnetWebhookEvent::CaptureCreated
-            | AuthorizedotnetWebhookEvent::AuthCapCreated => Self::CapturedPendingSettlement,
-            AuthorizedotnetWebhookEvent::PriorAuthCapture => Self::SettledSuccessfully,
-            AuthorizedotnetWebhookEvent::VoidCreated => Self::Voided,
-            AuthorizedotnetWebhookEvent::RefundCreated => Self::RefundSettledSuccessfully,
+            | AuthorizedotnetWebhookEvent::AuthCapCreated => Ok(Self::CapturedPendingSettlement),
+            AuthorizedotnetWebhookEvent::PriorAuthCapture => Ok(Self::SettledSuccessfully),
+            AuthorizedotnetWebhookEvent::VoidCreated => Ok(Self::Voided),
+            AuthorizedotnetWebhookEvent::RefundCreated => Ok(Self::RefundSettledSuccessfully),
+            AuthorizedotnetWebhookEvent::Unknown => {
+                Err(errors::ConnectorError::WebhookBodyDecodingFailed.into())
+            }
         }
     }
 }
@@ -2326,10 +2396,12 @@ pub fn get_trans_id(
 impl TryFrom<AuthorizedotnetWebhookObjectId> for AuthorizedotnetSyncResponse {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: AuthorizedotnetWebhookObjectId) -> Result<Self, Self::Error> {
+        let transaction_id = get_trans_id(&item)?;
+        let transaction_status = SyncStatus::try_from(item.event_type)?;
         Ok(Self {
             transaction: Some(SyncTransactionResponse {
-                transaction_id: get_trans_id(&item)?,
-                transaction_status: SyncStatus::from(item.event_type),
+                transaction_id,
+                transaction_status,
             }),
             messages: ResponseMessages {
                 ..Default::default()


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- gracefully handle unknown response enum variants and missing optional fields

- This pull request improves the robustness and error handling of the Authorize.Net connector integration in several key areas. The changes focus on gracefully handling unknown or empty responses, ensuring safe deserialization, and maintaining previous statuses when encountering unexpected or unknown status codes. These improvements help prevent panics, provide better logging, and make the connector more resilient to upstream changes or malformed data.

**Error Handling and Deserialization Improvements:**

- Added explicit handling for empty responses in both payment and webhook flows, returning default or endpoint verification responses when appropriate.
- Improved error response deserialization by safely matching on the deserialization result and logging errors, rather than panicking on failure. Also, event builders are updated with error context.
**Status Handling Enhancements:**

- Introduced `Unknown` variants for all relevant enums (`AuthorizedotnetPaymentStatus`, `AuthorizedotnetRefundStatus`, `AuthorizedotnetVoidStatus`, `ResultCode`, `SyncStatus`, `RSyncStatus`) to handle unexpected status codes from the connector without failing. 
- Updated status mapping logic to retain the previous status and log a warning if an unknown status is received, rather than defaulting to a potentially incorrect state. 

**Transformer Logic Adjustments:**

- Refactored the transformation functions to pass along previous statuses, ensuring that state is preserved across unknown or unexpected responses for payments, voids, refunds, and sync operations. 
- Modified the handling of `ResultCode::Unknown` and `ResultCode::Error` to ensure customer ID extraction and error handling works for both cases.

**Data Structure Updates:**

- Made `messages` in `AuthorizedotnetNonZeroMandateResponse` optional to handle cases where this field may be missing in the response.

**Webhook Robustness:**

- Added explicit error handling for unknown webhook event types, returning a decoding failure error.

These changes collectively make the connector more robust against API changes and unexpected data, improving reliability and maintainability.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="785" height="837" alt="Screenshot 2026-07-08 at 4 16 14 PM" src="https://github.com/user-attachments/assets/67dc787c-0684-43e9-a199-e85a4c2449ca" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
