### PR TITLE
fix(ucs): surface connector error code from unified_details on no-code UCS errors

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -1162,6 +1162,20 @@ impl UnifiedConnectorServiceError {
                 .as_ref()
                 .and_then(|error_info| error_info.connector_details.as_ref())
                 .and_then(|connector_details| connector_details.code.clone())
+                // `connector_details.code` is left unset by UCS when the connector
+                // returned no specific error code (the transformer emits the
+                // `NO_ERROR_CODE` sentinel, which is deliberately not surfaced as a
+                // connector-specific code). In that case the connector's actual code
+                // still lives verbatim in `unified_details.code`, so prefer it over the
+                // generic `CONNECTOR_ERROR_RESPONSE` discriminator to stay in parity with
+                // the native connector path (e.g. cybersource psync 404 -> "No error code").
+                .or_else(|| {
+                    connector_error
+                        .error_info
+                        .as_ref()
+                        .and_then(|error_info| error_info.unified_details.as_ref())
+                        .and_then(|unified_details| unified_details.code.clone())
+                })
                 .unwrap_or_else(|| connector_error.error_code.clone()),
             message: connector_error.error_message,
             status_code,


### PR DESCRIPTION
## What

On shadow-validation, cybersource **psync** error paths diverge between the native (Direct) gateway and the UCS/prism path on `response.Err.code`:

| field | native (Direct) | UCS-derived (before) |
|---|---|---|
| `response.Err.code` | `"No error code"` | `"CONNECTOR_ERROR_RESPONSE"` |
| `connector_http_status_code` | `Some(404)` | `Some(404)` (already fixed by #13003) |

Resolves the `router.valueDiff:response.Err.code` facet of juspay/hyperswitch-cloud#18280 (child #18282). The `router.typeDiff:connector_http_status_code` facet (child #18281) is already fixed on `main` by #13003 (deploy-lag only).

## Root cause

When a connector returns an error **without a connector-specific code**, its transformer emits the `NO_ERROR_CODE` sentinel (`"No error code"`). Prism deliberately omits that sentinel from the structured `ConnectorErrorDetails.code` (leaving it `None`) — see `ForeignFrom<&ErrorResponse>` in prism, which gates `connector_details.code` on `code != NO_ERROR_CODE`.

`decode_connector_error_response` (added in #13003) reads `error_info.connector_details.code` and, when it is `None`, falls back to the **top-level `connector_error.error_code`**. But that top-level value is always the generic `CONNECTOR_ERROR_RESPONSE` discriminator (it is also the sentinel used at the top of this function to recognise a connector HTTP error, so prism must keep sending it). The connector's actual code (`"No error code"`) is still carried verbatim in `error_info.unified_details.code`, but was never consulted.

## Fix

Prefer `unified_details.code` over the generic discriminator when `connector_details.code` is absent. This completes #13003 for the no-connector-code case; connectors that return a real code are unaffected (they populate `connector_details.code`, which is still checked first).

## Proof (local shadow repro on clean main)

Deterministic 404 psync repro (transaction-search-lag surrogate): manual-capture cybersource payment (non-terminal), point its stored `connector_transaction_id` at a non-existent id, `GET /payments/{id}?force_sync=true` → cybersource TSS returns HTTP 404 `The requested resource does not exist`.

**Before** (x-request-id `019f43a5-14f8-72e3-9b0d-4de4efa80158`):
```
Connector error via UCS: ConnectorErrorInner { code: "CONNECTOR_ERROR_RESPONSE", status_code: 404, ... }
psync_gateway: Connector error via UCS for psync (cybersource, status 404): CONNECTOR_ERROR_RESPONSE - The requested resource does not exist
```
native side: `error_code - Some("No error code")`  → **valueDiff**

**After** (x-request-id `019f43ad-a62d-7fd3-9e9a-bd9ded6afa94`, same repro, rebuilt router):
```
Connector error via UCS: ConnectorErrorInner { code: "No error code", status_code: 404, ... }
psync_gateway: Connector error via UCS for psync (cybersource, status 404): No error code - The requested resource does not exist
```
native side: `error_code - Some("No error code")`  → **matches, diff cleared**

`connector_http_status_code = Some(404)` on both sides throughout (via #13003).
