### PR TITLE
feat(revenue-recovery): A/B testing framework to compare retry algorithms

### DIFF
--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -23574,6 +23574,11 @@
             "description": "First Payment Attempt Network Advice Code",
             "example": "02",
             "nullable": true
+          },
+          "recovery_routing": {
+            "type": "object",
+            "description": "Revenue recovery A/B routing assignment (opaque JSON; the typed shape is\nowned and (de)serialized by the router's revenue_recovery::routing module).",
+            "nullable": true
           }
         }
       },

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -571,6 +571,39 @@ impl PaymentsUpdateIntentRequest {
             enable_partial_authorization: None,
         }
     }
+
+    /// Build an update that changes ONLY `feature_metadata`, leaving the active
+    /// attempt (and every other field) unchanged. `set_active_attempt_id: None`
+    /// means "don't touch the active attempt". Used to persist data such as the
+    /// revenue-recovery A/B routing assignment without side effects.
+    pub fn update_feature_metadata_with_api(feature_metadata: FeatureMetadata) -> Self {
+        Self {
+            feature_metadata: Some(feature_metadata),
+            set_active_attempt_id: None,
+            amount_details: None,
+            routing_algorithm_id: None,
+            capture_method: None,
+            authentication_type: None,
+            billing: None,
+            shipping: None,
+            customer_present: None,
+            description: None,
+            return_url: None,
+            setup_future_usage: None,
+            apply_mit_exemption: None,
+            statement_descriptor: None,
+            order_details: None,
+            allowed_payment_method_types: None,
+            metadata: None,
+            connector_metadata: None,
+            payment_link_config: None,
+            request_incremental_authorization: None,
+            session_expiry: None,
+            frm_metadata: None,
+            request_external_three_ds_authentication: None,
+            enable_partial_authorization: None,
+        }
+    }
 }
 
 #[derive(Debug, serde::Serialize, Clone, ToSchema)]
@@ -13409,6 +13442,11 @@ pub struct PaymentRevenueRecoveryMetadata {
     /// First Payment Attempt Network Advice Code
     #[schema(value_type = Option<String>, example = "02")]
     pub first_payment_attempt_network_advice_code: Option<String>,
+    /// Revenue recovery A/B routing assignment (opaque JSON; the typed shape is
+    /// owned and (de)serialized by the router's revenue_recovery::routing module).
+    #[serde(default)]
+    #[schema(value_type = Option<Object>)]
+    pub recovery_routing: Option<serde_json::Value>,
 }
 
 #[cfg(feature = "v2")]

--- a/crates/common_utils/src/id_type/global_id/payment.rs
+++ b/crates/common_utils/src/id_type/global_id/payment.rs
@@ -43,6 +43,12 @@ impl GlobalPaymentId {
     }
 }
 
+impl crate::id_type::TargetingKey for GlobalPaymentId {
+    fn targeting_key_value(&self) -> &str {
+        self.get_string_repr()
+    }
+}
+
 // TODO: refactor the macro to include this id use case as well
 impl TryFrom<std::borrow::Cow<'static, str>> for GlobalPaymentId {
     type Error = error_stack::Report<errors::ValidationError>;

--- a/crates/diesel_models/src/types.rs
+++ b/crates/diesel_models/src/types.rs
@@ -490,6 +490,10 @@ pub struct PaymentRevenueRecoveryMetadata {
     pub first_payment_attempt_network_decline_code: Option<String>,
     /// First Payment Attempt Network Advice Code
     pub first_payment_attempt_network_advice_code: Option<String>,
+    /// Revenue recovery A/B routing assignment (opaque JSON; the typed shape is
+    /// owned and (de)serialized by the router's revenue_recovery::routing module).
+    #[serde(default)]
+    pub recovery_routing: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/crates/hyperswitch_domain_models/src/lib.rs
+++ b/crates/hyperswitch_domain_models/src/lib.rs
@@ -947,6 +947,7 @@ impl ApiModelToDieselModelConvertor<ApiRevenueRecoveryMetadata> for PaymentReven
                 .first_payment_attempt_network_decline_code,
             first_payment_attempt_pg_error_code: from.first_payment_attempt_pg_error_code,
             invoice_billing_started_at_time: from.invoice_billing_started_at_time,
+            recovery_routing: from.recovery_routing,
         }
     }
 
