### PR TITLE
fix(ucs): preserve connector errors across gateway flows

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -1253,8 +1253,25 @@ impl ErrorSwitch<ConnectorError> for UnifiedConnectorServiceError {
                     error_body.to_string(),
                 )))
             }
-            // Connector errors with status code → ResponseHandlingFailed
-            Self::ConnectorError(_) => ConnectorError::ResponseHandlingFailed,
+            // Connector HTTP errors returned through UCS must keep their
+            // connector payload instead of collapsing to ResponseHandlingFailed,
+            // otherwise payment/payout error mappers surface them as HS 500s.
+            Self::ConnectorError(inner) => {
+                let error_body = serde_json::json!({
+                    "code": inner.code.clone(),
+                    "message": inner.message.clone(),
+                    "status_code": inner.status_code,
+                    "reason": inner.reason.clone(),
+                    "connector": inner.connector.clone(),
+                    "connector_transaction_id": inner.connector_transaction_id.clone(),
+                    "network_decline_code": inner.network_decline_code.clone(),
+                    "network_advice_code": inner.network_advice_code.clone(),
+                    "network_error_message": inner.network_error_message.clone(),
+                });
+                ConnectorError::ProcessingStepFailed(Some(bytes::Bytes::from(
+                    error_body.to_string(),
+                )))
+            }
             // Connection/availability errors → ResponseHandlingFailed
             Self::ConnectionError(_) => ConnectorError::ResponseHandlingFailed,
             // Request encoding errors

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -1677,5 +1677,5 @@ pub async fn call_unified_connector_service_pre_authenticate(
         },
     ))
     .await
-    .change_context(interface_errors::ConnectorError::ResponseHandlingFailed)
+    .map_err(payments_gateway::convert_ucs_error_to_connector_error)
 }

--- a/crates/router/src/core/payments/flows/complete_authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/complete_authorize_flow.rs
@@ -856,7 +856,7 @@ pub async fn call_unified_connector_service_authenticate(
         },
     ))
     .await
-    .change_context(interface_errors::ConnectorError::ResponseHandlingFailed)?;
+    .map_err(payments_gateway::convert_ucs_error_to_connector_error)?;
 
     Ok(router_data)
 }
@@ -962,7 +962,7 @@ pub async fn call_unified_connector_service_post_authenticate(
         },
     ))
     .await
-    .change_context(interface_errors::ConnectorError::ResponseHandlingFailed)?;
+    .map_err(payments_gateway::convert_ucs_error_to_connector_error)?;
 
     Ok(router_data)
 }

--- a/crates/router/src/core/payments/gateway/access_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/access_token_gateway.rs
@@ -202,7 +202,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)
+        .map_err(super::convert_ucs_error_to_connector_error)
     }
 }
 

--- a/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
@@ -169,7 +169,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)
+        .map_err(super::convert_ucs_error_to_connector_error)
     }
 }
 

--- a/crates/router/src/core/payments/gateway/create_customer_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_customer_gateway.rs
@@ -160,7 +160,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)
+        .map_err(super::convert_ucs_error_to_connector_error)
     }
 }
 

--- a/crates/router/src/core/payments/gateway/create_order_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_order_gateway.rs
@@ -155,7 +155,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)
+        .map_err(super::convert_ucs_error_to_connector_error)
     }
 }
 

--- a/crates/router/src/core/payments/gateway/incremental_authorization_gateway.rs
+++ b/crates/router/src/core/payments/gateway/incremental_authorization_gateway.rs
@@ -152,7 +152,7 @@ where
             ))
             .await
             .map(|(router_data, _)| router_data)
-            .change_context(ConnectorError::ResponseHandlingFailed)?;
+            .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }

--- a/crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs
+++ b/crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs
@@ -157,7 +157,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)
+        .map_err(super::convert_ucs_error_to_connector_error)
     }
 }
 

--- a/crates/router/src/core/payments/gateway/pre_authorize_void_gateway.rs
+++ b/crates/router/src/core/payments/gateway/pre_authorize_void_gateway.rs
@@ -157,7 +157,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)
+        .map_err(super::convert_ucs_error_to_connector_error)
     }
 }
 

--- a/crates/router/src/core/payments/gateway/session_gateway.rs
+++ b/crates/router/src/core/payments/gateway/session_gateway.rs
@@ -153,7 +153,7 @@ where
             ))
             .await
             .map(|(router_data, _)| router_data)
-            .change_context(ConnectorError::ResponseHandlingFailed)?;
+            .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }

