### PR TITLE
fix(ucs): forward 3DS authentication fields to UCS on cybersource authorize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.08.1#e90e5a7b1c121c543511ee571bb579b676c393d1"
+source = "git+https://github.com/juspay/connector-service?tag=2026.07.10.1#51237c677236384f806534e9e0105cc3deedc566"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3982,7 +3982,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.08.1#e90e5a7b1c121c543511ee571bb579b676c393d1"
+source = "git+https://github.com/juspay/connector-service?tag=2026.07.10.1#51237c677236384f806534e9e0105cc3deedc566"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.08.1#e90e5a7b1c121c543511ee571bb579b676c393d1"
+source = "git+https://github.com/juspay/connector-service?tag=2026.07.10.1#51237c677236384f806534e9e0105cc3deedc566"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11013,7 +11013,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.08.1#e90e5a7b1c121c543511ee571bb579b676c393d1"
+source = "git+https://github.com/juspay/connector-service?tag=2026.07.10.1#51237c677236384f806534e9e0105cc3deedc566"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11029,7 +11029,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.08.1#e90e5a7b1c121c543511ee571bb579b676c393d1"
+source = "git+https://github.com/juspay/connector-service?tag=2026.07.10.1#51237c677236384f806534e9e0105cc3deedc566"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11040,7 +11040,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.08.1#e90e5a7b1c121c543511ee571bb579b676c393d1"
+source = "git+https://github.com/juspay/connector-service?tag=2026.07.10.1#51237c677236384f806534e9e0105cc3deedc566"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -82,7 +82,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.08.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.10.1", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.114.0", optional = true}
 superposition_types = "0.114.0"

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -820,9 +820,9 @@ impl UnifiedConnectorServiceClient {
             build_unified_connector_service_grpc_headers(connector_auth_metadata, grpc_headers)?;
         *request.metadata_mut() = metadata;
 
-        self.payment_service_client
-            .clone()
-            .setup_recurring(request)
+        // Box the setup_recurring future: the merged UCS proto request types are large enough
+        // to trip clippy::large_futures when this is awaited inline.
+        Box::pin(self.payment_service_client.clone().setup_recurring(request))
             .await
             .map_err(|error| {
                 error_stack::Report::new(UnifiedConnectorServiceError::from_grpc_error(

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.08.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.10.1", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.08.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.07.08.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.10.1", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.07.10.1", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2302,6 +2302,9 @@ impl
                 currency: currency.into(),
             }),
             original_payment_authorized_amount: None,
+            auth_type: Some(
+                payments_grpc::AuthenticationType::foreign_try_from(router_data.auth_type)?.into(),
+            ),
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             metadata: router_data
                 .request
@@ -4450,7 +4453,29 @@ impl transformers::ForeignTryFrom<AuthenticationData> for payments_grpc::Authent
                 .cb_network_params
                 .map(payments_grpc::NetworkParams::foreign_try_from)
                 .transpose()?,
+            created_at: Some(authentication_data.created_at.assume_utc().unix_timestamp()),
+            challenge_code: authentication_data.challenge_code,
+            challenge_cancel: authentication_data.challenge_cancel,
+            challenge_code_reason: authentication_data.challenge_code_reason,
+            message_extension: authentication_data
+                .message_extension
+                .map(|message_extension| message_extension.expose().to_string()),
+            authentication_type: authentication_data
+                .authentication_type
+                .map(payments_grpc::DecoupledAuthenticationType::foreign_from)
+                .map(i32::from),
         })
+    }
+}
+
+impl ForeignFrom<common_enums::DecoupledAuthenticationType>
+    for payments_grpc::DecoupledAuthenticationType
+{
+    fn foreign_from(authentication_type: common_enums::DecoupledAuthenticationType) -> Self {
+        match authentication_type {
+            common_enums::DecoupledAuthenticationType::Challenge => Self::Challenge,
+            common_enums::DecoupledAuthenticationType::Frictionless => Self::Frictionless,
+        }
     }
 }
 
@@ -4479,6 +4504,14 @@ impl transformers::ForeignTryFrom<router_request_types::UcsAuthenticationData>
             ucaf_collection_indicator: authentication_data.ucaf_collection_indicator,
             exemption_indicator: None,
             network_params: None,
+            // `UcsAuthenticationData` is the pre-serialized 3DS payload and carries none of
+            // these; only the router-internal `AuthenticationData` above has them.
+            created_at: None,
+            challenge_code: None,
+            challenge_cancel: None,
+            challenge_code_reason: None,
+            message_extension: None,
+            authentication_type: None,
         })
     }
 }
@@ -4662,6 +4695,12 @@ impl transformers::ForeignTryFrom<payments_grpc::AuthenticationData>
             ucaf_collection_indicator,
             exemption_indicator: _,
             network_params: _,
+            created_at: _,
+            challenge_code: _,
+            challenge_cancel: _,
+            challenge_code_reason: _,
+            message_extension: _,
+            authentication_type: _,
         } = response;
         let trans_status = trans_status
             .map(payments_grpc::TransactionStatus::try_from)