@@ -972,6 +973,7 @@ impl ApiModelToDieselModelConvertor<ApiRevenueRecoveryMetadata> for PaymentReven
                 .first_payment_attempt_network_decline_code,
             first_payment_attempt_pg_error_code: self.first_payment_attempt_pg_error_code,
             invoice_billing_started_at_time: self.invoice_billing_started_at_time,
+            recovery_routing: self.recovery_routing,
         }
     }
 }

--- a/crates/hyperswitch_domain_models/src/payments.rs
+++ b/crates/hyperswitch_domain_models/src/payments.rs
@@ -1664,6 +1664,13 @@ where
                 first_payment_attempt_network_advice_code: first_network_advice_code,
                 first_payment_attempt_network_decline_code: first_network_decline_code,
                 first_payment_attempt_pg_error_code: first_pg_error_code,
+                // Preserve the existing A/B routing assignment. The router
+                // chokepoint sets it on first assignment; it must stay sticky
+                // across subsequent attempts (rebuilding this metadata must not
+                // wipe assigned_at/outcome or force a Superposition re-query).
+                recovery_routing: revenue_recovery
+                    .as_ref()
+                    .and_then(|data| data.recovery_routing.clone()),
             }),
             None => Err(errors::api_error_response::ApiErrorResponse::InternalServerError)
                 .attach_printable("Connector not found in payment attempt")?,

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -438,6 +438,8 @@ pub mod superposition {
     pub const INCOMING_WEBHOOK_DISABLED_EVENTS: &str = "incoming_webhook_disabled_events";
     /// save wallet decrypted data in locker
     pub const SAVE_WALLET_DECRYPTED_DATA: &str = "save_wallet_decrypted_data";
+    /// Revenue recovery A/B routing configuration key
+    pub const REVENUE_RECOVERY_ROUTING: &str = "revenue_recovery_routing";
 }
 
 #[cfg(test)]

--- a/crates/router/src/core/configs/dimension_config.rs
+++ b/crates/router/src/core/configs/dimension_config.rs
@@ -655,6 +655,20 @@ impl DatabaseBackedConfig for PtMappingPcrRetries {
     }
 }
 
+// Revenue Recovery A/B routing decision. Resolved from Superposition; under an
+// experiment (keyed on the payment id targeting key) this is the assigned
+// variant's value. v2-only because the output type lives in the v2-gated
+// revenue_recovery module; gating the block keeps v1 builds from referencing it.
+#[cfg(feature = "v2")]
+config! {
+    superposition_key = REVENUE_RECOVERY_ROUTING,
+    output = crate::core::revenue_recovery::routing::RecoveryRoutingDecision,
+    default = crate::core::revenue_recovery::routing::RecoveryRoutingDecision::default(),
+    object = true,
+    requires = dimension_state::DimensionsWithProcessorMerchantIdAndConnector,
+    targeting_key = id_type::GlobalPaymentId
+}
+
 config! {
     superposition_key = PT_MAPPING_PAYMENT_SYNC,
     output = scheduler::types::process_data::ConnectorPTMapping,

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -7658,6 +7658,7 @@ impl ForeignFrom<&diesel_models::types::FeatureMetadata> for api_models::payment
                         .clone(),
                     invoice_billing_started_at_time: payment_revenue_recovery_metadata
                         .invoice_billing_started_at_time,
+                    recovery_routing: payment_revenue_recovery_metadata.recovery_routing.clone(),
                 }
             });
         let apple_pay_details = feature_metadata

