### PR TITLE
fix(worldpayxml): allow hyphenated ids in DDC redirect regex

### DIFF
--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1694,7 +1694,7 @@ pub fn build_redirection_form(
                                     var data = JSON.parse(event.data);
                                     var responseForm = document.createElement('form');
                                     responseForm.action=window.location.pathname.replace(
-                                        new RegExp("payments/redirect/(\\w+)/(\\w+)/\\w+"),
+                                        new RegExp("payments/redirect/([^/]+)/([^/]+)/[^/]+"),
                                         "payments/$1/$2/redirect/complete/worldpayxml"
                                     );
                                     responseForm.method='POST';
@@ -1716,7 +1716,7 @@ pub fn build_redirection_form(
                                 }} catch (e) {{
                                     var responseForm = document.createElement('form');
                                     responseForm.action=window.location.pathname.replace(
-                                        new RegExp("payments/redirect/(\\w+)/(\\w+)/\\w+"),
+                                        new RegExp("payments/redirect/([^/]+)/([^/]+)/[^/]+"),
                                         "payments/$1/$2/redirect/complete/worldpayxml"
                                     );
                                     responseForm.method='POST';
@@ -1898,8 +1898,31 @@ pub fn extract_field_by_dot_path(
 
 #[cfg(test)]
 mod tests {
+    use hyperswitch_domain_models::router_response_types::RedirectForm;
+
     #[test]
     fn test_mime_essence() {
         assert_eq!(mime::APPLICATION_JSON.essence_str(), "application/json");
+    }
+
+    #[test]
+    fn worldpayxml_ddc_redirect_regex_allows_hyphenated_ids() {
+        let html = super::build_redirection_form(
+            &RedirectForm::WorldpayxmlDDCForm {
+                bin: "451903".to_string(),
+                jwt: "jwt".to_string(),
+            },
+            None,
+            "500".to_string(),
+            "CAD".to_string(),
+            crate::configs::Settings::default(),
+        )
+        .into_string();
+
+        let ddc_redirect_regex = r#"new RegExp("payments/redirect/([^/]+)/([^/]+)/[^/]+")"#;
+        let word_only_redirect_regex = r#"new RegExp("payments/redirect/(\\w+)/(\\w+)/\\w+")"#;
+
+        assert_eq!(html.matches(ddc_redirect_regex).count(), 2);
+        assert!(!html.contains(word_only_redirect_regex));
     }
 }


### PR DESCRIPTION
## Summary
- update the Worldpay XML DDC redirect-complete action regex to match path segments instead of word-only tokens
- add a regression test for the generated Worldpay XML DDC form HTML

## Root Cause
Worldpay XML DDC receives browser `postMessage` data and builds the completion form action from `/payments/redirect/{payment_id}/{merchant_id}/{attempt_id}`.

The existing regex used `\w+` for all path params. Payment IDs and attempt IDs can contain hyphens, for example `45551_53015744-414a-46fc-94cf-013fb7d06689`, so the replacement is skipped and the form POSTs back to the GET-only `/payments/redirect/...` route. That matches the merchant console error: `405 Method Not Allowed`.

## Validation
- `cargo fmt --all` completed successfully on stable rustfmt, with warnings for nightly-only rustfmt options in repo config
- `node -e` redirect rewrite check confirms the old regex leaves the merchant-style DDC URL unchanged, while the new regex rewrites it to `/payments/{payment_id}/{merchant_id}/redirect/complete/worldpayxml`
- `cargo test -p router worldpayxml_ddc_redirect_regex_allows_hyphenated_ids` could not run to completion locally because `grpc-api-types` fails in its build script before router tests execute: local `protoc` is not installed and `g2h` reports an `axum` dependency version mismatch


## Related
Fixes #13219

