### PR TITLE
test(cypress): add Klarna PayLater mandate test cases for Adyen connector

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
@@ -2016,6 +2016,50 @@ export const connectorDetails = {
         },
       },
     }),
+    KlarnaMandateAutoCapture: getCustomExchange({
+      Request: {
+        payment_method: "pay_later",
+        payment_method_type: "klarna",
+        payment_experience: "redirect_to_url",
+        payment_method_data: {
+          pay_later: {
+            klarna_redirect: {
+              billing_email: "guest@juspay.in",
+              billing_country: "DE",
+            },
+          },
+        },
+        setup_future_usage: "off_session",
+        customer_acceptance: customerAcceptance,
+        billing: {
+          email: "guest@juspay.in",
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "San Fransico",
+            state: "California",
+            zip: "94122",
+            country: "DE",
+            first_name: "joseph",
+            last_name: "Doe",
+          },
+        },
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
     AutoCapture: getCustomExchange({
       Request: {
         currency: "EUR",

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -693,6 +693,7 @@ export const CONNECTOR_LISTS = {
       "payjustnow",
       "payjustnowinstore",
     ],
+    PAY_LATER_KLARNA_MANDATE: ["adyen"],
     AFFIRM: ["stripe"],
     ATOME: ["adyen"],
     PAYJUSTNOW: ["payjustnow"],

--- a/cypress-tests/cypress/e2e/spec/Payment/43-PayLater.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/43-PayLater.cy.js
@@ -365,6 +365,77 @@ describe("PayLater tests", () => {
     });
   });
 
+  context("Klarna PayLater - Mandate AutoCapture flow test (CIT only)", () => {
+    before(function () {
+      if (
+        shouldIncludeConnector(
+          globalState.get("connectorId"),
+          CONNECTOR_LISTS.INCLUDE.PAY_LATER_KLARNA_MANDATE
+        )
+      ) {
+        this.skip();
+      }
+    });
+
+    it("Create Payment Intent -> List Merchant Payment Methods -> Confirm with Customer Acceptance (off_session) -> Retrieve Payment", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "pay_later_pm"
+        ]["AutoCapture"];
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "three_ds",
+          "automatic",
+          globalState
+        );
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("List Merchant Payment Methods", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: List Merchant Payment Methods");
+          return;
+        }
+        cy.paymentMethodsCallTest(globalState);
+      });
+
+      cy.step("Confirm Payment with Customer Acceptance (off_session)", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "pay_later_pm"
+        ]["KlarnaMandateAutoCapture"];
+        cy.confirmBankRedirectCallTest(
+          fixtures.confirmBody,
+          confirmData,
+          true,
+          globalState
+        );
+        if (!utils.should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "pay_later_pm"
+        ]["KlarnaMandateAutoCapture"];
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+
   context("Capture on wrong status - Error test", () => {
     it("Create Payment Intent -> Confirm Payment -> Attempt Capture on requires_customer_action status", () => {
       let shouldContinue = true;


### PR DESCRIPTION
## Summary

- Adds `KlarnaMandateAutoCapture` config to Adyen connector (`cypress-tests/cypress/e2e/configs/Payment/Adyen.js`)
- Adds `PAY_LATER_KLARNA_MANDATE: ["adyen"]` connector list entry in `Utils.js`
- Adds new `context` block in `43-PayLater.cy.js` covering the Klarna mandate CIT flow (Create Intent → List Methods → Confirm with `customer_acceptance` + `setup_future_usage: off_session` → Retrieve; expects `requires_customer_action`)
- MIT flow not included — cannot complete Klarna redirect end-to-end in CI

Closes #12559

## Test plan

- [ ] Verify test runs and skips correctly for non-Adyen connectors
- [ ] Verify Adyen connector returns `requires_customer_action` on confirm with off_session setup_future_usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)