### PR TITLE
fix(analytics): apply merchant_order_reference_id, authentication_type and card_discovery filters in global search

### DIFF
--- a/crates/analytics/src/search.rs
+++ b/crates/analytics/src/search.rs
@@ -158,6 +158,24 @@ pub async fn msearch_results(
         append_filter!(query_builder, filters, payment_id, "payment_id.keyword");
         append_filter!(query_builder, filters, amount, "amount");
         append_filter!(query_builder, filters, customer_id, "customer_id.keyword");
+        append_filter!(
+            query_builder,
+            filters,
+            authentication_type,
+            "authentication_type.keyword"
+        );
+        append_filter!(
+            query_builder,
+            filters,
+            card_discovery,
+            "card_discovery.keyword"
+        );
+        append_filter!(
+            query_builder,
+            filters,
+            merchant_order_reference_id,
+            "merchant_order_reference_id.keyword"
+        );
     };
 
     if let Some(time_range) = req.time_range {

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -3962,81 +3962,7 @@ pub mod routes {
                 if !permission_groups.contains(&common_enums::PermissionGroup::OperationsView) {
                     Err(OpenSearchError::AccessForbiddenError)?;
                 }
-                let user_roles: HashSet<UserRole> = match role_info.get_entity_type() {
-                    EntityType::Tenant => state
-                        .global_store
-                        .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
-                            user_id: &auth.user_id,
-                            tenant_id: auth.tenant_id.as_ref().unwrap_or(&state.tenant.tenant_id),
-                            org_id: None,
-                            merchant_id: None,
-                            profile_id: None,
-                            entity_id: None,
-                            version: None,
-                            status: None,
-                            limit: None,
-                        })
-                        .await
-                        .change_context(UserErrors::InternalServerError)
-                        .change_context(OpenSearchError::UnknownError)?
-                        .into_iter()
-                        .collect(),
-                    EntityType::Organization | EntityType::Merchant | EntityType::Profile => state
-                        .global_store
-                        .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
-                            user_id: &auth.user_id,
-                            tenant_id: auth.tenant_id.as_ref().unwrap_or(&state.tenant.tenant_id),
-                            org_id: Some(&auth.org_id),
-                            merchant_id: None,
-                            profile_id: None,
-                            entity_id: None,
-                            version: None,
-                            status: None,
-                            limit: None,
-                        })
-                        .await
-                        .change_context(UserErrors::InternalServerError)
-                        .change_context(OpenSearchError::UnknownError)?
-                        .into_iter()
-                        .collect(),
-                };
-
                 let state = Arc::new(state);
