### PR TITLE
refactor(connector): [Nexixpay] fail 3DS validation when PaRes missing from ACS return

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nexixpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nexixpay/transformers.rs
@@ -676,57 +676,60 @@ pub struct RedirectPayload {
     payment_id: Option<String>,
 }
 
-impl TryFrom<&PaymentsPreProcessingRouterData> for NexixpayRedirectRequest {
-    type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &PaymentsPreProcessingRouterData) -> Result<Self, Self::Error> {
-        let redirect_response = item.request.redirect_response.clone().ok_or(
-            errors::ConnectorError::MissingRequiredField {
-                field_name: "redirect_response",
-            },
-        )?;
+impl NexixpayRedirectRequest {
+    // Build the 3-step validation payload from the customer's return-from-3DS
+    // redirect body. If either `PaRes` or `paymentId` is absent — which is what
+    // happens when the customer abandons or fails to complete the ACS challenge —
+    // fail here rather than forwarding null values to Nexi (which would surface
+    // as opaque `GW0001`).
+    fn from_redirect_response(
+        redirect_response: Option<CompleteAuthorizeRedirectResponse>,
+    ) -> Result<Self, error_stack::Report<errors::ConnectorError>> {
         let redirect_payload = redirect_response
+            .ok_or(errors::ConnectorError::MissingRequiredField {
+                field_name: "redirect_response",
+            })?
             .payload
             .ok_or(errors::ConnectorError::MissingConnectorRedirectionPayload {
                 field_name: "request.redirect_response.payload",
             })?
             .expose();
         let customer_details_encrypted: RedirectPayload =
-            serde_json::from_value::<RedirectPayload>(redirect_payload.clone()).change_context(
+            serde_json::from_value::<RedirectPayload>(redirect_payload).change_context(
                 errors::ConnectorError::MissingConnectorRedirectionPayload {
                     field_name: "redirection_payload",
                 },
             )?;
+
+        let three_d_s_auth_response = customer_details_encrypted.pa_res.ok_or(
+            errors::ConnectorError::MissingConnectorRedirectionPayload {
+                field_name: "PaRes",
+            },
+        )?;
+        let operation_id = customer_details_encrypted.payment_id.ok_or(
+            errors::ConnectorError::MissingConnectorRedirectionPayload {
+                field_name: "paymentId",
+            },
+        )?;
+
         Ok(Self {
-            operation_id: customer_details_encrypted.payment_id,
-            three_d_s_auth_response: customer_details_encrypted.pa_res,
+            operation_id: Some(operation_id),
+            three_d_s_auth_response: Some(three_d_s_auth_response),
         })
+    }
+}
+
+impl TryFrom<&PaymentsPreProcessingRouterData> for NexixpayRedirectRequest {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(item: &PaymentsPreProcessingRouterData) -> Result<Self, Self::Error> {
+        Self::from_redirect_response(item.request.redirect_response.clone())
     }
 }
 
 impl TryFrom<&PaymentsPostAuthenticateRouterData> for NexixpayRedirectRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &PaymentsPostAuthenticateRouterData) -> Result<Self, Self::Error> {
-        let redirect_response = item.request.redirect_response.clone().ok_or(
-            errors::ConnectorError::MissingRequiredField {
-                field_name: "redirect_response",
-            },
-        )?;
-        let redirect_payload = redirect_response
-            .payload
-            .ok_or(errors::ConnectorError::MissingConnectorRedirectionPayload {
-                field_name: "request.redirect_response.payload",
-            })?
-            .expose();
-        let customer_details_encrypted: RedirectPayload =
-            serde_json::from_value::<RedirectPayload>(redirect_payload.clone()).change_context(
-                errors::ConnectorError::MissingConnectorRedirectionPayload {
-                    field_name: "redirection_payload",
-                },
-            )?;
-        Ok(Self {
-            operation_id: customer_details_encrypted.payment_id,
-            three_d_s_auth_response: customer_details_encrypted.pa_res,
-        })
+        Self::from_redirect_response(item.request.redirect_response.clone())
     }
 }
 


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- When the customer abandons or fails to complete the ACS challenge, the return-from-3DS payload lands at PostAuthenticate without `PaRes` / `paymentId`. Prior behaviour silently
   deserialized both to `None` and forwarded `{"operationId": null, "threeDSAuthResponse": null}` to Nexi's `/orders/3steps/validation`, which came back with the opaque `GW0001 -
  An internal error occurred` — leaving merchants without a meaningful failure reason.
  - This change short-circuits `NexixpayRedirectRequest::from_redirect_response` (shared by the `PreProcessing` and `PostAuthenticate` `TryFrom` impls) to fail locally with
  `MissingConnectorRedirectionPayload { field_name: "PaRes" }` (or `"paymentId"`) instead of making the doomed connector call.
  - Happy path (challenge completed) is unchanged: both fields are present, the guards pass, and the same request goes to Nexi as before.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
