### PR TITLE
chore: address Rust 1.97.0 clippy lints

### DIFF
--- a/crates/analytics/src/query.rs
+++ b/crates/analytics/src/query.rs
@@ -912,7 +912,7 @@ where
         if !self.outer_select.is_empty() {
             query.insert_str(
                 0,
-                format!("SELECT {} FROM (", &self.get_outer_select_clause()).as_str(),
+                format!("SELECT {} FROM (", self.get_outer_select_clause()).as_str(),
             );
             query.push_str(") _");
         }

--- a/crates/cards/src/validate.rs
+++ b/crates/cards/src/validate.rs
@@ -85,7 +85,7 @@ impl CardNumber {
         let mut no_of_supported_card_networks = 0;
 
         let card_number_str = self.get_card_no();
-        for (_, regex) in CARD_NETWORK_REGEX.iter() {
+        for regex in CARD_NETWORK_REGEX.values() {
             let card_regex = match regex.as_ref() {
                 Ok(regex) => Ok(regex),
                 Err(_) => Err(report!(ValidationError::InvalidValue {

--- a/crates/common_utils/src/keymanager.rs
+++ b/crates/common_utils/src/keymanager.rs
@@ -131,7 +131,7 @@ where
     T: GetKeymanagerTenant + ConvertRaw + Send + Sync + 'static + Debug,
     R: serde::de::DeserializeOwned,
 {
-    let url = format!("{}/{endpoint}", &state.url);
+    let url = format!("{}/{endpoint}", state.url);
 
     logger::info!(key_manager_request=?request_body);
     let mut header = vec![];

--- a/crates/hsdev/src/main.rs
+++ b/crates/hsdev/src/main.rs
@@ -80,7 +80,7 @@ pub fn get_toml_table<'a>(table_name: &'a str, toml_data: &'a Value) -> &'a Valu
         match toml_data.get(table_name) {
             Some(value) => value,
             None => {
-                eprintln!("Unable to find toml table: \"{}\"", &table_name);
+                eprintln!("Unable to find toml table: \"{table_name}\"");
                 std::process::abort()
             }
         }

--- a/crates/hyperswitch_connectors/src/connectors/barclaycard.rs
+++ b/crates/hyperswitch_connectors/src/connectors/barclaycard.rs
@@ -1658,11 +1658,7 @@ impl ConnectorSpecifications for Barclaycard {
                 // during authorize flow, there is no post_authentication call needed
                 false
             }
-            api::CurrentFlowInfo::CompleteAuthorize {
-                request_data,
-                payment_method: _,
-                ..
-            } => {
+            api::CurrentFlowInfo::CompleteAuthorize { request_data, .. } => {
                 // TODO: add logic before deciding the pre processing flow Authenticate or PostAuthenticate
                 let redirection_params = request_data
                     .redirect_response
@@ -1686,11 +1682,7 @@ impl ConnectorSpecifications for Barclaycard {
                 // during authorize flow, there is no post_authentication call needed
                 false
             }
-            api::CurrentFlowInfo::CompleteAuthorize {
-                request_data,
-                payment_method: _,
-                ..
-            } => {
+            api::CurrentFlowInfo::CompleteAuthorize { request_data, .. } => {
                 // TODO: add logic before deciding the pre processing flow Authenticate or PostAuthenticate
                 let redirection_params = request_data
                     .redirect_response

--- a/crates/hyperswitch_connectors/src/connectors/boku.rs
+++ b/crates/hyperswitch_connectors/src/connectors/boku.rs
@@ -114,7 +114,7 @@ where
 
         let to_sign = format!(
             "{} {}\nContent-Type: {}\n{}",
-            connector_method, boku_url, &content_type, timestamp
+            connector_method, boku_url, content_type, timestamp
         );
 
         let key = hmac::Key::new(hmac::HMAC_SHA256, secret_key.as_bytes());

--- a/crates/hyperswitch_connectors/src/connectors/checkout.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout.rs
@@ -733,7 +733,7 @@ impl ConnectorIntegration<Void, PaymentsCancelData, PaymentsResponseData> for Ch
         Ok(format!(
             "{}payments/{}/voids",
             self.base_url(connectors),
-            &req.request.connector_transaction_id
+            req.request.connector_transaction_id
         ))
     }
 

--- a/crates/hyperswitch_connectors/src/connectors/cybersource.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource.rs
@@ -2275,11 +2275,7 @@ impl ConnectorSpecifications for Cybersource {
                 // during authorize flow, there is no pre processing flow. Only alternate PreAuthenticate flow
                 None
             }
-            api::CurrentFlowInfo::CompleteAuthorize {
-                request_data,
-                payment_method: _,
-                ..
-            } => {
+            api::CurrentFlowInfo::CompleteAuthorize { request_data, .. } => {
                 // TODO: add logic before deciding the pre processing flow Authenticate or PostAuthenticate
                 let redirect_response = request_data.redirect_response.as_ref()?;
                 match redirect_response.params.as_ref() {
@@ -2339,11 +2335,7 @@ impl ConnectorSpecifications for Cybersource {
                 // during authorize flow, there is no post_authentication call needed
                 false
             }
-            api::CurrentFlowInfo::CompleteAuthorize {
-                request_data,
-                payment_method: _,
-                ..
-            } => {
+            api::CurrentFlowInfo::CompleteAuthorize { request_data, .. } => {
                 // TODO: add logic before deciding the pre processing flow Authenticate or PostAuthenticate
                 let redirection_params = request_data
                     .redirect_response
@@ -2367,11 +2359,7 @@ impl ConnectorSpecifications for Cybersource {
                 // during authorize flow, there is no post_authentication call needed
                 false
             }
-            api::CurrentFlowInfo::CompleteAuthorize {
-                request_data,
-                payment_method: _,
-                ..
-            } => {
+            api::CurrentFlowInfo::CompleteAuthorize { request_data, .. } => {
                 // TODO: add logic before deciding the pre processing flow Authenticate or PostAuthenticate
                 let redirection_params = request_data
                     .redirect_response

--- a/crates/hyperswitch_connectors/src/connectors/finix.rs
+++ b/crates/hyperswitch_connectors/src/connectors/finix.rs
@@ -1157,7 +1157,7 @@ impl webhooks::IncomingWebhook for Finix {
 
         Ok(format!(
             "{}:{}",
-            &security_header_kvs.timestamp,
+            security_header_kvs.timestamp,
             String::from_utf8_lossy(request.body)
         )
         .into_bytes())

--- a/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
@@ -762,7 +762,7 @@ fn get_payment_source(
     bank_redirection_data: &BankRedirectData,
 ) -> Result<PaymentSourceItem, error_stack::Report<errors::ConnectorError>> {
     match bank_redirection_data {
-        BankRedirectData::Eps { bank_name: _, .. } => Ok(PaymentSourceItem::Eps(RedirectRequest {
+        BankRedirectData::Eps { .. } => Ok(PaymentSourceItem::Eps(RedirectRequest {
             name: item.get_billing_full_name()?,
             country_code: item.get_billing_country()?,
             experience_context: ContextStruct {
@@ -790,26 +790,21 @@ fn get_payment_source(
                 user_action: Some(UserAction::PayNow),
             },
         })),
-        BankRedirectData::Ideal { bank_name: _, .. } => {
-            Ok(PaymentSourceItem::IDeal(RedirectRequest {
-                name: item.get_billing_full_name()?,
-                country_code: item.get_billing_country()?,
-                experience_context: ContextStruct {
-                    return_url: item.request.complete_authorize_url.clone(),
-                    cancel_url: item.request.complete_authorize_url.clone(),
-                    shipping_preference: if item.get_optional_shipping_country().is_some() {
-                        ShippingPreference::SetProvidedAddress
-                    } else {
-                        ShippingPreference::GetFromFile
-                    },
-                    user_action: Some(UserAction::PayNow),
+        BankRedirectData::Ideal { .. } => Ok(PaymentSourceItem::IDeal(RedirectRequest {
+            name: item.get_billing_full_name()?,
+            country_code: item.get_billing_country()?,
+            experience_context: ContextStruct {
+                return_url: item.request.complete_authorize_url.clone(),
+                cancel_url: item.request.complete_authorize_url.clone(),
+                shipping_preference: if item.get_optional_shipping_country().is_some() {
+                    ShippingPreference::SetProvidedAddress
+                } else {
+                    ShippingPreference::GetFromFile
                 },
-            }))
-        }
-        BankRedirectData::Sofort {
-            preferred_language: _,
-            ..
-        } => Ok(PaymentSourceItem::Sofort(RedirectRequest {
+                user_action: Some(UserAction::PayNow),
+            },
+        })),
+        BankRedirectData::Sofort { .. } => Ok(PaymentSourceItem::Sofort(RedirectRequest {
             name: item.get_billing_full_name()?,
             country_code: item.get_billing_country()?,
             experience_context: ContextStruct {

--- a/crates/hyperswitch_connectors/src/connectors/worldline/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldline/transformers.rs
@@ -341,7 +341,7 @@ fn make_card_request(
     let secret_value = format!(
         "{}{}",
         ccard.card_exp_month.peek(),
-        &expiry_year
+        expiry_year
             .get(expiry_year.len() - 2..)
             .ok_or(errors::ConnectorError::RequestEncodingFailed)?
     );

--- a/crates/hyperswitch_connectors/src/connectors/worldpayvantiv/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpayvantiv/transformers.rs
@@ -1677,13 +1677,9 @@ impl TryFrom<PaymentsCaptureResponseRouterData<CnpOnlineResponse>> for PaymentsC
 }
 
 fn get_vantiv_customer_reference(customer_id: &Option<String>) -> Option<String> {
-    customer_id.clone().and_then(|id| {
-        if id.len() <= worldpayvantiv_constants::CUSTOMER_REFERENCE_MAX_LENGTH {
-            Some(id)
-        } else {
-            None
-        }
-    })
+    customer_id
+        .clone()
+        .filter(|id| id.len() <= worldpayvantiv_constants::CUSTOMER_REFERENCE_MAX_LENGTH)
 }
 
 impl TryFrom<PaymentsCancelResponseRouterData<CnpOnlineResponse>> for PaymentsCancelRouterData {
@@ -2269,7 +2265,7 @@ impl<F>
                 ..item.data
             })},
             (_, _) => {  Err(errors::ConnectorError::UnexpectedResponseError(
-                bytes::Bytes::from("Only one of 'sale_response' or 'authorisation_response' is expected, but both were received".to_string()),           
+                bytes::Bytes::from("Only one of 'sale_response' or 'authorisation_response' is expected, but both were received".to_string()),
              ))?
             },
     }

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -1024,13 +1024,8 @@ impl<Flow, Request, Response> RouterData
     }
 
     fn get_optional_billing_state_2_digit(&self) -> Option<Secret<String>> {
-        self.get_optional_billing_state().and_then(|state| {
-            if state.clone().expose().len() != 2 {
-                None
-            } else {
-                Some(state)
-            }
-        })
+        self.get_optional_billing_state()
+            .filter(|state| state.peek().len() == 2)
     }
 
     fn get_optional_billing_state_code(&self) -> Option<Secret<String>> {

--- a/crates/hyperswitch_domain_models/src/address.rs
+++ b/crates/hyperswitch_domain_models/src/address.rs
@@ -26,13 +26,7 @@ impl Address {
             phone: {
                 self.phone
                     .clone()
-                    .and_then(|phone_details| {
-                        if phone_details.number.is_some() {
-                            Some(phone_details)
-                        } else {
-                            None
-                        }
-                    })
+                    .filter(|phone_details| phone_details.number.is_some())
                     .or_else(|| other.and_then(|other| other.phone.clone()))
             },
         }

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -1176,6 +1176,8 @@ Never share your secret api keys. Keep them guarded and secure.
 #[allow(dead_code)]
 pub(crate) struct ApiDoc;
 
+// Bypass clippy lint for not being constructed
+#[allow(dead_code)]
 struct SecurityAddon;
 
 impl utoipa::Modify for SecurityAddon {

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -3960,7 +3960,7 @@ pub mod routes {
                 .change_context(OpenSearchError::UnknownError)?;
                 let permission_groups = role_info.get_permission_groups();
                 if !permission_groups.contains(&common_enums::PermissionGroup::OperationsView) {
-                    return Err(OpenSearchError::AccessForbiddenError)?;
+                    Err(OpenSearchError::AccessForbiddenError)?;
                 }
                 let user_roles: HashSet<UserRole> = match role_info.get_entity_type() {
                     EntityType::Tenant => state
@@ -4117,7 +4117,7 @@ pub mod routes {
                 .change_context(OpenSearchError::UnknownError)?;
                 let permission_groups = role_info.get_permission_groups();
                 if !permission_groups.contains(&common_enums::PermissionGroup::OperationsView) {
-                    return Err(OpenSearchError::AccessForbiddenError)?;
+                    Err(OpenSearchError::AccessForbiddenError)?;
                 }
                 let user_roles: HashSet<UserRole> = match role_info.get_entity_type() {
                     EntityType::Tenant => state

--- a/crates/router/src/core/health_check.rs
+++ b/crates/router/src/core/health_check.rs
@@ -199,7 +199,7 @@ impl HealthCheckInterface for app::SessionState {
         &self,
     ) -> CustomResult<HealthState, errors::HealthCheckDecisionEngineError> {
         if self.conf.open_router.dynamic_routing_enabled {
-            let url = format!("{}/{}", &self.conf.open_router.url, "health");
+            let url = format!("{}/{}", self.conf.open_router.url, "health");
             let request = services::Request::new(services::Method::Get, &url);
             let _ = services::call_connector_api(self, request, "health_check_for_decision_engine")
                 .await

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2166,7 +2166,7 @@ pub async fn create_customer_if_not_exist<'a, F: Clone, R, D>(
                     if customers::is_customer_id_in_global_format(&customer_id) {
                         Err(report!(errors::StorageError::InvalidDataFormat(format!(
                             "customer_id '{}' format is not supported",
-                            &customer_id.get_string_repr()
+                            customer_id.get_string_repr()
                         ))))?
                     }
 
@@ -4327,7 +4327,7 @@ pub async fn make_ephemeral_key(
 ) -> errors::RouterResponse<ephemeral_key::EphemeralKey> {
     let store = &state.store;
     let id = utils::generate_id(consts::ID_LENGTH, "eki");
-    let secret = format!("epk_{}", &Uuid::new_v4().simple().to_string());
+    let secret = format!("epk_{}", Uuid::new_v4().simple());
     let ek = ephemeral_key::EphemeralKeyNew {
         id,
         customer_id,
@@ -7515,7 +7515,7 @@ impl GooglePayTokenDecryptor {
             check_expiration_date_is_valid(&signed_key.key_expiration),
             Ok(true)
         ) {
-            return Err(errors::GooglePayDecryptionError::SignedKeyExpired)?;
+            Err(errors::GooglePayDecryptionError::SignedKeyExpired)?;
         }
         Ok(signed_key)
     }

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -378,7 +378,7 @@ async fn get_tracker_for_sync<
         .attach_printable_lazy(|| {
             format!(
                 "Failed while getting refund list for, payment_id: {:?}, merchant_id: {:?}",
-                &payment_id,
+                payment_id,
                 platform.get_processor().get_account().get_id()
             )
         })?;
@@ -393,7 +393,7 @@ async fn get_tracker_for_sync<
         .attach_printable_lazy(|| {
             format!(
                 "Failed while getting authorizations list for, payment_id: {:?}, merchant_id: {:?}",
-                &payment_id,
+                payment_id,
                 platform.get_processor().get_account().get_id()
             )
         })?;

--- a/crates/router/src/core/payouts/helpers.rs
+++ b/crates/router/src/core/payouts/helpers.rs
@@ -1491,22 +1491,16 @@ pub async fn update_payouts_and_payout_attempt(
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Error updating payouts")?;
-    let updated_business_country =
-        payout_attempt
-            .business_country
-            .map_or(req.business_country.to_owned(), |c| {
-                req.business_country
-                    .to_owned()
-                    .and_then(|nc| if nc != c { Some(nc) } else { None })
-            });
-    let updated_business_label =
-        payout_attempt
-            .business_label
-            .map_or(req.business_label.to_owned(), |l| {
-                req.business_label
-                    .to_owned()
-                    .and_then(|nl| if nl != l { Some(nl) } else { None })
-            });
+    let updated_business_country = payout_attempt
+        .business_country
+        .map_or(req.business_country.to_owned(), |c| {
+            req.business_country.to_owned().filter(|&nc| nc != c)
+        });
+    let updated_business_label = payout_attempt
+        .business_label
+        .map_or(req.business_label.to_owned(), |l| {
+            req.business_label.to_owned().filter(|nl| *nl != l)
+        });
     if updated_business_country.is_some()
         || updated_business_label.is_some()
         || customer_id.is_some()

--- a/crates/router/src/db/address.rs
+++ b/crates/router/src/db/address.rs
@@ -566,7 +566,7 @@ mod storage {
                         merchant_id: &merchant_id,
                         payment_id,
                     };
-                    let field = format!("add_{}", &address_new.address_id);
+                    let field = format!("add_{}", address_new.address_id);
                     let created_address = diesel_models::Address {
                         address_id: address_new.address_id.clone(),
                         city: address_new.city.clone(),

--- a/crates/router/src/db/ephemeral_key.rs
+++ b/crates/router/src/db/ephemeral_key.rs
@@ -86,8 +86,8 @@ mod storage {
             new: EphemeralKeyNew,
             validity: i64,
         ) -> CustomResult<EphemeralKey, errors::StorageError> {
-            let secret_key = format!("epkey_{}", &new.secret);
-            let id_key = format!("epkey_{}", &new.id);
+            let secret_key = format!("epkey_{}", new.secret);
+            let id_key = format!("epkey_{}", new.id);
 
             let created_at = date_time::now();
             let expires = created_at.saturating_add(validity.hours());
@@ -161,13 +161,13 @@ mod storage {
 
             self.get_redis_conn()
                 .map_err(Into::<errors::StorageError>::into)?
-                .delete_key(&format!("epkey_{}", &ek.id).into())
+                .delete_key(&format!("epkey_{}", ek.id).into())
                 .await
                 .change_context(errors::StorageError::KVError)?;
 
             self.get_redis_conn()
                 .map_err(Into::<errors::StorageError>::into)?
-                .delete_key(&format!("epkey_{}", &ek.secret).into())
+                .delete_key(&format!("epkey_{}", ek.secret).into())
                 .await
                 .change_context(errors::StorageError::KVError)?;
             Ok(ek)

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -661,7 +661,7 @@ mod storage {
 
                     let field = format!(
                         "pa_{}_ref_{}",
-                        &created_refund.attempt_id, &created_refund.refund_id
+                        created_refund.attempt_id, created_refund.refund_id
                     );
 
                     let mut reverse_lookups = vec![
@@ -844,7 +844,7 @@ mod storage {
                 merchant_id: &merchant_id,
                 payment_id: &payment_id,
             };
-            let field = format!("pa_{}_ref_{}", &this.attempt_id, &this.refund_id);
+            let field = format!("pa_{}_ref_{}", this.attempt_id, this.refund_id);
             let storage_scheme = Box::pin(decide_storage_scheme::<_, diesel_refund::Refund>(
                 self,
                 storage_scheme,

--- a/crates/router/src/db/reverse_lookup.rs
+++ b/crates/router/src/db/reverse_lookup.rs
@@ -127,7 +127,7 @@ mod storage {
                         PartitionKey::CombinationKey {
                             combination: &format!(
                                 "reverse_lookup_{}",
-                                &created_rev_lookup.lookup_id
+                                created_rev_lookup.lookup_id
                             ),
                         },
                     ))

--- a/crates/router/src/utils/currency.rs
+++ b/crates/router/src/utils/currency.rs
@@ -387,14 +387,10 @@ pub async fn fetch_forex_rates_from_fallback_api(
 
     let mut conversions: HashMap<enums::Currency, CurrencyFactors> = HashMap::new();
     for enum_curr in enums::Currency::iter() {
-        match fallback_forex_response.quotes.get(
-            format!(
-                "{}{}",
-                FALLBACK_FOREX_API_CURRENCY_PREFIX,
-                &enum_curr.to_string()
-            )
-            .as_str(),
-        ) {
+        match fallback_forex_response
+            .quotes
+            .get(format!("{}{}", FALLBACK_FOREX_API_CURRENCY_PREFIX, enum_curr).as_str())
+        {
             Some(rate) => {
                 let from_factor = match Decimal::new(1, 0).checked_div(**rate) {
                     Some(rate) => rate,

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -264,7 +264,7 @@ fn connector_list() {
 
     let json = serde_json::to_string(&connector_list).unwrap();
 
-    println!("{}", &json);
+    println!("{}", json);
 
     let newlist: types::ConnectorsList = serde_json::from_str(&json).unwrap();
 

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -23,7 +23,7 @@ fn connector_list() {
 
     let json = serde_json::to_string(&connector_list).unwrap();
 
-    println!("{}", &json);
+    println!("{}", json);
 
     let newlist: types::ConnectorsList = serde_json::from_str(&json).unwrap();
 

--- a/crates/scheduler/src/consumer/types/batch.rs
+++ b/crates/scheduler/src/consumer/types/batch.rs
@@ -82,7 +82,7 @@ impl ProcessTrackerBatch {
                     .change_context(errors::ParsingError::UnknownError)
                     .change_context(errors::ProcessTrackerError::DeserializationFailed)?,
             )
-            .attach_printable_lazy(|| format!("Unable to parse time {}", &created_time))
+            .attach_printable_lazy(|| format!("Unable to parse time {}", created_time))
             .change_context(errors::ProcessTrackerError::MissingRequiredField)?;
             PrimitiveDateTime::new(offset_date_time.date(), offset_date_time.time())
         };

--- a/crates/storage_impl/src/lookup.rs
+++ b/crates/storage_impl/src/lookup.rs
@@ -103,7 +103,7 @@ impl<T: DatabaseStore> ReverseLookupInterface for KVRouterStore<T> {
                     self,
                     KvOperation::SetNx(&created_rev_lookup, drainer_query),
                     PartitionKey::CombinationKey {
-                        combination: &format!("reverse_lookup_{}", &created_rev_lookup.lookup_id),
+                        combination: &format!("reverse_lookup_{}", created_rev_lookup.lookup_id),
                     },
                 ))
                 .await

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -831,7 +831,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     lookup_id: format!(
                         "pa_{}_{}",
                         created_attempt.processor_merchant_id.get_string_repr(),
-                        &created_attempt.attempt_id,
+                        created_attempt.attempt_id,
                     ),
                     pk_id: key_str.clone(),
                     sk_id: field.clone(),

--- a/crates/storage_impl/src/payouts/payout_attempt.rs
+++ b/crates/storage_impl/src/payouts/payout_attempt.rs
@@ -103,8 +103,8 @@ impl<T: DatabaseStore> PayoutAttemptInterface for KVRouterStore<T> {
                 let reverse_lookup = ReverseLookupNew {
                     lookup_id: format!(
                         "poa_{}_{}",
-                        &created_attempt.merchant_id.get_string_repr(),
-                        &created_attempt.payout_attempt_id,
+                        created_attempt.merchant_id.get_string_repr(),
+                        created_attempt.payout_attempt_id,
                     ),
                     pk_id: key_str.clone(),
                     sk_id: field.clone(),

--- a/crates/test_utils/src/newman_runner.rs
+++ b/crates/test_utils/src/newman_runner.rs
@@ -165,7 +165,7 @@ pub fn generate_newman_command_for_users() -> Result<ReturnArgs> {
 
     newman_command.args([
         "--delay-request",
-        format!("{}", &args.delay_request).as_str(),
+        format!("{}", args.delay_request).as_str(),
     ]);
 
     newman_command.arg("--color").arg("on");
@@ -299,7 +299,7 @@ pub fn generate_newman_command_for_connector() -> Result<ReturnArgs> {
 
     newman_command.args([
         "--delay-request",
-        format!("{}", &args.delay_request).as_str(),
+        format!("{}", args.delay_request).as_str(),
     ]);
 
     newman_command.arg("--color").arg("on");


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR addresses clippy lints due to Rust 1.97.0. Most of the changes are straightforward, one of the lints with some changes was [`clippy::manual_filter`](https://rust-lang.github.io/rust-clippy/stable/index.html#manual_filter).

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This PR addresses clippy lints arising due to a new Rust version.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

`just clippy` and `just clippy_v2` pass locally when run with Rust 1.97 locally.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