-                let role_info_map: HashMap<String, RoleInfo> = user_roles
-                    .iter()
-                    .map(|user_role| {
-                        let state = Arc::clone(&state);
-                        let role_id = user_role.role_id.clone();
-                        let org_id = user_role.org_id.clone().unwrap_or_default();
-                        let tenant_id = &user_role.tenant_id;
-                        async move {
-                            RoleInfo::from_role_id_org_id_tenant_id(
-                                &state, &role_id, &org_id, tenant_id,
-                            )
-                            .await
-                            .change_context(UserErrors::InternalServerError)
-                            .change_context(OpenSearchError::UnknownError)
-                            .map(|role_info| (role_id, role_info))
-                        }
-                    })
-                    .collect::<FuturesUnordered<_>>()
-                    .collect::<Vec<_>>()
-                    .await
-                    .into_iter()
-                    .collect::<Result<HashMap<_, _>, _>>()?;
-
-                let filtered_user_roles: Vec<&UserRole> = user_roles
-                    .iter()
-                    .filter(|user_role| {
-                        let user_role_id = &user_role.role_id;
-                        if let Some(role_info) = role_info_map.get(user_role_id) {
-                            let permissions = role_info.get_permission_groups();
-                            permissions.contains(&common_enums::PermissionGroup::OperationsView)
-                        } else {
-                            false
-                        }
-                    })
-                    .collect();
 
                 let search_params: Vec<AuthInfo> = if role_info.is_internal() {
                     vec![AuthInfo::MerchantLevel {
@@ -4045,6 +3971,89 @@ pub mod routes {
                         processor_merchant_ids: None,
                     }]
                 } else {
+                    let user_roles: HashSet<UserRole> = match role_info.get_entity_type() {
+                        EntityType::Tenant => state
+                            .global_store
+                            .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
+                                user_id: &auth.user_id,
+                                tenant_id: auth
+                                    .tenant_id
+                                    .as_ref()
+                                    .unwrap_or(&state.tenant.tenant_id),
+                                org_id: None,
+                                merchant_id: None,
+                                profile_id: None,
+                                entity_id: None,
+                                version: None,
+                                status: None,
+                                limit: None,
+                            })
+                            .await
+                            .change_context(UserErrors::InternalServerError)
+                            .change_context(OpenSearchError::UnknownError)?
+                            .into_iter()
+                            .collect(),
+                        EntityType::Organization | EntityType::Merchant | EntityType::Profile => {
+                            state
+                                .global_store
+                                .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
+                                    user_id: &auth.user_id,
+                                    tenant_id: auth
+                                        .tenant_id
+                                        .as_ref()
+                                        .unwrap_or(&state.tenant.tenant_id),
+                                    org_id: Some(&auth.org_id),
+                                    merchant_id: None,
+                                    profile_id: None,
+                                    entity_id: None,
+                                    version: None,
+                                    status: None,
+                                    limit: None,
+                                })
+                                .await
+                                .change_context(UserErrors::InternalServerError)
+                                .change_context(OpenSearchError::UnknownError)?
+                                .into_iter()
+                                .collect()
+                        }
+                    };
+
+                    let role_info_map: HashMap<String, RoleInfo> = user_roles
+                        .iter()
+                        .map(|user_role| {
+                            let state = Arc::clone(&state);
+                            let role_id = user_role.role_id.clone();
+                            let org_id = user_role.org_id.clone().unwrap_or_default();
+                            let tenant_id = &user_role.tenant_id;
+                            async move {
+                                RoleInfo::from_role_id_org_id_tenant_id(
+                                    &state, &role_id, &org_id, tenant_id,
+                                )
+                                .await
+                                .change_context(UserErrors::InternalServerError)
+                                .change_context(OpenSearchError::UnknownError)
+                                .map(|role_info| (role_id, role_info))
+                            }
+                        })
+                        .collect::<FuturesUnordered<_>>()
+                        .collect::<Vec<_>>()
+                        .await
+                        .into_iter()
+                        .collect::<Result<HashMap<_, _>, _>>()?;
+
+                    let filtered_user_roles: Vec<&UserRole> = user_roles
+                        .iter()
+                        .filter(|user_role| {
+                            let user_role_id = &user_role.role_id;
+                            if let Some(role_info) = role_info_map.get(user_role_id) {
+                                let permissions = role_info.get_permission_groups();
+                                permissions.contains(&common_enums::PermissionGroup::OperationsView)
+                            } else {
+                                false
+                            }
+                        })
+                        .collect();
+
                     filtered_user_roles
                         .iter()
                         .filter_map(|user_role| {
@@ -4127,80 +4136,7 @@ pub mod routes {
                 if !permission_groups.contains(&common_enums::PermissionGroup::OperationsView) {
                     Err(OpenSearchError::AccessForbiddenError)?;
                 }
-                let user_roles: HashSet<UserRole> = match role_info.get_entity_type() {
-                    EntityType::Tenant => state
-                        .global_store
-                        .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
-                            user_id: &auth.user_id,
-                            tenant_id: auth.tenant_id.as_ref().unwrap_or(&state.tenant.tenant_id),
-                            org_id: None,
-                            merchant_id: None,
-                            profile_id: None,
-                            entity_id: None,
-                            version: None,
-                            status: None,
-                            limit: None,
-                        })
-                        .await
-                        .change_context(UserErrors::InternalServerError)
-                        .change_context(OpenSearchError::UnknownError)?
-                        .into_iter()
-                        .collect(),
-                    EntityType::Organization | EntityType::Merchant | EntityType::Profile => state
-                        .global_store
-                        .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
-                            user_id: &auth.user_id,
-                            tenant_id: auth.tenant_id.as_ref().unwrap_or(&state.tenant.tenant_id),
-                            org_id: Some(&auth.org_id),
-                            merchant_id: None,
-                            profile_id: None,
-                            entity_id: None,
-                            version: None,
-                            status: None,
-                            limit: None,
-                        })
-                        .await
-                        .change_context(UserErrors::InternalServerError)
-                        .change_context(OpenSearchError::UnknownError)?
-                        .into_iter()
-                        .collect(),
-                };
                 let state = Arc::new(state);
