### PR TITLE
feat: support payment saved views for advance payment page

### DIFF
--- a/crates/api_models/src/user/dashboard_metadata.rs
+++ b/crates/api_models/src/user/dashboard_metadata.rs
@@ -212,8 +212,15 @@ pub enum SavedViewFiltersV1 {
 
 #[cfg(feature = "v1")]
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "entity", content = "filters")]
+#[serde(rename_all = "snake_case")]
+pub enum SavedViewFiltersV2 {
+    PaymentViews(PaymentListFilterConstraintsV2),
+}
+
+#[cfg(feature = "v1")]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct PaymentListFilterConstraintsV1 {
-    pub query: Option<String>,
     pub payment_id: Option<id_type::PaymentId>,
     pub profile_id: Option<id_type::ProfileId>,
     pub customer_id: Option<id_type::CustomerId>,
@@ -233,25 +240,20 @@ pub struct PaymentListFilterConstraintsV1 {
     #[serde(default)]
     pub order: payments::Order,
     pub card_network: Option<Vec<enums::CardNetwork>>,
-    pub card_last_4: Option<Vec<String>>,
-    pub active_attempt_id: Option<Vec<String>>,
-    pub card_issuer: Option<Vec<String>>,
-    pub routing_approach: Option<Vec<enums::RoutingApproach>>,
-    pub refunds_status: Option<Vec<String>>,
-    pub dispute_status: Option<Vec<String>>,
-    pub client_source: Option<Vec<String>>,
-    pub client_version: Option<Vec<String>>,
-    pub first_attempt: Option<Vec<bool>>,
     pub merchant_order_reference_id: Option<String>,
     pub card_discovery: Option<Vec<enums::CardDiscovery>>,
     pub customer_email: Option<pii::Email>,
 }
 
 #[cfg(feature = "v1")]
+pub type PaymentListFilterConstraintsV2 = payments::PaymentListFilterConstraints;
+
+#[cfg(feature = "v1")]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "version", rename_all = "snake_case")]
 pub enum SavedViewFilters {
-    V1(SavedViewFiltersV1),
+    V1(Box<SavedViewFiltersV1>),
+    V2(Box<SavedViewFiltersV2>),
 }
 
 #[cfg(feature = "v1")]

--- a/crates/router/src/core/user/dashboard_metadata.rs
+++ b/crates/router/src/core/user/dashboard_metadata.rs
@@ -11,6 +11,8 @@ use hyperswitch_masking::ExposeInterface;
 use hyperswitch_masking::{PeekInterface, Secret};
 use router_env::logger;
 