--- a/crates/router/src/core/revenue_recovery.rs
+++ b/crates/router/src/core/revenue_recovery.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod routing;
 pub mod transformers;
 pub mod types;
 use std::marker::PhantomData;
@@ -499,6 +500,49 @@ async fn insert_psync_pcr_task_to_pt(
     Ok(response)
 }
 
+/// Persist a revenue-recovery A/B routing record (assignment, and any outcome set
+/// on it) onto the payment intent's `feature_metadata`. feature_metadata-only
+/// update, so the active attempt is left untouched. Persist failures are logged,
+/// not propagated — an analytics write must never break recovery.
+async fn persist_recovery_routing(
+    state: &SessionState,
+    payment_intent: &PaymentIntent,
+    revenue_recovery_payment_data: &pcr::RevenueRecoveryPaymentData,
+    routing_data: &routing::RevenueRecoveryRoutingData,
+    context: &'static str,
+) {
+    let Some(mut api_metadata) = payment_intent
+        .feature_metadata
+        .as_ref()
+        .and_then(|feature_metadata| feature_metadata.payment_revenue_recovery_metadata.clone())
+        .map(|diesel_metadata| diesel_metadata.convert_back())
+    else {
+        logger::warn!(context, "A/B routing: recovery metadata absent, skipping persist");
+        return;
+    };
+    api_metadata.recovery_routing = serde_json::to_value(routing_data).ok();
+    let updated_feature_metadata = payment_intent
+        .feature_metadata
+        .clone()
+        .unwrap_or_default()
+        .convert_back()
+        .set_payment_revenue_recovery_metadata_using_api(api_metadata);
+    let update_request = api_payments::PaymentsUpdateIntentRequest::update_feature_metadata_with_api(
+        updated_feature_metadata,
+    );
+    match Box::pin(api::update_payment_intent_api(
+        state,
+        payment_intent.id.clone(),
+        revenue_recovery_payment_data,
+        update_request,
+    ))
+    .await
+    {
+        Ok(_) => logger::info!(context, variant = %routing_data.variant, "A/B routing: persisted"),
+        Err(error) => logger::error!(?error, context, "A/B routing: persist failed"),
+    }
+}
+
 pub async fn perform_payments_sync(
     state: &SessionState,
     process: &storage::ProcessTracker,
@@ -546,6 +590,12 @@ pub async fn perform_payments_sync(
     )
     .await?;
 
+    // Revenue Recovery A/B routing: the outcome is NOT persisted here. Whether the
+    // invoice recovered is already authoritatively recorded on the payment itself
+    // (`payment_intent.status`), and the assigned algorithm/variant is persisted on
+    // the assignment at CALCULATE time. Analytics derives the per-variant outcome by
+    // joining the two (status/amount/modified_at × recovery_routing.assigned_algorithm),
+    // so there is nothing to write on the succeeded psync path.
     Ok(())
 }
 
@@ -597,6 +647,74 @@ pub async fn perform_calculate_workflow(
             return Err(sch_errors::ProcessTrackerError::ProcessUpdateFailed);
         }
     };
