### PR TITLE
docs(readme): fix broken cloud deployment link (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Hyperswitch offers a fully hosted sandbox environment that requires no setup. Yo
 
 You can deploy to AWS, GCP, or Azure using Helm Charts.
 
-<a href="https://docs.hyperswitch.io/hyperswitch-open-source/deploy-on-kubernetes-using-helm">Cloud Deployment Instructions</a>.
+<a href="https://docs.hyperswitch.io/self-hosting">Cloud Deployment Instructions</a>.
 
 
 <a href="#architectural-overview">


### PR DESCRIPTION
Closes #13337

The "Cloud Deployment Instructions" link in the README returned HTTP 404 after a docs-site restructure that retired the `/hyperswitch-open-source/...` path space.

- Old (404): https://docs.hyperswitch.io/hyperswitch-open-source/deploy-on-kubernetes-using-helm
- New (200): https://docs.hyperswitch.io/self-hosting — current self-hosting landing page covering Kubernetes/Helm deployment for AWS, GCP & Azure.

One-line README link update. Both URLs verified via curl (old=404, new=200).