+#[cfg(feature = "v1")]
+use crate::types::transformers::ForeignFrom;
 use crate::{
     core::errors::{UserErrors, UserResponse, UserResult},
     routes::{app::ReqState, SessionState},
@@ -247,15 +249,7 @@ fn into_response(
             Ok(api::GetMetaDataResponse::PaymentViews(resp.map(|d| {
                 d.views
                     .into_iter()
-                    .map(|v| api::SavedViewResponse {
-                        view_id: v.view_id,
-                        view_name: v.view_name,
-                        data: api::SavedViewFilters::V1(api::SavedViewFiltersV1::PaymentViews(
-                            v.filters,
-                        )),
-                        created_at: v.created_at.to_string(),
-                        updated_at: v.updated_at.to_string(),
-                    })
+                    .map(api::SavedViewResponse::foreign_from)
                     .collect()
             })))
         }

--- a/crates/router/src/types/domain/user/dashboard_metadata.rs
+++ b/crates/router/src/types/domain/user/dashboard_metadata.rs
@@ -3,6 +3,9 @@ use diesel_models::enums::DashboardMetadata as DBEnum;
 use hyperswitch_masking::Secret;
 use time::PrimitiveDateTime;
 
+#[cfg(feature = "v1")]
+use crate::types::transformers::ForeignFrom;
+
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum MetaData {
     ProductionAgreement(ProductionAgreementValue),
@@ -75,6 +78,7 @@ pub struct ProductionAgreementValue {
 
 #[cfg(feature = "v1")]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SavedViewV1 {
     pub view_id: String,
     pub view_name: String,
@@ -85,6 +89,78 @@ pub struct SavedViewV1 {
 
 #[cfg(feature = "v1")]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SavedViewV2 {
+    pub view_id: String,
+    pub view_name: String,
+    pub filters: api::PaymentListFilterConstraintsV2,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[cfg(feature = "v1")]
+#[derive(Debug, serde::Serialize)]
+#[serde(tag = "version", rename_all = "snake_case")]
+pub enum SavedView {
+    V1(Box<SavedViewV1>),
+    V2(Box<SavedViewV2>),
+}
+
+#[cfg(feature = "v1")]
+impl<'de> serde::Deserialize<'de> for SavedView {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(tag = "version", rename_all = "snake_case")]
+        enum VersionedSavedView {
+            V1(Box<SavedViewV1>),
+            V2(Box<SavedViewV2>),
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum SavedViewData {
+            Versioned(VersionedSavedView),
+            LegacyV1(Box<SavedViewV1>),
+        }
+
+        match <SavedViewData as serde::Deserialize>::deserialize(deserializer)? {
+            SavedViewData::Versioned(VersionedSavedView::V1(view))
+            | SavedViewData::LegacyV1(view) => Ok(Self::V1(view)),
+            SavedViewData::Versioned(VersionedSavedView::V2(view)) => Ok(Self::V2(view)),
+        }
+    }
+}
+
+#[cfg(feature = "v1")]
+impl ForeignFrom<SavedView> for api::SavedViewResponse {
+    fn foreign_from(from: SavedView) -> Self {
+        match from {
+            SavedView::V1(view) => Self {
+                view_id: view.view_id,
+                view_name: view.view_name,
+                data: api::SavedViewFilters::V1(Box::new(api::SavedViewFiltersV1::PaymentViews(
+                    view.filters,
+                ))),
+                created_at: view.created_at,
+                updated_at: view.updated_at,
+            },
+            SavedView::V2(view) => Self {
+                view_id: view.view_id,
+                view_name: view.view_name,
+                data: api::SavedViewFilters::V2(Box::new(api::SavedViewFiltersV2::PaymentViews(
+                    view.filters,
+                ))),
+                created_at: view.created_at,
+                updated_at: view.updated_at,
+            },
+        }
+    }
+}
+
+#[cfg(feature = "v1")]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct PaymentViewsValue {
-    pub views: Vec<SavedViewV1>,
+    pub views: Vec<SavedView>,
 }

--- a/crates/router/src/utils/user/dashboard_metadata.rs
+++ b/crates/router/src/utils/user/dashboard_metadata.rs
@@ -1,17 +1,14 @@
 use std::{net::IpAddr, ops::Not, str::FromStr};
 
 use actix_web::http::header::HeaderMap;
+#[cfg(feature = "v1")]
+use api_models::user::dashboard_metadata::{
+    CreateSavedViewRequest, SavedViewFilters, SavedViewFiltersV1, SavedViewFiltersV2,
+    SavedViewOperation, UpdateSavedViewRequest,
+};
 use api_models::user::dashboard_metadata::{
     DeleteSavedViewRequest, GetMetaDataRequest, GetMultipleMetaDataPayload, ProdIntent,
     SetMetaDataRequest,
-};
-#[cfg(feature = "v1")]
-use api_models::{
-    payments,
-    user::dashboard_metadata::{
-        CreateSavedViewRequest, PaymentListFilterConstraintsV1, SavedViewFilters,
-        SavedViewFiltersV1, SavedViewOperation, UpdateSavedViewRequest,
-    },
 };
 use common_enums::EntityType;
 use common_utils::id_type;
@@ -27,7 +24,7 @@ use crate::{
     core::errors::{UserErrors, UserResult},
     headers,
     services::{authentication::UserFromToken, authorization::roles::RoleInfo},
-    types::{domain::user::dashboard_metadata as types, transformers::ForeignFrom},
+    types::domain::user::dashboard_metadata as types,
     SessionState,
 };
 
@@ -464,148 +461,110 @@ where
 }
 
 #[cfg(feature = "v1")]
-impl ForeignFrom<payments::PaymentListFilterConstraints> for PaymentListFilterConstraintsV1 {
-    fn foreign_from(item: payments::PaymentListFilterConstraints) -> Self {
-        let payments::PaymentListFilterConstraints {
-            query,
-            payment_id,
-            profile_id,
-            customer_id,
-            limit,
-            offset,
-            amount_filter,
-            time_range,
-            connector,
-            currency,
-            status,
-            payment_method,
-            payment_method_type,
-            authentication_type,
-            merchant_connector_id,
-            order,
-            card_network,
-            card_last_4,
-            active_attempt_id,
-            card_issuer,
-            routing_approach,
-            refunds_status,
-            dispute_status,
-            client_source,
-            client_version,
-            first_attempt,
-            merchant_order_reference_id,
-            card_discovery,
-            customer_email,
-        } = item;
-        Self {
-            query,
-            payment_id,
-            profile_id,
-            customer_id,
-            limit,
-            offset,
-            amount_filter,
-            time_range,
-            connector,
-            currency,
-            status,
-            payment_method,
-            payment_method_type,
-            authentication_type,
-            merchant_connector_id,
-            order,
-            card_network,
-            card_last_4,
-            active_attempt_id,
-            card_issuer,
-            routing_approach,
-            refunds_status,
-            dispute_status,
-            client_source,
-            client_version,
-            first_attempt,
-            merchant_order_reference_id,
-            card_discovery,
-            customer_email,
-        }
-    }
-}
-
-#[cfg(feature = "v1")]
-impl ForeignFrom<PaymentListFilterConstraintsV1> for payments::PaymentListFilterConstraints {
-    fn foreign_from(item: PaymentListFilterConstraintsV1) -> Self {
-        let PaymentListFilterConstraintsV1 {
-            query,
-            payment_id,
-            profile_id,
-            customer_id,
-            limit,
-            offset,
-            amount_filter,
-            time_range,
-            connector,
-            currency,
-            status,
-            payment_method,
-            payment_method_type,
-            authentication_type,
-            merchant_connector_id,
-            order,
-            card_network,
-            card_last_4,
-            active_attempt_id,
-            card_issuer,
-            routing_approach,
-            refunds_status,
-            dispute_status,
-            client_source,
-            client_version,
-            first_attempt,
-            merchant_order_reference_id,
-            card_discovery,
-            customer_email,
-        } = item;
-        Self {
-            query,
-            payment_id,
-            profile_id,
-            customer_id,
-            limit,
-            offset,
-            amount_filter,
-            time_range,
-            connector,
-            currency,
-            status,
-            payment_method,
-            payment_method_type,
-            authentication_type,
-            merchant_connector_id,
-            order,
-            card_network,
-            card_last_4,
-            active_attempt_id,
-            card_issuer,
-            routing_approach,
-            refunds_status,
-            dispute_status,
-            client_source,
-            client_version,
-            first_attempt,
-            merchant_order_reference_id,
-            card_discovery,
-            customer_email,
-        }
-    }
-}
-
-#[cfg(feature = "v1")]
-fn get_payment_views_filters_v1(data: SavedViewFilters) -> PaymentListFilterConstraintsV1 {
+fn create_payment_view(
+    view_id: String,
+    view_name: String,
+    data: SavedViewFilters,
+    created_at: String,
+    updated_at: String,
+) -> types::SavedView {
     match data {
-        SavedViewFilters::V1(f) => match f {
-            SavedViewFiltersV1::PaymentViews(p) => p,
+        SavedViewFilters::V1(filters) => match *filters {
+            SavedViewFiltersV1::PaymentViews(filters) => {
+                types::SavedView::V1(Box::new(types::SavedViewV1 {
+                    view_id,
+                    view_name,
+                    filters,
+                    created_at,
+                    updated_at,
+                }))
+            }
+        },
+        SavedViewFilters::V2(filters) => match *filters {
+            SavedViewFiltersV2::PaymentViews(filters) => {
+                types::SavedView::V2(Box::new(types::SavedViewV2 {
+                    view_id,
+                    view_name,
+                    filters,
+                    created_at,
+                    updated_at,
+                }))
+            }
         },
     }
+}
+
+#[cfg(feature = "v1")]
+fn payment_view_id(view: &types::SavedView) -> &str {
+    match view {
+        types::SavedView::V1(view) => &view.view_id,
+        types::SavedView::V2(view) => &view.view_id,
+    }
+}
+
+#[cfg(feature = "v1")]
+fn payment_view_name(view: &types::SavedView) -> &str {
+    match view {
+        types::SavedView::V1(view) => &view.view_name,
+        types::SavedView::V2(view) => &view.view_name,
+    }
+}
+
+#[cfg(feature = "v1")]
+fn is_same_payment_view_version(left: &types::SavedView, right: &types::SavedView) -> bool {
+    matches!(
+        (left, right),
+        (types::SavedView::V1(_), types::SavedView::V1(_))
+            | (types::SavedView::V2(_), types::SavedView::V2(_))
+    )
+}
+
+#[cfg(feature = "v1")]
+fn matches_payment_view_filter_version(
+    view: &types::SavedView,
+    filters: &SavedViewFilters,
+) -> bool {
+    matches!(
+        (view, filters),
+        (types::SavedView::V1(_), SavedViewFilters::V1(_))
+            | (types::SavedView::V2(_), SavedViewFilters::V2(_))
+    )
+}
+
+#[cfg(feature = "v1")]
+fn update_payment_view(
+    view: &mut types::SavedView,
+    view_name: Option<String>,
+    filters: SavedViewFilters,
+) -> UserResult<()> {
+    let updated_at = common_utils::date_time::now().to_string();
+
+    match (view, filters) {
+        (types::SavedView::V1(view), SavedViewFilters::V1(filters)) => {
+            match *filters {
+                SavedViewFiltersV1::PaymentViews(filters) => view.filters = filters,
+            }
+            if let Some(view_name) = view_name {
+                view.view_name = view_name;
+            }
+            view.updated_at = updated_at;
+        }
+        (types::SavedView::V2(view), SavedViewFilters::V2(filters)) => {
+            match *filters {
+                SavedViewFiltersV2::PaymentViews(filters) => view.filters = filters,
+            }
+            if let Some(view_name) = view_name {
+                view.view_name = view_name;
+            }
+            view.updated_at = updated_at;
+        }
+        _ => {
+            return Err(report!(UserErrors::SavedViewNotFound))
+                .attach_printable("Saved view with this version not found");
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(feature = "v1")]
@@ -644,13 +603,13 @@ async fn create_saved_view(
 
     let now = common_utils::date_time::now();
     let view_id = common_utils::generate_id(common_utils::consts::ID_LENGTH, "view");
-    let new_view_domain = types::SavedViewV1 {
+    let new_view_domain = create_payment_view(
         view_id,
-        view_name: request.view_name.clone(),
-        filters: get_payment_views_filters_v1(request.data),
-        created_at: now.to_string(),
-        updated_at: now.to_string(),
-    };
+        request.view_name.clone(),
+        request.data,
+        now.to_string(),
+        now.to_string(),
+    );
 
     modify_dashboard_metadata(
         state,
@@ -660,16 +619,21 @@ async fn create_saved_view(
         |existing: Option<types::PaymentViewsValue>| {
             let mut views_data = existing.unwrap_or(types::PaymentViewsValue { views: vec![] });
 
-            if views_data.views.len() >= MAX_SAVED_VIEWS {
-                return Err(report!(UserErrors::MaxSavedViewsReached))
-                    .attach_printable("Maximum of 5 saved views reached");
-            }
-
             if views_data
                 .views
                 .iter()
-                .any(|v| v.view_name == request.view_name)
+                .filter(|view| is_same_payment_view_version(view, &new_view_domain))
+                .count()
+                >= MAX_SAVED_VIEWS
             {
+                return Err(report!(UserErrors::MaxSavedViewsReached))
+                    .attach_printable("Maximum of 5 saved views reached for this view type");
+            }
+
+            if views_data.views.iter().any(|view| {
+                is_same_payment_view_version(view, &new_view_domain)
+                    && payment_view_name(view) == request.view_name
+            }) {
                 return Err(report!(UserErrors::SavedViewNameAlreadyExists))
                     .attach_printable("A saved view with this name already exists");
             }
@@ -689,6 +653,8 @@ async fn update_saved_view(
     profile_id: Option<String>,
     request: UpdateSavedViewRequest,
 ) -> UserResult<DashboardMetadata> {
+    let filters = request.data;
+
     modify_dashboard_metadata(
         state,
         user,
@@ -697,11 +663,10 @@ async fn update_saved_view(
         |existing: Option<types::PaymentViewsValue>| {
             let mut views_data = existing.ok_or(report!(UserErrors::SavedViewNotFound))?;
 
-            if !views_data
-                .views
-                .iter()
-                .any(|v| v.view_id == request.view_id)
-            {
+            if !views_data.views.iter().any(|view| {
+                payment_view_id(view) == request.view_id
+                    && matches_payment_view_filter_version(view, &filters)
+            }) {
                 return Err(report!(UserErrors::SavedViewNotFound))
                     .attach_printable("Saved view with this ID not found");
             }
@@ -712,11 +677,11 @@ async fn update_saved_view(
                         .attach_printable("Saved view name cannot be empty");
                 }
 
-                if views_data
-                    .views
-                    .iter()
-                    .any(|v| v.view_id != request.view_id && v.view_name == *new_name)
-                {
+                if views_data.views.iter().any(|view| {
+                    matches_payment_view_filter_version(view, &filters)
+                        && payment_view_id(view) != request.view_id
+                        && payment_view_name(view) == *new_name
+                }) {
                     return Err(report!(UserErrors::SavedViewNameAlreadyExists))
                         .attach_printable("A saved view with this name already exists");
                 }
@@ -725,14 +690,13 @@ async fn update_saved_view(
             let view = views_data
                 .views
                 .iter_mut()
-                .find(|v| v.view_id == request.view_id)
+                .find(|view| {
+                    payment_view_id(view) == request.view_id
+                        && matches_payment_view_filter_version(view, &filters)
+                })
                 .ok_or(report!(UserErrors::SavedViewNotFound))?;
 
-            if let Some(new_name) = request.view_name {
-                view.view_name = new_name;
-            }
-            view.filters = get_payment_views_filters_v1(request.data);
-            view.updated_at = common_utils::date_time::now().to_string();
+            update_payment_view(view, request.view_name, filters)?;
 
             Ok(views_data)
         },
@@ -759,7 +723,7 @@ async fn delete_saved_view(
             let position = views_data
                 .views
                 .iter()
-                .position(|v| v.view_id == request.view_id)
+                .position(|view| payment_view_id(view) == request.view_id)
                 .ok_or_else(|| {
                     report!(UserErrors::SavedViewNotFound)
                         .attach_printable("Saved view with this ID not found")


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds V2 saved-view support for payment views so Normal and Advanced payment list views can be saved independently.

- Adds a V2 `PaymentViews` saved-view request/response contract.
- Stores saved-view version in dashboard metadata, defaulting existing saved views to V1.
- Keeps V1 responses backward compatible by converting stored filters back to the V1 response shape.
- Returns the full payment list filter contract for V2 views.
- Scopes saved-view duplicate-name and max-count checks by version.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Advanced payment-list filters need saved views without breaking existing Normal payment views. This change separates V1 and V2 saved views so users can maintain independent saved views for Normal and Advanced modes.

Closes #13189

## How did you test it?

- Ran `cargo +nightly fmt --all`
- Verified V2 payment saved-view create API locally
- Verified saved view is returned from metadata GET API with `version: "v2"`

Create request used locally:

```bash
curl "http://127.0.0.1:8080/user/data" \
  -H "Content-Type: application/json" \
  -H "X-Merchant-Id: merchant_1757944600" \
  -H "X-Profile-Id: pro_oeh0UKY9ELlgThifhCEk" \
  -H "api-key: hyperswitch" \
  -H "authorization: Bearer <local-jwt>" \
  --data-raw "{\"PaymentViews\":{\"type\":\"Create\",\"data\":{\"view_name\":\"Advanced API V2 Test 20260707152606\",\"version\":\"v2\",\"entity\":\"payment_views\",\"filters\":{\"start_time\":\"2026-06-05T18:30:00Z\",\"end_time\":\"2026-07-06T07:10:18Z\",\"order\":{\"on\":\"created\",\"by\":\"desc\"},\"status\":[\"succeeded\"],\"first_attempt\":[true],\"card_last_4\":[\"4242\"],\"refunds_status\":[\"success\"],\"dispute_status\":[\"dispute_opened\"]}}}}"
```

Create response: `HTTP 200`.

Verify request used locally:

```bash
curl "http://127.0.0.1:8080/user/data?keys=PaymentViews" \
  -H "X-Merchant-Id: merchant_1757944600" \
  -H "X-Profile-Id: pro_oeh0UKY9ELlgThifhCEk" \
  -H "api-key: hyperswitch" \
  -H "authorization: Bearer <local-jwt>"
```

Verify response included `version: "v2"`, `card_last_4`, `refunds_status`, `dispute_status`, and `first_attempt`.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