--- a/crates/router/src/core/payments/gateway/session_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/session_token_gateway.rs
@@ -155,7 +155,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)
+        .map_err(super::convert_ucs_error_to_connector_error)
     }
 }
 

--- a/crates/router/src/core/payments/gateway/setup_mandate.rs
+++ b/crates/router/src/core/payments/gateway/setup_mandate.rs
@@ -165,7 +165,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)
+        .map_err(super::convert_ucs_error_to_connector_error)
     }
 }
 

--- a/crates/router/src/core/payouts/gateway.rs
+++ b/crates/router/src/core/payouts/gateway.rs
@@ -6,3 +6,19 @@ pub mod quote_gateway;
 pub mod recipient_account_gateway;
 pub mod recipient_gateway;
 pub mod sync_gateway;
+use common_utils::errors::ErrorSwitch;
+use error_stack::Report;
+use hyperswitch_interfaces::{
+    errors::ConnectorError, unified_connector_service::transformers::UnifiedConnectorServiceError,
+};
+
+/// Converts a `Report<UnifiedConnectorServiceError>` into a `Report<ConnectorError>`.
+///
+/// This preserves connector HTTP errors returned through UCS as structured
+/// connector failures instead of collapsing them to generic HS 500s.
+pub(crate) fn convert_ucs_error_to_connector_error(
+    report: Report<UnifiedConnectorServiceError>,
+) -> Report<ConnectorError> {
+    let connector_error = report.current_context().switch();
+    report.change_context(connector_error)
+}

--- a/crates/router/src/core/payouts/gateway/cancel_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/cancel_gateway.rs
@@ -140,7 +140,7 @@ where
             ))
             .await
             .map(|(router_data, _)| router_data)
-            .change_context(ConnectorError::ResponseHandlingFailed)?;
+            .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }

--- a/crates/router/src/core/payouts/gateway/create_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/create_gateway.rs
@@ -145,7 +145,7 @@ where
             ))
             .await
             .map(|(router_data, _)| router_data)
-            .change_context(ConnectorError::ResponseHandlingFailed)?;
+            .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }

--- a/crates/router/src/core/payouts/gateway/fulfill_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/fulfill_gateway.rs
@@ -140,7 +140,7 @@ where
             ))
             .await
             .map(|(router_data, _)| router_data)
-            .change_context(ConnectorError::ResponseHandlingFailed)?;
+            .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }

--- a/crates/router/src/core/payouts/gateway/quote_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/quote_gateway.rs
@@ -140,7 +140,7 @@ where
             ))
             .await
             .map(|(router_data, _)| router_data)
-            .change_context(ConnectorError::ResponseHandlingFailed)?;
+            .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }

--- a/crates/router/src/core/payouts/gateway/recipient_account_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/recipient_account_gateway.rs
@@ -139,7 +139,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)?;
+        .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }

--- a/crates/router/src/core/payouts/gateway/recipient_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/recipient_gateway.rs
@@ -139,7 +139,7 @@ where
         ))
         .await
         .map(|(router_data, _)| router_data)
-        .change_context(ConnectorError::ResponseHandlingFailed)?;
+        .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }

--- a/crates/router/src/core/payouts/gateway/sync_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/sync_gateway.rs
@@ -140,7 +140,7 @@ where
             ))
             .await
             .map(|(router_data, _)| router_data)
-            .change_context(ConnectorError::ResponseHandlingFailed)?;
+            .map_err(super::convert_ucs_error_to_connector_error)?;
 
         Ok(updated_router_data)
     }


### PR DESCRIPTION
## Summary
- preserve UCS connector HTTP errors as structured connector failures instead of collapsing them to `ResponseHandlingFailed`
- route all payment UCS gateway wrappers through the shared UCS error converter, including access token and complete authorize paths
- add the same shared converter for payout UCS gateway wrappers and use it across payout flows

## Investigation
The UCS client already decodes `CONNECTOR_ERROR_RESPONSE` with original connector `http_status_code`, but several gateway wrappers used `change_context(ConnectorError::ResponseHandlingFailed)`. That made connector 4xx responses from UCS surface as HS 500.

Covered UCS wrapper paths include access token, complete authorize, setup mandate, session/session token, create customer/order, incremental auth, payment method tokenization, pre/auth/post-authenticate flow helpers, and payout create/fulfill/sync/cancel/quote/recipient flows. Existing psync webhook-transform deserialization errors were intentionally left as `ResponseHandlingFailed` because those are not UCS connector HTTP responses.

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo check -p router`

Note: I briefly added a focused unit test while validating the conversion behavior, then removed it to keep this PR minimal.