-                let role_info_map: HashMap<String, RoleInfo> = user_roles
-                    .iter()
-                    .map(|user_role| {
-                        let state = Arc::clone(&state);
-                        let role_id = user_role.role_id.clone();
-                        let org_id = user_role.org_id.clone().unwrap_or_default();
-                        let tenant_id = &user_role.tenant_id;
-                        async move {
-                            RoleInfo::from_role_id_org_id_tenant_id(
-                                &state, &role_id, &org_id, tenant_id,
-                            )
-                            .await
-                            .change_context(UserErrors::InternalServerError)
-                            .change_context(OpenSearchError::UnknownError)
-                            .map(|role_info| (role_id, role_info))
-                        }
-                    })
-                    .collect::<FuturesUnordered<_>>()
-                    .collect::<Vec<_>>()
-                    .await
-                    .into_iter()
-                    .collect::<Result<HashMap<_, _>, _>>()?;
-
-                let filtered_user_roles: Vec<&UserRole> = user_roles
-                    .iter()
-                    .filter(|user_role| {
-                        let user_role_id = &user_role.role_id;
-                        if let Some(role_info) = role_info_map.get(user_role_id) {
-                            let permissions = role_info.get_permission_groups();
-                            permissions.contains(&common_enums::PermissionGroup::OperationsView)
-                        } else {
-                            false
-                        }
-                    })
-                    .collect();
 
                 let search_params: Vec<AuthInfo> = if role_info.is_internal() {
                     vec![AuthInfo::MerchantLevel {
@@ -4209,6 +4145,89 @@ pub mod routes {
                         processor_merchant_ids: None,
                     }]
                 } else {
+                    let user_roles: HashSet<UserRole> = match role_info.get_entity_type() {
+                        EntityType::Tenant => state
+                            .global_store
+                            .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
+                                user_id: &auth.user_id,
+                                tenant_id: auth
+                                    .tenant_id
+                                    .as_ref()
+                                    .unwrap_or(&state.tenant.tenant_id),
+                                org_id: None,
+                                merchant_id: None,
+                                profile_id: None,
+                                entity_id: None,
+                                version: None,
+                                status: None,
+                                limit: None,
+                            })
+                            .await
+                            .change_context(UserErrors::InternalServerError)
+                            .change_context(OpenSearchError::UnknownError)?
+                            .into_iter()
+                            .collect(),
+                        EntityType::Organization | EntityType::Merchant | EntityType::Profile => {
+                            state
+                                .global_store
+                                .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
+                                    user_id: &auth.user_id,
+                                    tenant_id: auth
+                                        .tenant_id
+                                        .as_ref()
+                                        .unwrap_or(&state.tenant.tenant_id),
+                                    org_id: Some(&auth.org_id),
+                                    merchant_id: None,
+                                    profile_id: None,
+                                    entity_id: None,
+                                    version: None,
+                                    status: None,
+                                    limit: None,
+                                })
+                                .await
+                                .change_context(UserErrors::InternalServerError)
+                                .change_context(OpenSearchError::UnknownError)?
+                                .into_iter()
+                                .collect()
+                        }
+                    };
+
+                    let role_info_map: HashMap<String, RoleInfo> = user_roles
+                        .iter()
+                        .map(|user_role| {
+                            let state = Arc::clone(&state);
+                            let role_id = user_role.role_id.clone();
+                            let org_id = user_role.org_id.clone().unwrap_or_default();
+                            let tenant_id = &user_role.tenant_id;
+                            async move {
+                                RoleInfo::from_role_id_org_id_tenant_id(
+                                    &state, &role_id, &org_id, tenant_id,
+                                )
+                                .await
+                                .change_context(UserErrors::InternalServerError)
+                                .change_context(OpenSearchError::UnknownError)
+                                .map(|role_info| (role_id, role_info))
+                            }
+                        })
+                        .collect::<FuturesUnordered<_>>()
+                        .collect::<Vec<_>>()
+                        .await
+                        .into_iter()
+                        .collect::<Result<HashMap<_, _>, _>>()?;
+
+                    let filtered_user_roles: Vec<&UserRole> = user_roles
+                        .iter()
+                        .filter(|user_role| {
+                            let user_role_id = &user_role.role_id;
+                            if let Some(role_info) = role_info_map.get(user_role_id) {
+                                let permissions = role_info.get_permission_groups();
+                                permissions.contains(&common_enums::PermissionGroup::OperationsView)
+                            } else {
+                                false
+                            }
+                        })
+                        .collect();
+
                     filtered_user_roles
                         .iter()
                         .filter_map(|user_role| {

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -4038,32 +4038,40 @@ pub mod routes {
                     })
                     .collect();
 
-                let search_params: Vec<AuthInfo> = filtered_user_roles
-                    .iter()
-                    .filter_map(|user_role| {
-                        user_role
-                            .get_entity_id_and_type()
-                            .and_then(|(_, entity_type)| match entity_type {
-                                EntityType::Profile => Some(AuthInfo::ProfileLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                    merchant_id: user_role.merchant_id.clone()?,
-                                    profile_ids: vec![user_role.profile_id.clone()?],
-                                    processor_merchant_id: None,
-                                }),
-                                EntityType::Merchant => Some(AuthInfo::MerchantLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                    merchant_ids: vec![user_role.merchant_id.clone()?],
-                                    processor_merchant_ids: None,
-                                }),
-                                EntityType::Organization => Some(AuthInfo::OrgLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                }),
-                                EntityType::Tenant => Some(AuthInfo::OrgLevel {
-                                    org_id: auth.org_id.clone(),
-                                }),
-                            })
-                    })
-                    .collect();
+                let search_params: Vec<AuthInfo> = if role_info.is_internal() {
+                    vec![AuthInfo::MerchantLevel {
+                        org_id: auth.org_id.clone(),
+                        merchant_ids: vec![auth.merchant_id.clone()],
+                        processor_merchant_ids: None,
+                    }]
+                } else {
+                    filtered_user_roles
+                        .iter()
+                        .filter_map(|user_role| {
+                            user_role
+                                .get_entity_id_and_type()
+                                .and_then(|(_, entity_type)| match entity_type {
+                                    EntityType::Profile => Some(AuthInfo::ProfileLevel {
+                                        org_id: user_role.org_id.clone()?,
+                                        merchant_id: user_role.merchant_id.clone()?,
+                                        profile_ids: vec![user_role.profile_id.clone()?],
+                                        processor_merchant_id: None,
+                                    }),
+                                    EntityType::Merchant => Some(AuthInfo::MerchantLevel {
+                                        org_id: user_role.org_id.clone()?,
+                                        merchant_ids: vec![user_role.merchant_id.clone()?],
+                                        processor_merchant_ids: None,
+                                    }),
+                                    EntityType::Organization => Some(AuthInfo::OrgLevel {
+                                        org_id: user_role.org_id.clone()?,
+                                    }),
+                                    EntityType::Tenant => Some(AuthInfo::OrgLevel {
+                                        org_id: auth.org_id.clone(),
+                                    }),
+                                })
+                        })
+                        .collect()
+                };
 
                 analytics::search::msearch_results(
                     state
@@ -4194,32 +4202,40 @@ pub mod routes {
                     })
                     .collect();
 
