### PR TITLE
docs: fix broken Cloud Deployment link in README (#13337)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Hyperswitch offers a fully hosted sandbox environment that requires no setup. Yo
 
 You can deploy to AWS, GCP, or Azure using Helm Charts.
 
-<a href="https://docs.hyperswitch.io/hyperswitch-open-source/deploy-on-kubernetes-using-helm">Cloud Deployment Instructions</a>.
+<a href="https://docs.hyperswitch.io/self-hosting">Cloud Deployment Instructions</a>.
 
 
 <a href="#architectural-overview">


### PR DESCRIPTION
## Description

Fixes the broken "Cloud Deployment Instructions" link in `README.md`.

The old URL returned HTTP 404 (the `/hyperswitch-open-source/...` docs path space was retired during a docs restructure):
- Old: `https://docs.hyperswitch.io/hyperswitch-open-source/deploy-on-kubernetes-using-helm`
- New: `https://docs.hyperswitch.io/self-hosting` (verified HTTP 200 — current self-hosting landing page covering Kubernetes/Helm deployment for AWS, GCP & Azure)

Closes #13337

## Type of change

- [x] Documentation update

## How did you test it?

Verified the old URL returns 404 and the replacement URL returns 200 and covers the same Kubernetes/Helm self-hosting content. Docs-only, one-line change.
