### PR TITLE
fix(ucs): map an empty connector_transaction_id to NoResponseId on PSync

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -402,9 +402,6 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
     ) -> Result<Self, Self::Error> {
         let status_code = convert_connector_service_status_code(response.status_code)?;
 
-        // `connector_transaction_id` is a plain proto3 string, so a connector that returned no
-        // transaction id reaches us as "" rather than as an absent field. Map it back to
-        // NoResponseId, the way the flows whose id is an `optional` proto field already do.
         let connector_transaction_id = if response.connector_transaction_id.is_empty() {
             hyperswitch_domain_models::router_request_types::ResponseId::NoResponseId
         } else {

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -402,10 +402,16 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
     ) -> Result<Self, Self::Error> {
         let status_code = convert_connector_service_status_code(response.status_code)?;
 
-        let connector_transaction_id =
+        // `connector_transaction_id` is a plain proto3 string, so a connector that returned no
+        // transaction id reaches us as "" rather than as an absent field. Map it back to
+        // NoResponseId, the way the flows whose id is an `optional` proto field already do.
+        let connector_transaction_id = if response.connector_transaction_id.is_empty() {
+            hyperswitch_domain_models::router_request_types::ResponseId::NoResponseId
+        } else {
             hyperswitch_domain_models::router_request_types::ResponseId::ConnectorTransactionId(
                 response.connector_transaction_id.clone(),
-            );
+            )
+        };
 
         let connector_details = response
             .error


### PR DESCRIPTION
## What

`PaymentServiceGetResponse.connector_transaction_id` is a **plain proto3 string** (`payment.proto:2625`), not an `optional`. So a connector that returned no transaction id reaches the client as `""` rather than as an absent field — UCS serialises `ResponseId::NoResponseId` to exactly that (`domain_types/src/types.rs:5354` maps it to `None`, then `:7550` does `.unwrap_or_default()`).

The client wrapped it unconditionally:

```rust
let connector_transaction_id =
    ResponseId::ConnectorTransactionId(response.connector_transaction_id.clone());
```

…minting a `ConnectorTransactionId("")` where the direct integration produces a `NoResponseId`. The two serialise differently — `"NoResponseId"` (a string) vs `{"ConnectorTransactionId": ""}` (an object) — which is the reported `typeDiff`.

This PR guards on the empty string, the way the flows whose id **is** an `optional` proto field already do (they map `None → NoResponseId`, e.g. `router/src/core/unified_connector_service/transformers.rs:2562`, `:3057`, `:4542`). PSync's field has no `Option` to lean on, which is why it was missed.

It also stops an empty id leaking into the error path's `connector_transaction_id` (`.get_optional_response_id()`), which now correctly resolves to `None` instead of `Some("")`.

Fixes juspay/hyperswitch-cloud#19535 (parent #19534).

## Root cause (prod)

Shadow-diff `router.typeDiff:response.Ok.TransactionResponse.resource_id`, merchant `merchant_1771364887457` / `nmi` / `psync`, x-request-id `019f211d-0b72-7fd1-873a-ab4875c91ea7` (UUIDv7 → txn **2026-07-02T04:36:19Z**).

Loki confirms this is **not** the synthetic-502 class — both legs got a genuine NMI **HTTP 200** (UCS `"stage":"ConnectorCall","latency_ms":2905,"status_code":200,"error":null`; Direct `[CALL_CONNECTOR_API] status_code = 200`). NMI returned an empty transaction list for an attempt it had never seen. Requests were byte-identical; only the response mapping diverged.

The direct leg keeps the `NoResponseId` that PSync pre-fills into `RouterData` (`router/src/core/payments/transformers.rs:1947-1968`, then NMI's `None => Ok(Self { ..item.data })` leaves it alone). The shadow leg re-wrapped UCS's `""` into `ConnectorTransactionId("")`. UCS is innocent here — it emits `NoResponseId` correctly; the signal is destroyed at the proto boundary and mis-restored by this client.

## Before / after

Reproduced locally on clean `main` against the real NMI sandbox: attempt in `payment_method_awaited` with no connector txn id → `GET /payments/{id}?force_sync=true&all_keys_required=true`.

**BEFORE** (`VS_48`, x-req `019f581d-ae17`) — reproduces the prod payload exactly:
```json
"differences": {
  "keyDiff": {},
  "valueDiff": {"status": {"hyperswitch": "payment_method_awaited", "ucs": "authentication_pending"}},
  "typeDiff": {"response.Ok.TransactionResponse.resource_id": {"hyperswitch": "string", "ucs": "object"}}
}
```

**AFTER** (`VS_46`, x-req `019f5823-d6e3`) — with this PR + juspay/hyperswitch-prism#1923:
```json
"Router data comparison completed successfully - no differences found"
"summary": {"total_key_differences": 0, "total_value_differences": 0, "total_type_differences": 0},
"data_sizes": {"hyperswitch_data_keys": 56, "ucs_data_keys": 56}
```

56/56 keys mapped on both sides, so the UCS leg really ran (not a false green).

> The `status` half of the diff is a separate defect in UCS's NMI transformer and is fixed by **juspay/hyperswitch-prism#1923**; both are needed for the fully-green run above.

## Regression check — a real transaction id still round-trips

Real NMI authorize → approved (txn `12295063749`), then PSync so `query.php` returns an actual transaction:

`VS_51`: `hyperswitch_status = ucs_status = charged` · `keyDiff {}` · `valueDiff {}` · **`resource_id` absent from `typeDiff`** — the non-empty id maps to `ConnectorTransactionId("12295063749")` on both legs, unchanged by this guard.

(The two `typeDiff` keys left on that run — `amount_captured` / `minor_amount_captured` — are the pre-existing PSync bug at `psync_gateway.rs:108`/`:279`, already tracked by the open PR #13206. Unrelated to this issue.)

## Notes

- **No proto change and no rev-pin** — this is a client-side mapping fix only, so it is not a draft.
- The guard is generic, not NMI-specific: any connector whose PSync returns no transaction id benefits.