+
+    // ── Revenue Recovery A/B routing ────────────────────────────────────────
+    // Superposition's experiment engine makes the decision, keyed on the invoice
+    // id (the targeting key). We reuse the persisted assignment if present (sticky
+    // — no re-query), and only query Superposition on the first assignment. When
+    // an assignment exists it overrides the algorithm choice below; when the
+    // experiment is off there is no assignment and legacy routing is unchanged.
+    let ab_assigned_algorithm = {
+        let existing_routing = payment_intent
+            .feature_metadata
+            .as_ref()
+            .and_then(|feature_metadata| feature_metadata.payment_revenue_recovery_metadata.as_ref())
+            .and_then(|metadata| metadata.recovery_routing.as_ref())
+            .and_then(|value| {
+                serde_json::from_value::<routing::RevenueRecoveryRoutingData>(value.clone()).ok()
+            });
+        let ab_resolution = match existing_routing {
+            Some(existing) => routing::AbRoutingResolution::Reused(existing),
+            None => {
+                let ab_dimensions = crate::core::configs::dimension_state::Dimensions::new()
+                    .with_processor_merchant_id(payment_intent.merchant_id.clone().into())
+                    .with_connector(revenue_recovery_payment_data.billing_mca.connector_name);
+                let decision = ab_dimensions
+                    .get_revenue_recovery_routing(
+                        db,
+                        state.superposition_service.as_ref(),
+                        Some(&tracking_data.global_payment_id),
+                    )
+                    .await;
+                routing::from_decision(&decision, common_utils::date_time::now())
+            }
+        };
+        // When an assignment exists (created or reused), it drives the algorithm.
+        let assigned_algorithm = match &ab_resolution {
+            routing::AbRoutingResolution::Created(data)
+            | routing::AbRoutingResolution::Reused(data) => Some(data.assigned_algorithm),
+            _ => None,
+        };
+        match ab_resolution {
+            routing::AbRoutingResolution::Created(routing_data) => {
+                persist_recovery_routing(
+                    state,
+                    payment_intent,
+                    revenue_recovery_payment_data,
+                    &routing_data,
+                    "assignment created",
+                )
+                .await;
+            }
+            routing::AbRoutingResolution::Reused(routing_data) => {
+                logger::info!(
+                    variant = %routing_data.variant,
+                    "revenue_recovery A/B routing: reused existing assignment"
+                );
+            }
+            other => {
+                logger::info!(
+                    resolution = ?other,
+                    "revenue_recovery A/B routing: no assignment (disabled/invalid)"
+                );
+            }
+        }
+        assigned_algorithm
+    };
+
+    // An A/B assignment (when present) overrides the legacy algorithm choice; with
+    // the experiment off there is no assignment, so legacy routing is unchanged.
+    let retry_algorithm_type = ab_assigned_algorithm.unwrap_or(retry_algorithm_type);
 
     // External Payments which enter the calculate workflow for the first time will have active attempt id as None
     // Then we dont need to send an webhook to the merchant as its not a failure from our side.

