### PR TITLE
perf(router): Remove MCA decryption call in routing

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -3820,6 +3820,20 @@ impl std::ops::Deref for TtlForExtendedCardInfo {
     }
 }
 
+#[cfg(feature = "v2")]
+#[derive(Debug)]
+pub struct MCACGraphData {
+    pub connector_name: common_enums::connector_enums::Connector,
+    pub payment_methods_enabled: Option<Vec<common_types::payment_methods::PaymentMethodsEnabled>>,
+}
+
+#[cfg(feature = "v1")]
+#[derive(Debug, Deserialize)]
+pub struct MCACGraphData {
+    pub connector_name: String,
+    pub payment_methods_enabled: Option<Vec<PaymentMethodsEnabled>>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/euclid_wasm/src/lib.rs
+++ b/crates/euclid_wasm/src/lib.rs
@@ -170,7 +170,14 @@ pub fn seed_knowledge_graph(mcas: JsValue) -> JsResult {
         connector_configs: HashMap::new(),
         default_configs: Some(pm_filter),
     };
-    let mca_graph = kgraph_utils::mca::make_mca_graph(mcas, &config).err_to_js()?;
+    let mca_graph_data = mcas
+        .iter()
+        .map(|mca| api_models::admin::MCACGraphData {
+            connector_name: mca.connector_name.clone(),
+            payment_methods_enabled: mca.payment_methods_enabled.clone(),
+        })
+        .collect::<Vec<_>>();
+    let mca_graph = kgraph_utils::mca::make_mca_graph(mca_graph_data, &config).err_to_js()?;
     let analysis_graph = hyperswitch_constraint_graph::ConstraintGraph::combine(
         &mca_graph,
         &dssa::truth::ANALYSIS_GRAPH,

--- a/crates/kgraph_utils/benches/evaluation.rs
+++ b/crates/kgraph_utils/benches/evaluation.rs
@@ -76,29 +76,9 @@ fn build_test_data(
     // };
 
     #[cfg(feature = "v1")]
-    let stripe_account = MerchantConnectorResponse {
-        connector_type: api_enums::ConnectorType::FizOperations,
+    let stripe_account = MCACGraphData {
         connector_name: "stripe".to_string(),
-        merchant_connector_id:
-            common_utils::generate_merchant_connector_account_id_of_default_length(),
-        connector_account_details: hyperswitch_masking::Secret::new(serde_json::json!({})),
-        test_mode: None,
-        disabled: None,
-        metadata: None,
         payment_methods_enabled: Some(pms_enabled),
-        business_country: Some(api_enums::CountryAlpha2::US),
-        business_label: Some("hello".to_string()),
-        connector_label: Some("something".to_string()),
-        business_sub_label: Some("something".to_string()),
-        frm_configs: None,
-        connector_webhook_details: None,
-        profile_id,
-        applepay_verified_domains: None,
-        pm_auth_config: None,
-        status: api_enums::ConnectorStatus::Inactive,
-        additional_merchant_data: None,
-        connector_wallets_details: None,
-        webhook_setup_capabilities: None,
     };
     let config = CountryCurrencyFilter {
         connector_configs: HashMap::new(),

--- a/crates/kgraph_utils/src/mca.rs
+++ b/crates/kgraph_utils/src/mca.rs
@@ -917,7 +917,7 @@ fn compile_config_graph(
 #[cfg(feature = "v2")]
 fn compile_merchant_connector_graph(
     builder: &mut cgraph::ConstraintGraphBuilder<dir::DirValue>,
-    mca: admin_api::MerchantConnectorResponse,
+    mca: admin_api::MCACGraphData,
     config: &kgraph_types::CountryCurrencyFilter,
 ) -> Result<(), KgraphError> {
     let connector = euclid::enums::RoutableConnectors::try_from(mca.connector_name)
@@ -988,7 +988,7 @@ fn compile_merchant_connector_graph(
 #[cfg(feature = "v1")]
 fn compile_merchant_connector_graph(
     builder: &mut cgraph::ConstraintGraphBuilder<dir::DirValue>,
-    mca: admin_api::MerchantConnectorResponse,
+    mca: admin_api::MCACGraphData,
     config: &kgraph_types::CountryCurrencyFilter,
 ) -> Result<(), KgraphError> {
     let connector = euclid::enums::RoutableConnectors::from_str(&mca.connector_name)
@@ -1058,7 +1058,7 @@ fn compile_merchant_connector_graph(
 
 // #[cfg(feature = "v1")]
 pub fn make_mca_graph(
-    accts: Vec<admin_api::MerchantConnectorResponse>,
+    accts: Vec<admin_api::MCACGraphData>,
     config: &kgraph_types::CountryCurrencyFilter,
 ) -> Result<cgraph::ConstraintGraph<dir::DirValue>, KgraphError> {
     let mut builder = cgraph::ConstraintGraphBuilder::new();
@@ -1090,7 +1090,6 @@ mod tests {
 
     fn build_test_data() -> ConstraintGraph<dir::DirValue> {
         use api_models::{admin::*, payment_methods::*};
-        let profile_id = common_utils::generate_profile_id_of_default_length();
 
         // #[cfg(feature = "v2")]
         // let stripe_account = MerchantConnectorResponse {
@@ -1148,19 +1147,8 @@ mod tests {
         //     connector_wallets_details: None,
         // };
         #[cfg(feature = "v1")]
-        let stripe_account = MerchantConnectorResponse {
-            connector_type: api_enums::ConnectorType::FizOperations,
+        let stripe_account = MCACGraphData {
             connector_name: "stripe".to_string(),
-            merchant_connector_id:
-                common_utils::generate_merchant_connector_account_id_of_default_length(),
-            business_country: Some(api_enums::CountryAlpha2::US),
-            connector_label: Some("something".to_string()),
-            business_label: Some("food".to_string()),
-            business_sub_label: None,
-            connector_account_details: hyperswitch_masking::Secret::new(serde_json::json!({})),
-            test_mode: None,
-            disabled: None,
-            metadata: None,
             payment_methods_enabled: Some(vec![PaymentMethodsEnabled {
                 payment_method: api_enums::PaymentMethod::Card,
                 payment_method_types: Some(vec![
@@ -1198,15 +1186,6 @@ mod tests {
                     },
                 ]),
             }]),
-            frm_configs: None,
-            connector_webhook_details: None,
-            profile_id,
-            applepay_verified_domains: None,
-            pm_auth_config: None,
-            status: api_enums::ConnectorStatus::Inactive,
-            additional_merchant_data: None,
-            connector_wallets_details: None,
-            webhook_setup_capabilities: None,
         };
 
         let config_map = kgraph_types::CountryCurrencyFilter {
@@ -1559,8 +1538,7 @@ mod tests {
             }
         ]);
 
-        let data: Vec<admin_api::MerchantConnectorResponse> =
-            serde_json::from_value(value).expect("data");
+        let data: Vec<admin_api::MCACGraphData> = serde_json::from_value(value).expect("data");
         let config = kgraph_types::CountryCurrencyFilter {
             connector_configs: HashMap::new(),
             default_configs: None,

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -2080,10 +2080,9 @@ pub async fn refresh_cgraph_cache(
 ) -> RoutingResult<Arc<hyperswitch_constraint_graph::ConstraintGraph<euclid_dir::DirValue>>> {
     let mut merchant_connector_accounts = state
         .store
-        .find_merchant_connector_account_by_merchant_id_and_disabled_list(
+        .find_merchant_connector_account_without_encrypted_by_merchant_id_and_disabled_list(
             &key_store.merchant_id,
             false,
-            key_store,
         )
         .await
         .change_context(errors::RoutingError::KgraphCacheRefreshFailed)?;
@@ -2121,7 +2120,7 @@ pub async fn refresh_cgraph_cache(
 
     let api_mcas = merchant_connector_accounts
         .into_iter()
-        .map(admin_api::MerchantConnectorResponse::foreign_try_from)
+        .map(admin_api::MCACGraphData::foreign_try_from)
         .collect::<Result<Vec<_>, _>>()
         .change_context(errors::RoutingError::KgraphCacheRefreshFailed)?;
     let connector_configs = state

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -1244,6 +1244,38 @@ impl ForeignTryFrom<domain::MerchantConnectorAccount>
     }
 }
 
+impl ForeignTryFrom<domain::MerchantConnectorAccountWithoutEncrypted>
+    for api_models::admin::MCACGraphData
+{
+    type Error = error_stack::Report<errors::ApiErrorResponse>;
+    fn foreign_try_from(
+        item: domain::MerchantConnectorAccountWithoutEncrypted,
+    ) -> Result<Self, Self::Error> {
+        #[cfg(feature = "v1")]
+        let payment_methods_enabled = match item.payment_methods_enabled {
+            Some(secret_val) => {
+                let val = secret_val
+                    .into_iter()
+                    .map(|secret| secret.expose())
+                    .collect();
+                serde_json::Value::Array(val)
+                    .parse_value("PaymentMethods")
+                    .change_context(errors::ApiErrorResponse::InternalServerError)?
+            }
+            None => None,
+        };
+
+        #[cfg(feature = "v2")]
+        let payment_methods_enabled = item.payment_methods_enabled;
+
+        let response = Self {
+            connector_name: item.connector_name,
+            payment_methods_enabled,
+        };
+        Ok(response)
+    }
+}
+
 #[cfg(feature = "v2")]
 impl ForeignTryFrom<domain::MerchantConnectorAccount>
     for api_models::admin::MerchantConnectorResponse


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
`refresh_cgraph_cache` in routing.rs does not use encrypted data from the MCA, but it was calling the DB function that calls encryption service to decrypt the data. Moved it to call `find_merchant_connector_account_without_encrypted_by_merchant_id_and_disabled_list` to reduce encryption service calls. It only access connector_name and payment_methods_enabled.

Added `MCACGraphData` instead of converting MCA data to MerchantConnectorResponse and using that in `kgraph`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Compilation locally

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
