### PR TITLE
fix(connector): [worldpayxml] gracefully handle unknown response enum variants and missing optional fields

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/worldpayxml.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpayxml.rs
@@ -168,6 +168,22 @@ impl ConnectorCommon for Worldpayxml {
         res: Response,
         event_builder: Option<&mut ConnectorEvent>,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        if res.response.is_empty() {
+            return Ok(ErrorResponse {
+                status_code: res.status_code,
+                code: consts::NO_ERROR_CODE.to_string(),
+                message: consts::NO_ERROR_MESSAGE.to_string(),
+                reason: None,
+                attempt_status: None,
+                connector_transaction_id: None,
+                connector_response_reference_id: None,
+                network_advice_code: None,
+                network_decline_code: None,
+                network_error_message: None,
+                connector_metadata: None,
+            });
+        }
+
         let response: Result<worldpayxml::PaymentService, _> =
             utils::deserialize_xml_to_struct(&res.response);
 
@@ -1410,6 +1426,10 @@ impl webhooks::IncomingWebhook for Worldpayxml {
         request: &webhooks::IncomingWebhookRequestDetails<'_>,
         _context: Option<&webhooks::WebhookContext>,
     ) -> CustomResult<api_models::webhooks::IncomingWebhookEvent, errors::ConnectorError> {
+        if request.body.is_empty() {
+            return Ok(api_models::webhooks::IncomingWebhookEvent::EndpointVerification);
+        }
+
         let body_str = std::str::from_utf8(request.body)
             .map_err(|_| errors::ConnectorError::WebhookBodyDecodingFailed)?;
 

--- a/crates/hyperswitch_connectors/src/connectors/worldpayxml/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpayxml/transformers.rs
@@ -291,20 +291,20 @@ struct ReturnCode {
 #[derive(Debug, Deserialize, Serialize)]
 struct ResultCode {
     #[serde(rename = "@description")]
-    description: String,
+    description: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Balance {
     #[serde(rename = "@accountType")]
-    account_type: String,
-    amount: WorldpayXmlAmount,
+    account_type: Option<String>,
+    amount: Option<WorldpayXmlAmount>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PaymentMethodDetail {
-    card: CardResponse,
+    card: Option<CardResponse>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -313,14 +313,14 @@ struct CardResponse {
     #[serde(rename = "@number")]
     number: Option<Secret<String>>,
     #[serde(rename = "@type")]
-    card_type: String,
+    card_type: Option<String>,
     expiry_date: Option<ExpiryDate>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 struct AuthorisationId {
     #[serde(rename = "@id")]
-    id: Secret<String>,
+    id: Option<Secret<String>>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]

--- a/crates/hyperswitch_connectors/src/connectors/worldpayxml/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpayxml/transformers.rs
@@ -216,7 +216,7 @@ struct OrderStatus {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Token {
-    authenticated_shopper_i_d: String,
+    authenticated_shopper_i_d: Option<String>,
     token_details: TokenDetails,
 }
 
@@ -224,7 +224,7 @@ struct Token {
 #[serde(rename_all = "camelCase")]
 struct TokenDetails {
     #[serde(rename = "@tokenEvent")]
-    token_event: String,
+    token_event: Option<String>,
     payment_token_i_d: Secret<String>,
 }
 
@@ -248,8 +248,8 @@ struct ThreeDSChallengeDetails {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Payment {
-    payment_method: String,
-    amount: WorldpayXmlAmount,
+    payment_method: Option<String>,
+    amount: Option<WorldpayXmlAmount>,
     pub last_event: LastEvent,
     #[serde(rename = "AuthorisationId")]
     authorisation_id: Option<AuthorisationId>,
@@ -347,6 +347,8 @@ pub enum LastEvent {
     PushRequested,
     PushRefused,
     SettledByMerchant,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1664,6 +1666,14 @@ fn get_attempt_status(
             Ok(common_enums::AttemptStatus::Charged)
         }
         LastEvent::SentForAuthorisation => Ok(common_enums::AttemptStatus::Authorizing),
+        LastEvent::Unknown => {
+            let status = previous_status.copied().unwrap_or_default();
+            router_env::logger::warn!(
+                "Unknown worldpayxml connector status received; retaining previous status {:?}",
+                status
+            );
+            Ok(status)
+        }
         _ => Err(errors::ConnectorError::UnexpectedResponseError(
             bytes::Bytes::from("Invalid LastEvent".to_string()),
         )),
@@ -1672,6 +1682,7 @@ fn get_attempt_status(
 
 fn get_attempt_status_for_setup_mandate(
     last_event: LastEvent,
+    previous_status: Option<&common_enums::AttemptStatus>,
 ) -> Result<common_enums::AttemptStatus, errors::ConnectorError> {
     match last_event {
         LastEvent::Refused => Ok(common_enums::AttemptStatus::Failure),
@@ -1681,13 +1692,24 @@ fn get_attempt_status_for_setup_mandate(
         | LastEvent::Settled
         | LastEvent::SettledByMerchant => Ok(common_enums::AttemptStatus::Charged),
         LastEvent::SentForAuthorisation => Ok(common_enums::AttemptStatus::Authorizing),
+        LastEvent::Unknown => {
+            let status = previous_status.copied().unwrap_or_default();
+            router_env::logger::warn!(
+                "Unknown worldpayxml connector status received; retaining previous status {:?}",
+                status
+            );
+            Ok(status)
+        }
         _ => Err(errors::ConnectorError::UnexpectedResponseError(
             bytes::Bytes::from("Invalid LastEvent".to_string()),
         )),
     }
 }
 
-fn get_refund_status(last_event: LastEvent) -> Result<enums::RefundStatus, errors::ConnectorError> {
+fn get_refund_status(
+    last_event: LastEvent,
+    previous_status: enums::RefundStatus,
+) -> Result<enums::RefundStatus, errors::ConnectorError> {
     match last_event {
         LastEvent::Refunded | LastEvent::RefundedByMerchant => Ok(enums::RefundStatus::Success),
         LastEvent::SentForRefund | LastEvent::RefundRequested | LastEvent::SentForFastRefund => {
@@ -1695,6 +1717,13 @@ fn get_refund_status(last_event: LastEvent) -> Result<enums::RefundStatus, error
         }
         LastEvent::RefundFailed => Ok(enums::RefundStatus::Failure),
         LastEvent::Captured | LastEvent::Settled => Ok(enums::RefundStatus::Pending),
+        LastEvent::Unknown => {
+            router_env::logger::warn!(
+                "Unknown worldpayxml connector status received for refund; retaining previous status {:?}",
+                previous_status
+            );
+            Ok(previous_status)
+        }
         _ => Err(errors::ConnectorError::UnexpectedResponseError(
             bytes::Bytes::from("Invalid LastEvent".to_string()),
         )),
@@ -2409,7 +2438,10 @@ impl<F>
             validate_order_status(&order_status)?;
 
             if let Some(payment_data) = order_status.payment {
-                let status = get_attempt_status_for_setup_mandate(payment_data.last_event)?;
+                let status = get_attempt_status_for_setup_mandate(
+                    payment_data.last_event,
+                    Some(&item.data.status),
+                )?;
                 let response = process_payment_response(
                     status,
                     &payment_data,
@@ -2797,7 +2829,10 @@ impl TryFrom<RefundsResponseRouterData<RSync, WorldpayxmlSyncResponse>>
                     validate_order_status(&order_status)?;
 
                     if let Some(payment_data) = order_status.payment {
-                        let status = get_refund_status(payment_data.last_event)?;
+                        let status = get_refund_status(
+                            payment_data.last_event,
+                            item.data.request.refund_status,
+                        )?;
                         let response = if connector_utils::is_refund_failure(status) {
                             let error_code = payment_data
                                 .return_code
@@ -2863,7 +2898,8 @@ impl TryFrom<RefundsResponseRouterData<RSync, WorldpayxmlSyncResponse>>
                 }
             }
             WorldpayxmlSyncResponse::Webhook(data) => {
-                let status = get_refund_status(data.payment_status)?;
+                let status =
+                    get_refund_status(data.payment_status, item.data.request.refund_status)?;
                 let response = if connector_utils::is_refund_failure(status) {
                     let error_code = data.return_code;
                     let error_message = data.return_message;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- build_error_response: empty-body guard → safe NO_ERROR_CODE/NO_ERROR_MESSAGE response.
- get_webhook_event_type: empty-body guard → EndpointVerification.

worldpayxml/transformers.rs
- LastEvent enum: added #[serde(other)] Unknown.
- get_attempt_status, get_attempt_status_for_setup_mandate (now takes previous_status), get_refund_status (now takes previous_status: RefundStatus): explicit Unknown arm that logs a warning and retains the previous status instead of erroring or assuming a terminal state.
- Updated all 3 call sites accordingly (setup mandate now passes item.data.status; both refund call sites now pass item.data.request.refund_status).
- 10 unused mandatory response fields wrapped in Option<T> across Payment, Token, TokenDetails, AuthorisationId, PaymentMethodDetail, CardResponse, ResultCode, Balance.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<img width="709" height="898" alt="Screenshot 2026-07-09 at 5 51 41 PM" src="https://github.com/user-attachments/assets/50a96e71-9e69-4231-b308-c0c4ed20e366" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
