### PR TITLE
fix(nmi): harden connector against unknown enum variants and non-JSON error bodies

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nmi.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nmi.rs
@@ -41,6 +41,7 @@ use hyperswitch_interfaces::{
         ConnectorSpecifications, ConnectorValidation,
     },
     configs::Connectors,
+    consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
     errors::ConnectorError,
     events::connector_api_logs::ConnectorEvent,
     types::{
@@ -123,27 +124,55 @@ impl ConnectorCommon for Nmi {
         res: Response,
         event_builder: Option<&mut ConnectorEvent>,
     ) -> CustomResult<ErrorResponse, ConnectorError> {
-        let response: nmi::StandardResponse = res
-            .response
-            .parse_struct("StandardResponse")
-            .change_context(ConnectorError::ResponseDeserializationFailed)?;
+        if res.response.is_empty() {
+            return Ok(ErrorResponse {
+                status_code: res.status_code,
+                code: NO_ERROR_CODE.to_string(),
+                message: NO_ERROR_MESSAGE.to_string(),
+                reason: None,
+                attempt_status: None,
+                connector_transaction_id: None,
+                connector_response_reference_id: None,
+                network_advice_code: None,
+                network_decline_code: None,
+                network_error_message: None,
+                connector_metadata: None,
+            });
+        }
 
-        event_builder.map(|i| i.set_error_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
+        let response: Result<nmi::StandardResponse, _> =
+            res.response.parse_struct("StandardResponse");
 
-        Ok(ErrorResponse {
-            message: response.responsetext.to_owned(),
-            status_code: res.status_code,
-            reason: Some(response.responsetext),
-            code: response.response_code,
-            attempt_status: None,
-            connector_transaction_id: Some(response.transactionid),
-            connector_response_reference_id: None,
-            network_advice_code: None,
-            network_decline_code: None,
-            network_error_message: None,
-            connector_metadata: None,
-        })
+        match response {
+            Ok(response) => {
+                event_builder.map(|i| i.set_error_response_body(&response));
+                router_env::logger::info!(connector_response=?response);
+
+                Ok(ErrorResponse {
+                    message: response.responsetext.to_owned(),
+                    status_code: res.status_code,
+                    reason: Some(response.responsetext),
+                    code: response.response_code,
+                    attempt_status: None,
+                    connector_transaction_id: Some(response.transactionid),
+                    connector_response_reference_id: None,
+                    network_advice_code: None,
+                    network_decline_code: None,
+                    network_error_message: None,
+                    connector_metadata: None,
+                })
+            }
+            Err(error_msg) => {
+                if let Some(event) = event_builder {
+                    event.set_error(serde_json::json!({
+                        "error": "Error response parsing failed",
+                        "status_code": res.status_code
+                    }));
+                }
+                router_env::logger::error!(deserialization_error =? error_msg);
+                crate::utils::handle_json_response_deserialization_failure(res, "nmi")
+            }
+        }
     }
 }
 
@@ -1015,6 +1044,10 @@ impl IncomingWebhook for Nmi {
         request: &IncomingWebhookRequestDetails<'_>,
         _context: Option<&WebhookContext>,
     ) -> CustomResult<IncomingWebhookEvent, ConnectorError> {
+        if request.body.is_empty() {
+            return Ok(IncomingWebhookEvent::EventNotSupported);
+        }
+
         let event_type_body: nmi::NmiWebhookEventBody = request
             .body
             .parse_struct("nmi NmiWebhookEventType")
@@ -1043,6 +1076,7 @@ impl IncomingWebhook for Nmi {
                 Ok(Box::new(nmi::SyncResponse::try_from(&webhook_body)?))
             }
             nmi::NmiActionType::Refund => Ok(Box::new(webhook_body)),
+            nmi::NmiActionType::Unknown => Err(ConnectorError::WebhooksNotImplemented)?,
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs
@@ -201,6 +201,7 @@ fn process_nmi_vault_response(
     vault_response: &NmiVaultResponse,
     http_code: u16,
     connector_request_reference_id: String,
+    prev_status: AttemptStatus,
 ) -> Result<(Result<PaymentsResponseData, ErrorResponse>, AttemptStatus), Error> {
     let auth_type: NmiAuthType = connector_auth_type.try_into()?;
     let amount_data = amount;
@@ -215,6 +216,7 @@ fn process_nmi_vault_response(
         vault_response,
         http_code,
         connector_request_reference_id,
+        prev_status,
     )
 }
 
@@ -225,6 +227,7 @@ fn build_nmi_vault_response(
     vault_response: &NmiVaultResponse,
     http_code: u16,
     connector_request_reference_id: String,
+    prev_status: AttemptStatus,
 ) -> Result<(Result<PaymentsResponseData, ErrorResponse>, AttemptStatus), Error> {
     let (response, status) = match vault_response.response {
         Response::Approved => (
@@ -276,6 +279,28 @@ fn build_nmi_vault_response(
             }),
             AttemptStatus::Failure,
         ),
+        Response::Unknown => {
+            router_env::logger::warn!(
+                "NMI returned unknown response code for vault request; retaining previous status {:?}",
+                prev_status
+            );
+            (
+                Err(ErrorResponse {
+                    code: vault_response.response_code.clone(),
+                    message: vault_response.responsetext.to_owned(),
+                    reason: Some(vault_response.responsetext.clone()),
+                    status_code: http_code,
+                    attempt_status: None,
+                    connector_transaction_id: Some(vault_response.transactionid.clone()),
+                    connector_response_reference_id: None,
+                    network_advice_code: None,
+                    network_decline_code: None,
+                    network_error_message: None,
+                    connector_metadata: None,
+                }),
+                prev_status,
+            )
+        }
     };
     Ok((response, status))
 }
@@ -294,6 +319,7 @@ impl TryFrom<PaymentsPreprocessingResponseRouterData<NmiVaultResponse>>
             &item.response,
             item.http_code,
             item.data.connector_request_reference_id.clone(),
+            item.data.status,
         )?;
 
         Ok(Self {
@@ -318,6 +344,7 @@ impl TryFrom<PaymentsPreAuthenticateResponseRouterData<NmiVaultResponse>>
             &item.response,
             item.http_code,
             item.data.connector_request_reference_id.clone(),
+            item.data.status,
         )?;
 
         Ok(Self {
@@ -481,6 +508,17 @@ impl
                 Err(get_nmi_error_response(item.response, item.http_code)),
                 AttemptStatus::Failure,
             ),
+            Response::Unknown => {
+                let prev_status = item.data.status;
+                router_env::logger::warn!(
+                    "NMI returned unknown response code for complete authorize; retaining previous status {:?}",
+                    prev_status
+                );
+                (
+                    Err(get_nmi_error_response(item.response, item.http_code)),
+                    prev_status,
+                )
+            }
         };
         Ok(Self {
             status,
@@ -1183,6 +1221,17 @@ impl
                 Err(get_standard_error_response(item.response, item.http_code)),
                 AttemptStatus::CaptureFailed,
             ),
+            Response::Unknown => {
+                let prev_status = item.data.status;
+                router_env::logger::warn!(
+                    "NMI returned unknown response code for capture; retaining previous status {:?}",
+                    prev_status
+                );
+                (
+                    Err(get_standard_error_response(item.response, item.http_code)),
+                    prev_status,
+                )
+            }
         };
         Ok(Self {
             status,
@@ -1246,6 +1295,8 @@ pub enum Response {
     Declined,
     #[serde(alias = "3")]
     Error,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1300,6 +1351,17 @@ impl<T> TryFrom<ResponseRouterData<SetupMandate, StandardResponse, T, PaymentsRe
                 Err(get_standard_error_response(item.response, item.http_code)),
                 AttemptStatus::Failure,
             ),
+            Response::Unknown => {
+                let prev_status = item.data.status;
+                router_env::logger::warn!(
+                    "NMI returned unknown response code for setup mandate; retaining previous status {:?}",
+                    prev_status
+                );
+                (
+                    Err(get_standard_error_response(item.response, item.http_code)),
+                    prev_status,
+                )
+            }
         };
         Ok(Self {
             status,
@@ -1372,6 +1434,17 @@ impl TryFrom<PaymentsResponseRouterData<StandardResponse>>
                 Err(get_standard_error_response(item.response, item.http_code)),
                 AttemptStatus::Failure,
             ),
+            Response::Unknown => {
+                let prev_status = item.data.status;
+                router_env::logger::warn!(
+                    "NMI returned unknown response code for authorize; retaining previous status {:?}",
+                    prev_status
+                );
+                (
+                    Err(get_standard_error_response(item.response, item.http_code)),
+                    prev_status,
+                )
+            }
         };
         Ok(Self {
             status,
@@ -1410,6 +1483,17 @@ impl<T> TryFrom<ResponseRouterData<Void, StandardResponse, T, PaymentsResponseDa
                 Err(get_standard_error_response(item.response, item.http_code)),
                 AttemptStatus::VoidFailed,
             ),
+            Response::Unknown => {
+                let prev_status = item.data.status;
+                router_env::logger::warn!(
+                    "NMI returned unknown response code for void; retaining previous status {:?}",
+                    prev_status
+                );
+                (
+                    Err(get_standard_error_response(item.response, item.http_code)),
+                    prev_status,
+                )
+            }
         };
         Ok(Self {
             status,
@@ -1536,7 +1620,8 @@ impl TryFrom<RefundsResponseRouterData<Execute, StandardResponse>> for RefundsRo
     fn try_from(
         item: RefundsResponseRouterData<Execute, StandardResponse>,
     ) -> Result<Self, Self::Error> {
-        let refund_status = RefundStatus::from(item.response.response);
+        let refund_status =
+            get_nmi_refund_status(item.response.response, item.data.request.refund_status);
         Ok(Self {
             response: Ok(RefundsResponseData {
                 connector_refund_id: item.response.orderid,
@@ -1552,7 +1637,8 @@ impl TryFrom<RefundsResponseRouterData<Capture, StandardResponse>> for RefundsRo
     fn try_from(
         item: RefundsResponseRouterData<Capture, StandardResponse>,
     ) -> Result<Self, Self::Error> {
-        let refund_status = RefundStatus::from(item.response.response);
+        let refund_status =
+            get_nmi_refund_status(item.response.response, item.data.request.refund_status);
         Ok(Self {
             response: Ok(RefundsResponseData {
                 connector_refund_id: item.response.transactionid,
@@ -1563,11 +1649,16 @@ impl TryFrom<RefundsResponseRouterData<Capture, StandardResponse>> for RefundsRo
     }
 }
 
-impl From<Response> for RefundStatus {
-    fn from(item: Response) -> Self {
-        match item {
-            Response::Approved => Self::Success,
-            Response::Declined | Response::Error => Self::Failure,
+fn get_nmi_refund_status(response: Response, prev_refund_status: RefundStatus) -> RefundStatus {
+    match response {
+        Response::Approved => RefundStatus::Success,
+        Response::Declined | Response::Error => RefundStatus::Failure,
+        Response::Unknown => {
+            router_env::logger::warn!(
+                "NMI returned unknown response code for refund; retaining previous refund status {:?}",
+                prev_refund_status
+            );
+            prev_refund_status
         }
     }
 }
@@ -1681,6 +1772,8 @@ pub enum NmiActionType {
     Refund,
     Sale,
     Void,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1720,6 +1813,8 @@ pub enum NmiWebhookEventType {
     CaptureFailure,
     #[serde(rename = "transaction.capture.unknown")]
     CaptureUnknown,
+    #[serde(other)]
+    Unknown,
 }
 
 pub fn get_nmi_webhook_event(status: NmiWebhookEventType) -> IncomingWebhookEvent {
@@ -1739,6 +1834,12 @@ pub fn get_nmi_webhook_event(status: NmiWebhookEventType) -> IncomingWebhookEven
         | NmiWebhookEventType::AuthUnknown
         | NmiWebhookEventType::VoidUnknown
         | NmiWebhookEventType::CaptureUnknown => IncomingWebhookEvent::EventNotSupported,
+        NmiWebhookEventType::Unknown => {
+            router_env::logger::warn!(
+                "Unknown nmi webhook event type received; acknowledging without processing"
+            );
+            IncomingWebhookEvent::EventNotSupported
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `#[serde(other)] Unknown` catch-alls to NMI's `Response`, `NmiWebhookEventType`, and `NmiActionType` enums so a new connector-side status/event/action code degrades gracefully instead of hard-failing deserialization (mirrors the pattern already merged for Adyen in #12877, #13161).
- Unknown payment/refund statuses now retain the pre-call `AttemptStatus`/`RefundStatus` (threaded through as `prev_status` / `request.refund_status`) with a warn log, rather than assuming success or failure.
- `build_error_response` now guards against an empty body and falls back to `handle_json_response_deserialization_failure` for non-JSON error responses instead of panicking (NMI is known to return non-JSON bodies on some failure paths).
- `get_webhook_event_type` guards against an empty webhook body.
- Reviewed but not changed: `NmiStatus` (already resilient via its existing `From<String>` fallback to `Pending`), dispute handling (NMI has none), UCS/hyperswitch-prism gap (not applicable — no such code in this repo), unused response fields (none found), `deny_unknown_fields` (not used anywhere in this connector).

Cypress Tests
<img width="732" height="1072" alt="image" src="https://github.com/user-attachments/assets/b9c0aeff-b3a1-466b-b4e0-343cd5705603" />