### PR TITLE
feat(deja): [4/5] external I/O + crypto capture (redis, HTTP, RNG/nonce/hash)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,6 +2863,7 @@ dependencies = [
  "deja-core",
  "deja-derive",
  "deja-runtime",
+ "error-stack 0.4.1",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,7 +2857,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "deja"
 version = "0.1.0"
-source = "git+https://github.com/juspay/deja?rev=2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716#2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716"
+source = "git+https://github.com/juspay/deja?rev=2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3#2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3"
 dependencies = [
  "deja-context",
  "deja-core",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "deja-context"
 version = "0.1.0"
-source = "git+https://github.com/juspay/deja?rev=2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716#2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716"
+source = "git+https://github.com/juspay/deja?rev=2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3#2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3"
 dependencies = [
  "pin-project-lite",
 ]
@@ -2879,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "deja-core"
 version = "0.1.0"
-source = "git+https://github.com/juspay/deja?rev=2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716#2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716"
+source = "git+https://github.com/juspay/deja?rev=2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3#2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "deja-derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/deja?rev=2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716#2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716"
+source = "git+https://github.com/juspay/deja?rev=2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3#2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2899,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "deja-runtime"
 version = "0.1.0"
-source = "git+https://github.com/juspay/deja?rev=2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716#2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716"
+source = "git+https://github.com/juspay/deja?rev=2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3#2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3"
 dependencies = [
  "async-trait",
  "deja-context",
@@ -3546,6 +3546,7 @@ dependencies = [
  "error-stack 0.4.1",
  "hex",
  "http 0.2.12",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.32",
  "hyper-proxy",
@@ -3556,6 +3557,7 @@ dependencies = [
  "once_cell",
  "open-feature",
  "prost 0.14.3",
+ "prost-reflect",
  "prost-types 0.14.3",
  "quick-xml",
  "reqwest 0.11.27",
@@ -3570,6 +3572,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time 0.3.41",
  "tokio 1.48.0",
+ "tokio-stream",
  "tonic 0.14.5",
  "tonic-prost",
  "tonic-prost-build",
@@ -7453,6 +7456,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
+dependencies = [
+ "base64 0.22.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "serde",
+ "serde-value",
 ]
 
 [[package]]

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -168,7 +168,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -1077,7 +1077,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -1085,7 +1085,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -1096,7 +1096,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/development.toml
+++ b/config/development.toml
@@ -34,7 +34,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -46,7 +46,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/superposition_seed.toml
+++ b/config/superposition_seed.toml
@@ -11,10 +11,10 @@
 overrides = []
 
 [default-configs.deja_record]
-value = true
+value = false
 schema = { type = "boolean" }
-description = "Whether Deja request recording is enabled for matching request contexts (inert unless deja.sampler.enabled is set)"
-change_reason = "Initial setup"
+description = "Deja per-request recording decision — default SKIP (false). The deja_dimension cohort override (seeded by scripts/seed_superposition.sh) sets this true for the recordable endpoint bucket; /health and other probe traffic fall through to false."
+change_reason = "Deja recording sampler"
 
 
 [dimensions.connector]
@@ -70,6 +70,24 @@ position = 9
 schema = { type = "string" }
 description = "Business profile identifier"
 change_reason = "Initial setup"
+
+# ── Deja recording sampler dimensions ────────────────────────────────────────
+# The sampler passes the RAW request `path` + `method` as evaluation context;
+# Superposition derives the `deja_dimension` cohort (a LOCAL_COHORT on `path`,
+# seeded by scripts/seed_superposition.sh) and resolves `deja_record`. `path`
+# must be a registered dimension so the server builds the cohort's dependency
+# graph (path → deja_dimension).
+[dimensions.path]
+position = 10
+schema = { type = "string" }
+description = "HTTP request path (Deja recording sampler context; basis of the deja_dimension cohort)"
+change_reason = "Deja recording sampler"
+
+[dimensions.method]
+position = 11
+schema = { type = "string" }
+description = "HTTP request method (Deja recording sampler context)"
+change_reason = "Deja recording sampler"
 
 [default-configs.requires_cvv]
 value = true

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -31,7 +31,7 @@ base64-serde = "0.8.0"
 blake3 = { version = "1.8.2", features = ["serde"] }
 bytes = "1.10.1"
 diesel = "2.2.10"
-deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false }
+deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false }
 error-stack = "0.4.1"
 futures = { version = "0.3.31", optional = true }
 globset = "0.4.16"

--- a/crates/common_utils/src/crypto.rs
+++ b/crates/common_utils/src/crypto.rs
@@ -26,7 +26,32 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-struct NonceSequence(u128);
+#[cfg_attr(feature = "deja", derive(serde::Serialize, serde::Deserialize))]
+struct NonceSequence(
+    // deja: serialize the 96-bit nonce as its 16 big-endian BYTES, not a bare
+    // u128. A nonce routinely exceeds u64::MAX, and `serde_json::Value::Number`
+    // cannot hold a u128 beyond u64 range — so capturing it as a number FAILED
+    // and the boundary recorded `null`, leaving nothing to substitute (the real
+    // random nonce then ran on replay → divergent at-rest ciphertext). A byte
+    // array is small-int-only, so it round-trips through serde_json and any
+    // JSON event transport losslessly, exactly like `generate_aes256_key`.
+    #[cfg_attr(feature = "deja", serde(with = "deja_nonce_bytes"))] u128,
+);
+
+/// deja: lossless u128 nonce (de)serialization via its 16 big-endian bytes.
+#[cfg(feature = "deja")]
+mod deja_nonce_bytes {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &u128, s: S) -> Result<S::Ok, S::Error> {
+        v.to_be_bytes().serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<u128, D::Error> {
+        let bytes = <[u8; 16]>::deserialize(d)?;
+        Ok(u128::from_be_bytes(bytes))
+    }
+}
 
 impl NonceSequence {
     /// Byte index at which sequence number starts in a 16-byte (128-bit) sequence.
@@ -35,6 +60,21 @@ impl NonceSequence {
     const SEQUENCE_NUMBER_START_INDEX: usize = 4;
 
     /// Generate a random nonce sequence.
+    //
+    // deja: the AEAD nonce is the single source of ciphertext non-determinism.
+    // Recording it (Ok-only; the ring error type is non-serializable) and
+    // replaying it in call order makes `encode_message` reproduce byte-identical
+    // ciphertext for the same key+plaintext, so encrypted DB columns and HTTP
+    // bodies match the recording exactly. Real AES still runs; only the random
+    // nonce is substituted.
+    #[cfg_attr(
+        feature = "deja",
+        deja::id(
+            component = "common_utils::crypto",
+            operation = "GcmAes256::nonce",
+            codec = ResultOkCodec,
+        )
+    )]
     fn new() -> Result<Self, ring::error::Unspecified> {
         use ring::rand::{SecureRandom, SystemRandom};
 
@@ -608,6 +648,14 @@ impl EncodeMessage for TripleDesEde3CBC {
 /// Generate a random string using a cryptographically secure pseudo-random number generator
 /// (CSPRNG). Typically used for generating (readable) keys and passwords.
 #[inline]
+#[cfg_attr(
+    feature = "deja",
+    deja::id(
+        component = "common_utils::crypto",
+        operation = "generate_cryptographically_secure_random_string",
+        codec = SerdeCodec,
+    )
+)]
 pub fn generate_cryptographically_secure_random_string(length: usize) -> String {
     use rand::distributions::DistString;
 

--- a/crates/diesel_models/Cargo.toml
+++ b/crates/diesel_models/Cargo.toml
@@ -33,7 +33,7 @@ common_types = { version = "0.1.0", path = "../common_types" }
 hyperswitch_masking = "0.0.1"
 router_derive = { version = "0.1.0", path = "../router_derive" }
 router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"] }
-deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false, features = ["error-stack"] }
+deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false, features = ["error-stack"] }
 
 [lints]
 workspace = true

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -20,7 +20,13 @@ superposition = [
 ]
 v1 = ["hyperswitch_interfaces/v1", "common_utils/v1"]
 v2 = ["hyperswitch_interfaces/v2", "common_utils/v2"]
-deja = ["dep:bytes", "dep:deja"]
+deja = [
+    "dep:bytes",
+    "dep:deja",
+    "dep:http-body",
+    "dep:http-body-util",
+    "dep:prost-reflect",
+]
 revenue_recovery = [
     "dep:prost",
     "dep:router_env",
@@ -56,7 +62,7 @@ aws-smithy-runtime-api = { version = "1.7", features = ["client"] }
 aws-smithy-types = "1.3.1"
 base64 = "0.22.1"
 dyn-clone = "1.0.19"
-deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false }
+deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false }
 error-stack = "0.4.1"
 hex = "0.4.3"
 hyper = "0.14.32"
@@ -69,6 +75,7 @@ serde_json = "1.0.140"
 serde_urlencoded = "0.7.1"
 vaultrs = { version = "0.7.4", optional = true }
 prost = { version = "0.14", optional = true }
+prost-reflect = { version = "0.16.5", features = ["serde"], optional = true }
 prost-types = { version = "0.14", optional = true }
 time = { version = "0.3.41", features = ["serde", "serde-well-known", "std"] }
 tokio = "1.48.0"
@@ -79,6 +86,7 @@ tonic-types = "0.13.1"
 typed-builder = "0.21.2"
 hyper-util = { version = "0.1.12", optional = true }
 http-body-util = { version = "0.1.3", optional = true }
+http-body = { version = "1.0.1", optional = true }
 reqwest = { version = "0.11.27", features = ["rustls-tls"] }
 http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
@@ -107,6 +115,11 @@ api_models = { version = "0.1.0", path = "../api_models", optional = true }
 [build-dependencies]
 router_env = { version = "0.1.0", path = "../router_env", default-features = false, optional = true }
 tonic-prost-build = "0.14"
+
+[dev-dependencies]
+# Test-only: the deja gRPC transport test drives a real tonic server over a
+# TcpListener via `tokio_stream::wrappers::TcpListenerStream` (the `net` feature).
+tokio-stream = { version = "0.1.17", features = ["net"] }
 
 [lints]
 workspace = true

--- a/crates/external_services/build.rs
+++ b/crates/external_services/build.rs
@@ -11,6 +11,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .out_dir(&out_dir)
             .compile_well_known_types(true)
             .extern_path(".google.protobuf.Timestamp", "::prost_types::Timestamp")
+            // The deja gRPC boundary decodes this descriptor set at runtime to
+            // render request/response messages structurally.
+            .file_descriptor_set_path(out_dir.join("deja_recovery_descriptor.bin"))
             .compile_protos(&recovery_proto_files, &[proto_base_path])
             .expect("Failed to compile revenue-recovery proto files");
     }
@@ -29,6 +32,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Compile the .proto file
         #[allow(clippy::expect_used, clippy::unwrap_in_result)]
         tonic_prost_build::configure()
+            // The deja gRPC boundary decodes this descriptor set at runtime to
+            // render request/response messages structurally.
+            .file_descriptor_set_path(out_dir.join("deja_dynamic_routing_descriptor.bin"))
             .out_dir(out_dir)
             .compile_protos(
                 &[

--- a/crates/external_services/src/grpc_client.rs
+++ b/crates/external_services/src/grpc_client.rs
@@ -10,6 +10,18 @@ pub mod revenue_recovery;
 
 /// gRPC based Unified Connector Service Client interface implementation
 pub mod unified_connector_service;
+
+/// Deja gRPC egress boundary: the transport-layer tower Service wrapper.
+/// Installed at transport construction
+/// sites so every unary rpc crosses one deja boundary; identity is rank-2
+/// span-path (no explicit call-site tag), routing hardcoded Substitute.
+#[cfg(feature = "deja")]
+pub mod deja_transport;
+/// Deja gRPC egress semantics: recorded result envelope, byte-faithful response
+/// reconstruction.
+#[cfg(feature = "deja")]
+pub mod semantic_boundary;
+
 use std::{fmt::Debug, sync::Arc};
 
 #[cfg(feature = "dynamic_routing")]
@@ -40,9 +52,25 @@ use crate::grpc_client::unified_connector_service::{
     UnifiedConnectorServiceClient, UnifiedConnectorServiceClientConfig,
 };
 
-#[cfg(any(feature = "dynamic_routing", feature = "revenue_recovery"))]
+#[cfg(all(
+    any(feature = "dynamic_routing", feature = "revenue_recovery"),
+    not(feature = "deja")
+))]
 /// Hyper based Client type for maintaining connection pool for all gRPC services
 pub type Client = hyper_util::client::legacy::Client<HttpConnector, Body>;
+
+#[cfg(all(
+    any(feature = "dynamic_routing", feature = "revenue_recovery"),
+    feature = "deja"
+))]
+/// Hyper based Client type for maintaining connection pool for all gRPC services.
+///
+/// Under the `deja` feature the pool is wrapped in the deja gRPC egress boundary
+/// at this single definition site — every unary rpc on every service client built
+/// over it (dynamic routing, health check, recovery decider, future) is
+/// recorded/substituted at the wire level with zero call-site changes.
+pub type Client =
+    deja_transport::DejaGrpcTransport<hyper_util::client::legacy::Client<HttpConnector, Body>>;
 
 /// Struct contains all the gRPC Clients
 #[derive(Debug, Clone)]
@@ -85,6 +113,13 @@ impl GrpcClientSettings {
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
                 .http2_only(true)
                 .build_http();
+        // deja: wrap the shared pool in the gRPC egress boundary at its one
+        // construction site.
+        #[cfg(all(
+            any(feature = "dynamic_routing", feature = "revenue_recovery"),
+            feature = "deja"
+        ))]
+        let client = deja_transport::DejaGrpcTransport::new(client);
 
         #[cfg(feature = "dynamic_routing")]
         let dynamic_routing_connection = self

