### PR TITLE
chore(codeowners): add Prism ownership for UCS bridge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,7 @@ crates/router/src/core/unified_connector_service.rs @juspay/hyperswitch-prism
 crates/router/src/core/unified_connector_service/* @juspay/hyperswitch-prism
 crates/hyperswitch_interfaces/src/unified_connector_service.rs @juspay/hyperswitch-prism
 crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs @juspay/hyperswitch-prism
+crates/common_utils/src/ucs_types.rs @juspay/hyperswitch-prism
 crates/external_services/src/grpc_client/unified_connector_service.rs @juspay/hyperswitch-prism
 
 crates/external_services/Cargo.toml @juspay/hyperswitch-framework @juspay/hyperswitch-prism

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,6 +60,17 @@ crates/router/src/compatibility/ @juspay/hyperswitch-compatibility
 crates/router/src/core/ @juspay/hyperswitch-core
 crates/router/src/core/connector_validation.rs @juspay/hyperswitch-connector
 
+# Unified Connector Service bridge ownership
+crates/router/src/core/unified_connector_service.rs @juspay/hyperswitch-prism
+crates/router/src/core/unified_connector_service/* @juspay/hyperswitch-prism
+crates/hyperswitch_interfaces/src/unified_connector_service.rs @juspay/hyperswitch-prism
+crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs @juspay/hyperswitch-prism
+crates/external_services/src/grpc_client/unified_connector_service.rs @juspay/hyperswitch-prism
+
+crates/external_services/Cargo.toml @juspay/hyperswitch-framework @juspay/hyperswitch-prism
+crates/hyperswitch_interfaces/Cargo.toml @juspay/hyperswitch-framework @juspay/hyperswitch-prism
+crates/router/Cargo.toml @juspay/hyperswitch-framework @juspay/hyperswitch-prism
+
 crates/api_models/src/routing.rs @juspay/hyperswitch-routing
 crates/hyperswitch_constraint_graph @juspay/hyperswitch-routing
 crates/euclid @juspay/hyperswitch-routing


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Assigns the HS<>UCS bridge implementation files to `@juspay/hyperswitch-prism`. Adds Prism alongside Framework for the three crate manifests so Prism members can approve UCS client dependency updates without removing existing manifest ownership.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

UCS bridge changes currently fall under broad crate and router-core ownership rules. This adds specific ownership rules so active Prism team members can review and approve UCS-related changes.

## How did you test it?

- Confirmed every listed path exists.
- Verified the specific rules appear after the broad crate and router-core rules.
- Ran `git diff --check`.

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

Formatting, Clippy, and unit tests are not applicable because this PR only changes `.github/CODEOWNERS`.