### PR TITLE
fix(analytics): tolerate null destination and exclude shadow events from connector event logs

### DIFF
--- a/crates/analytics/src/connector_events/core.rs
+++ b/crates/analytics/src/connector_events/core.rs
@@ -27,7 +27,6 @@ pub async fn connector_events_core(
     }
     .switch()?;
 
-    // Shadow events are internal comparison traffic, not the merchant's call.
     Ok(data
         .into_iter()
         .filter(|event| !event.is_shadow())

--- a/crates/analytics/src/connector_events/core.rs
+++ b/crates/analytics/src/connector_events/core.rs
@@ -26,5 +26,10 @@ pub async fn connector_events_core(
         }
     }
     .switch()?;
-    Ok(data)
+
+    // Shadow events are internal comparison traffic, not the merchant's call.
+    Ok(data
+        .into_iter()
+        .filter(|event| !event.is_shadow())
+        .collect())
 }

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -93,10 +93,5 @@ pub struct ConnectorEventsResult {
     #[serde(with = "common_utils::custom_serde::iso8601")]
     pub created_at: PrimitiveDateTime,
     pub method: Option<String>,
-    #[serde(default = "default_connector_event_destination")]
-    pub destination: common_enums::EventDestination,
-}
-
-fn default_connector_event_destination() -> common_enums::EventDestination {
-    common_enums::EventDestination::Connector
+    pub destination: Option<String>,
 }

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -94,14 +94,11 @@ pub struct ConnectorEventsResult {
     pub created_at: PrimitiveDateTime,
     pub method: Option<String>,
     pub destination: Option<String>,
-    /// Read to filter shadow-mode events out of the response; never surfaced to the caller.
     #[serde(skip_serializing)]
     pub execution_mode: Option<String>,
 }
 
 impl ConnectorEventsResult {
-    /// An absent, null or unrecognised execution_mode is treated as primary, so that a value the
-    /// reader does not know about cannot hide a connector call from the log.
     pub fn is_shadow(&self) -> bool {
         self.execution_mode
             .as_deref()

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -94,6 +94,7 @@ pub struct ConnectorEventsResult {
     pub created_at: PrimitiveDateTime,
     pub method: Option<String>,
     pub destination: Option<String>,
+    /// Read to filter shadow-mode events out of the response; never surfaced to the caller.
     #[serde(skip_serializing)]
     pub execution_mode: Option<String>,
 }

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -94,4 +94,17 @@ pub struct ConnectorEventsResult {
     pub created_at: PrimitiveDateTime,
     pub method: Option<String>,
     pub destination: Option<String>,
+    /// Read to filter shadow-mode events out of the response; never surfaced to the caller.
+    #[serde(skip_serializing)]
+    pub execution_mode: Option<String>,
+}
+
+impl ConnectorEventsResult {
+    /// An absent, null or unrecognised execution_mode is treated as primary, so that a value the
+    /// reader does not know about cannot hide a connector call from the log.
+    pub fn is_shadow(&self) -> bool {
+        self.execution_mode
+            .as_deref()
+            .is_some_and(|mode| mode.eq_ignore_ascii_case("shadow"))
+    }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

`GET /analytics/v1/profile/connector_event_logs` returns `500 HE_00` for any payment whose `connector_events_audit` rows carry a `NULL` `destination`.

#13177 added `destination` to `ConnectorEventsResult` as a non-optional enum, guarded by `#[serde(default)]`:

```rust
#[serde(default = "default_connector_event_destination")]
pub destination: common_enums::EventDestination,
```

`#[serde(default)]` fires when a key is **absent**. It does not fire when the key is **present and `null`** — those are two different things to serde. The query path is `SELECT *`, so ClickHouse always emits every column of the table; a `Nullable` column with no value comes back as `"destination": null`, the key *is* present, the default never applies, and serde is asked to build an enum from `null`:

```
Failed to parse ConnectorEventsResult in clickhouse results
  at crates/analytics/src/clickhouse.rs:241
invalid type: null, expected string or map
```

Rows are deserialized as a set, so a single unparseable row fails the entire response — the whole connector event log 500s rather than degrading.

Every row written before `ALTER TABLE connector_events_audit ADD COLUMN destination` holds `NULL`, so this reproduces on any environment where the column was added to a table that already had rows.

## Fix

Map the column the way every other nullable column in this struct is already mapped:

```rust
pub destination: Option<String>,
```

`Option<T>` needs no attributes — serde resolves a missing key *and* an explicit `null` to `None`, which is exactly why `masked_response`, `error`, `refund_id`, `dispute_id` and `latency` have never hit this.

`String` rather than `Option<EventDestination>`, for two reasons:

- **Nothing enforces the value set.** The column is `LowCardinality(Nullable(String))` and is written by a hand-authored materialized view as a SQL string literal — not round-tripped through the Rust enum. An `ifNull(destination, '')` (an idiom these MVs already use for `merchant_id` and `method`), a typo, or a third destination added to the MV all deserialize as `unknown variant …` and 500 the whole log again. `Option<EventDestination>` fixes `null` and leaves that hole open.
- **It matches this file.** No analytics event-log struct binds a ClickHouse column to a typed enum — `connector`, `payment_method`, `payment_method_type`, `api_auth_type` and `routing_approach` are all `Option<String>`, despite being enums in the domain. Typed enums (`Option<DBEnumWrapper<AttemptStatus>>`) are used only for metrics dimensions that HS itself writes from the same enum, where the value set cannot drift ahead of the reader.

No Rust code branches on `destination`; it is read from ClickHouse and serialized straight through to Control Center, which compares strings.

`null` is reported as `null`, not coerced to `connector`. `null` means "not recorded", which is not the same claim as "went directly to the connector" — coercing it in the read layer would make an ingestion gap indistinguishable from a real direct call for every consumer, forever. Consumers that need a display value should apply the fallback themselves: Control Center should render a row with no destination exactly as it does today.

## Also: shadow events are excluded from the log

Shadow-mode events are internal comparison traffic, not calls the merchant made. They must not appear in the connector event log once they start landing in the audit tables.

`execution_mode` is read **for filtering only** and carries `#[serde(skip_serializing)]`, so the response shape to Control Center is unchanged:

```rust
/// Read to filter shadow-mode events out of the response; never surfaced to the caller.
#[serde(skip_serializing)]
pub execution_mode: Option<String>,
```

Returning it would not break the dashboard, but it would not be ignored either. `AuditLogUI.res` renders every response key that is not in `detailsSectionFilterKeys` into the details panel, auto-labelled — so an unfiltered `execution_mode` would surface as a literal "Execution Mode: primary" row to merchants, with no frontend change. (`destination` is in the same position today.)

Filtering is done in Rust rather than in the query, because a `WHERE` clause fails both requirements:

- it errors outright in any environment where the column has not been rolled out yet. The schema is applied per environment, so the reader must not depend on the column existing;
- `NULL != 'shadow'` evaluates to `NULL` under SQL three-valued logic, so it would silently drop exactly the rows that should be kept.

`Option<String>` covers every state:

| ClickHouse state | deserializes to | outcome |
|---|---|---|
| column absent | key absent → `None` | kept, treated as primary |
| column present, `NULL` | `None` | kept, treated as primary |
| malformed (`''`, `PRIMARY`, unknown) | `Some(..)`, no match | kept — fail open |
| `shadow` (any case) | `Some("shadow")` | excluded |

Fail-open is deliberate: a bad value in a materialized view must never hide a real connector call from the merchant.

Only primary events are emitted today, so this changes nothing in practice. It takes effect if and when shadow events start being ingested, at which point the alternative is phantom duplicate connector calls in every merchant's log.

## How did you test it?

`cargo check -p router` passes. Beyond that, the fix was verified against a **running router backed by a real ClickHouse**, seeded with every state the pipeline can produce, exercising **all four audit tables** through **both routes**.

### Setup

Local router (this branch) + postgres + ClickHouse. All four tables created to match the shapes the prod migration produces, including `execution_mode` on `connector_events_payout_audit` and the `url` column on the prism tables. A real merchant, payment and payout were created so the `check_if_profile_id_is_present_in_intent_table` guard is satisfied.

Rows seeded into `connector_events_audit` (mirrored into the other three):

| request_id | destination | execution_mode | represents |
| --- | --- | --- | --- |
| r01 | `NULL` | `NULL` | **the 500** — a row written before the column was populated |
| r02 / r03 | `connector` / `NULL` | `NULL` / `primary` | one column populated, not the other |
| r04 | `connector` | `primary` | a normal HS row |
| r05 | `unified_connector_service` | `primary` | the HS to UCS hop |
| r06 / r07 / r08 | `connector` / `unified_connector_service` | `shadow` / `SHADOW` | shadow traffic, incl. casing |
| r09 | `prism` | `primary` | a value outside the enum |
| r10 | `""` | `""` | what an `ifNull(x, '')` in a materialized view produces |
| r11 | `connector` | `primary_v2` | an execution_mode the reader does not know |
| r12 / r13 | refund rows, one `shadow` | | refund log path |
| r14 | dispute row | | dispute log path |

Rows are also present with the columns entirely **absent** from the table, covering an environment where the migration has not run.

### Before — `main` today

Every endpoint fails, not just the payment log:

```
Payment  type=Payment&payment_id               HTTP 500  {"error":{"type":"api","message":"Something went wrong","code":"HE_00"}}
Refund   payment_id&refund_id                  HTTP 500  {"error":{"type":"api","message":"Something went wrong","code":"HE_00"}}
Dispute  payment_id&dispute_id                 HTTP 500  {"error":{"type":"api","message":"Something went wrong","code":"HE_00"}}
Payout   type=Payout&payout_id                 HTTP 500  {"error":{"type":"api","message":"Something went wrong","code":"HE_00"}}
Prism payment  type=Payment&payment_id         HTTP 500  {"error":{"type":"api","message":"Something went wrong","code":"HE_00"}}
Prism payout   type=Payout&payout_id           HTTP 500  {"error":{"type":"api","message":"Something went wrong","code":"HE_00"}}
```

Router log: `invalid type: null, expected string or map` — the same error seen on integ for `pay_5fsVKr5n7G8103nuLH1k`.

A single `NULL` row fails the whole result set, so one legacy row takes down the entire log for that payment.

### After — this branch

```
Payment  type=Payment&payment_id           HTTP 200   rows=10
Refund   payment_id&refund_id              HTTP 200   rows=1
Dispute  payment_id&dispute_id             HTTP 200   rows=1
Payout   type=Payout&payout_id             HTTP 200   rows=2
Prism payment  type=Payment&payment_id     HTTP 200   rows=3
Prism refund   payment_id&refund_id        HTTP 200   rows=1
Prism payout   type=Payout&payout_id       HTTP 200   rows=1
```

Rows below are the seeded fixtures above, not production traffic — `prism` and `primary_v2` cannot occur naturally, which is why they are seeded. The response is unedited:

```console
$ curl -s "$BASE/analytics/v1/profile/connector_event_logs?type=Payment&payment_id=pay_YWnB2gWOaHLlmsg0JP5W" \
    -H "authorization: Bearer $JWT" -H "x-profile-id: pro_..." -H "x-merchant-id: merchant_local_test"
```

One full row, nothing removed — note there is no `execution_mode` key:

```json
{
  "merchant_id": "merchant_local_test",
  "payment_id": "pay_YWnB2gWOaHLlmsg0JP5W",
  "payout_id": null,
  "connector_name": "stripe",
  "request_id": "r01",
  "flow": "Authorize",
  "request": "{}",
  "masked_response": "{}",
  "error": null,
  "status_code": 200,
  "latency": 1073,
  "created_at": "2026-07-13T11:48:01.031Z",
  "method": "POST",
  "destination": null
}
```

The 10 returned rows, abridged to the fields under test:

```json
[
  { "request_id": "r01", "flow": "Authorize", "status_code": 200, "destination": null },
  { "request_id": "r02", "flow": "Authorize", "status_code": 200, "destination": "connector" },
  { "request_id": "r03", "flow": "Authorize", "status_code": 200, "destination": null },
  { "request_id": "r04", "flow": "Authorize", "status_code": 200, "destination": "connector" },
  { "request_id": "r05", "flow": "Authorize", "status_code": 200, "destination": "unified_connector_service" },
  { "request_id": "r09", "flow": "Authorize", "status_code": 200, "destination": "prism" },
  { "request_id": "r10", "flow": "Authorize", "status_code": 200, "destination": "" },
  { "request_id": "r11", "flow": "Authorize", "status_code": 200, "destination": "connector" },
  { "request_id": "r12", "flow": "Refund",    "status_code": 200, "destination": null },
  { "request_id": "r14", "flow": "Dsync",     "status_code": 200, "destination": null }
]
```

14 rows seeded, 10 returned:

- **r01 parses** and reports `destination: null` rather than 500ing.
- **r06, r07, r08, r13 are gone** — every shadow row, in every table, including the uppercase `SHADOW`.
- **r09 (`prism`), r10 (`""`), r11 (`primary_v2`) survive.** These are the values an `Option<EventDestination>` would still have rejected with `unknown variant`, taking the whole log down with them.
- **`execution_mode` is absent from every row of every response** — verified across all rows, not just inferred from `skip_serializing`.

Absent columns, `NULL`, recognised, unrecognised and empty values are all handled; the only rows removed are those explicitly marked `shadow`.


**tested lcoally with latest control center**
Hyperswitch direct event
<img width="1319" height="618" alt="image" src="https://github.com/user-attachments/assets/98ed6927-40a3-4bf4-a5ed-bca91cb1909f" />



## Deployment note

The ClickHouse migration adds `destination` to `connector_events_audit` **and** `connector_events_payout_audit` without a backfill, so every pre-existing row in both is `NULL`. That is correct and intentional — a backfill to `'connector'` would mislabel the HS to UCS hops already recorded.

It does mean the migration is safe against a router that predates #13177 (no such field, key ignored), and the failure appears on the **first deploy carrying #13177 afterwards**. This PR must therefore ship in, or before, that release.