### PR DESCRIPTION
## Summary

Fixes the residual `consumerAuthenticationInformation` request_diff on **cybersource / authorize** reported in shadow-validation issues **juspay/hyperswitch-cloud#19112** and **juspay/hyperswitch-cloud#19114** (merchant `flowbird`, org `Flowbird`).

The UCS gRPC client drops six fields that the **Direct** cybersource transformer already reads off the router-internal `AuthenticationData` (`crates/hyperswitch_domain_models/src/router_request_types.rs:1437`):

| router-internal field | Direct cybersource use (`hyperswitch_connectors/.../cybersource/transformers.rs`) |
|---|---|
| `created_at` | `authenticationDate` (L231) |
| `authentication_type` | `effectiveAuthenticationType` (L223) |
| `challenge_code` | `challengeCode` (L270) |
| `challenge_code_reason` | `signedParesStatusReason` (L271) |
| `challenge_cancel` | `challengeCancelCode` (L272) |
| `message_extension` | `networkScore` (Cartes Bancaires, L237) |

Because `ForeignTryFrom<AuthenticationData> for payments_grpc::AuthenticationData` never forwarded them, the shadow UCS request emitted `authenticationDate`, `challengeCode` and `effectiveAuthenticationType` as `null` while the Direct leg sent real values.

`connector-service` grew these as `AuthenticationData` proto fields 12–17 in **prism [#1594](https://github.com/juspay/hyperswitch-prism/pull/1594)** (merged 2026-07-10T08:55:24Z, `bfb78aeb3`). It first ships in CalVer tag `2026.07.10.1` (`51237c677`), so this PR pins all four connector-service deps (diamond dependency) to tag `2026.07.10.1`, which contains it.

## Rev pin → CalVer tag (resolved)

The temporary `rev` pin has been replaced with `tag = "2026.07.10.1"` — the first released CalVer
tag containing prism #1594 (`bfb78aeb3`). `cargo build -p router` is green against it. Undrafted.

## Changes

- `crates/router/src/core/unified_connector_service/transformers.rs`
  - forward the six fields in `ForeignTryFrom<AuthenticationData>`
  - add `ForeignFrom<common_enums::DecoupledAuthenticationType> for payments_grpc::DecoupledAuthenticationType`
  - `UcsAuthenticationData` (pre-serialized 3DS payload) carries none of them → `None`
  - set `RecurringPaymentServiceChargeRequest.auth_type`, a new required proto field on this revision
- rev-pin `external_services`, `hyperswitch_interfaces`, `router` (×2) + `Cargo.lock`

## Before / after proof

Repro mirrors prod x-request-id `019f1e33-ea00-7350-bfee-92ee8460e4c2` (txn `2026-07-01T15:02:26.560Z`, **MASTERCARD**, real cybersource **201 AUTHORIZED**).

**Before** — issue #19112 diff signature, UCS-side nulls:

```
body.typeDiff.consumerAuthenticationInformation.authenticationDate          = {"hyperswitch":"string","ucs":"null"}
body.typeDiff.consumerAuthenticationInformation.challengeCode               = {"hyperswitch":"string","ucs":"null"}
body.typeDiff.consumerAuthenticationInformation.effectiveAuthenticationType = {"hyperswitch":"string","ucs":"null"}
```

**After** — with prism #1594 and these fields populated on the wire, prism emits them (outbound cybersource body, captured from the grpc-server log):

```
authenticationDate          = '20260701150226'
challengeCode               = '01'
effectiveAuthenticationType = 'CH'
```

**No regression on the shadow path.** Router rebuilt on this branch (rev `bfb78aeb3`) + prism on `main`; a `/payments` shadow fire for the same merchant/metadata is fully green at the validation service:

```
key        = diff_result_authorize:cybersource:019f4b5a-14c4-71b0-81c3-52fac3e03e5d
keyDiff    = {}
valueDiff  = {}
typeDiff   = {}
```

### Scope note

Issue #19112 carried 14 diff facets. The other 11 are already fixed on `main` and are **deploy-lag only** (prod ran build `aef0be919`, image `2026.06.17.0`):

- 3 × `merchantDefinedInformation` `valueDiff` → merged prism [#1740](https://github.com/juspay/hyperswitch-prism/pull/1740)
- 8 × `consumerAuthenticationInformation` `typeDiff` (`specificationVersion`, `veresEnrolled`, `eciRaw`, `paresStatus`, `acsTransactionId`, `cavvAlgorithm`, `ucafCollectionIndicator`, `cavv`) → merged prism #1594

This PR closes the remaining 3. Verified against prism `main`: the Mastercard leg flips from a real `400 MISSING_FIELD consumerAuthenticationInformation.ucafCollectionIndicator` to a real `201 CHARGED`.

No credentials or local `config/development.toml` are included in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)