--- a/crates/router/src/core/revenue_recovery.rs
+++ b/crates/router/src/core/revenue_recovery.rs
@@ -517,7 +517,10 @@ async fn persist_recovery_routing(
         .and_then(|feature_metadata| feature_metadata.payment_revenue_recovery_metadata.clone())
         .map(|diesel_metadata| diesel_metadata.convert_back())
     else {
-        logger::warn!(context, "A/B routing: recovery metadata absent, skipping persist");
+        logger::warn!(
+            context,
+            "A/B routing: recovery metadata absent, skipping persist"
+        );
         return;
     };
     api_metadata.recovery_routing = serde_json::to_value(routing_data).ok();
@@ -527,9 +530,10 @@ async fn persist_recovery_routing(
         .unwrap_or_default()
         .convert_back()
         .set_payment_revenue_recovery_metadata_using_api(api_metadata);
-    let update_request = api_payments::PaymentsUpdateIntentRequest::update_feature_metadata_with_api(
-        updated_feature_metadata,
-    );
+    let update_request =
+        api_payments::PaymentsUpdateIntentRequest::update_feature_metadata_with_api(
+            updated_feature_metadata,
+        );
     match Box::pin(api::update_payment_intent_api(
         state,
         payment_intent.id.clone(),
@@ -658,7 +662,9 @@ pub async fn perform_calculate_workflow(
         let existing_routing = payment_intent
             .feature_metadata
             .as_ref()
-            .and_then(|feature_metadata| feature_metadata.payment_revenue_recovery_metadata.as_ref())
+            .and_then(|feature_metadata| {
+                feature_metadata.payment_revenue_recovery_metadata.as_ref()
+            })
             .and_then(|metadata| metadata.recovery_routing.as_ref())
             .and_then(|value| {
                 serde_json::from_value::<routing::RevenueRecoveryRoutingData>(value.clone()).ok()

--- a/crates/router/src/core/revenue_recovery/routing.rs
+++ b/crates/router/src/core/revenue_recovery/routing.rs
@@ -147,8 +147,10 @@ mod tests {
 
     #[test]
     fn enabled_decision_creates_assignment() {
-        let resolution =
-            from_decision(&decision(true, "treatment_smart", "smart"), fixed_timestamp());
+        let resolution = from_decision(
+            &decision(true, "treatment_smart", "smart"),
+            fixed_timestamp(),
+        );
         let expected = RevenueRecoveryRoutingData {
             experiment_name: "rr_smart_vs_cascading_2026_q3".to_string(),
             variant: "treatment_smart".to_string(),
@@ -172,8 +174,10 @@ mod tests {
 
     #[test]
     fn unsupported_algorithm_is_invalid() {
-        let resolution =
-            from_decision(&decision(true, "treatment", "nonexistent"), fixed_timestamp());
+        let resolution = from_decision(
+            &decision(true, "treatment", "nonexistent"),
+            fixed_timestamp(),
+        );
         assert_eq!(
             resolution,
             AbRoutingResolution::InvalidConfig("nonexistent".to_string())

--- a/crates/router/src/core/revenue_recovery/routing.rs
+++ b/crates/router/src/core/revenue_recovery/routing.rs
@@ -1,0 +1,182 @@
+//! A/B routing for Revenue Recovery (e.g. Smart vs Cascading).
+//!
+//! The routing *decision* is made by **Superposition's experiment engine**: the
+//! config key resolves — under an experiment, keyed on the invoice id (the
+//! targeting key) — to the assigned variant's value, which embeds both the
+//! `variant` label and the `algorithm` to run. This module maps that resolved
+//! decision into the record we persist on the payment intent and reuse for the
+//! invoice's whole recovery life.
+//!
+//! Stickiness comes from **persist-and-reuse** (the assignment is written to
+//! `feature_metadata` once and reused), not from recomputation — so a later
+//! config/split change never re-routes an in-flight invoice.
+//!
+//! Design reference: `revenue-recovery/ab-routing-approach.md`.
+
+use std::str::FromStr;
+
+use common_enums::enums::RevenueRecoveryAlgorithmType;
+use serde::{Deserialize, Serialize};
+use time::PrimitiveDateTime;
+
+/// The routing decision resolved from Superposition. Under an experiment this is
+/// the assigned variant's value (which embeds the variant label + algorithm);
+/// otherwise it is the base/default value.
+///
+/// `Default` is the safe/disabled state, so a missing or unparseable value falls
+/// back to legacy routing.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct RecoveryRoutingDecision {
+    /// `false` (default) → not enrolled in an experiment; keep legacy routing.
+    #[serde(default)]
+    pub enabled: bool,
+    /// The experiment this decision belongs to.
+    #[serde(default)]
+    pub experiment_name: String,
+    /// The assigned variant label (e.g. `treatment_smart`).
+    #[serde(default)]
+    pub variant: String,
+    /// The algorithm to run (`smart` / `cascading`).
+    #[serde(default)]
+    pub algorithm: String,
+}
+
+/// The persisted assignment record. Written once onto the payment intent's
+/// `feature_metadata` and reused for the rest of the invoice's recovery life.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevenueRecoveryRoutingData {
+    /// The experiment this invoice was assigned under.
+    pub experiment_name: String,
+    /// The assigned variant label.
+    pub variant: String,
+    /// The algorithm the experiment intended to run.
+    pub assigned_algorithm: RevenueRecoveryAlgorithmType,
+    /// When the assignment was made.
+    pub assigned_at: PrimitiveDateTime,
+}
+
+// NOTE: the algorithm that *actually* ran (after dispatch/fallbacks — e.g.
+// smart-with-retry vs smart-no-retry vs smart-error) is deliberately not stored
+// yet; capturing it needs the decider proto and is out of v1 scope. It is left
+// out rather than kept as an always-null field, since a null would be ambiguous
+// (`no fallback occurred` vs `never captured`). This record is opaque JSON with
+// serde defaults, so the field can be added later without a migration.
+
+// NOTE: the recovery outcome is intentionally NOT stored on the assignment.
+// Whether an invoice recovered is authoritative on `payment_intent.status`, and
+// the amount/timing are on the payment intent too; analytics derives the
+// per-variant outcome by joining those with `assigned_algorithm`/`variant`. So
+// there is nothing to persist on the psync path (which also avoids updating a
+// `Succeeded` intent, an operation the payments layer rejects).
+
+/// The outcome of the assignment chokepoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AbRoutingResolution {
+    /// The invoice already had an assignment; reuse it (sticky, never recomputed).
+    Reused(RevenueRecoveryRoutingData),
+    /// A fresh assignment was produced from the Superposition decision.
+    Created(RevenueRecoveryRoutingData),
+    /// No active experiment for this invoice; the caller keeps legacy routing.
+    DisabledOrUnavailable,
+    /// The decision was present but its algorithm is unsupported (holds the value).
+    InvalidConfig(String),
+}
+
+fn parse_algorithm(value: &str) -> Option<RevenueRecoveryAlgorithmType> {
+    RevenueRecoveryAlgorithmType::from_str(value).ok()
+}
+
+/// Map a Superposition routing decision into a fresh assignment.
+///
+/// - disabled → `DisabledOrUnavailable` (legacy routing)
+/// - unsupported `algorithm` → `InvalidConfig`
+/// - otherwise → `Created` (the assignment to persist and route by)
+///
+/// Reuse of an existing assignment is handled by the caller (it must not query
+/// Superposition when the invoice is already assigned) — that is what makes the
+/// assignment sticky.
+pub fn from_decision(
+    decision: &RecoveryRoutingDecision,
+    assigned_at: PrimitiveDateTime,
+) -> AbRoutingResolution {
+    if !decision.enabled {
+        return AbRoutingResolution::DisabledOrUnavailable;
+    }
+    match parse_algorithm(&decision.algorithm) {
+        Some(assigned_algorithm) => AbRoutingResolution::Created(RevenueRecoveryRoutingData {
+            experiment_name: decision.experiment_name.clone(),
+            variant: decision.variant.clone(),
+            assigned_algorithm,
+            assigned_at,
+        }),
+        None => AbRoutingResolution::InvalidConfig(decision.algorithm.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_timestamp() -> PrimitiveDateTime {
+        PrimitiveDateTime::new(
+            time::Date::from_calendar_date(2026, time::Month::January, 1).unwrap(),
+            time::Time::MIDNIGHT,
+        )
+    }
+
+    fn decision(enabled: bool, variant: &str, algorithm: &str) -> RecoveryRoutingDecision {
+        RecoveryRoutingDecision {
+            enabled,
+            experiment_name: "rr_smart_vs_cascading_2026_q3".to_string(),
+            variant: variant.to_string(),
+            algorithm: algorithm.to_string(),
+        }
+    }
+
+    #[test]
+    fn disabled_decision_is_disabled_or_unavailable() {
+        let resolution = from_decision(&decision(false, "", "cascading"), fixed_timestamp());
+        assert_eq!(resolution, AbRoutingResolution::DisabledOrUnavailable);
+    }
+
+    #[test]
+    fn default_decision_is_disabled() {
+        let resolution = from_decision(&RecoveryRoutingDecision::default(), fixed_timestamp());
+        assert_eq!(resolution, AbRoutingResolution::DisabledOrUnavailable);
+    }
+
+    #[test]
+    fn enabled_decision_creates_assignment() {
+        let resolution =
+            from_decision(&decision(true, "treatment_smart", "smart"), fixed_timestamp());
+        let expected = RevenueRecoveryRoutingData {
+            experiment_name: "rr_smart_vs_cascading_2026_q3".to_string(),
+            variant: "treatment_smart".to_string(),
+            assigned_algorithm: RevenueRecoveryAlgorithmType::Smart,
+            assigned_at: fixed_timestamp(),
+        };
+        assert_eq!(resolution, AbRoutingResolution::Created(expected));
+    }
+
+    #[test]
+    fn cascading_decision_creates_cascading_assignment() {
+        let resolution = from_decision(
+            &decision(true, "control_cascading", "cascading"),
+            fixed_timestamp(),
+        );
+        assert!(matches!(
+            resolution,
+            AbRoutingResolution::Created(data) if data.assigned_algorithm == RevenueRecoveryAlgorithmType::Cascading
+        ));
+    }
+
+    #[test]
+    fn unsupported_algorithm_is_invalid() {
+        let resolution =
+            from_decision(&decision(true, "treatment", "nonexistent"), fixed_timestamp());
+        assert_eq!(
+            resolution,
+            AbRoutingResolution::InvalidConfig("nonexistent".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds an A/B testing framework for Revenue Recovery retry routing, so the **Smart**
(decider-based) and **Cascading** (rules-based) algorithms can run side by side on live
traffic and be compared on real recovered revenue.

**The decision is made by Superposition's experiment engine**, keyed on the invoice id
(`GlobalPaymentId`) as the targeting key, which gives deterministic bucketing per invoice.
Each experiment variant overrides the whole config value with its own `variant` +
`algorithm`, so a single resolve returns the assigned arm — no separate
applicable-variants call is needed.

Changes:

- **`core/revenue_recovery/routing.rs`** (new): the pure assignment core.
  `RecoveryRoutingDecision { enabled, experiment_name, variant, algorithm }` is the value
  resolved from Superposition; `from_decision()` maps it to
  `AbRoutingResolution::{ Reused, Created, DisabledOrUnavailable, InvalidConfig }` and to
  the persisted `RevenueRecoveryRoutingData { experiment_name, variant, assigned_algorithm,
  assigned_at }`.
- **Superposition config key `revenue_recovery_routing`** wired through the existing
  `dimension_config!` macro — output `RecoveryRoutingDecision`, targeting key
  `GlobalPaymentId`, dimensions `processor_merchant_id` + `connector`, default
  `{ enabled: false }`.
- **Assignment chokepoint in `perform_calculate_workflow`**: reuse the persisted assignment
  if present (sticky — deliberately does *not* re-query Superposition), else resolve once and
  persist. The assigned algorithm then overrides `retry_algorithm_type` for that invoice.
- **Persistence via the existing `feature_metadata`** (no new table): stored at
  `feature_metadata.payment_revenue_recovery_metadata.recovery_routing`, written by a
  `persist_recovery_routing` helper that updates *only* `feature_metadata`.
- **`get_updated_feature_metadata` now preserves `recovery_routing`** — without this, every
  new failed-payment attempt rebuilds the recovery metadata and wipes the assignment,
  breaking stickiness.
- **`TargetingKey` impl for `GlobalPaymentId`** in `common_utils` (required there by the
  orphan rule).

**Fail-safe by design:** with no active experiment the decision resolves to
`enabled: false` → no assignment → legacy routing is completely unchanged. An unparseable
algorithm resolves to `InvalidConfig` → also legacy routing.

**The outcome is intentionally not stored.** Whether an invoice recovered is already
authoritative on `payment_intent.status` (with amount/timing on the intent), so analytics
derives per-variant results by joining that with the persisted assignment:

```sql
select feature_metadata->'payment_revenue_recovery_metadata'->'recovery_routing'->>'variant',
       count(*),
       count(*) filter (where status = 'succeeded') as recovered
from payment_intent
where feature_metadata->'payment_revenue_recovery_metadata'->'recovery_routing' is not null
group by 1;
```

This avoids storing redundant data and avoids writing to an intent in a terminal
(`succeeded`) state, which the payments update operation rejects by design.

> **Operational note:** a Superposition experiment only takes effect if at least one
> *user-created* experiment group exists in the workspace. With only auto-generated system
> groups, the client's context-less `/experiment-config` fetch returns no groups and routing
> silently falls back to legacy.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

**API contract:** additive and backward-compatible only — a new optional
`recovery_routing: Option<Value>` field on `PaymentRevenueRecoveryMetadata`
(`crates/api_models/src/payments.rs`), which is `ToSchema`/openapi-exposed. No existing
field changed. Also adds an internal `PaymentsUpdateIntentRequest::update_feature_metadata_with_api`
constructor (no new endpoint).

**No schema change:** the assignment lives in the existing `payment_intent.feature_metadata`
JSONB column — no migration.

**No config/env change:** no files under `config/`, `crates/router/src/configs`, or
`loadtest/config` were modified. The experiment itself is authored in Superposition at
runtime, which is the point — the split can be started, ramped, or stopped without a deploy.

## Motivation and Context

Closes #13324

Revenue Recovery routes every invoice through a single retry algorithm chosen per business
profile (`revenue_recovery_retry_algorithm_type`). A merchant has to pick `smart` or
`cascading` blind — there is no way to run both on live traffic and measure which actually
recovers more revenue.

This makes that comparison possible while guaranteeing the properties an experiment needs:

- **Deterministic** — the same invoice always buckets to the same arm.
- **Sticky** — the assignment is persisted once and reused for the invoice's entire recovery
  life, so an in-flight invoice never switches arms mid-retry even if the split changes.
- **Fail-safe** — no experiment means byte-identical legacy behaviour.
- **Runtime-configurable** — start/ramp/stop the split without a deploy.

## How did you test it?

**Unit tests** (5, in `core/revenue_recovery/routing.rs`) covering `from_decision`: disabled →
legacy, default → legacy, enabled → assignment created, cascading arm, and unsupported
algorithm → `InvalidConfig`.

**End-to-end against a live local stack** (router + scheduler producer/consumer + Postgres +
Redis + Superposition), by onboarding a v2 merchant/profile/connectors and driving real
invoices through `POST /v2/payments/recovery` → `CALCULATE_WORKFLOW`:

1. **Assignment + split** — 13 invoices routed through the real recovery flow produced both
   arms (7 `control_cascading` / 6 `treatment_smart`), each persisted to
   `feature_metadata.recovery_routing` with the correct `experiment_name`/`variant`/
   `assigned_algorithm`.
2. **Split ratio + determinism** — resolving 1000 synthetic invoice ids through the exact
   production resolve path gave **50.9% / 49.1%**, and re-resolving every id returned the
   same arm (200/200 stable).
3. **Stickiness (reuse)** — replaced a persisted assignment with a sentinel and re-ran
   `CALCULATE`: the sentinel survived byte-for-byte and the log confirmed
   `reused existing assignment` with **no** Superposition re-query.
4. **Stickiness across attempts** — firing additional failed-payment attempt webhooks at an
   assigned invoice keeps `variant`/`assigned_at` intact while `total_retry_count` still
   increments (this is the `get_updated_feature_metadata` fix; without it the assignment was
   wiped to `null`).
5. **Routing actually forks** — `pt_mapping_pcr_retries` is fetched *only* on the Cascading
   path. Across 6 invoices the correlation was exact: all 5 `cascading`-assigned invoices hit
   it, the `smart`-assigned one did not — proving the assignment drives which retry algorithm
   executes.
6. **Analytics derivation** — the per-variant recovery query above returns correct
   `invoices`/`recovered` counts per arm with no stored outcome.
7. **Fail-safe** — with the experiment not applying, every invoice resolved to
   `enabled: false` and used legacy routing.

Not covered: the Smart arm's decider gRPC call itself (the branch bails earlier when no PSP
tokens are present in Redis, and the decider service isn't run locally) — the *fork* is
verified, its internals are not.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