--- a/crates/external_services/src/grpc_client/deja_transport.rs
+++ b/crates/external_services/src/grpc_client/deja_transport.rs
@@ -1,0 +1,428 @@
+//! The deja gRPC egress boundary — a tower `Service` wrapper around the
+//! transport under every generated tonic client.
+//!
+//! The wrapper is installed at the transport CONSTRUCTION sites (the shared
+//! hyper pool `Client` type alias and the UCS channels), so every unary rpc —
+//! current and future, on any service client built over the wrapped transport
+//! — crosses one deja boundary with zero changes to how gRPC client code is
+//! written or called.
+//!
+//! Identity carries NO explicit call-site id: this is a generic transport
+//! wrapper, so there is no per-call-site literal to name. It is
+//! `CallsiteSource::SyntacticHash` with `scope = "grpc::/package.Service/Method"`
+//! — the rpc path is the most version-independent name an egress call has, and
+//! it rides in the scope rather than as a rank-1 id — plus the span path as the
+//! calling-context disambiguator. Routing is HARDCODED
+//! `ReplayStrategy::Substitute` — egress is never re-issued.
+//!
+//! Substitution replays the recorded wire bytes through tonic's own decoder
+//! (see [`super::semantic_boundary`]), so typed `Status` errors, trailers-only
+//! shapes, and metadata partitioning reproduce by construction.
+
+use std::{
+    future::Future,
+    panic::Location,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tonic::{body::Body as TonicBody, codegen::http};
+
+use super::semantic_boundary::{self, BufferedBody, GrpcResultEnvelope};
+
+/// Boxed error type matching the `GrpcService` transport-error bound.
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+const BOUNDARY: &str = "grpc";
+const COMPONENT: &str = "external_services::grpc_client::deja_transport";
+const OPERATION: &str = "unary";
+
+/// The transport wrapper. Generic over the inner tower service so the same
+/// type serves the shared hyper pool (dynamic routing / health / recovery)
+/// and the UCS `tonic::transport::Channel`s.
+#[derive(Debug, Clone)]
+pub struct DejaGrpcTransport<S> {
+    inner: S,
+}
+
+impl<S> DejaGrpcTransport<S> {
+    /// Wraps a transport. Call at the construction site, never per request.
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+/// Envelope smuggled through `http::Extensions` from the buffering `run`
+/// closure to the recording `extract` closure — the same trick the HTTP
+/// boundary uses for its response body (`CapturedResponseBody`).
+#[derive(Clone)]
+struct CapturedEnvelope(GrpcResultEnvelope);
+
+/// A substituted transport error: the recorded display chain of the original
+/// failure. Approximate by design (the original error struct is gone); tonic
+/// maps it through `Status::from_error` exactly as it would a live failure.
+#[derive(Debug)]
+pub struct ReplayedTransportError(pub String);
+
+impl std::fmt::Display for ReplayedTransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "deja replayed transport error: {}", self.0)
+    }
+}
+
+impl std::error::Error for ReplayedTransportError {}
+
+impl<S, RB> tonic::codegen::Service<http::Request<TonicBody>> for DejaGrpcTransport<S>
+where
+    S: tonic::codegen::Service<http::Request<TonicBody>, Response = http::Response<RB>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+    RB: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    RB::Error: Into<BoxError>,
+{
+    type Response = http::Response<TonicBody>;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, BoxError>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    #[track_caller]
+    fn call(&mut self, request: http::Request<TonicBody>) -> Self::Future {
+        // Standard tower clone-dance: `self.inner` was driven to readiness by
+        // poll_ready, so hand THAT instance to the future and keep the fresh
+        // clone (which will be polled to readiness before its own use).
+        let clone = self.inner.clone();
+        let inner = std::mem::replace(&mut self.inner, clone);
+
+        // Boundary engaged only when a deja hook is live (record or replay);
+        // otherwise pure passthrough — no buffering, no dispatch, streaming
+        // untouched.
+        if !is_active() {
+            return Box::pin(passthrough(inner, request));
+        }
+        let caller = Location::caller();
+        Box::pin(boundary_call(inner, request, caller))
+    }
+}
+
+fn is_active() -> bool {
+    // Covers BOTH worlds: replay/record via the runtime hook (runtime_mode)
+    // and record via the recording hook — substitution must engage in replay,
+    // so this must never be a record-only check.
+    deja::__private::observation_is_active()
+}
+
+async fn passthrough<S, RB>(
+    mut inner: S,
+    request: http::Request<TonicBody>,
+) -> Result<http::Response<TonicBody>, BoxError>
+where
+    S: tonic::codegen::Service<http::Request<TonicBody>, Response = http::Response<RB>>,
+    S::Error: Into<BoxError>,
+    RB: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    RB::Error: Into<BoxError>,
+{
+    let response = inner.call(request).await.map_err(Into::into)?;
+    Ok(response.map(TonicBody::new))
+}
+
+/// One unary gRPC exchange as one deja boundary crossing.
+async fn boundary_call<S, RB>(
+    inner: S,
+    request: http::Request<TonicBody>,
+    caller: &'static Location<'static>,
+) -> Result<http::Response<TonicBody>, BoxError>
+where
+    S: tonic::codegen::Service<http::Request<TonicBody>, Response = http::Response<RB>>
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+    RB: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    RB::Error: Into<BoxError>,
+{
+    let (parts, body) = request.into_parts();
+
+    // Unary request: buffer the frames before forwarding — args identity
+    // needs the message bytes, and the rebuilt body is what the inner
+    // transport actually sends.
+    let request_bytes = match http_body_util::BodyExt::collect(body).await {
+        Ok(collected) => collected.to_bytes(),
+        Err(error) => return Err(error.into()),
+    };
+
+    let rpc: String = parts.uri.path().to_owned();
+    let authority = parts.uri.authority().map(ToString::to_string);
+
+    // Descriptor-decoded proto3-JSON for the local protos; UCS (unknown
+    // schema) falls back to the canonical wire identity inside `grpc_args`.
+    #[cfg(any(feature = "dynamic_routing", feature = "revenue_recovery"))]
+    let decoded_request =
+        semantic_boundary::descriptors::decode_unary_request(&rpc, &request_bytes);
+    #[cfg(not(any(feature = "dynamic_routing", feature = "revenue_recovery")))]
+    let decoded_request: Option<serde_json::Value> = None;
+
+    let args_value = semantic_boundary::grpc_args(
+        &rpc,
+        authority.as_deref(),
+        &parts.headers,
+        &request_bytes,
+        decoded_request,
+    );
+    let correlation = semantic_boundary::correlation(&parts.headers);
+
+    // Identity: rank-2 span-path (from the ambient tracing context) — NO explicit
+    // call-site id. rank-1 Explicit is a hand-out tag, not a burden to stamp on
+    // call-sites; the rpc path lives in the ARGS (grpc_args), not the identity, so
+    // replay matches within a span by occurrence + args — exactly like the
+    // db / redis / superposition boundaries. The syntactic hash of "grpc::<path>"
+    // is the rank-3 fallback (each in-span call is still disambiguated by
+    // occurrence, so distinct rpcs never collapse onto one identity).
+    let scope = format!("grpc::{rpc}");
+    let identity = deja::__private::CallsiteIdentity {
+        version: 1,
+        source: deja::__private::CallsiteSource::SyntacticHash,
+        id: None,
+        scope: Some(scope.clone()),
+        occurrence: deja::__private::next_boundary_occurrence(
+            correlation.as_deref(),
+            deja::__private::CallsiteSource::SyntacticHash,
+            Some(&scope),
+        ),
+        caller_function: Some(COMPONENT.to_string()),
+        lexical_path: Some(scope.clone()),
+        syntax_hash: Some(deja::__private::stable_callsite_hash(&scope)),
+        span_path: deja::__private::current_span_path(),
+    };
+
+    // Egress routing is hardcoded: never re-issued on replay.
+    let semantics = deja::__private::BoundarySemantics {
+        replay_strategy: deja::ReplayStrategy::Substitute,
+        kind: Some(BOUNDARY.to_string()),
+        declaration: Some(
+            deja::BoundaryDeclaration::default().operation(deja::OperationKind::ExternalCall),
+        ),
+    };
+    let spec =
+        deja::__private::BoundarySpec::with_semantics(BOUNDARY, COMPONENT, OPERATION, semantics);
+    let observation =
+        deja::__private::CrossingObservation::with_correlation(spec, identity, caller, correlation);
+
+    let rebuilt_request = http::Request::from_parts(
+        parts,
+        TonicBody::new(BufferedBody::new(request_bytes, None)),
+    );
+
+    deja::__private::dispatch_async(
+        observation,
+        move || args_value,
+        move || run_and_capture(inner, rebuilt_request),
+        reconstruct_from_recorded,
+        extract_envelope,
+    )
+    .await
+}
+
+/// The `run` thunk: forward to the real transport, buffer the response
+/// verbatim (data frames + trailers), and hand tonic a response rebuilt over
+/// the SAME buffer the tape captures — byte-identical parity. The envelope
+/// rides `http::Extensions` to the extractor.
+async fn run_and_capture<S, RB>(
+    mut inner: S,
+    request: http::Request<TonicBody>,
+) -> Result<http::Response<TonicBody>, BoxError>
+where
+    S: tonic::codegen::Service<http::Request<TonicBody>, Response = http::Response<RB>>,
+    S::Error: Into<BoxError>,
+    RB: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    RB::Error: Into<BoxError>,
+{
+    let response = match inner.call(request).await {
+        Ok(response) => response,
+        Err(error) => return Err(error.into()),
+    };
+    let (parts, body) = response.into_parts();
+    let collected = match http_body_util::BodyExt::collect(body).await {
+        Ok(collected) => collected,
+        Err(error) => return Err(error.into()),
+    };
+    let trailers = collected.trailers().cloned();
+    let data = collected.to_bytes();
+
+    let envelope = GrpcResultEnvelope::from_response_parts(
+        parts.status.as_u16(),
+        &parts.headers,
+        &data,
+        trailers.as_ref(),
+    );
+    let mut rebuilt =
+        http::Response::from_parts(parts, TonicBody::new(BufferedBody::new(data, trailers)));
+    rebuilt.extensions_mut().insert(CapturedEnvelope(envelope));
+    Ok(rebuilt)
+}
+
+/// The `extract` closure: envelope out of the extensions (record path), or a
+/// transport-error envelope from the `Err` arm.
+fn extract_envelope(
+    result: &Result<http::Response<TonicBody>, BoxError>,
+) -> (serde_json::Value, bool) {
+    let envelope = match result {
+        Ok(response) => match response.extensions().get::<CapturedEnvelope>() {
+            Some(CapturedEnvelope(envelope)) => envelope.clone(),
+            // Unreachable on the record path (run_and_capture always stamps
+            // it); recorded loudly rather than silently if it ever happens.
+            None => GrpcResultEnvelope::TransportError {
+                error: "deja: response envelope was not captured".to_owned(),
+            },
+        },
+        Err(error) => GrpcResultEnvelope::TransportError {
+            error: format!("{error}"),
+        },
+    };
+    let is_error = envelope.is_err();
+    let value = serde_json::to_value(&envelope).unwrap_or_else(
+        |error| serde_json::json!({ "deja_grpc_capture_error": error.to_string() }),
+    );
+    (value, is_error)
+}
+
+/// The `reconstruct` closure: recorded envelope → the identical wire response
+/// through tonic's own decoder, or the recorded transport failure.
+fn reconstruct_from_recorded(
+    recorded: serde_json::Value,
+) -> deja::__private::Reconstructed<Result<http::Response<TonicBody>, BoxError>> {
+    let Ok(envelope) = serde_json::from_value::<GrpcResultEnvelope>(recorded) else {
+        return deja::__private::Reconstructed::Failed;
+    };
+    match &envelope {
+        GrpcResultEnvelope::Response { .. } => {
+            match semantic_boundary::reconstruct_response(&envelope) {
+                Some(response) => {
+                    deja::__private::Reconstructed::Value(Ok(response.map(TonicBody::new)))
+                }
+                None => deja::__private::Reconstructed::Failed,
+            }
+        }
+        GrpcResultEnvelope::TransportError { error } => deja::__private::Reconstructed::Value(Err(
+            Box::new(ReplayedTransportError(error.clone())),
+        )),
+    }
+}
+
+#[cfg(all(test, feature = "dynamic_routing"))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{
+        super::dynamic_routing::{
+            success_rate_client::success_rate::{
+                success_rate_calculator_server::{
+                    SuccessRateCalculator, SuccessRateCalculatorServer,
+                },
+                CalGlobalSuccessRateRequest, CalGlobalSuccessRateResponse, CalSuccessRateRequest,
+                CalSuccessRateResponse, InvalidateWindowsRequest, InvalidateWindowsResponse,
+                LabelWithScore, UpdateSuccessRateWindowRequest, UpdateSuccessRateWindowResponse,
+            },
+            SuccessRateCalculatorClient,
+        },
+        *,
+    };
+
+    /// Canned scorer: a deterministic Ok and a typed decline.
+    pub(crate) struct CannedScorer;
+
+    #[tonic::async_trait]
+    impl SuccessRateCalculator for CannedScorer {
+        async fn fetch_success_rate(
+            &self,
+            request: tonic::Request<CalSuccessRateRequest>,
+        ) -> Result<tonic::Response<CalSuccessRateResponse>, tonic::Status> {
+            let id = request.into_inner().id;
+            Ok(tonic::Response::new(CalSuccessRateResponse {
+                labels_with_score: vec![LabelWithScore {
+                    score: 0.75,
+                    label: format!("stripe:{id}"),
+                }],
+                routing_approach: 0,
+            }))
+        }
+
+        async fn update_success_rate_window(
+            &self,
+            _request: tonic::Request<UpdateSuccessRateWindowRequest>,
+        ) -> Result<tonic::Response<UpdateSuccessRateWindowResponse>, tonic::Status> {
+            Err(tonic::Status::invalid_argument("window rejected"))
+        }
+
+        async fn invalidate_windows(
+            &self,
+            _request: tonic::Request<InvalidateWindowsRequest>,
+        ) -> Result<tonic::Response<InvalidateWindowsResponse>, tonic::Status> {
+            Err(tonic::Status::unimplemented("not in this test"))
+        }
+
+        async fn fetch_entity_and_global_success_rate(
+            &self,
+            _request: tonic::Request<CalGlobalSuccessRateRequest>,
+        ) -> Result<tonic::Response<CalGlobalSuccessRateResponse>, tonic::Status> {
+            Err(tonic::Status::unimplemented("not in this test"))
+        }
+    }
+
+    /// Inactive-hook passthrough: real tonic server + wrapped hyper pool,
+    /// traffic must be untouched in both arms. (The RECORD side needs a
+    /// separate process, because the global hook OnceLock latches on first
+    /// read and this test must observe the pre-install state.)
+    #[tokio::test]
+    async fn inactive_wrapper_is_a_pure_passthrough() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(SuccessRateCalculatorServer::new(CannedScorer))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+
+        let pool =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                .http2_only(true)
+                .build_http();
+        let transport = DejaGrpcTransport::new(pool);
+        let uri: http::Uri = format!("http://127.0.0.1:{port}").parse().unwrap();
+        let mut client = SuccessRateCalculatorClient::with_origin(transport, uri);
+
+        assert!(!is_active(), "no deja hook may be active in the lib tests");
+        let response = client
+            .fetch_success_rate(tonic::Request::new(CalSuccessRateRequest {
+                id: "m1".to_owned(),
+                params: "card".to_owned(),
+                labels: vec![],
+                config: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.labels_with_score.len(), 1);
+        assert_eq!(
+            response.labels_with_score.first().unwrap().label,
+            "stripe:m1"
+        );
+
+        let status = client
+            .update_success_rate_window(UpdateSuccessRateWindowRequest {
+                id: "m1".to_owned(),
+                params: String::new(),
+                labels_with_status: vec![],
+                global_labels_with_status: vec![],
+                config: None,
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.message(), "window rejected");
+    }
+}

--- a/crates/external_services/src/grpc_client/semantic_boundary.rs
+++ b/crates/external_services/src/grpc_client/semantic_boundary.rs
@@ -1,0 +1,715 @@
+//! Deja gRPC egress semantics — the capture/reconstruct half of the gRPC
+//! boundary.
+//!
+//! Mirrors `http_client::semantic_boundary` one layer down: the boundary sits
+//! on the tonic *transport* (a tower `Service`), so everything here operates
+//! on wire-level values — http/2 response parts, length-prefixed gRPC frames,
+//! trailers — and never interprets gRPC framing. Recorded bytes are replayed
+//! verbatim through tonic's own decoder, which is what makes substitution
+//! byte-faithful: typed `Status` (including `grpc-status-details-bin`),
+//! trailers-only error shapes, and compression all reproduce by construction.
+//!
+//! Lookup identity note: undecoded (descriptor-less) request messages MUST be
+//! keyed by [`wire_canon`], never by raw bytes — prost encodes `map<..>`
+//! fields in per-process `HashMap` iteration order, so the same logical
+//! request produces different bytes across the recording and candidate
+//! processes. Responses are never hashed: they replay verbatim.
+
+use base64::Engine;
+use tonic::codegen::http;
+
+/// General purpose base64 engine used for wire payload capture.
+const B64: base64::engine::GeneralPurpose = base64::engine::general_purpose::STANDARD;
+
+/// Correlation for a gRPC egress call: the `x-request-id` request metadata,
+/// attached by all three client families (mirrors the HTTP boundary's
+/// `X-Request-Id` extractor).
+pub fn correlation(headers: &http::HeaderMap) -> Option<String> {
+    headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+/// Canonical boundary args for a unary gRPC call.
+///
+/// `decoded_request` is the descriptor-decoded proto3-JSON of the request
+/// message when the rpc's schema is known (local protos); when `None` the
+/// args instead carry the [`wire_canon`] form of each request message and an
+/// `undecoded: true` marker (UCS — field-level diffs deferred by design D2).
+pub fn grpc_args(
+    rpc: &str,
+    authority: Option<&str>,
+    headers: &http::HeaderMap,
+    request_body: &[u8],
+    decoded_request: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut args = serde_json::Map::new();
+    args.insert("rpc".to_owned(), serde_json::Value::from(rpc));
+    args.insert("authority".to_owned(), serde_json::Value::from(authority));
+    args.insert(
+        "metadata".to_owned(),
+        serde_json::json!(header_pairs(headers)),
+    );
+    match decoded_request {
+        Some(decoded) => {
+            args.insert("request".to_owned(), decoded);
+        }
+        None => {
+            // Canonicalize per message so the identity is stable under
+            // prost's map-entry encode-order nondeterminism. A body that does
+            // not parse as clean gRPC framing (or carries compressed frames)
+            // falls back to canonicalizing the whole body — still
+            // deterministic, weaker only in precision.
+            let canon: Vec<String> = match unframe_messages(request_body) {
+                Some(messages) => messages
+                    .iter()
+                    .map(|message| wire_canon::canonical_b64(message))
+                    .collect(),
+                None => vec![wire_canon::canonical_b64(request_body)],
+            };
+            args.insert("request_canon_b64".to_owned(), serde_json::json!(canon));
+            args.insert("undecoded".to_owned(), serde_json::Value::from(true));
+        }
+    }
+    serde_json::Value::Object(args)
+}
+
+/// Splits a raw gRPC message-stream body into its length-prefixed messages
+/// (`[compressed: u8][len: u32 BE][payload]`*). Returns `None` on malformed
+/// framing or any compressed frame (canonicalization cannot see inside
+/// compressed bytes; hyperswitch clients never negotiate compression).
+pub fn unframe_messages(body: &[u8]) -> Option<Vec<&[u8]>> {
+    let mut out = Vec::new();
+    let mut rest = body;
+    while !rest.is_empty() {
+        let (head, tail) = rest.split_at_checked(5)?;
+        if *head.first()? != 0 {
+            return None;
+        }
+        let len_bytes: [u8; 4] = head.get(1..5)?.try_into().ok()?;
+        let len = usize::try_from(u32::from_be_bytes(len_bytes)).ok()?;
+        let (message, remaining) = tail.split_at_checked(len)?;
+        out.push(message);
+        rest = remaining;
+    }
+    Some(out)
+}
+
+/// Schema-free canonicalization of protobuf wire bytes, used ONLY to derive
+/// stable lookup identity for undecoded messages.
+///
+/// The contract is DETERMINISM, not schema-correctness: both the lookup
+/// renderer and the replay hook apply the same procedure to their respective
+/// bytes, so any parse heuristic is fine as long as identical payloads make
+/// identical decisions. Canonicalization sorts repeated occurrences of the
+/// same field number (map entries are repeated messages on the wire), which
+/// erases order-sensitivity of genuinely ordered repeated fields FOR THE KEY
+/// — an accepted, documented trade-off (order-only changes substitute instead
+/// of re-keying).
+pub mod wire_canon {
+    use base64::Engine;
+
+    /// Nesting cap: beyond this the level is kept verbatim (still
+    /// deterministic — depth is a function of the data).
+    const MAX_DEPTH: usize = 32;
+
+    /// Canonical form of `bytes`; input that does not parse as protobuf wire
+    /// format is returned verbatim.
+    pub fn canonical(bytes: &[u8]) -> Vec<u8> {
+        canon_level(bytes, 0).unwrap_or_else(|| bytes.to_vec())
+    }
+
+    /// Base64 of [`canonical`] — the shape embedded in boundary args.
+    pub fn canonical_b64(bytes: &[u8]) -> String {
+        super::B64.encode(canonical(bytes))
+    }
+
+    fn canon_level(bytes: &[u8], depth: usize) -> Option<Vec<u8>> {
+        if depth >= MAX_DEPTH {
+            return None;
+        }
+        let mut items: Vec<(u64, u8, Vec<u8>)> = Vec::new();
+        let mut rest = bytes;
+        while !rest.is_empty() {
+            let (tag, remaining) = varint(rest)?;
+            rest = remaining;
+            let field = tag >> 3;
+            let wire_type = u8::try_from(tag & 7).ok()?;
+            if field == 0 {
+                return None;
+            }
+            let payload: Vec<u8> = match wire_type {
+                0 => {
+                    let (raw, remaining) = varint_raw(rest)?;
+                    rest = remaining;
+                    raw.to_vec()
+                }
+                1 => take(&mut rest, 8)?.to_vec(),
+                5 => take(&mut rest, 4)?.to_vec(),
+                2 => {
+                    let (len, remaining) = varint(rest)?;
+                    rest = remaining;
+                    let raw = take(&mut rest, usize::try_from(len).ok()?)?;
+                    // Recurse when the payload itself parses as wire format.
+                    // The decision depends only on the payload bytes, so it is
+                    // identical on both sides of a record/replay pair.
+                    canon_level(raw, depth.checked_add(1)?).unwrap_or_else(|| raw.to_vec())
+                }
+                // Groups (3/4) are deprecated and unused; anything else is
+                // malformed — keep the whole level verbatim.
+                _ => return None,
+            };
+            items.push((field, wire_type, payload));
+        }
+        items.sort();
+        let mut out = Vec::with_capacity(bytes.len());
+        for (field, wire_type, payload) in items {
+            put_varint(field.checked_shl(3)? | u64::from(wire_type), &mut out);
+            if wire_type == 2 {
+                put_varint(u64::try_from(payload.len()).ok()?, &mut out);
+            }
+            out.extend_from_slice(&payload);
+        }
+        Some(out)
+    }
+
+    fn take<'a>(rest: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+        let (head, tail) = rest.split_at_checked(n)?;
+        *rest = tail;
+        Some(head)
+    }
+
+    /// Decodes a varint, returning (value, rest). Rejects >10-byte runs.
+    fn varint(bytes: &[u8]) -> Option<(u64, &[u8])> {
+        let (raw, rest) = varint_raw(bytes)?;
+        let mut value: u64 = 0;
+        for (index, byte) in raw.iter().enumerate() {
+            let shift = u32::try_from(index).ok()?.checked_mul(7)?;
+            value |= u64::from(byte & 0x7f).checked_shl(shift)?;
+        }
+        Some((value, rest))
+    }
+
+    /// Splits off the raw encoded bytes of one varint (preserved verbatim so
+    /// re-emission never normalizes what the producer wrote).
+    fn varint_raw(bytes: &[u8]) -> Option<(&[u8], &[u8])> {
+        let end = bytes
+            .iter()
+            .take(10)
+            .position(|byte| byte & 0x80 == 0)?
+            .checked_add(1)?;
+        bytes.split_at_checked(end)
+    }
+
+    fn put_varint(mut value: u64, out: &mut Vec<u8>) {
+        loop {
+            let byte = u8::try_from(value & 0x7f).unwrap_or(0x7f);
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+}
+
+/// The recorded result of one unary gRPC exchange — everything needed to hand
+/// tonic's decoder a byte-identical response on replay.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GrpcResultEnvelope {
+    /// An HTTP/2 response arrived (any grpc-status, including declines —
+    /// gRPC errors are just recorded trailers, replayed verbatim).
+    Response {
+        /// HTTP status (gRPC uses 200 even for declines; transport-mapped
+        /// failures may differ).
+        http_status: u16,
+        /// Response headers, sorted by (name, value). gRPC metadata is ASCII
+        /// by spec (binary metadata rides base64 in `-bin` keys); non-UTF-8
+        /// values are captured lossily.
+        headers: Vec<(String, String)>,
+        /// Raw gRPC body frames exactly as received — length prefixes,
+        /// compression flags and all. Never parsed, never re-framed.
+        body_b64: String,
+        /// HTTP/2 trailers; `None` preserves the trailers-only/headers-only
+        /// error shape so `Status::metadata()` partitions identically.
+        trailers: Option<Vec<(String, String)>>,
+    },
+    /// The transport itself failed (connect refused, h2 reset, timeout).
+    /// Replays approximately: the recorded display chain, not the original
+    /// error struct.
+    TransportError {
+        /// Display chain of the transport error.
+        error: String,
+    },
+}
+
+impl GrpcResultEnvelope {
+    /// Captures a buffered response into its recorded envelope.
+    pub fn from_response_parts(
+        http_status: u16,
+        headers: &http::HeaderMap,
+        body: &[u8],
+        trailers: Option<&http::HeaderMap>,
+    ) -> Self {
+        Self::Response {
+            http_status,
+            headers: header_pairs(headers),
+            body_b64: B64.encode(body),
+            trailers: trailers.map(header_pairs),
+        }
+    }
+
+    /// Whether this result is an error in gRPC terms: transport failure,
+    /// non-zero `grpc-status` (trailers first, then the headers-only shape),
+    /// or a missing status on a non-200 response.
+    pub fn is_err(&self) -> bool {
+        match self {
+            Self::TransportError { .. } => true,
+            Self::Response {
+                http_status,
+                headers,
+                trailers,
+                ..
+            } => {
+                let grpc_status = trailers
+                    .as_ref()
+                    .and_then(|pairs| find_pair(pairs, "grpc-status"))
+                    .or_else(|| find_pair(headers, "grpc-status"));
+                match grpc_status {
+                    Some(status) => status != "0",
+                    None => *http_status != 200,
+                }
+            }
+        }
+    }
+}
+
+fn find_pair<'a>(pairs: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    pairs
+        .iter()
+        .find(|(key, _)| key == name)
+        .map(|(_, value)| value.as_str())
+}
+
+/// ALL request metadata, sorted by (name, value) so the serialized args are
+/// canonical (`args_hash` is order-sensitive).
+///
+/// Full-fidelity capture BY POLICY: everything the request carried is recorded
+/// — including connector auth metadata — exactly as the HTTP boundary records
+/// all request headers. Tape protection/redaction is a separate, deferred
+/// workstream; the capture layer never drops data. Replay stability holds
+/// because the candidate rebuilds requests from SEEDED state, so recorded
+/// values reproduce; a metadata change (auth, transport version, anything)
+/// re-keys the lookup and surfaces as an honest divergence — same semantics
+/// as HTTP.
+fn header_pairs(headers: &http::HeaderMap) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_owned(),
+                String::from_utf8_lossy(value.as_bytes()).into_owned(),
+            )
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn headers_from_pairs(pairs: &[(String, String)]) -> Option<http::HeaderMap> {
+    let mut map = http::HeaderMap::with_capacity(pairs.len());
+    for (name, value) in pairs {
+        map.append(
+            http::header::HeaderName::from_bytes(name.as_bytes()).ok()?,
+            http::header::HeaderValue::from_str(value).ok()?,
+        );
+    }
+    Some(map)
+}
+
+/// Rebuilds the `http::Response` a substituted call returns — tonic's own
+/// client stack decodes it exactly as it would a network response. `None`
+/// (malformed recorded data, or the transport-error arm which the seam
+/// handles separately) maps to a reconstruction failure at the boundary.
+pub fn reconstruct_response(envelope: &GrpcResultEnvelope) -> Option<http::Response<BufferedBody>> {
+    let GrpcResultEnvelope::Response {
+        http_status,
+        headers,
+        body_b64,
+        trailers,
+    } = envelope
+    else {
+        return None;
+    };
+    let data = B64.decode(body_b64).ok()?;
+    let trailer_map = match trailers {
+        Some(pairs) => Some(headers_from_pairs(pairs)?),
+        None => None,
+    };
+    let mut response =
+        http::Response::new(BufferedBody::new(bytes::Bytes::from(data), trailer_map));
+    *response.status_mut() = http::StatusCode::from_u16(*http_status).ok()?;
+    *response.headers_mut() = headers_from_pairs(headers)?;
+    Some(response)
+}
+
+/// A fully buffered http body: one data frame, then optional trailers, then
+/// end-of-stream. Serves both sides of the boundary — the record path hands
+/// tonic a response rebuilt over the same buffer it taped (byte-identical
+/// parity), and the replay path reconstructs from the recorded envelope.
+#[derive(Debug)]
+pub struct BufferedBody {
+    data: Option<bytes::Bytes>,
+    trailers: Option<http::HeaderMap>,
+}
+
+impl BufferedBody {
+    /// A body yielding `data` (skipped when empty) then `trailers`.
+    pub fn new(data: bytes::Bytes, trailers: Option<http::HeaderMap>) -> Self {
+        Self {
+            data: (!data.is_empty()).then_some(data),
+            trailers,
+        }
+    }
+}
+
+impl http_body::Body for BufferedBody {
+    type Data = bytes::Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        if let Some(data) = this.data.take() {
+            return std::task::Poll::Ready(Some(Ok(http_body::Frame::data(data))));
+        }
+        if let Some(trailers) = this.trailers.take() {
+            return std::task::Poll::Ready(Some(Ok(http_body::Frame::trailers(trailers))));
+        }
+        std::task::Poll::Ready(None)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.data.is_none() && self.trailers.is_none()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        match &self.data {
+            Some(data) => {
+                http_body::SizeHint::with_exact(u64::try_from(data.len()).unwrap_or(u64::MAX))
+            }
+            None => http_body::SizeHint::with_exact(0),
+        }
+    }
+}
+
+/// Descriptor-pool decoding for the local protos (dynamic routing, revenue
+/// recovery, health) — the readable-JSON projection and field-level diffs.
+/// UCS descriptors are deferred by design decision D2; UCS rpcs simply return
+/// `None` here and fall back to the wire-canonical identity.
+#[cfg(any(feature = "dynamic_routing", feature = "revenue_recovery"))]
+pub mod descriptors {
+    use std::sync::OnceLock;
+
+    use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
+
+    static POOLS: OnceLock<Vec<DescriptorPool>> = OnceLock::new();
+
+    /// One pool per emitted descriptor set (kept separate so shared
+    /// well-known files can never collide across sets).
+    fn pools() -> &'static [DescriptorPool] {
+        POOLS.get_or_init(|| {
+            let mut pools = Vec::new();
+            #[cfg(feature = "dynamic_routing")]
+            if let Ok(pool) = DescriptorPool::decode(
+                &include_bytes!(concat!(
+                    env!("OUT_DIR"),
+                    "/deja_dynamic_routing_descriptor.bin"
+                ))[..],
+            ) {
+                pools.push(pool);
+            }
+            #[cfg(feature = "revenue_recovery")]
+            if let Ok(pool) = DescriptorPool::decode(
+                &include_bytes!(concat!(env!("OUT_DIR"), "/deja_recovery_descriptor.bin"))[..],
+            ) {
+                pools.push(pool);
+            }
+            pools
+        })
+    }
+
+    /// `(input, output)` message descriptors for an rpc path of the form
+    /// `/package.Service/Method`, when the schema is known.
+    pub fn method_descriptors(rpc: &str) -> Option<(MessageDescriptor, MessageDescriptor)> {
+        let (service, method) = rpc.strip_prefix('/')?.split_once('/')?;
+        pools().iter().find_map(|pool| {
+            let service = pool
+                .services()
+                .find(|candidate| candidate.full_name() == service)?;
+            let method = service
+                .methods()
+                .find(|candidate| candidate.name() == method)?;
+            Some((method.input(), method.output()))
+        })
+    }
+
+    /// Proto3-JSON projection of one wire message.
+    pub fn decode_to_json(
+        descriptor: &MessageDescriptor,
+        message: &[u8],
+    ) -> Option<serde_json::Value> {
+        let decoded = DynamicMessage::decode(descriptor.clone(), message).ok()?;
+        serde_json::to_value(&decoded).ok()
+    }
+
+    /// Decodes a single-message request body (unary) into proto3-JSON using
+    /// the rpc's input descriptor. `None` = unknown schema or malformed body;
+    /// callers fall back to the wire-canonical identity.
+    pub fn decode_unary_request(rpc: &str, request_body: &[u8]) -> Option<serde_json::Value> {
+        let (input, _) = method_descriptors(rpc)?;
+        let messages = super::unframe_messages(request_body)?;
+        let (message, rest) = messages.split_first()?;
+        if !rest.is_empty() {
+            return None;
+        }
+        decode_to_json(&input, message)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    /// Minimal wire-format writer for test fixtures.
+    fn field(out: &mut Vec<u8>, number: u64, wire_type: u64, payload: &[u8]) {
+        put_test_varint(number << 3 | wire_type, out);
+        if wire_type == 2 {
+            put_test_varint(u64::try_from(payload.len()).unwrap(), out);
+        }
+        out.extend_from_slice(payload);
+    }
+
+    fn put_test_varint(mut value: u64, out: &mut Vec<u8>) {
+        loop {
+            let byte = u8::try_from(value & 0x7f).unwrap();
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    /// One `map<string, string>` entry: nested message {1: key, 2: value}.
+    fn map_entry(key: &str, value: &str) -> Vec<u8> {
+        let mut entry = Vec::new();
+        field(&mut entry, 1, 2, key.as_bytes());
+        field(&mut entry, 2, 2, value.as_bytes());
+        entry
+    }
+
+    fn frame(message: &[u8]) -> Vec<u8> {
+        let mut framed = vec![0u8];
+        framed.extend_from_slice(&u32::try_from(message.len()).unwrap().to_be_bytes());
+        framed.extend_from_slice(message);
+        framed
+    }
+
+    #[test]
+    fn map_reorder_is_canonically_stable() {
+        // message { 1: "id", map<string,string> 2 } with entries in both orders
+        let (mut ab, mut ba) = (Vec::new(), Vec::new());
+        field(&mut ab, 1, 2, b"payment_123");
+        field(&mut ab, 2, 2, &map_entry("alpha", "1"));
+        field(&mut ab, 2, 2, &map_entry("beta", "2"));
+        field(&mut ba, 1, 2, b"payment_123");
+        field(&mut ba, 2, 2, &map_entry("beta", "2"));
+        field(&mut ba, 2, 2, &map_entry("alpha", "1"));
+        assert_ne!(ab, ba, "fixtures must differ before canonicalization");
+        assert_eq!(wire_canon::canonical(&ab), wire_canon::canonical(&ba));
+    }
+
+    #[test]
+    fn value_changes_change_the_canonical_form() {
+        let (mut left, mut right) = (Vec::new(), Vec::new());
+        field(&mut left, 2, 2, &map_entry("alpha", "1"));
+        field(&mut right, 2, 2, &map_entry("alpha", "CHANGED"));
+        assert_ne!(wire_canon::canonical(&left), wire_canon::canonical(&right));
+    }
+
+    #[test]
+    fn nested_map_reorder_is_canonically_stable() {
+        // outer message { 3: inner } where inner carries the reordered map
+        let (mut inner_ab, mut inner_ba) = (Vec::new(), Vec::new());
+        field(&mut inner_ab, 2, 2, &map_entry("alpha", "1"));
+        field(&mut inner_ab, 2, 2, &map_entry("beta", "2"));
+        field(&mut inner_ba, 2, 2, &map_entry("beta", "2"));
+        field(&mut inner_ba, 2, 2, &map_entry("alpha", "1"));
+        let (mut outer_ab, mut outer_ba) = (Vec::new(), Vec::new());
+        field(&mut outer_ab, 3, 2, &inner_ab);
+        field(&mut outer_ba, 3, 2, &inner_ba);
+        assert_eq!(
+            wire_canon::canonical(&outer_ab),
+            wire_canon::canonical(&outer_ba)
+        );
+    }
+
+    #[test]
+    fn non_protobuf_input_passes_through_verbatim() {
+        let text = b"hello world! this is not protobuf";
+        assert_eq!(wire_canon::canonical(text), text.to_vec());
+        assert_eq!(wire_canon::canonical(&[]), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn unframe_roundtrip_and_rejections() {
+        let message = b"\x0a\x02hi".to_vec();
+        let mut body = frame(&message);
+        body.extend_from_slice(&frame(b"more"));
+        let messages = unframe_messages(&body).unwrap();
+        assert_eq!(messages, vec![&message[..], &b"more"[..]]);
+
+        // compressed flag and truncation are both rejected
+        let mut compressed = frame(&message);
+        compressed[0] = 1;
+        assert!(unframe_messages(&compressed).is_none());
+        assert!(unframe_messages(&body[..body.len() - 1]).is_none());
+    }
+
+    #[test]
+    fn args_capture_everything_sorted_full_fidelity() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-tenant-id", "t1".parse().unwrap());
+        headers.insert("x-request-id", "req_9".parse().unwrap());
+        headers.insert("x-api-key", "SECRET".parse().unwrap());
+        headers.insert("content-type", "application/grpc".parse().unwrap());
+
+        let args = grpc_args(
+            "/success_rate.SuccessRateCalculator/FetchSuccessRate",
+            Some("dyn-routing:7000"),
+            &headers,
+            &frame(b"\x0a\x02id"),
+            None,
+        );
+        // Full fidelity: EVERYTHING the request carried is on the tape —
+        // auth metadata included (protection is a deferred workstream, and
+        // the HTTP boundary records all headers identically). Sorted for a
+        // canonical args_hash.
+        assert_eq!(
+            args["metadata"],
+            serde_json::json!([
+                ["content-type", "application/grpc"],
+                ["x-api-key", "SECRET"],
+                ["x-request-id", "req_9"],
+                ["x-tenant-id", "t1"]
+            ])
+        );
+        assert_eq!(args["undecoded"], serde_json::json!(true));
+        assert_eq!(correlation(&headers).as_deref(), Some("req_9"));
+    }
+
+    #[test]
+    fn envelope_roundtrips_through_serde() {
+        let envelope = GrpcResultEnvelope::Response {
+            http_status: 200,
+            headers: vec![("content-type".to_owned(), "application/grpc".to_owned())],
+            body_b64: B64.encode(frame(b"\x08\x01")),
+            trailers: Some(vec![("grpc-status".to_owned(), "0".to_owned())]),
+        };
+        let json = serde_json::to_value(&envelope).unwrap();
+        let back: GrpcResultEnvelope = serde_json::from_value(json).unwrap();
+        assert_eq!(envelope, back);
+        assert!(!envelope.is_err());
+        assert!(GrpcResultEnvelope::TransportError {
+            error: "connect refused".to_owned()
+        }
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn buffered_body_emits_data_then_trailers() {
+        use http_body_util::BodyExt;
+
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "0".parse().unwrap());
+        let body = BufferedBody::new(bytes::Bytes::from_static(b"payload"), Some(trailers));
+        let collected = body.collect().await.unwrap();
+        assert_eq!(
+            collected.trailers().and_then(|t| t.get("grpc-status")),
+            Some(&"0".parse().unwrap())
+        );
+        assert_eq!(collected.to_bytes().as_ref(), b"payload");
+    }
+
+    #[tokio::test]
+    async fn recorded_decline_reconstructs_the_same_typed_status() {
+        use http_body_util::BodyExt;
+
+        // A recorded decline: grpc-status 3 (InvalidArgument) in trailers.
+        let envelope = GrpcResultEnvelope::Response {
+            http_status: 200,
+            headers: vec![("content-type".to_owned(), "application/grpc".to_owned())],
+            body_b64: String::new(),
+            trailers: Some(vec![
+                ("grpc-message".to_owned(), "card declined".to_owned()),
+                ("grpc-status".to_owned(), "3".to_owned()),
+            ]),
+        };
+        assert!(envelope.is_err());
+
+        let response = reconstruct_response(&envelope).unwrap();
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let collected = response.into_body().collect().await.unwrap();
+        let status = tonic::Status::from_header_map(collected.trailers().unwrap()).unwrap();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.message(), "card declined");
+    }
+
+    #[test]
+    fn trailers_only_shape_is_preserved() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("grpc-status", "14".parse().unwrap());
+        let envelope = GrpcResultEnvelope::from_response_parts(200, &headers, &[], None);
+        assert!(envelope.is_err());
+        let response = reconstruct_response(&envelope).unwrap();
+        // Status stays in the HEADERS — no synthesized trailers frame.
+        let status = tonic::Status::from_header_map(response.headers()).unwrap();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+    }
+
+    #[cfg(feature = "dynamic_routing")]
+    #[test]
+    fn descriptor_decode_by_rpc_path() {
+        use prost_reflect::prost::Message;
+
+        let rpc = "/success_rate.SuccessRateCalculator/FetchSuccessRate";
+        let (input, output) = descriptors::method_descriptors(rpc).unwrap();
+        assert_eq!(input.full_name(), "success_rate.CalSuccessRateRequest");
+        assert_eq!(output.full_name(), "success_rate.CalSuccessRateResponse");
+
+        // Round-trip a request through the descriptor: set fields dynamically,
+        // encode, decode back to proto3-JSON.
+        let mut message = prost_reflect::DynamicMessage::new(input.clone());
+        message.set_field_by_name("id", prost_reflect::Value::String("m1:gateway".to_owned()));
+        message.set_field_by_name(
+            "params",
+            prost_reflect::Value::String("card&credit".to_owned()),
+        );
+        let wire = message.encode_to_vec();
+
+        let json = descriptors::decode_unary_request(rpc, &frame(&wire)).unwrap();
+        assert_eq!(json["id"], serde_json::json!("m1:gateway"));
+        assert_eq!(json["params"], serde_json::json!("card&credit"));
+
+        // Unknown schema (UCS) falls back to None — the wire-canonical path.
+        assert!(descriptors::method_descriptors("/types.PaymentService/Authorize").is_none());
+    }
+}

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -21,33 +21,45 @@ use crate::{
 
 /// Result type for Dynamic Routing
 pub type UnifiedConnectorServiceResult<T> = CustomResult<T, UnifiedConnectorServiceError>;
+
+/// The transport under every UCS service client. Under the `deja` feature it is
+/// the gRPC egress boundary wrapper — every unary rpc (payment, refund, …) is
+/// recorded/substituted at the wire level with rank-2 span-path identity;
+/// otherwise it is the raw tonic channel. Threading this alias through the
+/// client fields + their construction keeps the feature-off build byte-identical.
+#[cfg(feature = "deja")]
+pub type UcsChannel = super::deja_transport::DejaGrpcTransport<tonic::transport::Channel>;
+/// The transport under every UCS service client (raw tonic channel; see the
+/// `deja`-gated definition above for the recording/substituting variant).
+#[cfg(not(feature = "deja"))]
+pub type UcsChannel = tonic::transport::Channel;
 /// Contains the  Unified Connector Service client
 #[derive(Debug, Clone)]
 pub struct UnifiedConnectorServiceClient {
     /// The Payment Service Client
-    pub payment_service_client: payments_grpc::payment_service_client::PaymentServiceClient<tonic::transport::Channel>,
+    pub payment_service_client: payments_grpc::payment_service_client::PaymentServiceClient<UcsChannel>,
     /// The Refund Service Client
-    pub refund_service_client: payments_grpc::refund_service_client::RefundServiceClient<tonic::transport::Channel>,
+    pub refund_service_client: payments_grpc::refund_service_client::RefundServiceClient<UcsChannel>,
     /// The Event Service Client
-    pub event_service_client: payments_grpc::event_service_client::EventServiceClient<tonic::transport::Channel>,
+    pub event_service_client: payments_grpc::event_service_client::EventServiceClient<UcsChannel>,
     /// The Recurring Payment Service Client
-    pub recurring_payment_service_client: payments_grpc::recurring_payment_service_client::RecurringPaymentServiceClient<tonic::transport::Channel>,
+    pub recurring_payment_service_client: payments_grpc::recurring_payment_service_client::RecurringPaymentServiceClient<UcsChannel>,
     /// The Dispute Service Client
-    pub dispute_service_client: payments_grpc::dispute_service_client::DisputeServiceClient<tonic::transport::Channel>,
+    pub dispute_service_client: payments_grpc::dispute_service_client::DisputeServiceClient<UcsChannel>,
     /// The Payment Method Service Client
-    pub payment_method_service_client: payments_grpc::payment_method_service_client::PaymentMethodServiceClient<tonic::transport::Channel>,
+    pub payment_method_service_client: payments_grpc::payment_method_service_client::PaymentMethodServiceClient<UcsChannel>,
     /// The Customer Service Client
-    pub customer_service_client: payments_grpc::customer_service_client::CustomerServiceClient<tonic::transport::Channel>,
+    pub customer_service_client: payments_grpc::customer_service_client::CustomerServiceClient<UcsChannel>,
     /// The Merchant Authentication Service Client
     pub merchant_authentication_service_client:
-        payments_grpc::merchant_authentication_service_client::MerchantAuthenticationServiceClient<tonic::transport::Channel>,
+        payments_grpc::merchant_authentication_service_client::MerchantAuthenticationServiceClient<UcsChannel>,
     /// The Payment Method Authentication Service Client
     pub payment_method_authentication_service_client:
-        payments_grpc::payment_method_authentication_service_client::PaymentMethodAuthenticationServiceClient<tonic::transport::Channel>,
+        payments_grpc::payment_method_authentication_service_client::PaymentMethodAuthenticationServiceClient<UcsChannel>,
         /// The Payout Service Client
-    pub payout_service_client: payments_grpc::payout_service_client::PayoutServiceClient<tonic::transport::Channel>,
+    pub payout_service_client: payments_grpc::payout_service_client::PayoutServiceClient<UcsChannel>,
     /// The Surcharge Service Client
-    pub surcharge_service_client: payments_grpc::surcharge_service_client::SurchargeServiceClient<tonic::transport::Channel>,
+    pub surcharge_service_client: payments_grpc::surcharge_service_client::SurchargeServiceClient<UcsChannel>,
 }
 
 /// Contains the Unified Connector Service Client config
@@ -188,7 +200,15 @@ macro_rules! build_grpc_client {
         let endpoint = tonic::transport::Channel::builder($uri.clone())
             .timeout($request_timeout.as_duration());
         match timeout($connection_timeout.as_duration(), endpoint.connect()).await {
-            Ok(Ok(channel)) => <$client>::new(channel),
+            Ok(Ok(channel)) => {
+                // deja: wrap the UCS channel in the gRPC egress boundary at its
+                // construction site so every unary rpc is recorded/substituted at
+                // the wire level (rank-2 identity). Feature-off passes the raw
+                // channel unchanged.
+                #[cfg(feature = "deja")]
+                let channel = $crate::grpc_client::deja_transport::DejaGrpcTransport::new(channel);
+                <$client>::new(channel)
+            }
             Ok(Err(err)) => {
                 router_env::logger::error!(
                     "Failed to connect to Unified Connector Service for {}: {:?}",
@@ -240,7 +260,7 @@ impl UnifiedConnectorServiceClient {
 
                 let payment_service_client = build_grpc_client!(
                     payments_grpc::payment_service_client::PaymentServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "payment_service_client",
                     uri,
@@ -250,7 +270,7 @@ impl UnifiedConnectorServiceClient {
 
                 let refund_service_client = build_grpc_client!(
                     payments_grpc::refund_service_client::RefundServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "refund_service_client",
                     uri,
@@ -260,7 +280,7 @@ impl UnifiedConnectorServiceClient {
 
                 let event_service_client = build_grpc_client!(
                     payments_grpc::event_service_client::EventServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "event_service_client",
                     uri,
@@ -270,7 +290,7 @@ impl UnifiedConnectorServiceClient {
 
                 let recurring_payment_service_client = build_grpc_client!(
                     payments_grpc::recurring_payment_service_client::RecurringPaymentServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "recurring_payment_service_client",
                     uri,
@@ -280,7 +300,7 @@ impl UnifiedConnectorServiceClient {
 
                 let dispute_service_client = build_grpc_client!(
                     payments_grpc::dispute_service_client::DisputeServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "dispute_service_client",
                     uri,
@@ -290,7 +310,7 @@ impl UnifiedConnectorServiceClient {
 
                 let payment_method_service_client = build_grpc_client!(
                     payments_grpc::payment_method_service_client::PaymentMethodServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "payment_method_service_client",
                     uri,
@@ -300,7 +320,7 @@ impl UnifiedConnectorServiceClient {
 
                 let customer_service_client = build_grpc_client!(
                     payments_grpc::customer_service_client::CustomerServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "customer_service_client",
                     uri,
@@ -309,7 +329,7 @@ impl UnifiedConnectorServiceClient {
                 );
 
                 let merchant_authentication_service_client = build_grpc_client!(
-                    payments_grpc::merchant_authentication_service_client::MerchantAuthenticationServiceClient<tonic::transport::Channel>,
+                    payments_grpc::merchant_authentication_service_client::MerchantAuthenticationServiceClient<UcsChannel>,
                     "merchant_authentication_service_client",
                     uri,
                     connection_timeout,
@@ -317,7 +337,7 @@ impl UnifiedConnectorServiceClient {
                 );
 
                 let payment_method_authentication_service_client = build_grpc_client!(
-                    payments_grpc::payment_method_authentication_service_client::PaymentMethodAuthenticationServiceClient<tonic::transport::Channel>,
+                    payments_grpc::payment_method_authentication_service_client::PaymentMethodAuthenticationServiceClient<UcsChannel>,
                     "payment_method_authentication_service_client",
                     uri,
                     connection_timeout,
@@ -326,7 +346,7 @@ impl UnifiedConnectorServiceClient {
 
                 let payout_service_client = build_grpc_client!(
                     payments_grpc::payout_service_client::PayoutServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "payout_service_client",
                     uri,
@@ -336,7 +356,7 @@ impl UnifiedConnectorServiceClient {
 
                 let surcharge_service_client = build_grpc_client!(
                     payments_grpc::surcharge_service_client::SurchargeServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "surcharge_service_client",
                     uri,

--- a/crates/external_services/src/http_client.rs
+++ b/crates/external_services/src/http_client.rs
@@ -12,6 +12,8 @@ pub mod client;
 pub mod metrics;
 /// request module
 pub mod request;
+#[cfg(feature = "deja")]
+mod semantic_boundary;
 use std::{error::Error, time::Duration};
 
 pub use common_utils::request::{ContentType, Method, RequestBuilder};
@@ -63,6 +65,19 @@ pub fn serialize_to_xml_bytes<T: serde::Serialize>(
 }
 
 #[allow(missing_docs)]
+#[cfg_attr(
+    feature = "deja",
+    deja::http(outgoing,
+        component = "external_services::http_client",
+        operation = "send_request",
+        correlation = semantic_boundary::request_id(&request),
+        args = semantic_boundary::request_args(&request, option_timeout_secs),
+        // Rebuild the recorded reqwest::Response (status+headers+body) so the
+        // outgoing call (e.g. Stripe) is served from the lookup table with no
+        // network. A recorded error reconstructs to None -> falls through to live.
+        codec = semantic_boundary::HttpResponseCodec,
+    )
+)]
 #[instrument(skip_all)]
 pub async fn send_request(
     client_proxy: &Proxy,
@@ -196,8 +211,7 @@ pub async fn send_request(
     // and written to at the same time the server is deciding to close the connection.
     // Since hyper already wrote some of the request,
     // it can’t really retry it automatically on a new connection, since the server may have acted already
-    match response {
-        Ok(response) => Ok(response),
+    let response = match response {
         Err(error)
             if error.current_context() == &HttpClientError::ConnectionClosedIncompleteMessage =>
         {
@@ -220,7 +234,22 @@ pub async fn send_request(
                 }
             }
         }
-        err @ Err(_) => err,
+        response => response,
+    };
+
+    #[cfg(feature = "deja")]
+    {
+        match response {
+            Ok(response) if semantic_boundary::is_active() => {
+                semantic_boundary::response_with_captured_body(response).await
+            }
+            response => response,
+        }
+    }
+
+    #[cfg(not(feature = "deja"))]
+    {
+        response
     }
 }
 

--- a/crates/external_services/src/http_client.rs
+++ b/crates/external_services/src/http_client.rs
@@ -71,7 +71,9 @@ pub fn serialize_to_xml_bytes<T: serde::Serialize>(
         component = "external_services::http_client",
         operation = "send_request",
         correlation = semantic_boundary::request_id(&request),
-        args = semantic_boundary::request_args(&request, option_timeout_secs),
+        // The deja handoff: expose the Secret-wrapped payload so the tape
+        // records full fidelity (Secret only redacts Debug/log output).
+        args = hyperswitch_masking::ExposeInterface::expose(semantic_boundary::request_args(&request, option_timeout_secs)),
         // Rebuild the recorded reqwest::Response (status+headers+body) so the
         // outgoing call (e.g. Stripe) is served from the lookup table with no
         // network. A recorded error reconstructs to None -> falls through to live.

--- a/crates/external_services/src/http_client.rs
+++ b/crates/external_services/src/http_client.rs
@@ -12,8 +12,10 @@ pub mod client;
 pub mod metrics;
 /// request module
 pub mod request;
+
 #[cfg(feature = "deja")]
-mod semantic_boundary;
+mod boundary;
+
 use std::{error::Error, time::Duration};
 
 pub use common_utils::request::{ContentType, Method, RequestBuilder};
@@ -70,14 +72,14 @@ pub fn serialize_to_xml_bytes<T: serde::Serialize>(
     deja::http(outgoing,
         component = "external_services::http_client",
         operation = "send_request",
-        correlation = semantic_boundary::request_id(&request),
+        correlation = boundary::request_id(&request),
         // The deja handoff: expose the Secret-wrapped payload so the tape
         // records full fidelity (Secret only redacts Debug/log output).
-        args = hyperswitch_masking::ExposeInterface::expose(semantic_boundary::request_args(&request, option_timeout_secs)),
+        args = hyperswitch_masking::ExposeInterface::expose(boundary::request_args(&request, option_timeout_secs)),
         // Rebuild the recorded reqwest::Response (status+headers+body) so the
         // outgoing call (e.g. Stripe) is served from the lookup table with no
         // network. A recorded error reconstructs to None -> falls through to live.
-        codec = semantic_boundary::HttpResponseCodec,
+        codec = boundary::HttpResponseCodec,
     )
 )]
 #[instrument(skip_all)]
@@ -242,8 +244,8 @@ pub async fn send_request(
     #[cfg(feature = "deja")]
     {
         match response {
-            Ok(response) if semantic_boundary::is_active() => {
-                semantic_boundary::response_with_captured_body(response).await
+            Ok(response) if boundary::is_active() => {
+                boundary::response_with_captured_body(response).await
             }
             response => response,
         }

--- a/crates/external_services/src/http_client/boundary.rs
+++ b/crates/external_services/src/http_client/boundary.rs
@@ -166,11 +166,16 @@ impl deja::codec::ReplayCodec for HttpResponseCodec {
 /// Replay: reconstruct a `reqwest::Response` from a recorded `response_result`
 /// payload (`{status, response_headers, response_body: {raw_bytes: [...]}}`).
 ///
-/// Returns `None` for a recorded error (no `status` field) so the boundary
-/// falls through to live execution (the Ok-only replay policy). Connectors consume
-/// status + headers + body bytes from the response, all of which are
-/// reconstructed verbatim from the recording — so a replayed outgoing call
-/// (e.g. to Stripe) is served entirely from the lookup table with no network.
+/// A recorded SUCCESS reconstructs verbatim: connectors read status, headers
+/// and body bytes, and all three come from the tape, so that call touches no
+/// network.
+///
+/// A recorded ERROR carries no `status` field and reconstructs to `None`, which
+/// the boundary treats as a lookup miss and answers by executing LIVE. Replaying
+/// a request whose connector call failed therefore issues a real outbound request
+/// to the real endpoint. This is the current Ok-only replay policy: replay is
+/// egress-free only for as long as every recorded call succeeded, so it must not
+/// be relied on as an egress guarantee.
 pub(super) fn replay_response(recorded: &serde_json::Value) -> Option<reqwest::Response> {
     let status_code = u16::try_from(recorded.get("status")?.as_u64()?).ok()?;
     let status = http::StatusCode::from_u16(status_code).ok()?;

--- a/crates/external_services/src/http_client/semantic_boundary.rs
+++ b/crates/external_services/src/http_client/semantic_boundary.rs
@@ -5,7 +5,7 @@ use common_utils::{
 use deja::DejaHook;
 use error_stack::ResultExt;
 use hyperswitch_interfaces::errors::HttpClientError;
-use hyperswitch_masking::{Maskable, PeekInterface};
+use hyperswitch_masking::{ExposeInterface, Maskable, PeekInterface, Secret};
 use reqwest::ResponseBuilderExt;
 use serde_json::json;
 
@@ -64,7 +64,7 @@ pub(super) fn request_id(request: &Request) -> Option<String> {
     })
 }
 
-pub(super) fn request_args(request: &Request, timeout_secs: Option<u64>) -> serde_json::Value {
+pub(super) fn request_args(request: &Request, timeout_secs: Option<u64>) -> Secret<serde_json::Value> {
     // Header storage iterates in non-deterministic (HashMap) order, so the raw
     // sequence differs between record and replay even when the header SET is
     // identical. The args matcher compares serialized JSON arrays
@@ -82,7 +82,7 @@ pub(super) fn request_args(request: &Request, timeout_secs: Option<u64>) -> serd
         .into_iter()
         .map(|(key, value)| json!({ "key": key, "value": value }))
         .collect();
-    json!({
+    Secret::new(json!({
         "method": format!("{:?}", request.method),
         "url": request.url.as_str(),
         "request_id": request_id(request),
@@ -95,17 +95,21 @@ pub(super) fn request_args(request: &Request, timeout_secs: Option<u64>) -> serd
             "certificate_key": request.certificate_key.is_some(),
             "ca_certificate": request.ca_certificate.is_some(),
         },
+    }))
+}
+
+// Captured payloads travel as `Secret<serde_json::Value>` between helpers so
+// their `Debug` output is redacted (response bodies/headers can carry PII or
+// credentials); they are `.expose()`d only at the deja handoff, where the tape
+// keeps full fidelity.
+fn captured_body_json(response: &reqwest::Response) -> Secret<serde_json::Value> {
+    Secret::new(match response.extensions().get::<CapturedResponseBody>() {
+        Some(CapturedResponseBody(bytes)) => deja::http::body(bytes),
+        None => deja::http::missing_body("response body not captured (missing extension)"),
     })
 }
 
-fn captured_body_json(response: &reqwest::Response) -> serde_json::Value {
-    match response.extensions().get::<CapturedResponseBody>() {
-        Some(CapturedResponseBody(bytes)) => deja::http::body(bytes),
-        None => deja::http::missing_body("response body not captured (missing extension)"),
-    }
-}
-
-fn response_headers_json(response: &reqwest::Response) -> serde_json::Value {
+fn response_headers_json(response: &reqwest::Response) -> Secret<serde_json::Value> {
     let mut map = serde_json::Map::new();
     for (key, value) in response.headers() {
         if let Ok(value) = value.to_str() {
@@ -115,19 +119,19 @@ fn response_headers_json(response: &reqwest::Response) -> serde_json::Value {
             );
         }
     }
-    serde_json::Value::Object(map)
+    Secret::new(serde_json::Value::Object(map))
 }
 
 pub(super) fn response_result(
     result: &CustomResult<reqwest::Response, HttpClientError>,
-) -> (serde_json::Value, bool) {
+) -> (Secret<serde_json::Value>, bool) {
     (
-        match result {
+        Secret::new(match result {
             Ok(response) => json!({
                 "status": response.status().as_u16(),
                 "reason": response.status().canonical_reason(),
-                "response_headers": response_headers_json(response),
-                "response_body": captured_body_json(response),
+                "response_headers": response_headers_json(response).expose(),
+                "response_body": captured_body_json(response).expose(),
             }),
             Err(error) => json!({
                 "error": format!("{error:?}"),
@@ -135,7 +139,7 @@ pub(super) fn response_result(
                     "captured": false,
                 },
             }),
-        },
+        }),
         result.is_err(),
     )
 }
@@ -146,7 +150,9 @@ impl deja::codec::ReplayCodec for HttpResponseCodec {
     type Value = CustomResult<reqwest::Response, HttpClientError>;
 
     fn capture(value: &Self::Value) -> (serde_json::Value, bool) {
-        response_result(value)
+        let (payload, is_error) = response_result(value);
+        // The deja handoff: the tape records the full-fidelity value.
+        (payload.expose(), is_error)
     }
 
     fn reconstruct(recorded: serde_json::Value) -> Option<Self::Value> {

--- a/crates/external_services/src/http_client/semantic_boundary.rs
+++ b/crates/external_services/src/http_client/semantic_boundary.rs
@@ -1,0 +1,222 @@
+use common_utils::{
+    errors::CustomResult,
+    request::{Request, RequestContent},
+};
+use deja::DejaHook;
+use error_stack::ResultExt;
+use hyperswitch_interfaces::errors::HttpClientError;
+use hyperswitch_masking::{Maskable, PeekInterface};
+use reqwest::ResponseBuilderExt;
+use serde_json::json;
+
+/// Extension key used to smuggle the captured response body out of the
+/// `send_request` function so that the boundary codec can report it without
+/// consuming the response stream.
+pub(super) struct CapturedResponseBody(pub(super) bytes::Bytes);
+
+pub(super) fn is_active() -> bool {
+    deja::global_hook_from_env().is_some_and(|hook| hook.is_active())
+}
+
+pub(super) async fn response_with_captured_body(
+    response: reqwest::Response,
+) -> CustomResult<reqwest::Response, HttpClientError> {
+    // Eagerly read the response body so the boundary result extractor can
+    // report it without consuming the stream a second time. The body is then
+    // cloned: one copy is rebuilt into a new reqwest::Response as a reusable
+    // Body, the other is stashed in http::Extensions so `response_result` can
+    // read it.
+    let status = response.status();
+    let headers = response.headers().clone();
+    let version = response.version();
+    let url = response.url().clone();
+    let body_bytes = response
+        .bytes()
+        .await
+        .change_context(HttpClientError::ResponseDecodingFailed)
+        .attach_printable("Failed to read response body for boundary capture")?;
+
+    let mut builder = http::Response::builder()
+        .status(status)
+        .version(version)
+        .url(url);
+    for (key, value) in &headers {
+        builder = builder.header(key, value);
+    }
+    let mut http_response = builder.body(body_bytes.clone()).map_err(|_| {
+        error_stack::report!(HttpClientError::UnexpectedState)
+            .attach_printable("Failed to rebuild HTTP response")
+    })?;
+    http_response
+        .extensions_mut()
+        .insert(CapturedResponseBody(body_bytes));
+
+    Ok(reqwest::Response::from(http_response))
+}
+
+pub(super) fn request_id(request: &Request) -> Option<String> {
+    request.headers.iter().find_map(|(key, value)| {
+        if key.eq_ignore_ascii_case(common_utils::consts::X_REQUEST_ID) {
+            Some(header_value(value))
+        } else {
+            None
+        }
+    })
+}
+
+pub(super) fn request_args(request: &Request, timeout_secs: Option<u64>) -> serde_json::Value {
+    // Header storage iterates in non-deterministic (HashMap) order, so the raw
+    // sequence differs between record and replay even when the header SET is
+    // identical. The args matcher compares serialized JSON arrays
+    // order-sensitively, so an unsorted list misses the lookup and the outgoing
+    // call falls through to a LIVE network request. Sort by (key, value) to
+    // produce a canonical, byte-stable representation. (Computed outside the
+    // json! macro, which cannot parse a block containing type annotations.)
+    let mut headers: Vec<(String, String)> = request
+        .headers
+        .iter()
+        .map(|(key, value)| (key.to_string(), header_value(value)))
+        .collect();
+    headers.sort();
+    let headers: Vec<serde_json::Value> = headers
+        .into_iter()
+        .map(|(key, value)| json!({ "key": key, "value": value }))
+        .collect();
+    json!({
+        "method": format!("{:?}", request.method),
+        "url": request.url.as_str(),
+        "request_id": request_id(request),
+        "headers": headers,
+        "query_params": request.query_params.clone(),
+        "timeout_secs": timeout_secs,
+        "request_body": request.body.as_ref().map(request_body),
+        "client_tls": {
+            "certificate": request.certificate.is_some(),
+            "certificate_key": request.certificate_key.is_some(),
+            "ca_certificate": request.ca_certificate.is_some(),
+        },
+    })
+}
+
+fn captured_body_json(response: &reqwest::Response) -> serde_json::Value {
+    match response.extensions().get::<CapturedResponseBody>() {
+        Some(CapturedResponseBody(bytes)) => deja::http::body(bytes),
+        None => deja::http::missing_body("response body not captured (missing extension)"),
+    }
+}
+
+fn response_headers_json(response: &reqwest::Response) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for (key, value) in response.headers() {
+        if let Ok(value) = value.to_str() {
+            map.insert(
+                key.as_str().to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
+        }
+    }
+    serde_json::Value::Object(map)
+}
+
+pub(super) fn response_result(
+    result: &CustomResult<reqwest::Response, HttpClientError>,
+) -> (serde_json::Value, bool) {
+    (
+        match result {
+            Ok(response) => json!({
+                "status": response.status().as_u16(),
+                "reason": response.status().canonical_reason(),
+                "response_headers": response_headers_json(response),
+                "response_body": captured_body_json(response),
+            }),
+            Err(error) => json!({
+                "error": format!("{error:?}"),
+                "response_body": {
+                    "captured": false,
+                },
+            }),
+        },
+        result.is_err(),
+    )
+}
+
+pub(super) struct HttpResponseCodec;
+
+impl deja::codec::ReplayCodec for HttpResponseCodec {
+    type Value = CustomResult<reqwest::Response, HttpClientError>;
+
+    fn capture(value: &Self::Value) -> (serde_json::Value, bool) {
+        response_result(value)
+    }
+
+    fn reconstruct(recorded: serde_json::Value) -> Option<Self::Value> {
+        replay_response(&recorded).map(Ok)
+    }
+}
+
+/// Replay: reconstruct a `reqwest::Response` from a recorded `response_result`
+/// payload (`{status, response_headers, response_body: {raw_bytes: [...]}}`).
+///
+/// Returns `None` for a recorded error (no `status` field) so the boundary
+/// falls through to live execution (the Ok-only replay policy). Connectors consume
+/// status + headers + body bytes from the response, all of which are
+/// reconstructed verbatim from the recording — so a replayed outgoing call
+/// (e.g. to Stripe) is served entirely from the lookup table with no network.
+pub(super) fn replay_response(recorded: &serde_json::Value) -> Option<reqwest::Response> {
+    let status_code = u16::try_from(recorded.get("status")?.as_u64()?).ok()?;
+    let status = http::StatusCode::from_u16(status_code).ok()?;
+
+    let raw_bytes: Vec<u8> = recorded
+        .get("response_body")
+        .and_then(|body| body.get("raw_bytes"))
+        .and_then(|value| value.as_array())
+        .map(|array| array.iter().filter_map(byte_from_json).collect())
+        .unwrap_or_default();
+
+    let mut builder = http::Response::builder().status(status);
+    if let Some(headers) = recorded.get("response_headers").and_then(|h| h.as_object()) {
+        for (name, value) in headers {
+            if let Some(value) = value.as_str() {
+                builder = builder.header(name.as_str(), value);
+            }
+        }
+    }
+    let http_response = builder.body(bytes::Bytes::from(raw_bytes)).ok()?;
+    Some(reqwest::Response::from(http_response))
+}
+
+fn byte_from_json(value: &serde_json::Value) -> Option<u8> {
+    value.as_u64().and_then(|byte| byte.try_into().ok())
+}
+
+fn header_value(value: &Maskable<String>) -> String {
+    match value {
+        Maskable::Masked(value) => value.peek().to_string(),
+        Maskable::Normal(value) => value.clone(),
+    }
+}
+
+fn request_body(body: &RequestContent) -> serde_json::Value {
+    match body {
+        RequestContent::RawBytes(bytes) => {
+            let mut body = deja::http::body(bytes);
+            if let serde_json::Value::Object(ref mut object) = body {
+                object.insert(
+                    "kind".to_string(),
+                    serde_json::Value::String("RawBytesRequestBody".to_string()),
+                );
+            }
+            body
+        }
+        _ => {
+            let value = body.get_inner_value();
+            let text = value.peek();
+            let kind = format!("{body:?}");
+            let mut captured = deja::http::body(text.as_bytes());
+            if let serde_json::Value::Object(ref mut object) = captured {
+                object.insert("kind".to_string(), serde_json::Value::String(kind));
+            }
+            captured
+        }
+    }
+}

--- a/crates/external_services/src/http_client/semantic_boundary.rs
+++ b/crates/external_services/src/http_client/semantic_boundary.rs
@@ -64,7 +64,10 @@ pub(super) fn request_id(request: &Request) -> Option<String> {
     })
 }
 
-pub(super) fn request_args(request: &Request, timeout_secs: Option<u64>) -> Secret<serde_json::Value> {
+pub(super) fn request_args(
+    request: &Request,
+    timeout_secs: Option<u64>,
+) -> Secret<serde_json::Value> {
     // Header storage iterates in non-deterministic (HashMap) order, so the raw
     // sequence differs between record and replay even when the header SET is
     // identical. The args matcher compares serialized JSON arrays

--- a/crates/external_services/src/superposition.rs
+++ b/crates/external_services/src/superposition.rs
@@ -38,6 +38,170 @@ pub use superposition_types::api::{
 pub use self::types::{ConfigContext, SuperpositionClientConfig, SuperpositionError, ToDocument};
 use crate::config_metrics;
 
+// ── Deja record/replay boundary for Superposition READS ──────────────────────
+// Wraps the read methods so each read is CAPTURED on record and SUBSTITUTED from
+// the tape on replay — no live Superposition service is consulted in replay. The
+// WHOLE `CustomResult<T, SuperpositionError>` round-trips ("recording threw ⇒
+// replay throws"). Identity is rank-2 span-path (no call-site id). A genuine tape
+// MISS returns `Err(SuperpositionError)` (via `dispatch_async_or_miss`) so the
+// caller's `fetch_db_config` ladder degrades to DB/default and replay progresses,
+// instead of the egress fail-stop. Reads are deja's per-request business config;
+// writes are deliberately NOT wrapped (they are leaving the OLTP path).
+#[cfg(feature = "deja")]
+mod deja_boundary {
+    use error_stack::report;
+
+    use super::{ConfigContext, CustomResult, SuperpositionError};
+
+    pub(super) const BOUNDARY: &str = "superposition";
+    pub(super) const COMPONENT: &str = "SuperpositionClient";
+
+    /// Serialize the whole `CustomResult<T, SuperpositionError>` for the tape:
+    /// the `Ok` value losslessly, or the error's current context (which the
+    /// caller's recovery branches on). Report attachments do not round-trip.
+    pub(super) fn capture<T: serde::Serialize>(
+        result: &CustomResult<T, SuperpositionError>,
+    ) -> (serde_json::Value, bool) {
+        match result {
+            Ok(value) => (
+                serde_json::json!({
+                    "result": "Ok",
+                    "value": serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+                }),
+                false,
+            ),
+            Err(err) => (
+                serde_json::json!({
+                    "result": "Err",
+                    "error": serde_json::to_value(err.current_context())
+                        .unwrap_or(serde_json::Value::Null),
+                }),
+                true,
+            ),
+        }
+    }
+
+    /// Rebuild the typed `CustomResult` from a recorded tape value. A recorded
+    /// `Err` replays as `Err(report!(E))` carrying the SAME typed context.
+    pub(super) fn reconstruct<T: serde::de::DeserializeOwned>(
+        recorded: serde_json::Value,
+    ) -> deja::__private::Reconstructed<CustomResult<T, SuperpositionError>> {
+        use deja::__private::Reconstructed;
+        let Some(object) = recorded.as_object() else {
+            return Reconstructed::Failed;
+        };
+        match object.get("result").and_then(serde_json::Value::as_str) {
+            Some("Ok") => match object
+                .get("value")
+                .cloned()
+                .map(serde_json::from_value::<T>)
+            {
+                Some(Ok(value)) => Reconstructed::Value(Ok(value)),
+                _ => Reconstructed::Failed,
+            },
+            Some("Err") => match object
+                .get("error")
+                .cloned()
+                .map(serde_json::from_value::<SuperpositionError>)
+            {
+                Some(Ok(error)) => Reconstructed::Value(Err(report!(error))),
+                _ => Reconstructed::Failed,
+            },
+            _ => Reconstructed::Failed,
+        }
+    }
+
+    /// Serialize a `ConfigContext` (+ targeting key) into the boundary args image
+    /// used for replay matching. The config key/method go in alongside.
+    pub(super) fn args_image(
+        method: &str,
+        key: Option<&str>,
+        context: Option<&ConfigContext>,
+        targeting_key: Option<&String>,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "method": method,
+            "key": key,
+            "context": context.map(|c| c.values.clone()),
+            "targeting_key": targeting_key,
+        })
+    }
+
+    /// Run one Superposition read through the deja boundary. `run` performs the
+    /// live read; on a substitute HIT it is skipped (tape value served), on a
+    /// genuine MISS `on_miss` yields a recoverable `Err`.
+    pub(super) async fn read<T, Fut, Run>(
+        operation: &'static str,
+        args: serde_json::Value,
+        caller: &'static core::panic::Location<'static>,
+        run: Run,
+    ) -> CustomResult<T, SuperpositionError>
+    where
+        Run: FnOnce() -> Fut,
+        Fut: core::future::Future<Output = CustomResult<T, SuperpositionError>>,
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        // Engage only when a deja hook is live (record or replay); else pure
+        // passthrough — no observation, no allocation.
+        if !deja::__private::observation_is_active() {
+            return run().await;
+        }
+
+        let correlation = deja::current_correlation_id();
+        let scope = format!("superposition::{operation}");
+        // Rank-2 span-path identity: NO explicit call-site id (rank-1 needs a
+        // call-site and is banned), so resolution uses the ambient span-path
+        // (rank 2), with the syntactic hash of the scope as the rank-3 fallback.
+        let identity = deja::__private::CallsiteIdentity {
+            version: 1,
+            source: deja::__private::CallsiteSource::SyntacticHash,
+            id: None,
+            scope: Some(scope.clone()),
+            occurrence: deja::__private::next_boundary_occurrence(
+                correlation.as_deref(),
+                deja::__private::CallsiteSource::SyntacticHash,
+                Some(&scope),
+            ),
+            caller_function: Some(operation.to_string()),
+            lexical_path: Some(scope.clone()),
+            syntax_hash: Some(deja::__private::stable_callsite_hash(&scope)),
+            span_path: deja::__private::current_span_path(),
+        };
+
+        let semantics = deja::__private::BoundarySemantics {
+            replay_strategy: deja::ReplayStrategy::Substitute,
+            kind: Some(BOUNDARY.to_string()),
+            declaration: Some(
+                deja::BoundaryDeclaration::default().operation(deja::OperationKind::ExternalCall),
+            ),
+        };
+        let spec = deja::__private::BoundarySpec::with_semantics(
+            BOUNDARY, COMPONENT, operation, semantics,
+        );
+        let observation = deja::__private::CrossingObservation::with_correlation(
+            spec,
+            identity,
+            caller,
+            correlation,
+        );
+
+        deja::__private::dispatch_async_or_miss(
+            observation,
+            move || args,
+            run,
+            reconstruct::<T>,
+            capture::<T>,
+            move || {
+                Err(report!(SuperpositionError::NotFound(format!(
+                    "deja replay: no recorded Superposition value for `{operation}` (novel \
+                     config read); caller falls back to DB/default"
+                ))))
+            },
+        )
+        .await
+    }
+}
+
 /// Convert an `aws_smithy_types::Document` to a `serde_json::Value`.
 pub fn document_to_value(doc: Document) -> serde_json::Value {
     match doc {
@@ -600,18 +764,50 @@ impl SuperpositionClient {
     ) -> CustomResult<T, SuperpositionError>
     where
         open_feature::Client: GetValue<T>,
+        // Deja captures the whole `CustomResult<T, _>` at the read boundary; the
+        // GetValue impls (bool/String/i64/u32/f64/Value) all satisfy these.
+        T: serde::Serialize + serde::de::DeserializeOwned,
     {
-        let evaluation_context = self.build_evaluation_context(context, targeting_key);
-        let type_name = std::any::type_name::<T>();
-
-        self.client
-            .get_value(key, &evaluation_context)
+        #[cfg(feature = "deja")]
+        {
+            let args =
+                deja_boundary::args_image("get_config_value", Some(key), context, targeting_key);
+            let key = key.to_owned();
+            let context = context.cloned();
+            let targeting_key = targeting_key.cloned();
+            deja_boundary::read(
+                "get_config_value",
+                args,
+                core::panic::Location::caller(),
+                move || async move {
+                    let evaluation_context =
+                        self.build_evaluation_context(context.as_ref(), targeting_key.as_ref());
+                    let type_name = std::any::type_name::<T>();
+                    self.client
+                        .get_value(&key, &evaluation_context)
+                        .await
+                        .map_err(|e| {
+                            report!(SuperpositionError::ClientError(format!(
+                                "Failed to get {type_name} value for key '{key}': {e:?}"
+                            )))
+                        })
+                },
+            )
             .await
-            .map_err(|e| {
-                report!(SuperpositionError::ClientError(format!(
-                    "Failed to get {type_name} value for key '{key}': {e:?}"
-                )))
-            })
+        }
+        #[cfg(not(feature = "deja"))]
+        {
+            let evaluation_context = self.build_evaluation_context(context, targeting_key);
+            let type_name = std::any::type_name::<T>();
+            self.client
+                .get_value(key, &evaluation_context)
+                .await
+                .map_err(|e| {
+                    report!(SuperpositionError::ClientError(format!(
+                        "Failed to get {type_name} value for key '{key}': {e:?}"
+                    )))
+                })
+        }
     }
 
     /// Resolve full configuration from Superposition
@@ -626,15 +822,43 @@ impl SuperpositionClient {
         context: Option<&ConfigContext>,
         targeting_key: Option<&String>,
     ) -> CustomResult<Map<String, serde_json::Value>, SuperpositionError> {
-        let evaluation_context = self.build_evaluation_context(context, targeting_key);
-        self.provider
-            .resolve_all_features(evaluation_context)
+        #[cfg(feature = "deja")]
+        {
+            let args =
+                deja_boundary::args_image("resolve_full_config", None, context, targeting_key);
+            let context = context.cloned();
+            let targeting_key = targeting_key.cloned();
+            deja_boundary::read(
+                "resolve_full_config",
+                args,
+                core::panic::Location::caller(),
+                move || async move {
+                    let evaluation_context =
+                        self.build_evaluation_context(context.as_ref(), targeting_key.as_ref());
+                    self.provider
+                        .resolve_all_features(evaluation_context)
+                        .await
+                        .map_err(|e| {
+                            report!(SuperpositionError::ProviderError(format!(
+                                "Failed to resolve full config: {e:?}"
+                            )))
+                        })
+                },
+            )
             .await
-            .map_err(|e| {
-                report!(SuperpositionError::ProviderError(format!(
-                    "Failed to resolve full config: {e:?}"
-                )))
-            })
+        }
+        #[cfg(not(feature = "deja"))]
+        {
+            let evaluation_context = self.build_evaluation_context(context, targeting_key);
+            self.provider
+                .resolve_all_features(evaluation_context)
+                .await
+                .map_err(|e| {
+                    report!(SuperpositionError::ProviderError(format!(
+                        "Failed to resolve full config: {e:?}"
+                    )))
+                })
+        }
     }
 
     /// Get cached configuration from Superposition
@@ -650,22 +874,61 @@ impl SuperpositionClient {
         prefix_filter: Option<Vec<String>>,
         dimension_filter: Option<Map<String, serde_json::Value>>,
     ) -> CustomResult<superposition_types::Config, SuperpositionError> {
-        use superposition_provider::data_source::SuperpositionDataSource;
-        let response = self
-            .provider
-            .fetch_filtered_config(dimension_filter, prefix_filter, None)
+        #[cfg(feature = "deja")]
+        {
+            let args = serde_json::json!({
+                "method": "get_cached_config",
+                "prefix_filter": prefix_filter.clone(),
+                "dimension_filter": dimension_filter.clone(),
+            });
+            deja_boundary::read(
+                "get_cached_config",
+                args,
+                core::panic::Location::caller(),
+                move || async move {
+                    use superposition_provider::data_source::SuperpositionDataSource;
+                    let response = self
+                        .provider
+                        .fetch_filtered_config(dimension_filter, prefix_filter, None)
+                        .await
+                        .map_err(|e| {
+                            report!(SuperpositionError::ProviderError(format!(
+                                "Failed to get cached config: {e:?}"
+                            )))
+                        })?;
+                    match response {
+                        superposition_provider::data_source::FetchResponse::Data(data) => {
+                            Ok(data.data)
+                        }
+                        superposition_provider::data_source::FetchResponse::NotModified => {
+                            Err(report!(SuperpositionError::ProviderError(
+                                "Config not modified but no data available".to_string()
+                            )))
+                        }
+                    }
+                },
+            )
             .await
-            .map_err(|e| {
-                report!(SuperpositionError::ProviderError(format!(
-                    "Failed to get cached config: {e:?}"
-                )))
-            })?;
-        match response {
-            superposition_provider::data_source::FetchResponse::Data(data) => Ok(data.data),
-            superposition_provider::data_source::FetchResponse::NotModified => {
-                Err(report!(SuperpositionError::ProviderError(
-                    "Config not modified but no data available".to_string()
-                )))
+        }
+        #[cfg(not(feature = "deja"))]
+        {
+            use superposition_provider::data_source::SuperpositionDataSource;
+            let response = self
+                .provider
+                .fetch_filtered_config(dimension_filter, prefix_filter, None)
+                .await
+                .map_err(|e| {
+                    report!(SuperpositionError::ProviderError(format!(
+                        "Failed to get cached config: {e:?}"
+                    )))
+                })?;
+            match response {
+                superposition_provider::data_source::FetchResponse::Data(data) => Ok(data.data),
+                superposition_provider::data_source::FetchResponse::NotModified => {
+                    Err(report!(SuperpositionError::ProviderError(
+                        "Config not modified but no data available".to_string()
+                    )))
+                }
             }
         }
     }
@@ -750,8 +1013,15 @@ pub trait WritableConfig {
 /// Each config type implements this trait to define how its value should be
 /// retrieved from Superposition.
 pub trait Config {
-    /// The output type of this configuration
-    type Output: Default + Clone;
+    /// The output type of this configuration.
+    ///
+    /// `Serialize + DeserializeOwned` are required because `get_config_value`
+    /// (which `fetch` calls) captures the whole `CustomResult<Output, _>` at the
+    /// deja read boundary. Declaring the bound on the associated type propagates
+    /// it to `fetch` and to every generic `C: Config` caller (e.g. router's
+    /// `fetch_db_config`) without scattering per-call-site where-clauses. All
+    /// real Output types (bool/String/i64/u32/f64/serde_json::Value) satisfy it.
+    type Output: Default + Clone + serde::Serialize + serde::de::DeserializeOwned;
 
     /// The type used as the targeting key for experiment traffic splitting
     type TargetingKey: TargetingKey + Send + Sync;

--- a/crates/external_services/src/superposition/types.rs
+++ b/crates/external_services/src/superposition/types.rs
@@ -103,6 +103,11 @@ impl Default for SuperpositionClientConfig {
 
 /// Errors that can occur when using Superposition
 #[derive(Debug, thiserror::Error)]
+// Deja records the WHOLE `CustomResult<T, SuperpositionError>` at the read
+// boundary ("recording threw ⇒ replay throws"), so the error must round-trip.
+// Every variant is `Variant(String)` → trivially (de)serializable. Feature-gated
+// so the release build (deja off) keeps the error type dependency-lean.
+#[cfg_attr(feature = "deja", derive(serde::Serialize, serde::Deserialize))]
 pub enum SuperpositionError {
     /// Error initializing the Superposition client
     #[error("Failed to initialize Superposition client: {0}")]

--- a/crates/hyperswitch_domain_models/src/type_encryption.rs
+++ b/crates/hyperswitch_domain_models/src/type_encryption.rs
@@ -1309,6 +1309,8 @@ pub enum CryptoOutput<T: Clone, S: hyperswitch_masking::Strategy<T>> {
     BatchOperation(FxHashMap<String, crypto::Encryptable<Secret<T, S>>>),
 }
 
+// deja: intentionally NOT a boundary — see `docs/design/deja-non-boundaries.md`.
+//
 // Do not remove the `skip_all` as the key would be logged otherwise
 #[instrument(skip_all, fields(table = table_name))]
 pub async fn crypto_operation<T: Clone + Send, S: hyperswitch_masking::Strategy<T>>(

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -35,7 +35,7 @@ fred = { version = "8.0.6", optional = true, features = [
 
 # First party crates
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"] }
-deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false, features = ["error-stack"] }
+deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false, features = ["error-stack"] }
 router_env = { version = "0.1.0", path = "../router_env", optional = true }
 
 [dev-dependencies]

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -35,7 +35,7 @@ fred = { version = "8.0.6", optional = true, features = [
 
 # First party crates
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"] }
-deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false }
+deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false, features = ["error-stack"] }
 router_env = { version = "0.1.0", path = "../router_env", optional = true }
 
 [dev-dependencies]

--- a/crates/redis_interface/src/errors.rs
+++ b/crates/redis_interface/src/errors.rs
@@ -1,5 +1,10 @@
 //! Errors specific to this custom redis interface
 
+// Deja replay reconstructs a recorded redis error as the SAME typed context the
+// recording threw ("recording threw ⇒ replay throws"); the serde derives give
+// the variants a lossless wire form (variant-name string; `InvalidConfiguration`
+// carries its String payload).
+#[cfg_attr(feature = "deja", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum RedisError {
     #[error("Invalid Redis configuration: {0}")]

--- a/crates/redis_interface/src/metrics.rs
+++ b/crates/redis_interface/src/metrics.rs
@@ -15,6 +15,7 @@ pub(crate) enum RedisOperation {
     SetKey,
     SetKeyWithoutModifyingTtl,
     SetKeyWithExpiry,
+    #[cfg(not(feature = "deja"))]
     SerializeAndSetKeyWithExpiry,
     SetMultipleKeysIfNotExist,
     SetKeyIfNotExistsWithExpiry,

--- a/crates/redis_interface/src/module/fred/commands.rs
+++ b/crates/redis_interface/src/module/fred/commands.rs
@@ -31,15 +31,112 @@ use crate::{
     },
 };
 
+// Deja: serde-native proxy mirror of `fred::types::RedisValue`.
+//
+// The concrete proxy lets replay substitute generic Redis reads without adding
+// serde bounds to public `FromRedis` APIs.
+#[cfg(feature = "deja")]
+#[derive(serde::Serialize, serde::Deserialize)]
+enum DejaRedisValue {
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    Double(f64),
+    String(String),
+    Bytes(Vec<u8>),
+    Array(Vec<Self>),
+    Map(Vec<(Self, Self)>),
+    Queued,
+}
+
+#[cfg(feature = "deja")]
+impl From<RedisValue> for DejaRedisValue {
+    fn from(v: RedisValue) -> Self {
+        use fred::types::RedisValue as R;
+        match v {
+            R::Null => Self::Null,
+            R::Boolean(b) => Self::Boolean(b),
+            R::Integer(i) => Self::Integer(i),
+            R::Double(d) => Self::Double(d),
+            R::String(s) => Self::String(s.to_string()),
+            R::Bytes(b) => Self::Bytes(b.to_vec()),
+            R::Queued => Self::Queued,
+            R::Array(a) => Self::Array(a.into_iter().map(Self::from).collect()),
+            R::Map(m) => Self::Map(
+                m.inner()
+                    .into_iter()
+                    .map(|(k, val)| (Self::from(R::from(k)), Self::from(val)))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "deja")]
+impl TryFrom<DejaRedisValue> for RedisValue {
+    type Error = fred::error::RedisError;
+
+    fn try_from(v: DejaRedisValue) -> Result<Self, Self::Error> {
+        match v {
+            DejaRedisValue::Null => Ok(Self::Null),
+            DejaRedisValue::Boolean(b) => Ok(Self::Boolean(b)),
+            DejaRedisValue::Integer(i) => Ok(Self::Integer(i)),
+            DejaRedisValue::Double(d) => Ok(Self::Double(d)),
+            DejaRedisValue::String(s) => Ok(Self::String(s.into())),
+            DejaRedisValue::Bytes(b) => Ok(Self::Bytes(b.into())),
+            DejaRedisValue::Queued => Ok(Self::Queued),
+            DejaRedisValue::Array(a) => Ok(Self::Array(
+                a.into_iter()
+                    .map(Self::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            DejaRedisValue::Map(m) => {
+                let pairs = m
+                    .into_iter()
+                    .map(|(k, val)| Ok((Self::try_from(k)?, Self::try_from(val)?)))
+                    .collect::<Result<Vec<_>, Self::Error>>()?;
+                pairs.try_into().map(Self::Map)
+            }
+        }
+    }
+}
+
 impl super::RedisConnectionPool {
     pub fn add_prefix(&self, key: &str) -> String {
-        if self.key_prefix.is_empty() {
+        let physical = if self.key_prefix.is_empty() {
             key.to_string()
         } else {
             format!("{}:{}", self.key_prefix, key)
+        };
+        // Deja replay isolation: during REPLAY, namespace every physical key
+        // by the active correlation so each test case's store is isolated — no
+        // cross-case collisions and no read-modify-write double-apply, which is
+        // what makes it safe to Execute stateful redis ops against the seeded
+        // store. The harness seeds each correlation under the same
+        // `{correlation}:{physical}` namespace. Inert during record and when no
+        // correlation is in scope, so recorded keys and normal operation are
+        // unchanged (and for Substitute ops the real command never runs anyway).
+        #[cfg(feature = "deja")]
+        if let Some(corr) = deja::replay_key_namespace() {
+            return format!("{corr}:{physical}");
         }
+        physical
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SET",
+                    "has_ttl": true,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_key<V>(&self, key: &RedisKey, value: V) -> CustomResult<(), errors::RedisError>
     where
@@ -60,6 +157,19 @@ impl super::RedisConnectionPool {
         .change_context(errors::RedisError::SetFailed)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key_without_modifying_ttl",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SET_KEEP_TTL",
+                })
+            },
+        )
+    )]
     pub async fn set_key_without_modifying_ttl<V>(
         &self,
         key: &RedisKey,
@@ -83,6 +193,18 @@ impl super::RedisConnectionPool {
         .change_context(errors::RedisError::SetFailed)
     }
 
+    #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_multiple_keys_if_not_exist",
+            args = {
+                serde_json::json!({
+                    "command": "MSETNX",
+                })
+            },
+        )
+    )]
     pub async fn set_multiple_keys_if_not_exist<K, V>(
         &self,
         key_value_pairs: &[(K, V)],
@@ -172,33 +294,62 @@ impl super::RedisConnectionPool {
             .encode_to_vec()
             .change_context(errors::RedisError::JsonSerializationFailed)?;
 
-        track_redis_call(
-            RedisOperation::SerializeAndSetKeyWithExpiry,
-            self.pool.set(
-                key.tenant_aware_key(self),
-                serialized.as_slice(),
-                Some(Expiration::EX(seconds)),
-                None,
-                false,
-            ),
-        )
-        .await
-        .change_context(errors::RedisError::SetExFailed)
+        #[cfg(feature = "deja")]
+        {
+            self.set_key_with_expiry(key, serialized.as_slice(), seconds)
+                .await
+        }
+
+        #[cfg(not(feature = "deja"))]
+        {
+            track_redis_call(
+                RedisOperation::SerializeAndSetKeyWithExpiry,
+                self.pool.set(
+                    key.tenant_aware_key(self),
+                    serialized.as_slice(),
+                    Some(Expiration::EX(seconds)),
+                    None,
+                    false,
+                ),
+            )
+            .await
+            .change_context(errors::RedisError::SetExFailed)
+        }
     }
 
+    // Deja hermetic boundary for GET.
+    //
+    // The boundary lives on this inner method, which fetches the RAW redis reply
+    // (`fred::types::RedisValue`) and mirrors it into the serde-native
+    // `DejaRedisValue`. Because the recorded/replayed type is concrete and
+    // serde-native, `codec = ResultOkCodec` works without leaking a serde bound
+    // onto the public `get_key<V>`.
+    #[cfg(feature = "deja")]
     #[instrument(level = "DEBUG", skip(self))]
-    pub async fn get_key<V>(&self, key: &RedisKey) -> CustomResult<V, errors::RedisError>
-    where
-        V: FromRedis + Unpin + Send + 'static,
-    {
+    #[deja::redis(
+        operation = "get_key",
+        codec = ResultOkCodec,
+        state_read = key.tenant_aware_key(self),
+        args = {
+            serde_json::json!({
+                "key": key.as_str(),
+                "command": "GET",
+            })
+        },
+    )]
+    async fn get_key_raw(
+        &self,
+        key: &RedisKey,
+    ) -> CustomResult<DejaRedisValue, errors::RedisError> {
         match track_redis_call(
             RedisOperation::GetKey,
-            self.pool.get(key.tenant_aware_key(self)),
+            self.pool
+                .get::<fred::types::RedisValue, _>(key.tenant_aware_key(self)),
         )
         .await
         .change_context(errors::RedisError::GetFailed)
         {
-            Ok(v) => Ok(v),
+            Ok(v) => Ok(DejaRedisValue::from(v)),
             Err(_err) => {
                 #[cfg(not(feature = "multitenancy_fallback"))]
                 {
@@ -209,10 +360,56 @@ impl super::RedisConnectionPool {
                 {
                     track_redis_call(
                         RedisOperation::GetKey,
-                        self.pool.get(key.tenant_unaware_key(self)),
+                        self.pool
+                            .get::<fred::types::RedisValue, _>(key.tenant_unaware_key(self)),
                     )
                     .await
                     .change_context(errors::RedisError::GetFailed)
+                    .map(DejaRedisValue::from)
+                }
+            }
+        }
+    }
+
+    #[instrument(level = "DEBUG", skip(self))]
+    pub async fn get_key<V>(&self, key: &RedisKey) -> CustomResult<V, errors::RedisError>
+    where
+        V: FromRedis + Unpin + Send + 'static,
+    {
+        #[cfg(feature = "deja")]
+        {
+            let raw = self.get_key_raw(key).await?;
+            let value = raw
+                .try_into()
+                .map_err(|err| report!(err).change_context(errors::RedisError::GetFailed))?;
+            V::from_value(value).change_context(errors::RedisError::GetFailed)
+        }
+
+        #[cfg(not(feature = "deja"))]
+        {
+            match track_redis_call(
+                RedisOperation::GetKey,
+                self.pool.get(key.tenant_aware_key(self)),
+            )
+            .await
+            .change_context(errors::RedisError::GetFailed)
+            {
+                Ok(v) => Ok(v),
+                Err(_err) => {
+                    #[cfg(not(feature = "multitenancy_fallback"))]
+                    {
+                        Err(_err)
+                    }
+
+                    #[cfg(feature = "multitenancy_fallback")]
+                    {
+                        track_redis_call(
+                            RedisOperation::GetKey,
+                            self.pool.get(key.tenant_unaware_key(self)),
+                        )
+                        .await
+                        .change_context(errors::RedisError::GetFailed)
+                    }
                 }
             }
         }
@@ -287,6 +484,29 @@ impl super::RedisConnectionPool {
         }
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "get_multiple_keys",
+            read_set = keys.iter().map(|key| key.tenant_aware_key(self)).collect::<Vec<_>>(),
+            args = {
+                serde_json::json!({
+                    "key_count": keys.len(),
+                    "keys": keys.iter().map(|key| key.as_str()).collect::<Vec<_>>(),
+                    "command": "MGET",
+                })
+            },
+            result = {
+                (
+                    match &__deja_result {
+                        Ok(_) => serde_json::json!({"ok": true}),
+                        Err(e) => serde_json::json!({"ok": false, "error": format!("{:?}", e)}),
+                    },
+                    __deja_result.is_err(),
+                )
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn get_multiple_keys<V>(
         &self,
@@ -320,6 +540,19 @@ impl super::RedisConnectionPool {
         }
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "exists",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "EXISTS",
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn exists<V>(&self, key: &RedisKey) -> CustomResult<bool, errors::RedisError>
     where
@@ -401,6 +634,19 @@ impl super::RedisConnectionPool {
         Ok(results)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "delete_key",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "DEL",
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn delete_key(&self, key: &RedisKey) -> CustomResult<DelReply, errors::RedisError> {
         match track_redis_call(
@@ -430,6 +676,8 @@ impl super::RedisConnectionPool {
         }
     }
 
+    // deja: NO boundary — the inner delete_key calls carry record/replay; an outer
+    // boundary would nest and omit them. See `docs/design/deja-non-boundaries.md`.
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn delete_multiple_keys(
         &self,
@@ -444,6 +692,20 @@ impl super::RedisConnectionPool {
         Ok(del_result)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key_with_expiry",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SETEX",
+                    "ttl_seconds": seconds,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_key_with_expiry<V>(
         &self,
@@ -469,6 +731,25 @@ impl super::RedisConnectionPool {
         .change_context(errors::RedisError::SetExFailed)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key_if_not_exists_with_expiry",
+            codec = ResultOkCodec,
+            // Declare the key we WRITE so the seed plan's pristine rule masks a
+            // later read-back of it (e.g. the lock GET after this SETNX). Without
+            // this the read-back is seeded as "present", and the replayed Execute
+            // SETNX then sees the lock held → never acquires → retry storm.
+            state_write = key.tenant_aware_key(self),
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SETNX",
+                    "ttl_seconds": seconds,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_key_if_not_exists_with_expiry<V>(
         &self,
@@ -496,6 +777,20 @@ impl super::RedisConnectionPool {
         .change_context(errors::RedisError::SetFailed)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_expiry",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "EXPIRE",
+                    "ttl_seconds": seconds,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_expiry(
         &self,
@@ -510,6 +805,20 @@ impl super::RedisConnectionPool {
         .change_context(errors::RedisError::SetExpiryFailed)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_expire_at",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "EXPIREAT",
+                    "timestamp": timestamp,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_expire_at(
         &self,
@@ -524,6 +833,19 @@ impl super::RedisConnectionPool {
         .change_context(errors::RedisError::SetExpiryFailed)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "get_ttl",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "TTL",
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn get_ttl(&self, key: &RedisKey) -> CustomResult<i64, errors::RedisError> {
         track_redis_call(
@@ -534,6 +856,20 @@ impl super::RedisConnectionPool {
         .change_context(errors::RedisError::GetFailed)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_hash_fields",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "HSET",
+                    "ttl_seconds": ttl,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_hash_fields<F, V>(
         &self,
@@ -561,13 +897,54 @@ impl super::RedisConnectionPool {
         .await
         .change_context(errors::RedisError::SetHashFailed);
         // setting expiry for the key
-        output
-            .async_and_then(|_| {
-                self.set_expiry(key, ttl.unwrap_or(self.config.default_hash_ttl.into()))
-            })
-            .await
+        #[cfg(not(feature = "deja"))]
+        {
+            output
+                .async_and_then(|_| {
+                    self.set_expiry(key, ttl.unwrap_or(self.config.default_hash_ttl.into()))
+                })
+                .await
+        }
+        // Deja: set expiry via a RAW `pool.expire`, NOT the instrumented
+        // `set_expiry`. This method already carries its own `set_hash_fields`
+        // Ok-only codec boundary; nesting the instrumented `set_expiry` under it
+        // would orphan the inner EXPIRE event on replay (the outer no-op
+        // substitution skips it → "omitted" divergence). Inlining keeps
+        // HSET+EXPIRE as one recorded write that round-trips cleanly.
+        #[cfg(feature = "deja")]
+        {
+            output
+                .async_and_then(|_| async {
+                    let _: () = track_redis_call(
+                        RedisOperation::SetExpiry,
+                        self.pool.expire(
+                            key.tenant_aware_key(self),
+                            ttl.unwrap_or(self.config.default_hash_ttl.into()),
+                        ),
+                    )
+                    .await
+                    .change_context(errors::RedisError::SetExpiryFailed)?;
+                    Ok(())
+                })
+                .await
+        }
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_hash_field_if_not_exist",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "HSETNX",
+                    "field": field,
+                    "ttl_seconds": ttl,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_hash_field_if_not_exist<V>(
         &self,
@@ -587,13 +964,37 @@ impl super::RedisConnectionPool {
         .await
         .change_context(errors::RedisError::SetHashFieldFailed);
 
-        output
-            .async_and_then(|inner| async {
-                self.set_expiry(key, ttl.unwrap_or(self.config.default_hash_ttl).into())
-                    .await?;
-                Ok(inner)
-            })
-            .await
+        #[cfg(not(feature = "deja"))]
+        {
+            output
+                .async_and_then(|inner| async {
+                    self.set_expiry(key, ttl.unwrap_or(self.config.default_hash_ttl).into())
+                        .await?;
+                    Ok(inner)
+                })
+                .await
+        }
+        // Deja: raw `pool.expire` (not the instrumented `set_expiry`) for the same
+        // reason as `set_hash_fields`: this method's own `set_hash_field_if_not_exist`
+        // Ok-only boundary would skip a nested instrumented EXPIRE on replay,
+        // orphaning its recorded event.
+        #[cfg(feature = "deja")]
+        {
+            output
+                .async_and_then(|inner| async {
+                    let _: () = track_redis_call(
+                        RedisOperation::SetExpiry,
+                        self.pool.expire(
+                            key.tenant_aware_key(self),
+                            ttl.unwrap_or(self.config.default_hash_ttl).into(),
+                        ),
+                    )
+                    .await
+                    .change_context(errors::RedisError::SetExpiryFailed)?;
+                    Ok(inner)
+                })
+                .await
+        }
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -636,6 +1037,20 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "increment_fields_in_hash",
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "HINCRBY",
+                    "field_count": fields_to_increment.len(),
+                })
+            },
+        )
+    )]
     pub async fn increment_fields_in_hash<T>(
         &self,
         key: &RedisKey,
@@ -661,6 +1076,19 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "hscan",
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "HSCAN",
+                    "pattern": pattern,
+                })
+            },
+        )
+    )]
     pub async fn hscan(
         &self,
         key: &RedisKey,
@@ -696,6 +1124,18 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "scan",
+            args = {
+                serde_json::json!({
+                    "pattern": pattern.as_str(),
+                    "command": "SCAN",
+                })
+            },
+        )
+    )]
     pub async fn scan(
         &self,
         pattern: &RedisKey,
@@ -751,6 +1191,64 @@ impl super::RedisConnectionPool {
             .collect())
     }
 
+    // Deja hermetic boundary for HGET — same shape as `get_key_raw`: the boundary
+    // lives on this inner method which fetches the RAW reply and mirrors it into
+    // the serde-native `DejaRedisValue`, so `codec = ResultOkCodec` substitutes the field read
+    // WITHOUT leaking a serde bound onto the public `get_hash_field<V>`. A
+    // record-only `result={"ok":bool}` capture would record NO value, leaving
+    // replay nothing to reconstruct `V` from — the read would fall through to
+    // live redis.
+    #[cfg(feature = "deja")]
+    #[instrument(level = "DEBUG", skip(self))]
+    #[deja::redis(
+        operation = "get_hash_field",
+        codec = ResultOkCodec,
+        state_read = format!("{}:{}", key.tenant_aware_key(self), field),
+        args = {
+            serde_json::json!({
+                "key": key.as_str(),
+                "command": "HGET",
+                "field": field,
+            })
+        },
+    )]
+    async fn get_hash_field_raw(
+        &self,
+        key: &RedisKey,
+        field: &str,
+    ) -> CustomResult<DejaRedisValue, errors::RedisError> {
+        match track_redis_call(
+            RedisOperation::GetHashField,
+            self.pool
+                .hget::<fred::types::RedisValue, _, _>(key.tenant_aware_key(self), field),
+        )
+        .await
+        .change_context(errors::RedisError::GetHashFieldFailed)
+        {
+            Ok(v) => Ok(DejaRedisValue::from(v)),
+            Err(_err) => {
+                #[cfg(feature = "multitenancy_fallback")]
+                {
+                    track_redis_call(
+                        RedisOperation::GetHashField,
+                        self.pool.hget::<fred::types::RedisValue, _, _>(
+                            key.tenant_unaware_key(self),
+                            field,
+                        ),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetHashFieldFailed)
+                    .map(DejaRedisValue::from)
+                }
+
+                #[cfg(not(feature = "multitenancy_fallback"))]
+                {
+                    Err(_err)
+                }
+            }
+        }
+    }
+
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn get_hash_field<V>(
         &self,
@@ -760,23 +1258,82 @@ impl super::RedisConnectionPool {
     where
         V: FromRedis + Unpin + Send + 'static,
     {
+        #[cfg(feature = "deja")]
+        {
+            let raw = self.get_hash_field_raw(key, field).await?;
+            let value = raw.try_into().map_err(|err| {
+                report!(err).change_context(errors::RedisError::GetHashFieldFailed)
+            })?;
+            V::from_value(value).change_context(errors::RedisError::GetHashFieldFailed)
+        }
+
+        #[cfg(not(feature = "deja"))]
+        {
+            match track_redis_call(
+                RedisOperation::GetHashField,
+                self.pool.hget(key.tenant_aware_key(self), field),
+            )
+            .await
+            .change_context(errors::RedisError::GetHashFieldFailed)
+            {
+                Ok(v) => Ok(v),
+                Err(_err) => {
+                    #[cfg(feature = "multitenancy_fallback")]
+                    {
+                        track_redis_call(
+                            RedisOperation::GetHashField,
+                            self.pool.hget(key.tenant_unaware_key(self), field),
+                        )
+                        .await
+                        .change_context(errors::RedisError::GetHashFieldFailed)
+                    }
+
+                    #[cfg(not(feature = "multitenancy_fallback"))]
+                    {
+                        Err(_err)
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "deja")]
+    #[instrument(level = "DEBUG", skip(self))]
+    #[deja::redis(
+        operation = "get_hash_fields",
+        codec = ResultOkCodec,
+        state_read = key.tenant_aware_key(self),
+        args = {
+            serde_json::json!({
+                "key": key.as_str(),
+                "command": "HGETALL",
+            })
+        },
+    )]
+    async fn get_hash_fields_raw(
+        &self,
+        key: &RedisKey,
+    ) -> CustomResult<DejaRedisValue, errors::RedisError> {
         match track_redis_call(
-            RedisOperation::GetHashField,
-            self.pool.hget(key.tenant_aware_key(self), field),
+            RedisOperation::GetHashFields,
+            self.pool
+                .hgetall::<fred::types::RedisValue, _>(key.tenant_aware_key(self)),
         )
         .await
         .change_context(errors::RedisError::GetHashFieldFailed)
         {
-            Ok(v) => Ok(v),
+            Ok(v) => Ok(DejaRedisValue::from(v)),
             Err(_err) => {
                 #[cfg(feature = "multitenancy_fallback")]
                 {
                     track_redis_call(
-                        RedisOperation::GetHashField,
-                        self.pool.hget(key.tenant_unaware_key(self), field),
+                        RedisOperation::GetHashFields,
+                        self.pool
+                            .hgetall::<fred::types::RedisValue, _>(key.tenant_unaware_key(self)),
                     )
                     .await
                     .change_context(errors::RedisError::GetHashFieldFailed)
+                    .map(DejaRedisValue::from)
                 }
 
                 #[cfg(not(feature = "multitenancy_fallback"))]
@@ -792,28 +1349,40 @@ impl super::RedisConnectionPool {
     where
         V: FromRedis + Unpin + Send + 'static,
     {
-        match track_redis_call(
-            RedisOperation::GetHashFields,
-            self.pool.hgetall(key.tenant_aware_key(self)),
-        )
-        .await
-        .change_context(errors::RedisError::GetHashFieldFailed)
+        #[cfg(feature = "deja")]
         {
-            Ok(v) => Ok(v),
-            Err(_err) => {
-                #[cfg(feature = "multitenancy_fallback")]
-                {
-                    track_redis_call(
-                        RedisOperation::GetHashFields,
-                        self.pool.hgetall(key.tenant_unaware_key(self)),
-                    )
-                    .await
-                    .change_context(errors::RedisError::GetHashFieldFailed)
-                }
+            let raw = self.get_hash_fields_raw(key).await?;
+            let value = raw.try_into().map_err(|err| {
+                report!(err).change_context(errors::RedisError::GetHashFieldFailed)
+            })?;
+            V::from_value(value).change_context(errors::RedisError::GetHashFieldFailed)
+        }
 
-                #[cfg(not(feature = "multitenancy_fallback"))]
-                {
-                    Err(_err)
+        #[cfg(not(feature = "deja"))]
+        {
+            match track_redis_call(
+                RedisOperation::GetHashFields,
+                self.pool.hgetall(key.tenant_aware_key(self)),
+            )
+            .await
+            .change_context(errors::RedisError::GetHashFieldFailed)
+            {
+                Ok(v) => Ok(v),
+                Err(_err) => {
+                    #[cfg(feature = "multitenancy_fallback")]
+                    {
+                        track_redis_call(
+                            RedisOperation::GetHashFields,
+                            self.pool.hgetall(key.tenant_unaware_key(self)),
+                        )
+                        .await
+                        .change_context(errors::RedisError::GetHashFieldFailed)
+                    }
+
+                    #[cfg(not(feature = "multitenancy_fallback"))]
+                    {
+                        Err(_err)
+                    }
                 }
             }
         }
@@ -840,6 +1409,21 @@ impl super::RedisConnectionPool {
             .change_context(errors::RedisError::JsonDeserializationFailed)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "sadd",
+            codec = ResultOkCodec,
+            state_write = key.tenant_aware_key(self),
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SADD",
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn delete_hash_fields<F>(
         &self,
@@ -876,6 +1460,19 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "stream_append_entry",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XADD",
+                })
+            },
+        )
+    )]
     pub async fn stream_append_entry<F, V>(
         &self,
         stream: &RedisKey,
@@ -912,6 +1509,19 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "stream_delete_entries",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XDEL",
+                })
+            },
+        )
+    )]
     pub async fn stream_delete_entries(
         &self,
         stream: &RedisKey,
@@ -927,6 +1537,19 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "stream_trim_entries",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XTRIM",
+                })
+            },
+        )
+    )]
     pub async fn stream_trim_entries(
         &self,
         stream: &RedisKey,
@@ -944,6 +1567,20 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "stream_acknowledge_entries",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XACK",
+                    "group": group,
+                })
+            },
+        )
+    )]
     pub async fn stream_acknowledge_entries(
         &self,
         stream: &RedisKey,
@@ -961,6 +1598,18 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "stream_get_length",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XLEN",
+                })
+            },
+        )
+    )]
     pub async fn stream_get_length(
         &self,
         stream: &RedisKey,
@@ -979,6 +1628,17 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "stream_read_entries",
+            args = {
+                serde_json::json!({
+                    "command": "XREAD",
+                })
+            },
+        )
+    )]
     pub async fn stream_read_entries(
         &self,
         streams: &[RedisKey],
@@ -1030,6 +1690,17 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "stream_read_with_options",
+            args = {
+                serde_json::json!({
+                    "command": if group.is_some() { "XREADGROUP" } else { "XREAD" },
+                })
+            },
+        )
+    )]
     pub async fn stream_read_with_options(
         &self,
         streams: &[RedisKey],
@@ -1102,6 +1773,19 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "append_elements_to_list",
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "RPUSH",
+                })
+            },
+        )
+    )]
     pub async fn append_elements_to_list<V>(
         &self,
         key: &RedisKey,
@@ -1120,6 +1804,20 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "get_list_elements",
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "LRANGE",
+                    "start": start,
+                    "stop": stop,
+                })
+            },
+        )
+    )]
     pub async fn get_list_elements(
         &self,
         key: &RedisKey,
@@ -1135,6 +1833,18 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "get_list_length",
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "LLEN",
+                })
+            },
+        )
+    )]
     pub async fn get_list_length(&self, key: &RedisKey) -> CustomResult<usize, errors::RedisError> {
         track_redis_call(
             RedisOperation::GetListLength,
@@ -1145,6 +1855,20 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "lpop_list_elements",
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "LPOP",
+                    "count": count,
+                })
+            },
+        )
+    )]
     pub async fn lpop_list_elements(
         &self,
         key: &RedisKey,
@@ -1161,6 +1885,20 @@ impl super::RedisConnectionPool {
     //                                              Consumer Group API
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "consumer_group_create",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XGROUP_CREATE",
+                    "group": group,
+                })
+            },
+        )
+    )]
     pub async fn consumer_group_create(
         &self,
         stream: &RedisKey,
@@ -1185,6 +1923,20 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "consumer_group_destroy",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XGROUP_DESTROY",
+                    "group": group,
+                })
+            },
+        )
+    )]
     pub async fn consumer_group_destroy(
         &self,
         stream: &RedisKey,
@@ -1202,6 +1954,21 @@ impl super::RedisConnectionPool {
 
     // the number of pending messages that the consumer had before it was deleted
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "consumer_group_delete_consumer",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XGROUP_DELCONSUMER",
+                    "group": group,
+                    "consumer": consumer,
+                })
+            },
+        )
+    )]
     pub async fn consumer_group_delete_consumer(
         &self,
         stream: &RedisKey,
@@ -1218,6 +1985,20 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "consumer_group_set_last_id",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XGROUP_SETID",
+                    "group": group,
+                })
+            },
+        )
+    )]
     pub async fn consumer_group_set_last_id(
         &self,
         stream: &RedisKey,
@@ -1236,6 +2017,33 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "consumer_group_set_message_owner",
+            args = {
+                serde_json::json!({
+                    "key": stream.as_str(),
+                    "command": "XCLAIM",
+                    "group": group,
+                    "consumer": consumer,
+                })
+            },
+            // Generic `R: FromRedis` is NOT `Debug`, so the default `result_debug`
+            // capture would not compile. Record only the ok/err verdict (record-only
+            // leaf — no replay reconstruction needed).
+            result = {
+                (
+                    match &__deja_result {
+                        Ok(_) => serde_json::json!({"ok": true}),
+                        Err(e) => serde_json::json!({"ok": false, "error": format!("{:?}", e)}),
+                    },
+                    __deja_result.is_err(),
+                )
+            },
+        )
+    )]
     pub async fn consumer_group_set_message_owner<R>(
         &self,
         stream: &RedisKey,
@@ -1268,6 +2076,31 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "evaluate_redis_script",
+            args = {
+                serde_json::json!({
+                    "command": "EVAL",
+                    "key_count": key.len(),
+                })
+            },
+            // Generic `T` is NOT `Debug`, so the default `result_debug` capture
+            // would not compile. Record only the ok/err verdict (record-only leaf —
+            // an EVAL result is never reconstructed without an explicit override).
+            result = {
+                (
+                    match &__deja_result {
+                        Ok(_) => serde_json::json!({"ok": true}),
+                        Err(e) => serde_json::json!({"ok": false, "error": format!("{:?}", e)}),
+                    },
+                    __deja_result.is_err(),
+                )
+            },
+        )
+    )]
     pub async fn evaluate_redis_script<V, T>(
         &self,
         lua_script: &'static str,
@@ -1318,6 +2151,32 @@ impl super::RedisConnectionPool {
     /// Sets a value in Redis if not already present, and returns the value (either existing or newly set).
     /// This operation is atomic using Redis transactions.
     #[instrument(level = "DEBUG", skip(self))]
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key_if_not_exists_and_get_value",
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SETNX_GET",
+                    "ttl_seconds": ttl,
+                })
+            },
+            // `SetGetReply<V>` carries a generic `V` with no `Debug` bound, so the
+            // default `result_debug` capture would not compile. Record only the
+            // ok/err verdict (record-only leaf — no replay reconstruction needed;
+            // an RMW transaction always re-executes live on replay).
+            result = {
+                (
+                    match &__deja_result {
+                        Ok(_) => serde_json::json!({"ok": true}),
+                        Err(e) => serde_json::json!({"ok": false, "error": format!("{:?}", e)}),
+                    },
+                    __deja_result.is_err(),
+                )
+            },
+        )
+    )]
     pub async fn set_key_if_not_exists_and_get_value<V>(
         &self,
         key: &RedisKey,

--- a/crates/redis_interface/src/module/fred/commands.rs
+++ b/crates/redis_interface/src/module/fred/commands.rs
@@ -344,7 +344,7 @@ impl super::RedisConnectionPool {
         match track_redis_call(
             RedisOperation::GetKey,
             self.pool
-                .get::<fred::types::RedisValue, _>(key.tenant_aware_key(self)),
+                .get::<RedisValue, _>(key.tenant_aware_key(self)),
         )
         .await
         .change_context(errors::RedisError::GetFailed)
@@ -361,7 +361,7 @@ impl super::RedisConnectionPool {
                     track_redis_call(
                         RedisOperation::GetKey,
                         self.pool
-                            .get::<fred::types::RedisValue, _>(key.tenant_unaware_key(self)),
+                            .get::<RedisValue, _>(key.tenant_unaware_key(self)),
                     )
                     .await
                     .change_context(errors::RedisError::GetFailed)
@@ -1222,7 +1222,7 @@ impl super::RedisConnectionPool {
         match track_redis_call(
             RedisOperation::GetHashField,
             self.pool
-                .hget::<fred::types::RedisValue, _, _>(key.tenant_aware_key(self), field),
+                .hget::<RedisValue, _, _>(key.tenant_aware_key(self), field),
         )
         .await
         .change_context(errors::RedisError::GetHashFieldFailed)
@@ -1233,7 +1233,7 @@ impl super::RedisConnectionPool {
                 {
                     track_redis_call(
                         RedisOperation::GetHashField,
-                        self.pool.hget::<fred::types::RedisValue, _, _>(
+                        self.pool.hget::<RedisValue, _, _>(
                             key.tenant_unaware_key(self),
                             field,
                         ),
@@ -1319,7 +1319,7 @@ impl super::RedisConnectionPool {
         match track_redis_call(
             RedisOperation::GetHashFields,
             self.pool
-                .hgetall::<fred::types::RedisValue, _>(key.tenant_aware_key(self)),
+                .hgetall::<RedisValue, _>(key.tenant_aware_key(self)),
         )
         .await
         .change_context(errors::RedisError::GetHashFieldFailed)
@@ -1331,7 +1331,7 @@ impl super::RedisConnectionPool {
                     track_redis_call(
                         RedisOperation::GetHashFields,
                         self.pool
-                            .hgetall::<fred::types::RedisValue, _>(key.tenant_unaware_key(self)),
+                            .hgetall::<RedisValue, _>(key.tenant_unaware_key(self)),
                     )
                     .await
                     .change_context(errors::RedisError::GetHashFieldFailed)

--- a/crates/redis_interface/src/module/fred/commands.rs
+++ b/crates/redis_interface/src/module/fred/commands.rs
@@ -127,7 +127,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_key",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -161,7 +161,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_key_without_modifying_ttl",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -322,13 +322,13 @@ impl super::RedisConnectionPool {
     // The boundary lives on this inner method, which fetches the RAW redis reply
     // (`fred::types::RedisValue`) and mirrors it into the serde-native
     // `DejaRedisValue`. Because the recorded/replayed type is concrete and
-    // serde-native, `codec = ResultOkCodec` works without leaking a serde bound
+    // serde-native, the typed `ResultCodec` works without leaking a serde bound
     // onto the public `get_key<V>`.
     #[cfg(feature = "deja")]
     #[instrument(level = "DEBUG", skip(self))]
     #[deja::redis(
         operation = "get_key",
-        codec = ResultOkCodec,
+        codec = deja::codec::ResultCodec::<DejaRedisValue, errors::RedisError>,
         state_read = key.tenant_aware_key(self),
         args = {
             serde_json::json!({
@@ -379,9 +379,11 @@ impl super::RedisConnectionPool {
         #[cfg(feature = "deja")]
         {
             let raw = self.get_key_raw(key).await?;
-            let value = raw
+            let value: RedisValue = raw
                 .try_into()
-                .map_err(|err| report!(err).change_context(errors::RedisError::GetFailed))?;
+                .map_err(|err: fred::error::RedisError| {
+                    report!(err).change_context(errors::RedisError::GetFailed)
+                })?;
             V::from_value(value).change_context(errors::RedisError::GetFailed)
         }
 
@@ -544,7 +546,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "exists",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<bool, errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -638,7 +640,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "delete_key",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<DelReply, errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -696,7 +698,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_key_with_expiry",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -735,7 +737,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_key_if_not_exists_with_expiry",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<SetnxReply, errors::RedisError>,
             // Declare the key we WRITE so the seed plan's pristine rule masks a
             // later read-back of it (e.g. the lock GET after this SETNX). Without
             // this the read-back is seeded as "present", and the replayed Execute
@@ -781,7 +783,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_expiry",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -809,7 +811,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_expire_at",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -837,7 +839,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "get_ttl",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<i64, errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -860,7 +862,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_hash_fields",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -934,7 +936,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_hash_field_if_not_exist",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<HsetnxReply, errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -1193,7 +1195,7 @@ impl super::RedisConnectionPool {
 
     // Deja hermetic boundary for HGET — same shape as `get_key_raw`: the boundary
     // lives on this inner method which fetches the RAW reply and mirrors it into
-    // the serde-native `DejaRedisValue`, so `codec = ResultOkCodec` substitutes the field read
+    // the serde-native `DejaRedisValue`, so the typed `ResultCodec` substitutes the field read
     // WITHOUT leaking a serde bound onto the public `get_hash_field<V>`. A
     // record-only `result={"ok":bool}` capture would record NO value, leaving
     // replay nothing to reconstruct `V` from — the read would fall through to
@@ -1202,7 +1204,7 @@ impl super::RedisConnectionPool {
     #[instrument(level = "DEBUG", skip(self))]
     #[deja::redis(
         operation = "get_hash_field",
-        codec = ResultOkCodec,
+        codec = deja::codec::ResultCodec::<DejaRedisValue, errors::RedisError>,
         state_read = format!("{}:{}", key.tenant_aware_key(self), field),
         args = {
             serde_json::json!({
@@ -1261,7 +1263,7 @@ impl super::RedisConnectionPool {
         #[cfg(feature = "deja")]
         {
             let raw = self.get_hash_field_raw(key, field).await?;
-            let value = raw.try_into().map_err(|err| {
+            let value: RedisValue = raw.try_into().map_err(|err: fred::error::RedisError| {
                 report!(err).change_context(errors::RedisError::GetHashFieldFailed)
             })?;
             V::from_value(value).change_context(errors::RedisError::GetHashFieldFailed)
@@ -1301,7 +1303,7 @@ impl super::RedisConnectionPool {
     #[instrument(level = "DEBUG", skip(self))]
     #[deja::redis(
         operation = "get_hash_fields",
-        codec = ResultOkCodec,
+        codec = deja::codec::ResultCodec::<DejaRedisValue, errors::RedisError>,
         state_read = key.tenant_aware_key(self),
         args = {
             serde_json::json!({
@@ -1352,7 +1354,7 @@ impl super::RedisConnectionPool {
         #[cfg(feature = "deja")]
         {
             let raw = self.get_hash_fields_raw(key).await?;
-            let value = raw.try_into().map_err(|err| {
+            let value: RedisValue = raw.try_into().map_err(|err: fred::error::RedisError| {
                 report!(err).change_context(errors::RedisError::GetHashFieldFailed)
             })?;
             V::from_value(value).change_context(errors::RedisError::GetHashFieldFailed)
@@ -1414,7 +1416,7 @@ impl super::RedisConnectionPool {
         deja::redis(
             replay = Substitute,
             operation = "sadd",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<SaddReply, errors::RedisError>,
             state_write = key.tenant_aware_key(self),
             args = {
                 serde_json::json!({

--- a/crates/redis_interface/src/module/fred/commands.rs
+++ b/crates/redis_interface/src/module/fred/commands.rs
@@ -343,8 +343,7 @@ impl super::RedisConnectionPool {
     ) -> CustomResult<DejaRedisValue, errors::RedisError> {
         match track_redis_call(
             RedisOperation::GetKey,
-            self.pool
-                .get::<RedisValue, _>(key.tenant_aware_key(self)),
+            self.pool.get::<RedisValue, _>(key.tenant_aware_key(self)),
         )
         .await
         .change_context(errors::RedisError::GetFailed)
@@ -360,8 +359,7 @@ impl super::RedisConnectionPool {
                 {
                     track_redis_call(
                         RedisOperation::GetKey,
-                        self.pool
-                            .get::<RedisValue, _>(key.tenant_unaware_key(self)),
+                        self.pool.get::<RedisValue, _>(key.tenant_unaware_key(self)),
                     )
                     .await
                     .change_context(errors::RedisError::GetFailed)
@@ -379,11 +377,9 @@ impl super::RedisConnectionPool {
         #[cfg(feature = "deja")]
         {
             let raw = self.get_key_raw(key).await?;
-            let value: RedisValue = raw
-                .try_into()
-                .map_err(|err: fred::error::RedisError| {
-                    report!(err).change_context(errors::RedisError::GetFailed)
-                })?;
+            let value: RedisValue = raw.try_into().map_err(|err: fred::error::RedisError| {
+                report!(err).change_context(errors::RedisError::GetFailed)
+            })?;
             V::from_value(value).change_context(errors::RedisError::GetFailed)
         }
 
@@ -1233,10 +1229,8 @@ impl super::RedisConnectionPool {
                 {
                     track_redis_call(
                         RedisOperation::GetHashField,
-                        self.pool.hget::<RedisValue, _, _>(
-                            key.tenant_unaware_key(self),
-                            field,
-                        ),
+                        self.pool
+                            .hget::<RedisValue, _, _>(key.tenant_unaware_key(self), field),
                     )
                     .await
                     .change_context(errors::RedisError::GetHashFieldFailed)

--- a/crates/redis_interface/src/module/fred/commands.rs
+++ b/crates/redis_interface/src/module/fred/commands.rs
@@ -1411,21 +1411,6 @@ impl super::RedisConnectionPool {
             .change_context(errors::RedisError::JsonDeserializationFailed)
     }
 
-    #[cfg_attr(
-        feature = "deja",
-        deja::redis(
-            replay = Substitute,
-            operation = "sadd",
-            codec = deja::codec::ResultCodec::<SaddReply, errors::RedisError>,
-            state_write = key.tenant_aware_key(self),
-            args = {
-                serde_json::json!({
-                    "key": key.as_str(),
-                    "command": "SADD",
-                })
-            },
-        )
-    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn delete_hash_fields<F>(
         &self,
@@ -1443,6 +1428,21 @@ impl super::RedisConnectionPool {
         .change_context(errors::RedisError::DeleteHashFieldFailed)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "sadd",
+            codec = deja::codec::ResultCodec::<SaddReply, errors::RedisError>,
+            state_write = key.tenant_aware_key(self),
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SADD",
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn sadd<V>(
         &self,

--- a/crates/redis_interface/src/module/redis_rs/commands.rs
+++ b/crates/redis_interface/src/module/redis_rs/commands.rs
@@ -32,17 +32,202 @@ use crate::{
     },
 };
 
+#[cfg(feature = "deja")]
+#[derive(serde::Serialize, serde::Deserialize)]
+enum DejaRedisValue {
+    Null,
+    Int(i64),
+    BulkString(Vec<u8>),
+    Array(Vec<Self>),
+    SimpleString(String),
+    Okay,
+    Map(Vec<(Self, Self)>),
+    Attribute {
+        data: Box<Self>,
+        attributes: Vec<(Self, Self)>,
+    },
+    Set(Vec<Self>),
+    Double(f64),
+    Boolean(bool),
+    VerbatimString {
+        format: String,
+        text: String,
+    },
+    Push {
+        kind: String,
+        data: Vec<Self>,
+    },
+    UnsupportedSuccessfulValue {
+        variant: String,
+    },
+}
+
+#[cfg(feature = "deja")]
+impl From<redis::Value> for DejaRedisValue {
+    fn from(value: redis::Value) -> Self {
+        match value {
+            redis::Value::Nil => Self::Null,
+            redis::Value::Int(value) => Self::Int(value),
+            redis::Value::BulkString(value) => Self::BulkString(value),
+            redis::Value::Array(values) => {
+                Self::Array(values.into_iter().map(Self::from).collect())
+            }
+            redis::Value::SimpleString(value) => Self::SimpleString(value),
+            redis::Value::Okay => Self::Okay,
+            redis::Value::Map(values) => Self::Map(
+                values
+                    .into_iter()
+                    .map(|(key, value)| (Self::from(key), Self::from(value)))
+                    .collect(),
+            ),
+            redis::Value::Attribute { data, attributes } => Self::Attribute {
+                data: Box::new(Self::from(*data)),
+                attributes: attributes
+                    .into_iter()
+                    .map(|(key, value)| (Self::from(key), Self::from(value)))
+                    .collect(),
+            },
+            redis::Value::Set(values) => Self::Set(values.into_iter().map(Self::from).collect()),
+            redis::Value::Double(value) => Self::Double(value),
+            redis::Value::Boolean(value) => Self::Boolean(value),
+            redis::Value::VerbatimString { format, text } => Self::VerbatimString {
+                format: format.to_string(),
+                text,
+            },
+            redis::Value::Push { kind, data } => Self::Push {
+                kind: kind.to_string(),
+                data: data.into_iter().map(Self::from).collect(),
+            },
+            redis::Value::BigNumber(_) => Self::UnsupportedSuccessfulValue {
+                variant: "BigNumber".to_string(),
+            },
+            redis::Value::ServerError(error) => Self::UnsupportedSuccessfulValue {
+                variant: match error.details() {
+                    Some(details) => format!("ServerError({}: {details})", error.code()),
+                    None => format!("ServerError({})", error.code()),
+                },
+            },
+            _ => Self::UnsupportedSuccessfulValue {
+                variant: "unknown non-exhaustive redis::Value variant".to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(feature = "deja")]
+impl DejaRedisValue {
+    fn into_supported_redis_value(self) -> Result<redis::Value, redis::RedisError> {
+        match self {
+            Self::Null => Ok(redis::Value::Nil),
+            Self::Int(value) => Ok(redis::Value::Int(value)),
+            Self::BulkString(value) => Ok(redis::Value::BulkString(value)),
+            Self::Array(values) => Ok(redis::Value::Array(
+                values
+                    .into_iter()
+                    .map(Self::into_supported_redis_value)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            Self::SimpleString(value) => Ok(redis::Value::SimpleString(value)),
+            Self::Okay => Ok(redis::Value::Okay),
+            Self::Map(values) => Ok(redis::Value::Map(
+                values
+                    .into_iter()
+                    .map(|(key, value)| {
+                        Ok((
+                            key.into_supported_redis_value()?,
+                            value.into_supported_redis_value()?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, redis::RedisError>>()?,
+            )),
+            Self::Attribute { data, attributes } => Ok(redis::Value::Attribute {
+                data: Box::new(data.into_supported_redis_value()?),
+                attributes: attributes
+                    .into_iter()
+                    .map(|(key, value)| {
+                        Ok((
+                            key.into_supported_redis_value()?,
+                            value.into_supported_redis_value()?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, redis::RedisError>>()?,
+            }),
+            Self::Set(values) => Ok(redis::Value::Set(
+                values
+                    .into_iter()
+                    .map(Self::into_supported_redis_value)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            Self::Double(value) => Ok(redis::Value::Double(value)),
+            Self::Boolean(value) => Ok(redis::Value::Boolean(value)),
+            Self::VerbatimString { format, text } => Ok(redis::Value::VerbatimString {
+                format: match format.as_str() {
+                    "mkd" => redis::VerbatimFormat::Markdown,
+                    "txt" => redis::VerbatimFormat::Text,
+                    other => redis::VerbatimFormat::Unknown(other.to_string()),
+                },
+                text,
+            }),
+            Self::Push { kind, data } => Ok(redis::Value::Push {
+                kind: match kind.as_str() {
+                    "disconnection" => redis::PushKind::Disconnection,
+                    "invalidate" => redis::PushKind::Invalidate,
+                    "message" => redis::PushKind::Message,
+                    "pmessage" => redis::PushKind::PMessage,
+                    "smessage" => redis::PushKind::SMessage,
+                    "unsubscribe" => redis::PushKind::Unsubscribe,
+                    "punsubscribe" => redis::PushKind::PUnsubscribe,
+                    "sunsubscribe" => redis::PushKind::SUnsubscribe,
+                    "subscribe" => redis::PushKind::Subscribe,
+                    "psubscribe" => redis::PushKind::PSubscribe,
+                    "ssubscribe" => redis::PushKind::SSubscribe,
+                    other => redis::PushKind::Other(other.to_string()),
+                },
+                data: data
+                    .into_iter()
+                    .map(Self::into_supported_redis_value)
+                    .collect::<Result<Vec<_>, _>>()?,
+            }),
+            Self::UnsupportedSuccessfulValue { variant } => Err((
+                redis::ErrorKind::UnexpectedReturnType,
+                "unsupported Redis value variant recorded by Deja replay",
+                variant,
+            )
+                .into()),
+        }
+    }
+}
+
 impl super::RedisConnectionPool {
     pub fn add_prefix(&self, key: &str) -> String {
-        if self.key_prefix.is_empty() {
+        let physical = if self.key_prefix.is_empty() {
             key.to_string()
         } else {
             format!("{}:{}", self.key_prefix, key)
+        };
+        #[cfg(feature = "deja")]
+        if let Some(corr) = deja::replay_key_namespace() {
+            return format!("{corr}:{physical}");
         }
+        physical
     }
 
     // ─── Key Commands ────────────────────────────────────────────────────────
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SET",
+                    "has_ttl": true,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_key<V>(&self, key: &RedisKey, value: V) -> CustomResult<(), errors::RedisError>
     where
@@ -60,6 +245,19 @@ impl super::RedisConnectionPool {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key_without_modifying_ttl",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SET_KEEP_TTL",
+                })
+            },
+        )
+    )]
     pub async fn set_key_without_modifying_ttl<V>(
         &self,
         key: &RedisKey,
@@ -160,33 +358,54 @@ impl super::RedisConnectionPool {
             .encode_to_vec()
             .change_context(errors::RedisError::JsonSerializationFailed)?;
 
-        let mut conn = self.pool.clone();
-        let options = SetOptions::default().with_expiration(SetExpiry::EX(
-            u64::try_from(seconds).change_context(errors::RedisError::SetExFailed)?,
-        ));
-        let _: Option<String> = track_redis_call(
-            RedisOperation::SerializeAndSetKeyWithExpiry,
-            conn.set_options(key.tenant_aware_key(self), serialized.as_slice(), options),
-        )
-        .await
-        .change_context(errors::RedisError::SetExFailed)?;
-        Ok(())
+        #[cfg(feature = "deja")]
+        {
+            self.set_key_with_expiry(key, serialized.as_slice(), seconds)
+                .await
+        }
+
+        #[cfg(not(feature = "deja"))]
+        {
+            let mut conn = self.pool.clone();
+            let options = SetOptions::default().with_expiration(SetExpiry::EX(
+                u64::try_from(seconds).change_context(errors::RedisError::SetExFailed)?,
+            ));
+            let _: Option<String> = track_redis_call(
+                RedisOperation::SerializeAndSetKeyWithExpiry,
+                conn.set_options(key.tenant_aware_key(self), serialized.as_slice(), options),
+            )
+            .await
+            .change_context(errors::RedisError::SetExFailed)?;
+            Ok(())
+        }
     }
 
+    #[cfg(feature = "deja")]
     #[instrument(level = "DEBUG", skip(self))]
-    pub async fn get_key<V>(&self, key: &RedisKey) -> CustomResult<V, errors::RedisError>
-    where
-        V: FromRedisValue + Send + 'static,
-    {
+    #[deja::redis(
+        operation = "get_key",
+        codec = ResultOkCodec,
+        state_read = key.tenant_aware_key(self),
+        args = {
+            serde_json::json!({
+                "key": key.as_str(),
+                "command": "GET",
+            })
+        },
+    )]
+    async fn get_key_raw(
+        &self,
+        key: &RedisKey,
+    ) -> CustomResult<DejaRedisValue, errors::RedisError> {
         let mut conn = self.pool.clone();
         match track_redis_call(
             RedisOperation::GetKey,
-            conn.get::<_, V>(key.tenant_aware_key(self)),
+            conn.get::<_, redis::Value>(key.tenant_aware_key(self)),
         )
         .await
         .change_context(errors::RedisError::GetFailed)
         {
-            Ok(v) => Ok(v),
+            Ok(value) => Ok(DejaRedisValue::from(value)),
             Err(_err) => {
                 #[cfg(not(feature = "multitenancy_fallback"))]
                 {
@@ -197,10 +416,58 @@ impl super::RedisConnectionPool {
                 {
                     track_redis_call(
                         RedisOperation::GetKey,
-                        conn.get::<_, V>(key.tenant_unaware_key(self)),
+                        conn.get::<_, redis::Value>(key.tenant_unaware_key(self)),
                     )
                     .await
+                    .map(DejaRedisValue::from)
                     .change_context(errors::RedisError::GetFailed)
+                }
+            }
+        }
+    }
+
+    #[instrument(level = "DEBUG", skip(self))]
+    pub async fn get_key<V>(&self, key: &RedisKey) -> CustomResult<V, errors::RedisError>
+    where
+        V: FromRedisValue + Send + 'static,
+    {
+        #[cfg(feature = "deja")]
+        {
+            let raw_value = self
+                .get_key_raw(key)
+                .await?
+                .into_supported_redis_value()
+                .map_err(|err| report!(err).change_context(errors::RedisError::GetFailed))?;
+            return V::from_redis_value(raw_value)
+                .map_err(|err| report!(err).change_context(errors::RedisError::GetFailed));
+        }
+
+        #[cfg(not(feature = "deja"))]
+        {
+            let mut conn = self.pool.clone();
+            match track_redis_call(
+                RedisOperation::GetKey,
+                conn.get::<_, V>(key.tenant_aware_key(self)),
+            )
+            .await
+            .change_context(errors::RedisError::GetFailed)
+            {
+                Ok(v) => Ok(v),
+                Err(_err) => {
+                    #[cfg(not(feature = "multitenancy_fallback"))]
+                    {
+                        Err(_err)
+                    }
+
+                    #[cfg(feature = "multitenancy_fallback")]
+                    {
+                        track_redis_call(
+                            RedisOperation::GetKey,
+                            conn.get::<_, V>(key.tenant_unaware_key(self)),
+                        )
+                        .await
+                        .change_context(errors::RedisError::GetFailed)
+                    }
                 }
             }
         }
@@ -278,6 +545,29 @@ impl super::RedisConnectionPool {
         }
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "get_multiple_keys",
+            read_set = keys.iter().map(|key| key.tenant_aware_key(self)).collect::<Vec<_>>(),
+            args = {
+                serde_json::json!({
+                    "key_count": keys.len(),
+                    "keys": keys.iter().map(|key| key.as_str()).collect::<Vec<_>>(),
+                    "command": "MGET",
+                })
+            },
+            result = {
+                (
+                    match &__deja_result {
+                        Ok(_) => serde_json::json!({"ok": true}),
+                        Err(e) => serde_json::json!({"ok": false, "error": format!("{:?}", e)}),
+                    },
+                    __deja_result.is_err(),
+                )
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn get_multiple_keys<V>(
         &self,
@@ -391,6 +681,19 @@ impl super::RedisConnectionPool {
         Ok(results)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "delete_key",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "DEL",
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn delete_key(&self, key: &RedisKey) -> CustomResult<DelReply, errors::RedisError> {
         let mut conn = self.pool.clone();
@@ -448,6 +751,20 @@ impl super::RedisConnectionPool {
         Ok(del_result)
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key_with_expiry",
+            codec = ResultOkCodec,
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SETEX",
+                    "ttl_seconds": seconds,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_key_with_expiry<V>(
         &self,
@@ -471,6 +788,21 @@ impl super::RedisConnectionPool {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            operation = "set_key_if_not_exists_with_expiry",
+            codec = ResultOkCodec,
+            state_write = key.tenant_aware_key(self),
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SETNX",
+                    "ttl_seconds": seconds,
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_key_if_not_exists_with_expiry<V>(
         &self,
@@ -920,6 +1252,21 @@ impl super::RedisConnectionPool {
 
     // ─── Set Commands ────────────────────────────────────────────────────────
 
+    #[cfg_attr(
+        feature = "deja",
+        deja::redis(
+            replay = Substitute,
+            operation = "sadd",
+            codec = ResultOkCodec,
+            state_write = key.tenant_aware_key(self),
+            args = {
+                serde_json::json!({
+                    "key": key.as_str(),
+                    "command": "SADD",
+                })
+            },
+        )
+    )]
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn sadd<V>(
         &self,

--- a/crates/redis_interface/src/module/redis_rs/commands.rs
+++ b/crates/redis_interface/src/module/redis_rs/commands.rs
@@ -218,7 +218,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_key",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -249,7 +249,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_key_without_modifying_ttl",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -384,7 +384,7 @@ impl super::RedisConnectionPool {
     #[instrument(level = "DEBUG", skip(self))]
     #[deja::redis(
         operation = "get_key",
-        codec = ResultOkCodec,
+        codec = deja::codec::ResultCodec::<DejaRedisValue, errors::RedisError>,
         state_read = key.tenant_aware_key(self),
         args = {
             serde_json::json!({
@@ -685,7 +685,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "delete_key",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<DelReply, errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -755,7 +755,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_key_with_expiry",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<(), errors::RedisError>,
             args = {
                 serde_json::json!({
                     "key": key.as_str(),
@@ -792,7 +792,7 @@ impl super::RedisConnectionPool {
         feature = "deja",
         deja::redis(
             operation = "set_key_if_not_exists_with_expiry",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<SetnxReply, errors::RedisError>,
             state_write = key.tenant_aware_key(self),
             args = {
                 serde_json::json!({
@@ -1257,7 +1257,7 @@ impl super::RedisConnectionPool {
         deja::redis(
             replay = Substitute,
             operation = "sadd",
-            codec = ResultOkCodec,
+            codec = deja::codec::ResultCodec::<SaddReply, errors::RedisError>,
             state_write = key.tenant_aware_key(self),
             args = {
                 serde_json::json!({

--- a/crates/redis_interface/src/types.rs
+++ b/crates/redis_interface/src/types.rs
@@ -161,24 +161,28 @@ impl RedisEntryId {
 // ─── Reply type enums ────────────────────────────────────────────────────────
 
 #[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "deja", derive(serde::Serialize, serde::Deserialize))]
 pub enum SetnxReply {
     KeySet,
     KeyNotSet, // Existing key
 }
 
 #[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "deja", derive(serde::Serialize, serde::Deserialize))]
 pub enum HsetnxReply {
     KeySet,
     KeyNotSet, // Existing key
 }
 
 #[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "deja", derive(serde::Serialize, serde::Deserialize))]
 pub enum MsetnxReply {
     KeysSet,
     KeysNotSet, // At least one existing key
 }
 
 #[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "deja", derive(serde::Serialize, serde::Deserialize))]
 pub enum DelReply {
     KeyDeleted,
     KeyNotDeleted, // Key not found
@@ -196,6 +200,7 @@ impl DelReply {
 
 /// Reply from SADD command
 #[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "deja", derive(serde::Serialize, serde::Deserialize))]
 pub enum SaddReply {
     /// Returned when atleast 1 value was inserted to Set
     /// i64 value represent the total number of values that were inserted.
@@ -355,6 +360,11 @@ impl std::error::Error for StreamTrimThresholdError {}
 pub struct RedisKey(String);
 
 impl RedisKey {
+    #[cfg(feature = "deja")]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
     pub fn tenant_aware_key(&self, pool: &crate::RedisConnectionPool) -> String {
         pool.add_prefix(&self.0)
     }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -21,7 +21,7 @@ encryption_service = ["keymanager_create", "hyperswitch_domain_models/encryption
 km_forward_x_request_id = ["common_utils/km_forward_x_request_id"]
 frm = ["api_models/frm", "hyperswitch_domain_models/frm", "hyperswitch_connectors/frm", "hyperswitch_interfaces/frm"]
 stripe = []
-release = ["stripe", "email", "accounts_cache", "kv_store", "vergen", "external_services/aws_kms", "external_services/aws_s3", "keymanager_mtls", "keymanager_create", "encryption_service", "dynamic_routing", "payout_retry"]
+release = ["stripe", "email", "accounts_cache", "kv_store", "vergen", "external_services/aws_kms", "external_services/aws_s3", "keymanager_mtls", "keymanager_create", "encryption_service", "dynamic_routing", "payout_retry", "deja"]
 oltp = ["storage_impl/oltp"]
 kv_store = ["scheduler/kv_store"]
 accounts_cache = ["storage_impl/accounts_cache"]
@@ -126,8 +126,8 @@ cards = { version = "0.1.0", path = "../cards" }
 common_enums = { version = "0.1.0", path = "../common_enums" }
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["signals", "async_ext", "logs", "metrics", "keymanager"] }
 common_types = { version = "0.1.0", path = "../common_types" }
-deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false }
-deja-core = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true }
+deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false }
+deja-core = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true }
 connector_configs = { version = "0.1.0", path = "../connector_configs" }
 currency_conversion = { version = "0.1.0", path = "../currency_conversion" }
 diesel_models = { version = "0.1.0", path = "../diesel_models", features = ["kv_store", "tokenization_v2"], default-features = false }

--- a/crates/router/src/bin/router.rs
+++ b/crates/router/src/bin/router.rs
@@ -24,6 +24,19 @@ async fn main() -> ApplicationResult<()> {
         println!("Starting router (Version: {})", router_env::git_tag!());
     }
 
+    #[cfg(feature = "deja")]
+    let deja_install_report = {
+        // An empty deja broker list inherits the analytics Kafka brokers
+        // (shared cluster provisioning, separate producer client).
+        let analytics_brokers = match &conf.events.source {
+            router::events::EventsSource::Kafka { kafka } => Some(kafka.brokers()),
+            _ => None,
+        };
+        router::deja_boot::install(&conf.deja, analytics_brokers).map_err(|message| {
+            error_stack::report!(ApplicationError::ConfigurationError).attach_printable(message)
+        })?
+    };
+
     let _guard = router_env::setup(
         &conf.log,
         router_env::service_name!(),
@@ -38,6 +51,15 @@ async fn main() -> ApplicationResult<()> {
     .change_context(ApplicationError::ConfigurationError)?;
 
     logger::info!("Application started [{:?}] [{:?}]", conf.server, conf.log);
+
+    #[cfg(feature = "deja")]
+    router_env::tracing::info!(
+        target: "deja",
+        mode = deja_install_report.mode,
+        run_id = ?deja_install_report.run_id,
+        detail = ?deja_install_report.detail,
+        "deja runtime hook initialized"
+    );
 
     // Spawn a thread for collecting metrics at fixed intervals
     metrics::bg_metrics_collector::spawn_metrics_collector(

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -34,6 +34,23 @@ async fn main() -> CustomResult<(), ProcessTrackerError> {
     #[allow(clippy::expect_used)]
     let conf = Settings::with_config_path(cmd_line.config_path)
         .expect("Unable to construct application configuration");
+
+    // Install the Deja runtime hook BEFORE AppState construction: state setup
+    // opens redis/DB pools whose instrumented calls would otherwise resolve —
+    // and permanently latch — the hook ahead of the configured install.
+    #[cfg(feature = "deja")]
+    let deja_install_report = {
+        // An empty deja broker list inherits the analytics Kafka brokers
+        // (shared cluster provisioning, separate producer client).
+        let analytics_brokers = match &conf.events.source {
+            router::events::EventsSource::Kafka { kafka } => Some(kafka.brokers()),
+            _ => None,
+        };
+        router::deja_boot::install(&conf.deja, analytics_brokers).map_err(|message| {
+            error_stack::report!(ProcessTrackerError::ConfigurationError).attach_printable(message)
+        })?
+    };
+
     let api_client = Box::new(
         services::ProxyClient::new(&conf.proxy)
             .change_context(ProcessTrackerError::ConfigurationError)?,
@@ -79,6 +96,15 @@ async fn main() -> CustomResult<(), ProcessTrackerError> {
             "superposition_provider",
             "superposition_sdk",
         ],
+    );
+
+    #[cfg(feature = "deja")]
+    router_env::tracing::info!(
+        target: "deja",
+        mode = deja_install_report.mode,
+        run_id = ?deja_install_report.run_id,
+        detail = ?deja_install_report.detail,
+        "deja runtime hook initialized"
     );
 
     #[allow(clippy::expect_used)]

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -305,11 +305,13 @@ pub struct DejaReplaySettings {
     pub observed_sink: Option<String>,
 }
 
+/// Per-request recording-sampler settings. The sampler is active exactly when
+/// `deja.mode = "record"` — there is no separate on/off switch; `fail_closed`
+/// governs what happens when the sampling source cannot answer.
 #[cfg(feature = "deja")]
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct DejaSamplerSettings {
-    pub enabled: bool,
     pub record_key: Option<String>,
     pub timeout_ms: u64,
     pub fail_closed: bool,
@@ -319,7 +321,6 @@ pub struct DejaSamplerSettings {
 impl Default for DejaSamplerSettings {
     fn default() -> Self {
         Self {
-            enabled: false,
             record_key: None,
             timeout_ms: 25,
             fail_closed: true,

--- a/crates/router/src/core/api_locking.rs
+++ b/crates/router/src/core/api_locking.rs
@@ -52,6 +52,8 @@ impl LockingInput {
 }
 
 impl LockAction {
+    // deja: NO boundary — the lock outcome replays from the recorded redis reply.
+    // See `docs/design/deja-non-boundaries.md`.
     #[instrument(skip_all)]
     pub async fn perform_locking_action<A>(
         self,
@@ -168,6 +170,8 @@ impl LockAction {
         }
     }
 
+    // deja: NO boundary — the release is the inner redis delete_key.
+    // See `docs/design/deja-non-boundaries.md`.
     #[instrument(skip_all)]
     pub async fn free_lock_action<A>(
         self,

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -2097,12 +2097,12 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
 
                     payment_data.payment_attempt.authentication_id = Some(auth_create_resp.authentication_id.clone());
 
-                    let elig_resp = crate::core::unified_authentication_service::authentication_eligibility_core(
+                    let elig_resp = Box::pin(crate::core::unified_authentication_service::authentication_eligibility_core(
                         state.clone(),
                         platform.clone(),
                         eligibility_req,
                         auth_create_resp.authentication_id.clone(),
-                    ).await?
+                    )).await?
                     .get_json_body()
                     .change_context(errors::ApiErrorResponse::InternalServerError)
                     .attach_printable("Failed to get json body from authentication eligibility response")?;

--- a/crates/router/src/deja_boot.rs
+++ b/crates/router/src/deja_boot.rs
@@ -1,0 +1,288 @@
+//! Boot-time composition of the typed Deja runtime hook.
+//!
+//! The router owns the transport wiring: typed router settings select disabled,
+//! Kafka recording, or lookup-table replay, and this module eagerly installs the
+//! process-wide runtime hook before any boundary or logger layer can observe the
+//! default environment-derived state.
+
+use std::{path::PathBuf, sync::Arc};
+
+use crate::{
+    configs::settings::{DejaMode, DejaReplaySettings, DejaSettings},
+    services::kafka::deja_record_sink::{
+        HyperswitchKafkaRecordSink, HyperswitchKafkaRecordSinkConfig,
+    },
+};
+
+#[derive(Debug, Clone)]
+pub struct InstallReport {
+    pub mode: &'static str,
+    pub run_id: Option<String>,
+    pub detail: Option<String>,
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn fallback_run_id() -> String {
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::ZERO)
+        .as_nanos();
+    format!("run-{now_ns}")
+}
+
+fn configured_run_id(settings: &DejaSettings) -> String {
+    settings
+        .effective_run_id()
+        .map(str::to_owned)
+        .unwrap_or_else(fallback_run_id)
+}
+
+fn configured_value(value: Option<&str>) -> Option<String> {
+    non_empty(value).map(str::to_owned)
+}
+
+fn env_value_named(name: &str) -> Option<String> {
+    let name = non_empty(Some(name))?;
+    configured_value(std::env::var(name).ok().as_deref())
+}
+
+fn fallback_instance_id() -> String {
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::ZERO)
+        .as_nanos();
+    format!("pi-{}-{now_ns}", std::process::id())
+}
+
+fn resolved_instance_id(settings: &DejaSettings) -> String {
+    configured_value(settings.identity.instance_id.as_deref())
+        .or_else(|| env_value_named(&settings.identity.pod_name_env))
+        .unwrap_or_else(fallback_instance_id)
+}
+
+fn resolved_code_sha(settings: &DejaSettings) -> Option<String> {
+    configured_value(settings.identity.code_sha.as_deref())
+        .or_else(|| env_value_named(&settings.identity.git_sha_env))
+        .or_else(|| option_env!("VERGEN_GIT_SHA").map(str::to_owned))
+        .or_else(|| Some("unknown".to_owned()))
+}
+
+fn writer_config(settings: &DejaSettings) -> deja::WriterConfig {
+    let writer = &settings.writer;
+    deja::WriterConfig {
+        queue_capacity: writer.queue_capacity.max(1),
+        batch_size: writer.batch_size.max(1),
+        flush_interval: std::time::Duration::from_millis(writer.flush_interval_ms.max(1)),
+        flush_timeout: std::time::Duration::from_millis(writer.shutdown_flush_ms.max(1)),
+        flush_after_records: (writer.flush_after_records > 0).then_some(writer.flush_after_records),
+        policy: deja::SinkPolicy::FailOpen,
+    }
+}
+
+fn disabled_report(detail: Option<String>) -> InstallReport {
+    InstallReport {
+        mode: "disabled",
+        run_id: None,
+        detail,
+    }
+}
+
+#[allow(clippy::print_stderr)] // The logger may not be initialized yet.
+fn print_configuration_error(error: &str) {
+    eprintln!("deja configuration error: {error}; runtime hook disabled");
+}
+
+fn try_install_hook(
+    hook: deja::RuntimeHook,
+    report: InstallReport,
+) -> Result<InstallReport, String> {
+    deja::set_global_runtime_hook(Some(hook))
+        .map_err(|error| error.to_owned())
+        .map(|()| report)
+}
+
+#[allow(clippy::print_stderr)] // The logger may not be initialized yet.
+fn install_hook(hook: deja::RuntimeHook, report: InstallReport) -> InstallReport {
+    match try_install_hook(hook, report) {
+        Ok(report) => report,
+        Err(error) => {
+            eprintln!(
+                "deja configuration error: {error}; requested runtime hook was not installed"
+            );
+            disabled_report(Some(error))
+        }
+    }
+}
+
+fn install_disabled(detail: Option<String>) -> InstallReport {
+    if let Some(error) = detail.as_deref() {
+        print_configuration_error(error);
+    }
+    install_hook(
+        deja::RuntimeHook::Disabled(deja::DisabledHook),
+        disabled_report(detail),
+    )
+}
+
+fn install_record(settings: &DejaSettings, inherited_brokers: Option<&[String]>) -> InstallReport {
+    let kafka = &settings.recording.kafka;
+    let Some(topic) = kafka.effective_topic() else {
+        return install_disabled(Some(
+            "record mode requires deja.recording.kafka.topic".to_owned(),
+        ));
+    };
+
+    // Broker resolution: an explicit deja broker list wins; an empty list
+    // inherits the deployment's analytics Kafka brokers, so both producers
+    // share cluster provisioning while remaining separate clients.
+    let brokers: &[String] = if kafka.brokers.is_empty() {
+        inherited_brokers.unwrap_or_default()
+    } else {
+        kafka.brokers.as_slice()
+    };
+    if brokers.is_empty() || brokers.iter().any(|broker| broker.trim().is_empty()) {
+        return install_disabled(Some(
+            "record mode requires Kafka brokers: set deja.recording.kafka.brokers, or \
+             configure [events.kafka] brokers for the recording sink to inherit"
+                .to_owned(),
+        ));
+    }
+
+    let run_id = configured_run_id(settings);
+    let sink = match HyperswitchKafkaRecordSink::new(HyperswitchKafkaRecordSinkConfig {
+        brokers,
+        topic,
+        recording_run_id: &run_id,
+        instance_id: resolved_instance_id(settings),
+        code_sha: resolved_code_sha(settings),
+        client_id: kafka.client_id.as_deref(),
+        acks: &kafka.acks,
+        enable_idempotence: kafka.idempotence,
+        compression: kafka.compression.as_deref(),
+        linger_ms: kafka.linger,
+        message_timeout_ms: kafka.message_timeout.unwrap_or(30_000),
+        queue_buffering_max_messages: kafka.queue_buffering_max_messages,
+    }) {
+        Ok(sink) => sink,
+        Err(error) => {
+            return install_disabled(Some(format!(
+                "failed to create Deja Kafka producer for topic '{topic}': {error}"
+            )));
+        }
+    };
+
+    let hook = Arc::new(deja::RecordingHook::with_sink(
+        sink,
+        run_id.clone(),
+        writer_config(settings),
+    ));
+    install_hook(
+        deja::RuntimeHook::Recording(hook),
+        InstallReport {
+            mode: "record",
+            run_id: Some(run_id),
+            detail: Some(format!("Kafka topic '{topic}'")),
+        },
+    )
+}
+
+/// Resolve the lookup-table path from `deja.replay.{source, lookup_dir}` with
+/// ONE rule and no shape-guessing:
+/// - absolute `source` → that file, `lookup_dir` ignored
+/// - relative `source` → a file name under `lookup_dir` (required)
+/// - `lookup_dir` alone → `<lookup_dir>/<run_id>.jsonl` (`run_id` required)
+///
+/// Anything else is a configuration error.
+fn replay_lookup_path(
+    settings: &DejaSettings,
+    replay: &DejaReplaySettings,
+) -> Result<PathBuf, String> {
+    let lookup_dir = replay
+        .lookup_dir
+        .as_deref()
+        .filter(|dir| !dir.as_os_str().is_empty());
+    match (non_empty(replay.source.as_deref()), lookup_dir) {
+        (Some(source), _) if PathBuf::from(&source).is_absolute() => Ok(PathBuf::from(source)),
+        (Some(source), Some(lookup_dir)) => Ok(lookup_dir.join(source)),
+        (Some(source), None) => Err(format!(
+            "deja.replay.source '{source}' is relative; set deja.replay.lookup_dir or make it absolute"
+        )),
+        (None, Some(lookup_dir)) => match settings.effective_run_id() {
+            Some(run_id) => Ok(lookup_dir.join(format!("{run_id}.jsonl"))),
+            None => Err(
+                "deja.replay.lookup_dir without deja.replay.source requires deja.run_id"
+                    .to_owned(),
+            ),
+        },
+        (None, None) => {
+            Err("replay mode requires deja.replay.source or deja.replay.lookup_dir".to_owned())
+        }
+    }
+}
+
+fn install_replay(settings: &DejaSettings) -> Result<InstallReport, String> {
+    let lookup_path = replay_lookup_path(settings, &settings.replay)?;
+
+    let observed_sink = non_empty(settings.replay.observed_sink.as_deref());
+    let hook = match observed_sink {
+        Some(path) => match deja::FileObservedSink::create(path) {
+            Ok(sink) => deja::LookupTableHook::from_source(
+                deja::LocalFileLookupSource::new(lookup_path.clone()),
+                sink,
+            ),
+            Err(error) => {
+                return Err(format!(
+                    "failed to open replay observed sink '{path}': {error}"
+                ));
+            }
+        },
+        None => deja::LookupTableHook::from_source(
+            deja::LocalFileLookupSource::new(lookup_path.clone()),
+            deja::InMemoryObservedSink::new(),
+        ),
+    };
+
+    let hook = hook.map_err(|error| {
+        format!(
+            "failed to load replay lookup table '{}': {error}",
+            lookup_path.display()
+        )
+    })?;
+    let entries = hook.entry_count();
+
+    try_install_hook(
+        deja::RuntimeHook::LookupReplay(hook),
+        InstallReport {
+            mode: "replay",
+            run_id: settings.effective_run_id().map(str::to_owned),
+            detail: Some(format!(
+                "lookup table '{}' with {entries} entries",
+                lookup_path.display()
+            )),
+        },
+    )
+    .map_err(|error| format!("failed to install replay runtime hook: {error}"))
+}
+
+/// Compose and install the process-wide Deja runtime hook from typed settings.
+///
+/// A hook is installed for every configured mode. Record misconfiguration never
+/// aborts router boot and never leaves the process to lazily infer a mode later:
+/// invalid record configuration installs a disabled hook with a clear pre-logger
+/// error. Replay misconfiguration is fail-loud and aborts boot with the replay
+/// error before logger setup.
+pub fn install(
+    settings: &DejaSettings,
+    inherited_brokers: Option<&[String]>,
+) -> Result<InstallReport, String> {
+    // Graph capture is coupled to the mode (the graph layer rides the installed
+    // Record/Replay hook), so there is no separate graph dial to declare here.
+    match &settings.mode {
+        DejaMode::Disabled => Ok(install_disabled(None)),
+        DejaMode::Record => Ok(install_record(settings, inherited_brokers)),
+        DejaMode::Replay => install_replay(settings),
+    }
+}

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -7,6 +7,8 @@ pub mod consts;
 pub mod core;
 pub mod cors;
 pub mod db;
+#[cfg(feature = "deja")]
+pub mod deja_boot;
 pub mod env;
 pub mod locale;
 pub(crate) mod macros;
@@ -38,6 +40,70 @@ use tokio::sync::{mpsc, oneshot};
 pub use self::env::logger;
 pub(crate) use self::macros::*;
 use crate::{configs::settings, core::errors};
+
+#[cfg(feature = "deja")]
+struct SuperpositionDejaRecordingSampler {
+    superposition_service: std::sync::Arc<external_services::superposition::SuperpositionClient>,
+    superposition_enabled: bool,
+    record_key: String,
+    timeout_ms: u64,
+    /// Decision when the sampling source cannot answer (superposition
+    /// disabled, lookup error, or timeout): `true` → don't record
+    /// (production-safe default), `false` → record (demo/dev rigs that must
+    /// never silently produce an empty tape).
+    fail_closed: bool,
+}
+
+#[cfg(feature = "deja")]
+impl router_env::request_id::RequestRecordingSampler for SuperpositionDejaRecordingSampler {
+    fn should_record(
+        &self,
+        facts: router_env::request_id::RequestRecordingFacts,
+    ) -> router_env::request_id::RequestRecordingSamplerFuture<'_> {
+        // No sampling source to consult: the configured failure default
+        // decides, exactly as it does for lookup errors and timeouts below.
+        let failure_default = !self.fail_closed;
+        if !self.superposition_enabled {
+            return Box::pin(async move { failure_default });
+        }
+
+        let superposition_service = std::sync::Arc::clone(&self.superposition_service);
+        let record_key = self.record_key.clone();
+        let timeout_ms = self.timeout_ms.max(1);
+        Box::pin(async move {
+            let context = external_services::superposition::ConfigContext::new()
+                .with("method", &facts.method)
+                .with("path", &facts.path);
+            let lookup = superposition_service.get_config_value::<bool>(
+                &record_key,
+                Some(&context),
+                Some(&facts.request_id),
+            );
+
+            match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), lookup).await {
+                Ok(Ok(decision)) => decision,
+                Ok(Err(error)) => {
+                    router_env::logger::warn!(
+                        error = ?error,
+                        request_id = %facts.request_id,
+                        failure_default,
+                        "Failed to resolve Deja recording sampler decision; using configured failure default"
+                    );
+                    failure_default
+                }
+                Err(_elapsed) => {
+                    router_env::logger::warn!(
+                        timeout_ms,
+                        request_id = %facts.request_id,
+                        failure_default,
+                        "Timed out resolving Deja recording sampler decision; using configured failure default"
+                    );
+                    failure_default
+                }
+            }
+        })
+    }
+}
 
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
@@ -124,10 +190,38 @@ pub fn mk_app(
         InitError = (),
     >,
 > {
+    // The recording sampler exists exactly when the process records: record
+    // mode always consults the sampling source per request, every other mode
+    // has nothing to sample.
+    #[cfg(feature = "deja")]
+    let deja_recording_sampler: Option<
+        std::sync::Arc<dyn router_env::request_id::RequestRecordingSampler>,
+    > = matches!(state.conf.deja.mode, settings::DejaMode::Record).then(|| {
+        let sampler: std::sync::Arc<dyn router_env::request_id::RequestRecordingSampler> =
+            std::sync::Arc::new(SuperpositionDejaRecordingSampler {
+                superposition_service: state.superposition_service.clone(),
+                superposition_enabled: state.conf.superposition.get_inner().validate().is_ok(),
+                record_key: state
+                    .conf
+                    .deja
+                    .sampler
+                    .record_key
+                    .as_deref()
+                    .filter(|record_key| !record_key.is_empty())
+                    .unwrap_or("deja_record")
+                    .to_owned(),
+                timeout_ms: state.conf.deja.sampler.timeout_ms,
+                fail_closed: state.conf.deja.sampler.fail_closed,
+            });
+        sampler
+    });
+
     let mut server_app = get_application_builder(
         request_body_limit,
         state.conf.cors.clone(),
         state.conf.trace_header.clone(),
+        #[cfg(feature = "deja")]
+        deja_recording_sampler,
     );
 
     #[cfg(feature = "dummy_connector")]
@@ -394,6 +488,9 @@ pub fn get_application_builder(
     request_body_limit: usize,
     cors: settings::CorsSettings,
     trace_header: settings::TraceHeaderConfig,
+    #[cfg(feature = "deja")] deja_recording_sampler: Option<
+        std::sync::Arc<dyn router_env::request_id::RequestRecordingSampler>,
+    >,
 ) -> actix_web::App<
     impl ServiceFactory<
         ServiceRequest,
@@ -407,6 +504,28 @@ pub fn get_application_builder(
         .limit(request_body_limit)
         .content_type_required(true)
         .error_handler(utils::error_parser::custom_json_error_handler);
+
+    let request_identifier = router_env::RequestIdentifier::new(&trace_header.header_name)
+        .use_incoming_id({
+            #[cfg(feature = "deja")]
+            {
+                if deja::replay_is_active() {
+                    router_env::IdReuse::UseIncoming
+                } else {
+                    trace_header.id_reuse_strategy
+                }
+            }
+            #[cfg(not(feature = "deja"))]
+            {
+                trace_header.id_reuse_strategy
+            }
+        });
+
+    #[cfg(feature = "deja")]
+    let request_identifier = match deja_recording_sampler {
+        Some(sampler) => request_identifier.with_recording_sampler(sampler),
+        None => request_identifier,
+    };
 
     actix_web::App::new()
         .app_data(json_cfg)
@@ -428,8 +547,5 @@ pub fn get_application_builder(
         .wrap(router_env::tracing_actix_web::TracingLogger::<
             router_env::CustomRootSpanBuilder,
         >::new())
-        .wrap(
-            router_env::RequestIdentifier::new(&trace_header.header_name)
-                .use_incoming_id(trace_header.id_reuse_strategy),
-        )
+        .wrap(request_identifier)
 }

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -114,7 +114,19 @@ pub async fn get_cache_store(
     RouterStore::<StoreType>::cache_store(&config.redis, shut_down_signal).await
 }
 
+// deja: the per-merchant data-encryption key (DEK) is random. It is stored
+// (master-key-encrypted) in merchant_key_store AND used to encrypt the merchant's
+// own columns, so it must replay to the recorded value or the substituted DB rows
+// and the response body diverge. Ok-only: the ring error type is non-serializable.
 #[inline]
+#[cfg_attr(
+    feature = "deja",
+    deja::id(
+        component = "router::services",
+        operation = "generate_aes256_key",
+        codec = ResultOkCodec,
+    )
+)]
 pub fn generate_aes256_key() -> errors::CustomResult<[u8; 32], common_utils::errors::CryptoError> {
     use ring::rand::SecureRandom;
 

--- a/crates/router/src/services/jwt.rs
+++ b/crates/router/src/services/jwt.rs
@@ -5,6 +5,14 @@ use jsonwebtoken::{encode, EncodingKey, Header};
 
 use crate::{configs::Settings, core::errors::UserErrors};
 
+// deja: JWT expiry uses a raw SystemTime::now() that bypasses the instrumented
+// date_time::now boundary, so the `exp` claim (and thus the whole signed token)
+// diverges on replay. Record/replay the absolute expiry (Ok-only) to reproduce
+// byte-identical JWTs.
+#[cfg_attr(
+    feature = "deja",
+    deja::id(component = "router::jwt", operation = "generate_exp", codec = ResultOkCodec,)
+)]
 pub fn generate_exp(
     exp_duration: std::time::Duration,
 ) -> CustomResult<std::time::Duration, UserErrors> {

--- a/crates/router/src/services/kafka.rs
+++ b/crates/router/src/services/kafka.rs
@@ -17,6 +17,8 @@ use diesel_models::fraud_check::FraudCheck;
 use crate::{events::EventType, services::kafka::fraud_check_event::KafkaFraudCheckEvent};
 mod authentication;
 mod authentication_event;
+#[cfg(feature = "deja")]
+pub mod deja_record_sink;
 mod dispute;
 mod dispute_event;
 mod fraud_check;
@@ -166,7 +168,29 @@ pub struct KafkaSettings {
     external_service_call_topic: String,
 }
 
+/// Base rdkafka client configuration for this deployment's Kafka cluster.
+///
+/// Cluster-level settings (bootstrap servers, and any future deployment-wide
+/// security options) live here so every producer in the process points at the
+/// same provisioned cluster. The analytics producer uses it as-is; the Deja
+/// recording sink layers its own delivery-guarantee overrides on top while
+/// remaining a separate client with its own queue and delivery thread.
+pub(crate) fn base_client_config(brokers: &[String]) -> rdkafka::ClientConfig {
+    let mut config = rdkafka::ClientConfig::new();
+    config.set("bootstrap.servers", brokers.join(","));
+    config
+}
+
 impl KafkaSettings {
+    /// Brokers of the provisioned Kafka cluster this deployment's analytics
+    /// events use. The Deja recording sink inherits these when
+    /// `deja.recording.kafka.brokers` is left empty, so both producers share
+    /// cluster provisioning without sharing a client.
+    #[cfg(feature = "deja")]
+    pub fn brokers(&self) -> &[String] {
+        &self.brokers
+    }
+
     pub fn validate(&self) -> Result<(), crate::core::errors::ApplicationError> {
         use common_utils::ext_traits::ConfigExt;
 
@@ -327,10 +351,8 @@ impl KafkaProducer {
     pub async fn create(conf: &KafkaSettings) -> MQResult<Self> {
         Ok(Self {
             producer: Arc::new(RdKafkaProducer(
-                ThreadedProducer::from_config(
-                    rdkafka::ClientConfig::new().set("bootstrap.servers", conf.brokers.join(",")),
-                )
-                .change_context(KafkaError::InitializationError)?,
+                ThreadedProducer::from_config(&base_client_config(&conf.brokers))
+                    .change_context(KafkaError::InitializationError)?,
             )),
 
             fraud_check_analytics_topic: conf.fraud_check_analytics_topic.clone(),

--- a/crates/router/src/services/kafka/deja_record_sink.rs
+++ b/crates/router/src/services/kafka/deja_record_sink.rs
@@ -1,0 +1,642 @@
+//! Deja recording sink: Kafka is THE record transport (no JSONL primary).
+//!
+//! The `deja-record` crate intentionally has no Kafka dependency: it defines
+//! the `RecordSink<DejaRecord>` trait; this module supplies the transport.
+//! The sink owns a DEDICATED `rdkafka` producer — deliberately not the shared
+//! analytics producer, though both are built from the same deployment-wide
+//! base client config so they share cluster provisioning — hardened for
+//! durability:
+//!
+//!   acks=all + enable.idempotence  → no acked-then-lost, no broker-side dupes
+//!   bounded buffering              → backpressure surfaces as enqueue errors
+//!                                    instead of unbounded memory
+//!   flush = short poll             → cadence flushes never park the writer
+//!                                    behind a slow broker; only the eof
+//!                                    marker drains fully, so end-of-run
+//!                                    means delivered
+//!
+//! Envelopes, all on the ONE topic: boundary events land as
+//! `deja.artifact_record/v2`; execution-graph nodes land as
+//! `deja.graph_node/v1`. Both carry producer identity (`instance_id`),
+//! capture window (`capture.mode`/`session_id`), and code provenance
+//! (`code.sha` from typed Deja identity settings, `code.deja_version`).
+//! Loss accounting rides the same topic as `deja_sink_marker` envelopes
+//! (checkpoint / eof / dropped), emitted by the writer through
+//! `write_marker` — the compactor skips them when building sessions;
+//! auditors read them to verify delivery.
+//!
+//! Partition key: `correlation_id` when present, otherwise
+//! `{recording_run_id}:{global_sequence}` so background-task events still
+//! land deterministically.
+//! Headers: `global_sequence`, `request_sequence`, `recording_run_id`,
+//! `boundary`, `method_name` — sufficient for a Vector consumer to route
+//! and structure without parsing the payload.
+//!
+//! Delivery semantics: enqueue errors surface as `io::Error` to the async
+//! writer, which accounts the affected batch as dropped (with a `dropped`
+//! marker) and keeps going; only a sustained failure streak disables
+//! recording. Request threads are never failed by instrumentation.
+
+use std::{io, time::Duration};
+
+use rdkafka::{
+    config::FromClientConfig,
+    message::{Header, OwnedHeaders},
+    producer::{BaseRecord, DefaultProducerContext, Producer, ThreadedProducer},
+};
+use serde::Serialize;
+
+const SCHEMA_VERSION: u32 = 2;
+const ARTIFACT_TYPE: &str = "deja_artifact_record";
+const GRAPH_SCHEMA_VERSION: u32 = 1;
+const GRAPH_ARTIFACT_TYPE: &str = "deja_graph_node";
+const MARKER_ARTIFACT_TYPE: &str = "deja_sink_marker";
+/// Cadence flushes are a short bounded poll: the threaded producer delivers on
+/// its own background thread, so waiting out a long drain here only parks the
+/// writer thread behind a slow broker.
+const CADENCE_FLUSH_POLL: Duration = Duration::from_millis(50);
+/// End-of-run drain: the eof marker means "everything before this landed", so
+/// shutdown waits for real delivery.
+const EOF_FLUSH_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Serialize)]
+struct Capture<'a> {
+    mode: &'static str,
+    session_id: &'a str,
+}
+
+#[derive(Serialize)]
+struct Code<'a> {
+    sha: Option<&'a str>,
+    deja_version: &'static str,
+}
+
+#[derive(Serialize)]
+struct Envelope<'a> {
+    schema_version: u32,
+    artifact_type: &'static str,
+    instance_id: &'a str,
+    recording_run_id: &'a str,
+    correlation_id: Option<&'a str>,
+    event_time_ns: u64,
+    capture: Capture<'a>,
+    code: Code<'a>,
+    event: &'a deja::BoundaryEvent,
+}
+
+/// Graph-node envelope (`deja.graph_node/v1`): same stream, same session
+/// identity as the artifact envelope, the execution-graph node as payload.
+/// Nested under `node` — the node carries its own `recording_run_id` /
+/// `global_sequence`, so flattening would collide with the envelope's.
+#[derive(Serialize)]
+struct GraphEnvelope<'a> {
+    schema_version: u32,
+    artifact_type: &'static str,
+    instance_id: &'a str,
+    recording_run_id: &'a str,
+    capture: Capture<'a>,
+    code: Code<'a>,
+    node: &'a deja_core::ExecutionGraphNode,
+}
+
+/// Marker envelope: same stream, same session identity, no event payload.
+#[derive(Serialize)]
+struct MarkerEnvelope<'a> {
+    schema_version: u32,
+    artifact_type: &'static str,
+    instance_id: &'a str,
+    recording_run_id: &'a str,
+    capture: Capture<'a>,
+    code: Code<'a>,
+    marker: MarkerBody<'a>,
+}
+
+#[derive(Serialize)]
+struct MarkerBody<'a> {
+    kind: &'static str,
+    #[serde(flatten)]
+    payload: &'a serde_json::Value,
+}
+
+pub struct HyperswitchKafkaRecordSinkConfig<'a> {
+    pub brokers: &'a [String],
+    pub topic: &'a str,
+    pub recording_run_id: &'a str,
+    pub instance_id: String,
+    pub code_sha: Option<String>,
+    pub client_id: Option<&'a str>,
+    pub acks: &'a str,
+    pub enable_idempotence: bool,
+    pub compression: Option<&'a str>,
+    pub linger_ms: Option<u64>,
+    pub message_timeout_ms: u64,
+    pub queue_buffering_max_messages: usize,
+}
+
+/// `RecordSink<deja::DejaRecord>` implementation over a deja-owned,
+/// durability-hardened Kafka producer.
+pub struct HyperswitchKafkaRecordSink {
+    producer: ThreadedProducer<DefaultProducerContext>,
+    topic: String,
+    recording_run_id: String,
+    /// Typed producer identity resolved during Deja boot; distinguishes
+    /// producers when several instances feed one session.
+    instance_id: String,
+    /// Typed code identity resolved during Deja boot; `None` when unavailable.
+    code_sha: Option<String>,
+}
+
+impl HyperswitchKafkaRecordSink {
+    /// Build the sink with its own hardened producer from the broker list of
+    /// Hyperswitch's events config (the brokers are shared; the producer and
+    /// its delivery guarantees are not).
+    pub fn new(config: HyperswitchKafkaRecordSinkConfig<'_>) -> io::Result<Self> {
+        // Start from the deployment-wide base client config (shared cluster
+        // provisioning), then layer the recording sink's delivery guarantees
+        // on top — a separate client with its own queue and delivery thread.
+        let mut producer_config = super::base_client_config(config.brokers);
+        producer_config
+            .set("acks", config.acks)
+            .set(
+                "enable.idempotence",
+                if config.enable_idempotence {
+                    "true"
+                } else {
+                    "false"
+                },
+            )
+            .set("message.timeout.ms", config.message_timeout_ms.to_string())
+            // Bounded buffering: a dead broker turns into enqueue errors
+            // (counted + ledgered by the writer), not unbounded memory.
+            .set(
+                "queue.buffering.max.messages",
+                config.queue_buffering_max_messages.to_string(),
+            )
+            .set("queue.buffering.max.kbytes", "262144");
+
+        if let Some(client_id) = config.client_id.filter(|value| !value.is_empty()) {
+            producer_config.set("client.id", client_id);
+        }
+        if let Some(compression) = config.compression.filter(|value| !value.is_empty()) {
+            producer_config.set("compression.type", compression);
+        }
+        if let Some(linger_ms) = config.linger_ms {
+            producer_config.set("linger.ms", linger_ms.to_string());
+        }
+
+        let producer = ThreadedProducer::from_config(&producer_config)
+            .map_err(|e| io::Error::other(format!("deja kafka producer: {e}")))?;
+        Ok(Self {
+            producer,
+            topic: config.topic.to_owned(),
+            recording_run_id: config.recording_run_id.to_owned(),
+            instance_id: config.instance_id,
+            code_sha: config.code_sha,
+        })
+    }
+
+    fn send(&self, key: &str, payload: &[u8], headers: OwnedHeaders) -> io::Result<()> {
+        self.producer
+            .send(
+                BaseRecord::to(&self.topic)
+                    .key(key)
+                    .payload(payload)
+                    .headers(headers),
+            )
+            .map_err(|(error, _record)| io::Error::other(format!("kafka send: {error}")))
+    }
+
+    fn write_boundary_event(&self, event: &deja::BoundaryEvent) -> io::Result<()> {
+        let envelope = Envelope {
+            schema_version: SCHEMA_VERSION,
+            artifact_type: ARTIFACT_TYPE,
+            instance_id: &self.instance_id,
+            recording_run_id: &self.recording_run_id,
+            correlation_id: event.correlation_id.as_deref(),
+            event_time_ns: event.timestamp_ns,
+            capture: Capture {
+                // Session capture is the only mode today; a windowed
+                // capture mode is a planned extension.
+                mode: "session",
+                session_id: &self.recording_run_id,
+            },
+            code: Code {
+                sha: self.code_sha.as_deref(),
+                deja_version: deja::PKG_VERSION,
+            },
+            event,
+        };
+        let payload = serde_json::to_vec(&envelope).map_err(io::Error::other)?;
+
+        let key = match &event.correlation_id {
+            Some(cid) => cid.clone(),
+            None => format!("{}:{}", self.recording_run_id, event.global_sequence),
+        };
+
+        let global_seq = event.global_sequence.to_string();
+        let request_seq = event.request_sequence.to_string();
+        let headers = OwnedHeaders::new()
+            .insert(Header {
+                key: "global_sequence",
+                value: Some(global_seq.as_str()),
+            })
+            .insert(Header {
+                key: "request_sequence",
+                value: Some(request_seq.as_str()),
+            })
+            .insert(Header {
+                key: "recording_run_id",
+                value: Some(self.recording_run_id.as_str()),
+            })
+            .insert(Header {
+                key: "boundary",
+                value: Some(event.boundary.as_str()),
+            })
+            .insert(Header {
+                key: "method_name",
+                value: Some(event.method_name.as_str()),
+            });
+
+        self.send(&key, &payload, headers)
+    }
+
+    fn write_graph_node(&self, node: &deja_core::ExecutionGraphNode) -> io::Result<()> {
+        let envelope = GraphEnvelope {
+            schema_version: GRAPH_SCHEMA_VERSION,
+            artifact_type: GRAPH_ARTIFACT_TYPE,
+            instance_id: &self.instance_id,
+            recording_run_id: &self.recording_run_id,
+            capture: Capture {
+                mode: "session",
+                session_id: &self.recording_run_id,
+            },
+            code: Code {
+                sha: self.code_sha.as_deref(),
+                deja_version: deja::PKG_VERSION,
+            },
+            node,
+        };
+        let payload = serde_json::to_vec(&envelope).map_err(io::Error::other)?;
+
+        // Partition alongside the request's boundary events when the span
+        // carries the request id; background spans key on stream identity.
+        let key = match node.request_id() {
+            Some(request_id) => request_id.to_owned(),
+            None => format!("{}:{}", self.recording_run_id, node.global_sequence),
+        };
+
+        let global_seq = node.global_sequence.to_string();
+        let headers = OwnedHeaders::new()
+            .insert(Header {
+                key: "global_sequence",
+                value: Some(global_seq.as_str()),
+            })
+            .insert(Header {
+                key: "recording_run_id",
+                value: Some(self.recording_run_id.as_str()),
+            })
+            .insert(Header {
+                key: "span_name",
+                value: Some(node.span_name.as_str()),
+            });
+
+        self.send(&key, &payload, headers)
+    }
+}
+
+impl deja::RecordSink<deja::DejaRecord> for HyperswitchKafkaRecordSink {
+    fn write_batch(&mut self, records: &[deja::DejaRecord]) -> io::Result<()> {
+        for record in records {
+            match record {
+                deja::DejaRecord::BoundaryEvent(event) => self.write_boundary_event(event)?,
+                deja::DejaRecord::GraphNode(node) => self.write_graph_node(node)?,
+                // Record mode never produces observations; skip instead of
+                // failing the writer if the library contract is breached.
+                deja::DejaRecord::Observed(_) => {
+                    debug_assert!(false, "observed record reached the record-mode Kafka sink");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // Cadence flush: a short bounded poll. Delivery happens continuously on
+        // the producer's own background thread; a long synchronous drain here
+        // would park the writer thread behind a slow broker, backing up the
+        // record channel into the request path. Messages still in flight when
+        // the poll expires are NOT a sink failure — enqueue errors in
+        // write_batch are where saturation and broker loss actually surface.
+        match self.producer.flush(CADENCE_FLUSH_POLL) {
+            Ok(()) => Ok(()),
+            Err(rdkafka::error::KafkaError::Flush(
+                rdkafka::types::RDKafkaErrorCode::OperationTimedOut,
+            )) => Ok(()),
+            Err(e) => Err(io::Error::other(format!("kafka flush: {e}"))),
+        }
+    }
+
+    fn write_marker(
+        &mut self,
+        kind: deja::MarkerKind,
+        payload: &serde_json::Value,
+    ) -> io::Result<()> {
+        let envelope = MarkerEnvelope {
+            schema_version: SCHEMA_VERSION,
+            artifact_type: MARKER_ARTIFACT_TYPE,
+            instance_id: &self.instance_id,
+            recording_run_id: &self.recording_run_id,
+            capture: Capture {
+                mode: "session",
+                session_id: &self.recording_run_id,
+            },
+            code: Code {
+                sha: self.code_sha.as_deref(),
+                deja_version: deja::PKG_VERSION,
+            },
+            marker: MarkerBody {
+                kind: kind.as_str(),
+                payload,
+            },
+        };
+        let bytes = serde_json::to_vec(&envelope).map_err(io::Error::other)?;
+        let key = format!("{}:marker", self.recording_run_id);
+        let headers = OwnedHeaders::new()
+            .insert(Header {
+                key: "recording_run_id",
+                value: Some(self.recording_run_id.as_str()),
+            })
+            .insert(Header {
+                key: "marker_kind",
+                value: Some(kind.as_str()),
+            });
+        self.send(&key, &bytes, headers)?;
+        // The eof marker bounds delivery audits — drain for real so "eof
+        // landed" means everything before it landed too.
+        if matches!(kind, deja::MarkerKind::Eof) {
+            let _ = self.producer.flush(EOF_FLUSH_TIMEOUT);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_serializes_artifact_record_v2_shape() {
+        let event = deja::BoundaryEvent {
+            global_sequence: 7,
+            request_sequence: 2,
+            correlation_id: Some("c-123".to_string()),
+            timestamp_ns: 1_000_000_000,
+            recording_run_id: Some("run-abc".to_string()),
+            graph_node_id: None,
+            tracing_span_id: None,
+            task_id: None,
+            parent_task_id: None,
+            task_bucket: None,
+            bucket_id: None,
+            fork_seq: None,
+            boundary: "redis".to_string(),
+            trait_name: "RedisConnectionInterface".to_string(),
+            method_name: "get_key".to_string(),
+            call_file: "x.rs".to_string(),
+            call_line: 10,
+            call_column: 5,
+            receiver: None,
+            request: serde_json::Value::Null,
+            args: serde_json::json!({"key": "foo"}),
+            response: serde_json::Value::Null,
+            result: serde_json::json!("bar"),
+            is_error: false,
+            duration_us: 42,
+            event_schema_version: deja::CURRENT_EVENT_SCHEMA_VERSION,
+            callsite_identity: None,
+            provenance: deja::Provenance::default(),
+            fidelity: deja::Fidelity::default(),
+            result_image: None,
+            pre_image: None,
+            read_set: Vec::new(),
+            write_set: Vec::new(),
+            value_digest: None,
+            entropy_source: None,
+            replay_strategy: deja::ReplayStrategy::Execute,
+            kind: Some("redis".to_string()),
+            declaration: Some(deja::BoundaryDeclaration::default().effect(deja::EffectKind::Redis)),
+            raw_draw: None,
+            end_timestamp_ns: Some(1_000_000_042),
+        };
+        let envelope = Envelope {
+            schema_version: 2,
+            artifact_type: "deja_artifact_record",
+            instance_id: "router-testhost-1",
+            recording_run_id: "run-abc",
+            correlation_id: event.correlation_id.as_deref(),
+            event_time_ns: event.timestamp_ns,
+            capture: Capture {
+                mode: "session",
+                session_id: "run-abc",
+            },
+            code: Code {
+                sha: Some("deadbeef"),
+                deja_version: deja::PKG_VERSION,
+            },
+            event: &event,
+        };
+        let value: serde_json::Value =
+            serde_json::from_slice(&serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert_eq!(
+            value.pointer("/schema_version"),
+            Some(&serde_json::json!(2))
+        );
+        assert_eq!(
+            value.pointer("/artifact_type"),
+            Some(&serde_json::json!("deja_artifact_record"))
+        );
+        assert_eq!(
+            value.pointer("/instance_id"),
+            Some(&serde_json::json!("router-testhost-1"))
+        );
+        assert_eq!(
+            value.pointer("/recording_run_id"),
+            Some(&serde_json::json!("run-abc"))
+        );
+        assert_eq!(
+            value.pointer("/correlation_id"),
+            Some(&serde_json::json!("c-123"))
+        );
+        assert_eq!(
+            value.pointer("/event_time_ns"),
+            Some(&serde_json::json!(1_000_000_000u64))
+        );
+        assert_eq!(
+            value.pointer("/capture/mode"),
+            Some(&serde_json::json!("session"))
+        );
+        assert_eq!(
+            value.pointer("/capture/session_id"),
+            Some(&serde_json::json!("run-abc"))
+        );
+        assert_eq!(
+            value.pointer("/code/sha"),
+            Some(&serde_json::json!("deadbeef"))
+        );
+        assert_eq!(
+            value.pointer("/code/deja_version"),
+            Some(&serde_json::json!(deja::PKG_VERSION))
+        );
+        assert_eq!(
+            value.pointer("/event/boundary"),
+            Some(&serde_json::json!("redis"))
+        );
+        assert_eq!(
+            value.pointer("/event/method_name"),
+            Some(&serde_json::json!("get_key"))
+        );
+        assert_eq!(
+            value.pointer("/event/global_sequence"),
+            Some(&serde_json::json!(7))
+        );
+        // The sink unwraps `DejaRecord` before enveloping: the payload is the
+        // plain event, never the internally tagged record.
+        assert!(value.pointer("/event/record_kind").is_none());
+    }
+
+    #[test]
+    fn graph_envelope_serializes_graph_node_v1_shape() {
+        let node = deja_core::ExecutionGraphNode {
+            node_id: 7,
+            global_sequence: 42,
+            parent_id: Some(3),
+            causal_parent_ids: vec![1],
+            sequence: 5,
+            recording_run_id: Some("run-abc".to_string()),
+            span_name: "payment.request".to_string(),
+            target: "router".to_string(),
+            level: "INFO".to_string(),
+            fields: [("request_id".to_string(), serde_json::json!("c-123"))]
+                .into_iter()
+                .collect(),
+            started_ns: 1_000_000_000,
+            closed_ns: Some(1_000_000_042),
+        };
+        let envelope = GraphEnvelope {
+            schema_version: 1,
+            artifact_type: "deja_graph_node",
+            instance_id: "router-testhost-1",
+            recording_run_id: "run-abc",
+            capture: Capture {
+                mode: "session",
+                session_id: "run-abc",
+            },
+            code: Code {
+                sha: Some("deadbeef"),
+                deja_version: deja::PKG_VERSION,
+            },
+            node: &node,
+        };
+        let value: serde_json::Value =
+            serde_json::from_slice(&serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert_eq!(
+            value.pointer("/schema_version"),
+            Some(&serde_json::json!(1))
+        );
+        assert_eq!(
+            value.pointer("/artifact_type"),
+            Some(&serde_json::json!("deja_graph_node"))
+        );
+        assert_eq!(
+            value.pointer("/instance_id"),
+            Some(&serde_json::json!("router-testhost-1"))
+        );
+        assert_eq!(
+            value.pointer("/recording_run_id"),
+            Some(&serde_json::json!("run-abc"))
+        );
+        assert_eq!(
+            value.pointer("/capture/mode"),
+            Some(&serde_json::json!("session"))
+        );
+        assert_eq!(
+            value.pointer("/capture/session_id"),
+            Some(&serde_json::json!("run-abc"))
+        );
+        assert_eq!(
+            value.pointer("/code/sha"),
+            Some(&serde_json::json!("deadbeef"))
+        );
+        assert_eq!(
+            value.pointer("/code/deja_version"),
+            Some(&serde_json::json!(deja::PKG_VERSION))
+        );
+        assert_eq!(value.pointer("/node/node_id"), Some(&serde_json::json!(7)));
+        assert_eq!(
+            value.pointer("/node/global_sequence"),
+            Some(&serde_json::json!(42))
+        );
+        assert_eq!(
+            value.pointer("/node/span_name"),
+            Some(&serde_json::json!("payment.request"))
+        );
+        assert_eq!(
+            value.pointer("/node/fields/request_id"),
+            Some(&serde_json::json!("c-123"))
+        );
+        assert_eq!(
+            value.pointer("/node/closed_ns"),
+            Some(&serde_json::json!(1_000_000_042u64))
+        );
+        assert!(value.pointer("/node/record_kind").is_none());
+        // No event payload on graph envelopes — the compactor routes by type.
+        assert!(value.get("event").is_none());
+    }
+
+    #[test]
+    fn marker_envelope_serializes_sink_marker_shape() {
+        let payload = serde_json::json!({ "last_seq": 206, "records_written": 207 });
+        let envelope = MarkerEnvelope {
+            schema_version: 2,
+            artifact_type: "deja_sink_marker",
+            instance_id: "router-testhost-1",
+            recording_run_id: "run-abc",
+            capture: Capture {
+                mode: "session",
+                session_id: "run-abc",
+            },
+            code: Code {
+                sha: Some("deadbeef"),
+                deja_version: deja::PKG_VERSION,
+            },
+            marker: MarkerBody {
+                kind: "eof",
+                payload: &payload,
+            },
+        };
+        let value: serde_json::Value =
+            serde_json::from_slice(&serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert_eq!(
+            value.pointer("/artifact_type"),
+            Some(&serde_json::json!("deja_sink_marker"))
+        );
+        assert_eq!(
+            value.pointer("/marker/kind"),
+            Some(&serde_json::json!("eof"))
+        );
+        assert_eq!(
+            value.pointer("/marker/last_seq"),
+            Some(&serde_json::json!(206))
+        );
+        assert_eq!(
+            value.pointer("/code/sha"),
+            Some(&serde_json::json!("deadbeef"))
+        );
+        assert_eq!(
+            value.pointer("/code/deja_version"),
+            Some(&serde_json::json!(deja::PKG_VERSION))
+        );
+        // No event payload on markers — the compactor skips them by type.
+        assert!(value.get("event").is_none());
+    }
+}

--- a/crates/router/src/utils/user/password.rs
+++ b/crates/router/src/utils/user/password.rs
@@ -15,13 +15,34 @@ use crate::core::errors::UserErrors;
 pub fn generate_password_hash(
     password: Secret<String>,
 ) -> CustomResult<Secret<String>, UserErrors> {
+    generate_password_hash_inner(password).map(Secret::new)
+}
+
+// deja: the Argon2 salt is random (OsRng), so the hash is non-deterministic. On
+// replay the recorded user row never matches (the `users` INSERT then executes
+// LIVE, collides with the record-phase user, and signup rolls everything back ->
+// HE_00). Record/replay the hash string so the user row is reproducible. The
+// annotated fn returns a PLAIN String (not Secret) on purpose: masking::Secret
+// serializes lossily to "***", which would record/replay a useless masked value;
+// the plain String records the real hash losslessly. The `password` arg still
+// masks to "***" in the recorded args — that's fine, it's consistent across
+// record/replay and avoids leaking the secret. Uses the Ok-only codec for the Result.
+#[cfg_attr(
+    feature = "deja",
+    deja::id(
+        component = "router::user::password",
+        operation = "generate_password_hash",
+        codec = ResultOkCodec,
+    )
+)]
+fn generate_password_hash_inner(password: Secret<String>) -> CustomResult<String, UserErrors> {
     let salt = SaltString::generate(&mut OsRng);
 
     let argon2 = Argon2::default();
     let password_hash = argon2
         .hash_password(password.expose().as_bytes(), &salt)
         .change_context(UserErrors::InternalServerError)?;
-    Ok(Secret::new(password_hash.to_string()))
+    Ok(password_hash.to_string())
 }
 
 pub fn is_correct_password(

--- a/crates/router/tests/deja_boot_fail_loud.rs
+++ b/crates/router/tests/deja_boot_fail_loud.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "deja")]
+
+use router::configs::settings::{DejaMode, DejaSettings};
+
+fn settings_for(mode: DejaMode) -> DejaSettings {
+    DejaSettings {
+        mode,
+        ..DejaSettings::default()
+    }
+}
+
+#[test]
+fn replay_mode_without_source_or_lookup_dir_fails_loudly() {
+    let err = router::deja_boot::install(&settings_for(DejaMode::Replay), None)
+        .expect_err("replay mode without source or lookup_dir must abort boot");
+
+    assert!(
+        err.contains("deja.replay.source") && err.contains("deja.replay.lookup_dir"),
+        "error should mention the missing replay source/lookup_dir, got: {err}"
+    );
+}
+
+#[test]
+fn replay_mode_with_missing_lookup_source_fails_loudly() {
+    let missing_source =
+        "/__hyperswitch_w3_deja_replay_lookup_table_must_not_exist__/missing.lookup.json";
+    let mut settings = settings_for(DejaMode::Replay);
+    settings.replay.source = Some(missing_source.to_owned());
+
+    let err = router::deja_boot::install(&settings, None)
+        .expect_err("replay mode with a missing lookup table source must abort boot");
+
+    assert!(
+        err.contains("failed to load replay lookup table") && err.contains(missing_source),
+        "error should mention lookup-table load failure for {missing_source}, got: {err}"
+    );
+}
+
+#[test]
+fn record_mode_without_kafka_topic_fails_open_with_disabled_report() {
+    let report = router::deja_boot::install(&settings_for(DejaMode::Record), None)
+        .expect("record-mode Kafka topic misconfiguration should fail open");
+
+    assert_eq!(report.mode, "disabled");
+    assert_eq!(report.run_id, None);
+    assert_eq!(
+        report.detail.as_deref(),
+        Some("record mode requires deja.recording.kafka.topic")
+    );
+}

--- a/crates/router_env/Cargo.toml
+++ b/crates/router_env/Cargo.toml
@@ -10,8 +10,8 @@ license.workspace = true
 [dependencies]
 cargo_metadata = "0.18.1"
 config = { version = "0.14.1", features = ["toml"] }
-deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false }
-deja-core = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true }
+deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false }
+deja-core = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true }
 error-stack = "0.4.1"
 gethostname = "0.4.3"
 # Optional (deja-only): types the captured request/response payloads as `Secret`

--- a/crates/storage_impl/Cargo.toml
+++ b/crates/storage_impl/Cargo.toml
@@ -29,7 +29,7 @@ api_models = { version = "0.1.0", path = "../api_models" }
 common_enums = { version = "0.1.0", path = "../common_enums" }
 common_utils = { version = "0.1.0", path = "../common_utils" }
 common_types = { version = "0.1.0", path = "../common_types" }
-deja = { git = "https://github.com/juspay/deja", rev = "2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716", optional = true, default-features = false }
+deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false }
 diesel_models = { version = "0.1.0", path = "../diesel_models", default-features = false }
 hyperswitch_domain_models = { version = "0.1.0", path = "../hyperswitch_domain_models", default-features = false }
 hyperswitch_masking = "0.0.1"

--- a/crates/storage_impl/src/redis/cache.rs
+++ b/crates/storage_impl/src/redis/cache.rs
@@ -339,6 +339,36 @@ where
     }
 }
 
+/// Deja boundary for the in-memory (L1) cache lookup. Captures the `Option<T>`
+/// outcome on record and Substitutes it per-correlation on replay: a recorded
+/// `Some(v)` returns the value; a recorded `None` (absence) returns `None`, so
+/// the caller re-runs the redis fallback — the same control flow as record. The
+/// `cache` handle is not serialized (args = cache name + physical key); the
+/// value round-trips through `SerdeCodec<Option<T>>`. NOT `fall_through_silent`:
+/// a novel L1 read on replay is a real divergence, and falling through would
+/// read the cross-correlation-shared moka — fail-stop is correct.
+#[cfg(feature = "deja")]
+#[deja::boundary(
+    boundary = "imc",
+    component = "storage_impl::redis::cache",
+    operation = "in_memory_get",
+    replay = Substitute,
+    effect = Imc,
+    codec = SerdeCodec,
+    args = deja_in_memory_args(cache.name, &cache_key),
+)]
+async fn deja_in_memory_get<T>(cache: &Cache, cache_key: CacheKey) -> Option<T>
+where
+    T: Clone + Cacheable + serde::Serialize + serde::de::DeserializeOwned,
+{
+    cache.get_val::<T>(cache_key).await
+}
+
+#[cfg(feature = "deja")]
+fn deja_in_memory_args(cache_name: &str, key: &CacheKey) -> serde_json::Value {
+    serde_json::json!({ "cache": cache_name, "key": String::from(key.clone()) })
+}
+
 #[instrument(skip_all)]
 pub async fn get_or_populate_in_memory<T, F, Fut>(
     store: &(dyn RedisConnInterface + Send + Sync),
@@ -357,12 +387,23 @@ where
             RedisError::RedisConnectionError.into(),
         ))
         .attach_printable("Failed to get redis connection")?;
-    let cache_val = cache
-        .get_val::<T>(CacheKey {
-            key: key.to_string(),
-            prefix: redis.key_prefix.clone(),
-        })
-        .await;
+    let cache_key = CacheKey {
+        key: key.to_string(),
+        prefix: redis.key_prefix.clone(),
+    };
+    // Deja L1 seam: the in-memory (moka) lookup is a process-global cache that
+    // spans correlations. Instrument the LOOKUP itself (not the surrounding
+    // populate) so its `Option` outcome is recorded per-correlation and
+    // Substituted on replay — a recorded `Some(v)` returns the value; a recorded
+    // `None` re-triggers the (separately instrumented) redis fallback below,
+    // identically on record and replay. Because the lookup returns BEFORE redis,
+    // L1 and L2 stay sequential (not nested) → no subsumed/orphan event. Record
+    // stays a pure observer (the real moka runs); replay never reads the shared
+    // moka, so cross-correlation contamination is impossible by construction.
+    #[cfg(feature = "deja")]
+    let cache_val = deja_in_memory_get::<T>(cache, cache_key).await;
+    #[cfg(not(feature = "deja"))]
+    let cache_val = cache.get_val::<T>(cache_key).await;
     if let Some(val) = cache_val {
         Ok(val)
     } else {

--- a/crates/storage_impl/src/redis/kv_store.rs
+++ b/crates/storage_impl/src/redis/kv_store.rs
@@ -145,6 +145,18 @@ pub enum KvResult<T: de::DeserializeOwned> {
     Scan(Vec<T>),
 }
 
+#[cfg(feature = "deja")]
+pub trait DejaKvValue: serde::Serialize {}
+
+#[cfg(feature = "deja")]
+impl<T: serde::Serialize> DejaKvValue for T {}
+
+#[cfg(not(feature = "deja"))]
+pub trait DejaKvValue {}
+
+#[cfg(not(feature = "deja"))]
+impl<T> DejaKvValue for T {}
+
 impl<T> std::fmt::Display for KvOperation<'_, T>
 where
     T: serde::Serialize + Debug,
@@ -167,7 +179,7 @@ pub async fn kv_wrapper<'a, T, D, S>(
     partition_key: PartitionKey<'a>,
 ) -> CustomResult<KvResult<T>, RedisError>
 where
-    T: de::DeserializeOwned,
+    T: de::DeserializeOwned + DejaKvValue,
     D: crate::database::store::DatabaseStore,
     S: serde::Serialize + Debug + KvStorePartition + UniqueConstraints + Sync,
 {

--- a/docs/design/deja-non-boundaries.md
+++ b/docs/design/deja-non-boundaries.md
@@ -1,0 +1,61 @@
+# Deja: sites deliberately left un-instrumented
+
+Most of the record/replay work is about choosing where a boundary goes. An equally
+load-bearing set of decisions is where a boundary deliberately does **not** go. Those
+choices are invisible in the code — an absent boundary looks identical to an oversight —
+so they are recorded here, and the call sites carry a one-line pointer back to this file.
+
+Two failure modes motivate every entry below.
+
+**Nesting.** A boundary that wraps other boundaries is substituted as a unit on replay.
+Substituting the outer call returns the recorded reply *without executing the body*, so
+the inner boundaries never run and their events are silently missing from the replay. An
+outer boundary over instrumented inner calls therefore does not add fidelity; it removes it.
+
+**Recording a secret that the seam already handles.** Where non-determinism enters at a
+narrow seam, instrumenting the seam records the minimum. Instrumenting the surrounding
+computation instead records its output — which may be the very secret the seam was chosen
+to keep off disk.
+
+## `crypto_operation` — `hyperswitch_domain_models::type_encryption`
+
+Not a boundary. `crypto_operation` is pure computation over inputs that are all already
+deterministic on replay, so it reproduces byte-identically when re-run live. Instrumenting
+it would only record non-`serde` metadata that cannot be substituted, forcing a dishonest
+verdict exclusion.
+
+The single source of crypto non-determinism — the AEAD nonce — is recorded and replayed at
+its own seam (`common_utils::crypto::NonceSequence::new`, a `deja::id` boundary). Given
+substituted inputs the rest of the chain is pure:
+
+- the master key is config, identical across record and replay;
+- `DecryptLocally` of the merchant key store derives the DEK via `GcmAes256::decode_message`,
+  which has no randomness;
+- the encrypted ciphertext (DEK and PII) arrives from substituted DB reads;
+- the plaintext arrives from the kernel-re-driven request.
+
+Recording the output instead would write the plaintext DEK — the merchant's data key — into
+the event log, where recording the seam does not.
+
+> **Open item (tracked, not resolved here).** The last paragraph does not currently hold
+> globally: `generate_aes256_key` *is* instrumented (`router::services`), and that is the DEK
+> generator used by `db::merchant_key_store`, `db::merchant_connector_account` and `db::events`.
+> The plaintext DEK therefore does reach the tape at that seam. Under the full-fidelity capture
+> policy this may be intended, but the "keeps it off disk" reasoning above is not a guarantee
+> the reader should rely on. Tape protection is a separate, deferred workstream.
+
+## `delete_multiple_keys` — `redis_interface` (fred and redis-rs)
+
+Not a boundary. It is a thin wrapper that maps `delete_key` over each key, and `delete_key`
+is already hermetic. An outer boundary would nest: substituting the wrapper on replay
+returns the recorded reply without executing, skipping the inner `delete_key` calls and
+omitting their recorded `DEL` events. The inner boundaries carry record and replay.
+
+## `perform_locking_action` and `free_lock_action` — `router::core::api_locking`
+
+Not boundaries. Acquiring a lock is a redis SETNX-and-get retry loop
+(`set_multiple_keys_if_not_exists_and_get_values`); releasing one is a `delete_key` on the
+lock key. Neither is an independent source of non-determinism. Once the redis boundary is
+hermetic the lock outcome replays deterministically from the recorded redis reply, so a
+separate `deja::lock` boundary would only double-record — and substituting it would skip,
+and therefore omit, the inner redis call.

--- a/scripts/seed_superposition.sh
+++ b/scripts/seed_superposition.sh
@@ -97,4 +97,58 @@ echo "$SEED_JSON" | jq -c '."default-configs" | to_entries[] | {key: .key, value
     post_or_fail "$SUPERPOSITION_URL/default-config" "$config" "default-config $key"
 done
 
+# Seed the Deja recording sampler: cohort dimension + override
+# ------------------------------------------------------------------------------
+# `deja_dimension` is a LOCAL_COHORT on the `path` dimension: its json-logic
+# classifies the RAW request path (substring `in`, so parametric paths like
+# /payments/{id}/confirm are covered) into "recordable"/"otherwise". The override
+# records the recordable bucket; `deja_record` defaults to false (seeded above),
+# so /health and other probe traffic skip. The path -> deja_dimension dependency
+# graph is derived server-side from the LOCAL_COHORT type.
+# Posted here as explicit JSON (not via the TOML) because a cohort's
+# dimension_type + json-logic definitions do not round-trip cleanly through yq.
+echo "Seeding Deja recording sampler (deja_dimension cohort + deja_record override)..."
+post_or_fail "$SUPERPOSITION_URL/dimension" '{
+    "dimension": "deja_dimension",
+    "position": 10,
+    "dimension_type": { "LOCAL_COHORT": "path" },
+    "description": "Deja request treatment class (path-derived cohort)",
+    "change_reason": "Deja recording sampler",
+    "schema": {
+        "type": "string",
+        "enum": ["recordable", "otherwise"],
+        "definitions": {
+            "recordable": { "or": [
+                { "in": ["/payments", { "var": "path" }] },
+                { "in": ["/accounts", { "var": "path" }] },
+                { "in": ["/user/signup", { "var": "path" }] },
+                { "in": ["/organization", { "var": "path" }] },
+                { "in": ["/api_keys", { "var": "path" }] },
+                { "in": ["/configs", { "var": "path" }] }
+            ]}
+        }
+    }
+}' "deja_dimension cohort"
+
+# The override context is created via PUT /context (context = condition map,
+# override = config values): deja_dimension == "recordable" -> deja_record = true.
+echo "Creating deja_record override for the recordable cohort..."
+ctx_tmp=$(mktemp)
+ctx_status=$(curl -sS -o "$ctx_tmp" -w "%{http_code}" -X PUT "$SUPERPOSITION_URL/context" \
+    -H "Content-Type: application/json" \
+    -H "x-org-id: $ORG_ID" \
+    -H "x-workspace: $WORKSPACE_ID" \
+    -d '{
+        "context": { "deja_dimension": "recordable" },
+        "override": { "deja_record": true },
+        "description": "Record the recordable endpoint bucket",
+        "change_reason": "Deja recording sampler"
+    }')
+case "$ctx_status" in
+    2??) ;;
+    409) echo "  deja_record override already exists (HTTP 409), continuing" ;;
+    *) echo "Error: deja_record override failed with HTTP $ctx_status"; cat "$ctx_tmp"; rm -f "$ctx_tmp"; exit 1 ;;
+esac
+rm -f "$ctx_tmp"
+
 echo "Seeding complete!"


### PR DESCRIPTION
Closes #13304

<!-- PART 4 OF 5 -->
# feat(deja) [4/5] — external I/O + crypto capture (redis, outbound HTTP, in-memory cache, RNG/nonce/hash)

## TL;DR
**Part 4 of a 5-PR stack** re-slicing #13237 (feature-gated **déjà** record/replay instrumentation) for review. **Base this PR on `deja/pr3-db-capture` (#13287).** This layer instruments the second big boundary class — cache, egress, and cryptographic nondeterminism. Compiles feature-off (byte-identical) and `--features deja`; inert until PR5 installs the hook.

## The stack
1. #13285 — foundation ← **full context** · 2. #13286 — correlation substrate · 3. #13287 — DB capture · **4. this (#13288)** — I/O + crypto capture · 5. #13289 — sink/boot.

> **What déjà is:** a deterministic record/replay harness for service boundaries; see #13285.

---

## What's in THIS PR (part 4)

### Redis command boundaries + typed wire codec
- `redis_interface/src/module/fred/commands.rs` and `module/redis_rs/commands.rs` — instrument the redis command surface on **both** backends as record/replay boundaries with a typed value codec (a `DejaRedisValue` proxy that round-trips `RedisValue`/`redis::Value`), explicit **multi-key read attribution**, and **SADD write attribution** (the boundary sits on `sadd` itself, with its own key attribution). Correlation-namespaced `add_prefix`.
- **Typed error round-trip**: all 22 boundary sites (15 fred + 7 redis-rs) use a typed `ResultCodec<_, RedisError>` — a recording that threw (e.g. `NotFound`, `SetNxFailed`) replays as the **same `RedisError` context** instead of an unreconstructable sentinel. `RedisError` gains feature-gated serde derives.
- `redis_interface/src/types.rs` — `RedisKey::as_str` + gated reply serde derives. `redis_interface/src/metrics.rs` — inverse-gates the `SerializeAndSetKeyWithExpiry` metric variant. `storage_impl/src/redis/kv_store.rs` — a `DejaKvValue` codec-capability marker (inert blanket-impl when off).

### In-memory-cache lookup boundary — `storage_impl/src/redis/cache.rs`
- The process-global moka L1 cache would break per-correlation replay isolation: a warm hit silently skips the instrumented redis/db boundary underneath, so two replayed requests could see each other's cached values. The L1 **lookup itself** becomes a boundary whose `Option` outcome is substituted on replay — neutral during recording, isolated during replay, and sequential (no orphaned downstream events).

### Outbound HTTP boundary
- `external_services/src/http_client/boundary.rs` (new, whole-file gated) + `http_client.rs` — a record/replay boundary around the outbound `send_request` path, with **eager body capture** for faithful replay. Captured request/response payloads are **`Secret`-wrapped** so they cannot leak through Debug/log formatting on the capture path.

### Cryptographic nondeterminism seams
- `common_utils/src/crypto.rs` — AEAD **nonce** bytes + CSPRNG (the ciphertext-reproducibility keystone).
- `router/src/utils/user/password.rs` — Argon2 hash. `router/src/services.rs` — AES-256 key. `router/src/services/jwt.rs` — JWT expiry. All gated `deja::id`/`deja::time` seams.
- `hyperswitch_domain_models/src/type_encryption.rs`, `router/src/core/api_locking.rs` — explanatory comments only (non-boundary notes).

## The pinned library revision
This PR pins `juspay/deja @ 2ae840aa2b0a5160dc1719c83ad6d3c6bbcfa716`. The library-side guarantees that matter here (measured on that revision): a boundary with the feature on but no hook installed costs **~1.5–2.0 ns**; a sampled-out request costs **~11 ns** and records nothing; all capture preparation runs inside a panic firewall, so a panicking capture expression can never fail the request.

## Feature-off guarantee
Fully gated, plus a few **behavior-preserving** ungated restructures that lower identically off (kept as the minimal structure for a gated boundary): the `add_prefix` restructure in both `commands.rs`, the response-`match` restructure in `http_client.rs`, and the `generate_password_hash_inner` split in `password.rs`.

**`fred/commands.rs` fix:** #13237 **ungated-replaced** `set_hash_fields` / `set_hash_field_if_not_exist`'s call to the instrumented `self.set_expiry(...)` with a raw `pool.expire`, which drops `set_expiry`'s `#[instrument]` DEBUG span in default builds. Restored: feature-off now calls `set_expiry` exactly as `main`; feature-on keeps the raw inline (needed so the EXPIRE isn't orphaned under the method's own replay boundary — a pure replay concern).

Build proof on this branch: a feature-off release `router` binary contains **zero** deja code paths (`strings` scan for deja source-path markers = 0).

## How to review
- **Redis proxy round-trip losslessness** — `into_supported_redis_value` can `Err` on exotic values (BigNumber/ServerError); check that a decodable read doesn't become a `GetFailed` under replay.
- The **typed `RedisError` round-trip** — error-path recordings replay as errors of the same shape (unit variants as bare strings; `InvalidConfiguration` keeps its payload).
- The **nonce byte-serde** — this is what makes recorded ciphertext reproducible on replay.
- The **in-memory-cache boundary** — the isolation argument (a warm L1 hit must not bypass replay).
- **HTTP full-body buffering** as a streaming/perf consideration (only active when the hook is installed).
- The `DejaKvValue` bound on `kv_wrapper` `T` (a feature-on `Serialize` requirement) — verify no caller type is left out.

## Verification
- `cargo check -p router` (feature-off) ✅ · `cargo check -p router --features deja` ✅
- Feature-off release binary: zero deja code strings ✅
- End-to-end on the integrated branch (all five parts + the pinned library): record → replay at concurrency 4 reproduces 7/7 correlations with zero divergences — including redis get/set/del/setnx, in-memory-cache hits, and AES/GCM crypto events on the tape; an injected silently-dropped cache write surfaces as an explicit divergence.
