### PR TITLE
fix(connector): [Peachpayments] Revert the Condition of cofData.source for Network Token Passthrough

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/peachpayments/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/peachpayments/transformers.rs
@@ -517,11 +517,7 @@ impl
                 amount: get_amount_details(item),
                 cof_data: CardOnFileData {
                     cof_type: get_cof_type(item),
-                    source: if item.router_data.request.is_cit_mandate_payment() {
-                        CofSource::Cit
-                    } else {
-                        CofSource::Mit
-                    },
+                    source: CofSource::Cit,
                     mode: CofMode::Initial,
                 },
                 rrn: get_rrn(&peachpayments_data),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

A network token presented directly via `payment_method_data.network_token` always requires `cofData`. A one-off NT presented this way with no other COF fields is fixed to `adhoc/cit/initial`, regardless of the usual derivation rules.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Payments - Create:

Request to Hyperswitch:

```
postman request POST 'http://localhost:8080/payments' \
  --header 'Content-Type: application/json' \
  --header 'Accept: application/json' \
  --header 'api-key: ***' \
  --body '{
    "amount": 1,
    "currency": "ZAR",
    "confirm": true,
    "capture_method": "automatic",
    "payment_method": "network_token",
    "payment_method_type": "network_token",
    "payment_method_data": {
        "network_token": {
            "network_token": "5454545454545454",
            "token_exp_month": "12",
            "token_exp_year": "26",
            "token_cryptogram": "AgAAAAAABk4DWZ4C28yUAAAAAAA=",
            "card_network": "Mastercard",
            "eci": "02"
        }
    },
    "all_keys_required": true
}
' \
  --auth-apikey-key 'api-key' \
  --auth-apikey-value '***'
```

Request to Peachpayments:

```
{
  "paymentMethod": "ecommerce_card_payment_only",
  "referenceId": "pay_y9UwY4DmKtGLkCQHGtI1_1",
  "ecommerceCardPaymentOnlyTransactionData": {
    "merchantInformation": {
      "clientMerchantReferenceId": "*** alloc::string::String ***"
    },
    "routingReference": {
      "merchantPaymentMethodRouteId": "*** alloc::string::String ***"
    },
    "networkTokenData": {
      "token": "545454**********",
      "expiryYear": "*** alloc::string::String ***",
      "expiryMonth": "*** alloc::string::String ***",
      "cryptogram": "*** alloc::string::String ***",
      "eci": "02",
      "scheme": "mastercard"
    },
    "amount": {
      "amount": 1,
      "currencyCode": "ZAR"
    },
    "cofData": {
      "type": "adhoc",
      "source": "cit",
      "mode": "initial"
    }
  },
  "sendDateTime": "2026-07-08T12:37:31.803109000Z"
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