-                let search_params: Vec<AuthInfo> = filtered_user_roles
-                    .iter()
-                    .filter_map(|user_role| {
-                        user_role
-                            .get_entity_id_and_type()
-                            .and_then(|(_, entity_type)| match entity_type {
-                                EntityType::Profile => Some(AuthInfo::ProfileLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                    merchant_id: user_role.merchant_id.clone()?,
-                                    profile_ids: vec![user_role.profile_id.clone()?],
-                                    processor_merchant_id: None,
-                                }),
-                                EntityType::Merchant => Some(AuthInfo::MerchantLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                    merchant_ids: vec![user_role.merchant_id.clone()?],
-                                    processor_merchant_ids: None,
-                                }),
-                                EntityType::Organization => Some(AuthInfo::OrgLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                }),
-                                EntityType::Tenant => Some(AuthInfo::OrgLevel {
-                                    org_id: auth.org_id.clone(),
-                                }),
-                            })
-                    })
-                    .collect();
+                let search_params: Vec<AuthInfo> = if role_info.is_internal() {
+                    vec![AuthInfo::MerchantLevel {
+                        org_id: auth.org_id.clone(),
+                        merchant_ids: vec![auth.merchant_id.clone()],
+                        processor_merchant_ids: None,
+                    }]
+                } else {
+                    filtered_user_roles
+                        .iter()
+                        .filter_map(|user_role| {
+                            user_role
+                                .get_entity_id_and_type()
+                                .and_then(|(_, entity_type)| match entity_type {
+                                    EntityType::Profile => Some(AuthInfo::ProfileLevel {
+                                        org_id: user_role.org_id.clone()?,
+                                        merchant_id: user_role.merchant_id.clone()?,
+                                        profile_ids: vec![user_role.profile_id.clone()?],
+                                        processor_merchant_id: None,
+                                    }),
+                                    EntityType::Merchant => Some(AuthInfo::MerchantLevel {
+                                        org_id: user_role.org_id.clone()?,
+                                        merchant_ids: vec![user_role.merchant_id.clone()?],
+                                        processor_merchant_ids: None,
+                                    }),
+                                    EntityType::Organization => Some(AuthInfo::OrgLevel {
+                                        org_id: user_role.org_id.clone()?,
+                                    }),
+                                    EntityType::Tenant => Some(AuthInfo::OrgLevel {
+                                        org_id: auth.org_id.clone(),
+                                    }),
+                                })
+                        })
+                        .collect()
+                };
                 analytics::search::search_results(
                     state
                         .opensearch_client


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Global search (`POST /analytics/v1/search`) accepts `merchant_order_reference_id`, `authentication_type` and `card_discovery` in `filters`, but never applies them to the OpenSearch query.

`SearchFilters` defines all three fields and `is_all_none()` accounts for them, but `msearch_results` does not have the corresponding `append_filter!` calls — the filter block ends at `customer_id`. The per index handler `search_results` already wires all three, so only global search is affected.

The result is that the API accepts the filter, responds `200`, and silently ignores it:

1. The field is a valid struct field, so `is_all_none()` returns `false` and the `Both query and filters are empty` guard does not trigger.
2. The filter is never converted into an OpenSearch clause.
3. On a field scoped search the free text `query` is empty, so the `multi_match` clause is skipped as well.

This leaves the `bool` query with no content constraints and only the auth clause. A `bool` query with no constraints matches every document, so a field scoped search returns all intents/attempts/refunds/disputes in scope instead of the matching records.

This PR adds the three missing `append_filter!` calls to `msearch_results`.

It also fixes the scope resolution for internal users in both search handlers. Internal users are not assigned a `user_role` in the merchant they switch into, so building `search_params` from `user_roles` resolves to an empty list for them. Both handlers now check `role_info.is_internal()` and scope to the merchant present in the token, which is the same approach already used while switching merchants.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes #13354

A field scoped global search returns everything instead of the matching payments.

For a merchant with 50 payments where 4 share the same `merchant_order_reference_id`, searching for that reference returns all 50 records. The more specific the search is, the less filtered the result becomes, because the filter is dropped and the free text query that would otherwise constrain the search is empty.

The same applies to `authentication_type` and `card_discovery`, which are accepted and ignored in the same way.

## How did you test it?

Tested manually on a local setup with OpenSearch enabled.

Test data: two merchants with 50 payments each. In every merchant 4 payments share `merchant_order_reference_id = ORDER-1001`, and each payment has `authentication_type` and `card_discovery` populated.

Ground truth from the database for the merchant under test:

```
merchant_order_reference_id = ORDER-1001  -> 4
card_discovery = manual                   -> 15
authentication_type = three_ds            -> 30
total payments in merchant                -> 50
```

**1. `merchant_order_reference_id` filter**

```bash
curl --location 'http://localhost:8080/analytics/v1/search' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <JWT>' \
--data '{"query":"","filters":{"merchant_order_reference_id":["ORDER-1001"]}}'
```

Before this change the filter was dropped and the query ran with only the auth clause, so this returned every payment in scope for the merchant (50 here, same as the unfiltered search in step 4).

After this change it returns only the 4 matching payments (`payment_id` and `merchant_order_reference_id` masked below):

```json
[
  {
    "count": 4,
    "index": "payment_intents",
    "status": "Success",
    "hits": [
      {
        "payment_id": "pay_1231",
        "merchant_order_reference_id": "ORDER-123",
        "merchant_id": "merchant_123",
        "organization_id": "org_123",
        "profile_id": "pro_123",
        "status": "requires_capture",
        "amount": 15000,
        "currency": "USD",
        "authentication_type": "three_ds",
        "attempt_count": 1
      },
      {
        "payment_id": "pay_1232",
        "merchant_order_reference_id": "ORDER-123",
        "merchant_id": "merchant_123",
        "organization_id": "org_123",
        "profile_id": "pro_123",
        "status": "processing",
        "amount": 6000,
        "currency": "EUR",
        "authentication_type": "three_ds",
        "attempt_count": 1
      },
      {
        "payment_id": "pay_1233",
        "merchant_order_reference_id": "ORDER-123",
        "merchant_id": "merchant_123",
        "organization_id": "org_123",
        "profile_id": "pro_123",
        "status": "processing",
        "amount": 37272,
        "currency": "GBP",
        "authentication_type": "no_three_ds",
        "attempt_count": 1
      },
      {
        "payment_id": "pay_1234",
        "merchant_order_reference_id": "ORDER-123",
        "merchant_id": "merchant_123",
        "organization_id": "org_123",
        "profile_id": "pro_123",
        "status": "succeeded",
        "amount": 37272,
        "currency": "GBP",
        "authentication_type": "no_three_ds",
        "attempt_count": 1
      }
    ]
  },
  { "count": 4, "index": "sessionizer_payment_intents", "status": "Success", "hits": [] },
  { "count": 0, "index": "payment_attempts", "status": "Success", "hits": [] },
  { "count": 0, "index": "refunds", "status": "Success", "hits": [] },
  { "count": 0, "index": "disputes", "status": "Success", "hits": [] }
]
```

**2. `card_discovery` filter**

```bash
curl --location 'http://localhost:8080/analytics/v1/search' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <JWT>' \
--data '{"query":"","filters":{"card_discovery":["manual"]}}'
```

```json
[{"index":"payment_attempts","count":15},{"index":"payment_intents","count":15},{"index":"sessionizer_payment_attempts","count":15},{"index":"sessionizer_payment_intents","count":15}]
```

**3. `authentication_type` filter**

```bash
curl --location 'http://localhost:8080/analytics/v1/search' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <JWT>' \
--data '{"query":"","filters":{"authentication_type":["three_ds"]}}'
```

```json
[{"index":"payment_attempts","count":30},{"index":"payment_intents","count":30},{"index":"sessionizer_payment_attempts","count":30},{"index":"sessionizer_payment_intents","count":30}]
```

All three match the database counts.

**4. Unfiltered search, for reference**

An unfiltered search returns all 50 payments of the merchant, which is what the field scoped search in step 1 was returning before this change:

```bash
curl --location 'http://localhost:8080/analytics/v1/search' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <JWT>' \
--data '{"query":"ORDER"}'
```

```json
[{"index":"payment_intents","count":50},{"index":"sessionizer_payment_intents","count":50}]
```

Free text search continues to work as before:

```bash
curl --location 'http://localhost:8080/analytics/v1/search' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <JWT>' \
--data '{"query":"ORDER-1001"}'
```

```json
[{"index":"payment_intents","count":4},{"index":"sessionizer_payment_intents","count":4}]
```

**5. Filters combine correctly**

```bash
curl --location 'http://localhost:8080/analytics/v1/search' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <JWT>' \
--data '{"query":"","filters":{"merchant_order_reference_id":["ORDER-1001"],"card_discovery":["manual"]}}'
```

```json
[{"index":"payment_intents","count":2},{"index":"sessionizer_payment_intents","count":2}]
```

**6. No cross merchant access**

Searching from merchant A for a reference that exists only in merchant B returns nothing:

```bash
curl --location 'http://localhost:8080/analytics/v1/search' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <JWT of merchant A>' \
--data '{"query":"","filters":{"merchant_order_reference_id":["ORDER-2001"]}}'
```

```json
[]
```

**7. Internal user scoping**

An internal user (`internal_view_only`) switches into a merchant and searches:

```bash
curl --location 'http://localhost:8080/user/switch/merchant' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <internal user JWT>' \
--data '{"merchant_id":"merchant_1234567890"}'

curl --location 'http://localhost:8080/analytics/v1/search' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <JWT returned above>' \
--data '{"query":"","filters":{"merchant_order_reference_id":["ORDER-1001"]}}'
```

Returns only the data of the merchant that was switched into:

```json
[{"index":"payment_intents","count":4},{"index":"sessionizer_payment_intents","count":4}]
```

Searching from that same token for a reference belonging to another merchant returns nothing:

```json
[]
```

Also verified from the dashboard: searching `merchant_order_reference_id:ORDER-1001` in the global search bar returns the 4 matching payment intents.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
