### PR TITLE
fix(cypress): accept 422 status for invalid currency in forex convert tests

### DIFF
--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -10464,7 +10464,7 @@ Cypress.Commands.add(
               "cli_log",
               `Converted ${amount} ${fromCurrency} → ${response.body.converted_amount} ${response.body.currency}`
             );
-          } else if (response.status === 400) {
+          } else if (response.status === 400 || response.status === 422) {
             expect(response.body).to.exist;
           } else {
             throw new Error(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Test 1: "should convert small amount from USD to EUR"
- amount=100, fromCurrency="USD", toCurrency="EUR"
- API returns 200 with converted_amount and currency
- Hits the if (response.status === 200) branch → asserts converted_amount and currency exist → passes

Test 2: "should fail to convert with negative amount"
- amount=-100, fromCurrency="USD", toCurrency="EUR"
- API returns 400
- Hits the else if (response.status === 400) branch → asserts response.body exists → passes

Test 3: "should fail to convert with invalid source currency"
- amount=100, fromCurrency="INVALID", toCurrency="USD"
- API returns 422 with {"error":{"type":"invalid_request","message":"The provided currency is not acceptable","code":"IR_06"}}
- Without the OR: 422 !== 200 and 422 !== 400 → falls into else → throws "Unexpected forex convert status: 422" → fails
- With the OR: 422 !== 200 but 422 === 422 → asserts response.body exists → passes

Test 4: "should fail to convert with invalid target currency"
- amount=100, fromCurrency="USD", toCurrency="INVALID"
- API returns 422 (same body as above)
- Same as Test 3 → fails without the OR, passes with it

So if we dropped 400 and only kept 422, Test 2 (negative amount) would fall into the else and throw. We genuinely need both.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
