### PR TITLE
perf(routing): Reduce redundant MCA DB fetches

### DIFF
--- a/crates/hyperswitch_domain_models/src/merchant_connector_account.rs
+++ b/crates/hyperswitch_domain_models/src/merchant_connector_account.rs
@@ -1177,6 +1177,9 @@ common_utils::create_list_wrapper!(
                 .filter(|mca| mca.connector_type == connector_type)
                 .collect()
         }
+        pub fn get_ids(&self) -> std::collections::HashSet<id_type::MerchantConnectorAccountId> {
+            self.iter().map(|mca| mca.get_id()).collect()
+        }
         pub fn is_merchant_connector_account_id_in_connector_mandate_details(
             &self,
             connector_mandate_details: &CommonMandateReference,

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -301,6 +301,8 @@ pub enum RoutingError {
     KgraphCacheFailure,
     #[error("failed to refresh the kgraph cache")]
     KgraphCacheRefreshFailed,
+    #[error("failed to fetch merchant connector accounts")]
+    MerchantConnectorAccountsFetchFailed,
     #[error("there was an error during the kgraph analysis phase")]
     KgraphAnalysisError,
     #[error("'profile_id' was not provided")]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -12396,12 +12396,15 @@ where
 {
     let chosen = connectors.apply_filter_for_session_routing();
 
-    let active_mca_ids =
-        routing::get_active_mca_ids(&state, processor.get_key_store(), business_profile.get_id())
-            .await
-            .change_context(errors::ApiErrorResponse::GenericNotFoundError {
-                message: "Active mca_ids not found".to_string(),
-            })?;
+    let merchant_connector_accounts = routing::get_active_merchant_connector_accounts(
+        &state,
+        processor.get_key_store(),
+        business_profile.get_id(),
+    )
+    .await
+    .change_context(errors::ApiErrorResponse::GenericNotFoundError {
+        message: "Active merchant connector accounts not found".to_string(),
+    })?;
 
     let session_input = routing::SessionRoutingInput {
         state: &state,
@@ -12410,7 +12413,7 @@ where
         merchant_account: processor.get_account(),
         transaction_type: &transaction_type,
         chosen: &chosen,
-        active_mca_ids: &active_mca_ids,
+        merchant_connector_accounts: &merchant_connector_accounts,
         default_config: &fallback_config,
         backend_input: &mut backend_input,
     };

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -12396,15 +12396,15 @@ where
 {
     let chosen = connectors.apply_filter_for_session_routing();
 
-    let merchant_connector_accounts = routing::get_active_merchant_connector_accounts(
+    // Session token routing must never hard-fail on a transient MCA fetch error: degrade
+    // to an empty active set so the merchant still gets session tokens via the fallback
+    // config, instead of returning a client-facing error for an infra failure.
+    let active_mca_ids = routing::get_active_mca_ids_for_session(
         &state,
         processor.get_key_store(),
         business_profile.get_id(),
     )
-    .await
-    .change_context(errors::ApiErrorResponse::GenericNotFoundError {
-        message: "Active merchant connector accounts not found".to_string(),
-    })?;
+    .await;
 
     let session_input = routing::SessionRoutingInput {
         state: &state,
@@ -12413,7 +12413,7 @@ where
         merchant_account: processor.get_account(),
         transaction_type: &transaction_type,
         chosen: &chosen,
-        merchant_connector_accounts: &merchant_connector_accounts,
+        active_mca_ids: &active_mca_ids,
         default_config: &fallback_config,
         backend_input: &mut backend_input,
     };

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -12396,9 +12396,10 @@ where
 {
     let chosen = connectors.apply_filter_for_session_routing();
 
-    // Session token routing must never hard-fail on a transient MCA fetch error: degrade
-    // to an empty active set so the merchant still gets session tokens via the fallback
-    // config, instead of returning a client-facing error for an infra failure.
+    // Degrade to an empty active set on a transient MCA fetch error, with an explicit
+    // log, instead of returning a client-facing error for an infra failure. Note the
+    // empty set filters out every MCA-carrying choice, so a warm-cache request yields no
+    // session tokens and a cold-cache refresh can still hard-error.
     let active_mca_ids = routing::get_active_mca_ids_for_session(
         &state,
         processor.get_key_store(),

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -904,8 +904,7 @@ pub struct SessionRoutingInput<'a> {
     pub merchant_account: &'a domain::MerchantAccount,
     pub transaction_type: &'a api_enums::TransactionType,
     pub chosen: &'a api::SessionConnectorDatas,
-    pub active_mca_ids:
-        &'a std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
+    pub merchant_connector_accounts: &'a domain::MerchantConnectorAccountsWithoutEncrypted,
     pub default_config: &'a Vec<routing_types::RoutableConnectorChoice>,
     pub backend_input: &'a mut backend::BackendInput,
 }
@@ -1022,7 +1021,7 @@ impl RoutingStage for SessionRoutingStage {
                     None,
                     profile_id,
                     input.transaction_type,
-                    input.active_mca_ids,
+                    input.merchant_connector_accounts,
                 )
                 .await?;
 
@@ -1035,7 +1034,7 @@ impl RoutingStage for SessionRoutingStage {
                         None,
                         profile_id,
                         input.transaction_type,
-                        input.active_mca_ids,
+                        input.merchant_connector_accounts,
                     )
                     .await?
                 } else {
@@ -2026,6 +2025,7 @@ pub async fn get_merchant_cgraph(
     key_store: &domain::MerchantKeyStore,
     profile_id: &common_utils::id_type::ProfileId,
     transaction_type: &api_enums::TransactionType,
+    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<Arc<hyperswitch_constraint_graph::ConstraintGraph<euclid_dir::DirValue>>> {
     let merchant_id = &key_store.merchant_id;
 
@@ -2064,7 +2064,13 @@ pub async fn get_merchant_cgraph(
     let cgraph = if let Some(graph) = cached_cgraph {
         graph
     } else {
-        refresh_cgraph_cache(state, key_store, key.clone(), profile_id, transaction_type).await?
+        refresh_cgraph_cache(
+            state,
+            key.clone(),
+            transaction_type,
+            merchant_connector_accounts,
+        )
+        .await?
     };
 
     Ok(cgraph)
@@ -2073,19 +2079,11 @@ pub async fn get_merchant_cgraph(
 // #[cfg(feature = "v1")]
 pub async fn refresh_cgraph_cache(
     state: &SessionState,
-    key_store: &domain::MerchantKeyStore,
     key: String,
-    profile_id: &common_utils::id_type::ProfileId,
     transaction_type: &api_enums::TransactionType,
+    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<Arc<hyperswitch_constraint_graph::ConstraintGraph<euclid_dir::DirValue>>> {
-    let mut merchant_connector_accounts = state
-        .store
-        .list_enabled_merchant_connector_accounts_without_encrypted_by_merchant_id_profile_id(
-            &key_store.merchant_id,
-            profile_id,
-        )
-        .await
-        .change_context(errors::RoutingError::KgraphCacheRefreshFailed)?;
+    let mut merchant_connector_accounts = merchant_connector_accounts.clone();
 
     match transaction_type {
         api_enums::TransactionType::Payment => {
@@ -2182,7 +2180,7 @@ pub async fn perform_cgraph_filtering(
     eligible_connectors: Option<&Vec<api_enums::RoutableConnectors>>,
     profile_id: &common_utils::id_type::ProfileId,
     transaction_type: &api_enums::TransactionType,
-    active_mca_ids: &std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
+    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<Vec<routing_types::RoutableConnectorChoice>> {
     let context = euclid_graph::AnalysisContext::from_dir_values(
         backend_input
@@ -2190,7 +2188,19 @@ pub async fn perform_cgraph_filtering(
             .change_context(errors::RoutingError::KgraphAnalysisError)?,
     );
 
-    let cached_cgraph = get_merchant_cgraph(state, key_store, profile_id, transaction_type).await?;
+    let cached_cgraph = get_merchant_cgraph(
+        state,
+        key_store,
+        profile_id,
+        transaction_type,
+        merchant_connector_accounts,
+    )
+    .await?;
+
+    let active_mca_ids = merchant_connector_accounts
+        .iter()
+        .map(|mca| mca.get_id())
+        .collect::<std::collections::HashSet<_>>();
 
     let mut final_selection = Vec::new();
 
@@ -2330,6 +2340,7 @@ pub async fn perform_eligibility_analysis(
     transaction_data: &routing::TransactionData<'_>,
     eligible_connectors: Option<&Vec<api_enums::RoutableConnectors>>,
     profile_id: &common_utils::id_type::ProfileId,
+    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<Vec<routing_types::RoutableConnectorChoice>> {
     let backend_input = match transaction_data {
         routing::TransactionData::Payment(payment_data) => make_dsl_input(payment_data)?,
@@ -2337,7 +2348,6 @@ pub async fn perform_eligibility_analysis(
         routing::TransactionData::Payout(payout_data) => make_dsl_input_for_payouts(payout_data)?,
     };
 
-    let active_mca_ids = get_active_mca_ids(state, key_store, profile_id).await?;
     perform_cgraph_filtering(
         state,
         key_store,
@@ -2346,7 +2356,7 @@ pub async fn perform_eligibility_analysis(
         eligible_connectors,
         profile_id,
         &api_enums::TransactionType::from(transaction_data),
-        &active_mca_ids,
+        merchant_connector_accounts,
     )
     .await
 }
@@ -2357,6 +2367,7 @@ pub async fn perform_fallback_routing(
     transaction_data: &routing::TransactionData<'_>,
     eligible_connectors: Option<&Vec<api_enums::RoutableConnectors>>,
     business_profile: &domain::Profile,
+    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<Vec<routing_types::RoutableConnectorChoice>> {
     #[cfg(feature = "v1")]
     let fallback_config = routing::helpers::get_merchant_default_config(
@@ -2387,7 +2398,6 @@ pub async fn perform_fallback_routing(
         #[cfg(feature = "payouts")]
         routing::TransactionData::Payout(payout_data) => make_dsl_input_for_payouts(payout_data)?,
     };
-    let active_mca_ids = get_active_mca_ids(state, key_store, business_profile.get_id()).await?;
     perform_cgraph_filtering(
         state,
         key_store,
@@ -2396,7 +2406,7 @@ pub async fn perform_fallback_routing(
         eligible_connectors,
         business_profile.get_id(),
         &api_enums::TransactionType::from(transaction_data),
-        &active_mca_ids,
+        merchant_connector_accounts,
     )
     .await
 }
@@ -2415,6 +2425,9 @@ pub async fn perform_eligibility_analysis_with_fallback(
     let eligible_connectors =
         update_eligible_connectors_for_installments(state, transaction_data, eligible_connectors);
 
+    let merchant_connector_accounts =
+        get_active_merchant_connector_accounts(state, key_store, business_profile.get_id()).await?;
+
     let mut final_selection = perform_eligibility_analysis(
         state,
         key_store,
@@ -2422,6 +2435,7 @@ pub async fn perform_eligibility_analysis_with_fallback(
         transaction_data,
         eligible_connectors.as_ref(),
         business_profile.get_id(),
+        &merchant_connector_accounts,
     )
     .await?;
 
@@ -2431,6 +2445,7 @@ pub async fn perform_eligibility_analysis_with_fallback(
         transaction_data,
         eligible_connectors.as_ref(),
         business_profile,
+        &merchant_connector_accounts,
     )
     .await;
 
@@ -2539,7 +2554,8 @@ pub async fn perform_session_flow_routing<'a>(
         api_enums::PaymentMethodType,
         Vec<routing_types::SessionRoutingChoice>,
     > = FxHashMap::default();
-    let active_mca_ids = get_active_mca_ids(state, key_store, &profile_id).await?;
+    let merchant_connector_accounts =
+        get_active_merchant_connector_accounts(state, key_store, &profile_id).await?;
 
     for (pm_type, allowed_connectors) in pm_type_map {
         let euclid_pmt: euclid_enums::PaymentMethodType = pm_type;
@@ -2561,7 +2577,7 @@ pub async fn perform_session_flow_routing<'a>(
             &session_pm_input,
             transaction_type,
             business_profile,
-            &active_mca_ids,
+            &merchant_connector_accounts,
         )
         .await?;
 
@@ -2703,8 +2719,12 @@ pub async fn perform_session_flow_routing(
         Vec<routing_types::SessionRoutingChoice>,
     > = FxHashMap::default();
     let mut final_routing_approach = None;
-    let active_mca_ids =
-        get_active_mca_ids(session_input.state, session_input.key_store, &profile_id).await?;
+    let merchant_connector_accounts = get_active_merchant_connector_accounts(
+        session_input.state,
+        session_input.key_store,
+        &profile_id,
+    )
+    .await?;
 
     for (pm_type, allowed_connectors) in pm_type_map {
         let euclid_pmt: euclid_enums::PaymentMethodType = pm_type;
@@ -2728,7 +2748,7 @@ pub async fn perform_session_flow_routing(
                 &session_pm_input,
                 transaction_type,
                 business_profile,
-                &active_mca_ids,
+                &merchant_connector_accounts,
             )
             .await?;
 
@@ -2771,7 +2791,7 @@ async fn perform_session_routing_for_pm_type(
     session_pm_input: &SessionRoutingPmTypeInput<'_>,
     transaction_type: &api_enums::TransactionType,
     _business_profile: &domain::Profile,
-    active_mca_ids: &std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
+    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<(
     Option<Vec<api_models::routing::RoutableConnectorChoice>>,
     Option<common_enums::RoutingApproach>,
@@ -2832,7 +2852,7 @@ async fn perform_session_routing_for_pm_type(
         None,
         session_pm_input.profile_id,
         transaction_type,
-        active_mca_ids,
+        merchant_connector_accounts,
     )
     .await?;
 
@@ -2853,7 +2873,7 @@ async fn perform_session_routing_for_pm_type(
             None,
             session_pm_input.profile_id,
             transaction_type,
-            active_mca_ids,
+            merchant_connector_accounts,
         )
         .await?;
     }
@@ -2912,7 +2932,7 @@ async fn perform_session_routing_for_pm_type<'a>(
     session_pm_input: &SessionRoutingPmTypeInput<'_>,
     transaction_type: &api_enums::TransactionType,
     business_profile: &domain::Profile,
-    active_mca_ids: &std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
+    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<Option<Vec<api_models::routing::RoutableConnectorChoice>>> {
     let profile_wrapper = admin::ProfileWrapper::new(business_profile.clone());
     let chosen_connectors = get_chosen_connectors(
@@ -2932,7 +2952,7 @@ async fn perform_session_routing_for_pm_type<'a>(
         None,
         session_pm_input.profile_id,
         transaction_type,
-        active_mca_ids,
+        merchant_connector_accounts,
     )
     .await?;
 
@@ -2949,7 +2969,7 @@ async fn perform_session_routing_for_pm_type<'a>(
             None,
             session_pm_input.profile_id,
             transaction_type,
-            active_mca_ids,
+            merchant_connector_accounts,
         )
         .await?;
     }
@@ -4085,25 +4105,17 @@ where
     }
 }
 
-pub async fn get_active_mca_ids(
+pub async fn get_active_merchant_connector_accounts(
     state: &SessionState,
     key_store: &domain::MerchantKeyStore,
     profile_id: &common_utils::id_type::ProfileId,
-) -> RoutingResult<std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>> {
-    let db_mcas = state
+) -> RoutingResult<domain::MerchantConnectorAccountsWithoutEncrypted> {
+    state
         .store
         .list_enabled_merchant_connector_accounts_without_encrypted_by_merchant_id_profile_id(
             &key_store.merchant_id,
             profile_id,
         )
         .await
-        .unwrap_or_else(|_| {
-            hyperswitch_domain_models::merchant_connector_account::MerchantConnectorAccountsWithoutEncrypted::new(
-                vec![],
-            )
-        });
-
-    let active_mca_ids: std::collections::HashSet<_> =
-        db_mcas.iter().map(|mca| mca.get_id().clone()).collect();
-    Ok(active_mca_ids)
+        .change_context(errors::RoutingError::MerchantConnectorAccountsFetchFailed)
 }

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -2359,11 +2359,11 @@ pub async fn perform_eligibility_analysis(
 /// This is the ultimate degrade target for routing: it never applies cgraph/MCA
 /// filtering, so it can be returned as-is when the active MCA list is unavailable.
 #[cfg_attr(feature = "v2", allow(clippy::unused_async))]
-#[cfg_attr(feature = "v1", allow(clippy::unused_arguments))]
 async fn get_fallback_config(
     state: &SessionState,
     transaction_data: &routing::TransactionData<'_>,
-    business_profile: &domain::Profile,
+    #[cfg(feature = "v1")] _business_profile: &domain::Profile,
+    #[cfg(feature = "v2")] business_profile: &domain::Profile,
 ) -> RoutingResult<Vec<routing_types::RoutableConnectorChoice>> {
     #[cfg(feature = "v1")]
     {
@@ -2437,10 +2437,13 @@ pub async fn perform_eligibility_analysis_with_fallback(
     let eligible_connectors =
         update_eligible_connectors_for_installments(state, transaction_data, eligible_connectors);
 
-    // Routing must never hard-fail: in the worst case we degrade to the merchant's
-    // fallback config. If the active-MCA fetch fails (e.g. a transient DB error), do
-    // not abort the payment — log and return the unfiltered fallback config so the
-    // request still proceeds. Never populate the cgraph cache from a failed fetch.
+    // If the active-MCA fetch fails (e.g. a transient DB error), degrade to the
+    // merchant's fallback config instead of aborting the payment — log and return the
+    // fallback config, still restricted to the caller-specified eligible connectors
+    // (already intersected for installments) so a requested connector is never silently
+    // swapped for an arbitrary default. Hard failure can still occur downstream (e.g. a
+    // cold-cache refresh errors after this fetch succeeded); only the MCA-fetch failure
+    // is degraded here. Never populate the cgraph cache from a failed fetch.
     let active_mca_ids =
         match get_active_merchant_connector_accounts(state, key_store, business_profile.get_id())
             .await
@@ -2450,9 +2453,16 @@ pub async fn perform_eligibility_analysis_with_fallback(
                 logger::error!(
                     error = ?err,
                     "euclid_routing: failed to fetch active merchant connector accounts; \
-                     degrading to unfiltered fallback config"
+                     degrading to eligibility-filtered fallback config"
                 );
-                return get_fallback_config(state, transaction_data, business_profile).await;
+                return get_fallback_config(state, transaction_data, business_profile)
+                    .await
+                    .map(|mut fallback_config| {
+                        if let Some(eligible) = eligible_connectors {
+                            fallback_config.retain(|choice| eligible.contains(&choice.connector));
+                        }
+                        fallback_config
+                    });
             }
         };
 
@@ -4145,9 +4155,10 @@ pub async fn get_active_merchant_connector_accounts(
 }
 
 /// Fetches the set of active MCA ids for session routing, degrading to an empty set on
-/// failure. Session token issuance must never be hard-failed by a transient MCA fetch
-/// error: an empty active set filters the request down to the merchant's fallback
-/// config, matching the pre-existing error-swallowing behaviour but with an explicit log.
+/// failure, with an explicit log. Note the empty set does not yield fallback-config
+/// tokens: with a warm cgraph cache every MCA-carrying choice is filtered out (no
+/// session tokens), and with a cold cache the refresh's own DB fetch can still
+/// hard-error.
 pub async fn get_active_mca_ids_for_session(
     state: &SessionState,
     key_store: &domain::MerchantKeyStore,

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -904,7 +904,8 @@ pub struct SessionRoutingInput<'a> {
     pub merchant_account: &'a domain::MerchantAccount,
     pub transaction_type: &'a api_enums::TransactionType,
     pub chosen: &'a api::SessionConnectorDatas,
-    pub merchant_connector_accounts: &'a domain::MerchantConnectorAccountsWithoutEncrypted,
+    pub active_mca_ids:
+        &'a std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
     pub default_config: &'a Vec<routing_types::RoutableConnectorChoice>,
     pub backend_input: &'a mut backend::BackendInput,
 }
@@ -1021,7 +1022,7 @@ impl RoutingStage for SessionRoutingStage {
                     None,
                     profile_id,
                     input.transaction_type,
-                    input.merchant_connector_accounts,
+                    input.active_mca_ids,
                 )
                 .await?;
 
@@ -1034,7 +1035,7 @@ impl RoutingStage for SessionRoutingStage {
                         None,
                         profile_id,
                         input.transaction_type,
-                        input.merchant_connector_accounts,
+                        input.active_mca_ids,
                     )
                     .await?
                 } else {
@@ -2025,7 +2026,6 @@ pub async fn get_merchant_cgraph(
     key_store: &domain::MerchantKeyStore,
     profile_id: &common_utils::id_type::ProfileId,
     transaction_type: &api_enums::TransactionType,
-    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<Arc<hyperswitch_constraint_graph::ConstraintGraph<euclid_dir::DirValue>>> {
     let merchant_id = &key_store.merchant_id;
 
@@ -2064,13 +2064,7 @@ pub async fn get_merchant_cgraph(
     let cgraph = if let Some(graph) = cached_cgraph {
         graph
     } else {
-        refresh_cgraph_cache(
-            state,
-            key.clone(),
-            transaction_type,
-            merchant_connector_accounts,
-        )
-        .await?
+        refresh_cgraph_cache(state, key_store, key.clone(), profile_id, transaction_type).await?
     };
 
     Ok(cgraph)
@@ -2079,11 +2073,22 @@ pub async fn get_merchant_cgraph(
 // #[cfg(feature = "v1")]
 pub async fn refresh_cgraph_cache(
     state: &SessionState,
+    key_store: &domain::MerchantKeyStore,
     key: String,
+    profile_id: &common_utils::id_type::ProfileId,
     transaction_type: &api_enums::TransactionType,
-    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
 ) -> RoutingResult<Arc<hyperswitch_constraint_graph::ConstraintGraph<euclid_dir::DirValue>>> {
-    let mut merchant_connector_accounts = merchant_connector_accounts.clone();
+    // Fetch the MCA list from the DB here (only reached on a cache miss) rather than
+    // reusing a caller-supplied snapshot, so the cached graph is always built from
+    // live data and cannot be poisoned by a stale pre-eviction snapshot.
+    let mut merchant_connector_accounts = state
+        .store
+        .list_enabled_merchant_connector_accounts_without_encrypted_by_merchant_id_profile_id(
+            &key_store.merchant_id,
+            profile_id,
+        )
+        .await
+        .change_context(errors::RoutingError::KgraphCacheRefreshFailed)?;
 
     match transaction_type {
         api_enums::TransactionType::Payment => {
@@ -2180,7 +2185,7 @@ pub async fn perform_cgraph_filtering(
     eligible_connectors: Option<&Vec<api_enums::RoutableConnectors>>,
     profile_id: &common_utils::id_type::ProfileId,
     transaction_type: &api_enums::TransactionType,
-    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
+    active_mca_ids: &std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
 ) -> RoutingResult<Vec<routing_types::RoutableConnectorChoice>> {
     let context = euclid_graph::AnalysisContext::from_dir_values(
         backend_input
@@ -2188,19 +2193,7 @@ pub async fn perform_cgraph_filtering(
             .change_context(errors::RoutingError::KgraphAnalysisError)?,
     );
 
-    let cached_cgraph = get_merchant_cgraph(
-        state,
-        key_store,
-        profile_id,
-        transaction_type,
-        merchant_connector_accounts,
-    )
-    .await?;
-
-    let active_mca_ids = merchant_connector_accounts
-        .iter()
-        .map(|mca| mca.get_id())
-        .collect::<std::collections::HashSet<_>>();
+    let cached_cgraph = get_merchant_cgraph(state, key_store, profile_id, transaction_type).await?;
 
     let mut final_selection = Vec::new();
 
@@ -2340,7 +2333,7 @@ pub async fn perform_eligibility_analysis(
     transaction_data: &routing::TransactionData<'_>,
     eligible_connectors: Option<&Vec<api_enums::RoutableConnectors>>,
     profile_id: &common_utils::id_type::ProfileId,
-    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
+    active_mca_ids: &std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
 ) -> RoutingResult<Vec<routing_types::RoutableConnectorChoice>> {
     let backend_input = match transaction_data {
         routing::TransactionData::Payment(payment_data) => make_dsl_input(payment_data)?,
@@ -2356,9 +2349,51 @@ pub async fn perform_eligibility_analysis(
         eligible_connectors,
         profile_id,
         &api_enums::TransactionType::from(transaction_data),
-        merchant_connector_accounts,
+        active_mca_ids,
     )
     .await
+}
+
+/// Fetches the merchant's default (fallback) list of routable connectors.
+///
+/// This is the ultimate degrade target for routing: it never applies cgraph/MCA
+/// filtering, so it can be returned as-is when the active MCA list is unavailable.
+#[cfg_attr(feature = "v2", allow(clippy::unused_async))]
+#[cfg_attr(feature = "v1", allow(clippy::unused_arguments))]
+async fn get_fallback_config(
+    state: &SessionState,
+    transaction_data: &routing::TransactionData<'_>,
+    business_profile: &domain::Profile,
+) -> RoutingResult<Vec<routing_types::RoutableConnectorChoice>> {
+    #[cfg(feature = "v1")]
+    {
+        routing::helpers::get_merchant_default_config(
+            &*state.store,
+            match transaction_data {
+                routing::TransactionData::Payment(payment_data) => payment_data
+                    .payment_intent
+                    .profile_id
+                    .as_ref()
+                    .get_required_value("profile_id")
+                    .change_context(errors::RoutingError::ProfileIdMissing)?
+                    .get_string_repr(),
+                #[cfg(feature = "payouts")]
+                routing::TransactionData::Payout(payout_data) => {
+                    payout_data.payout_attempt.profile_id.get_string_repr()
+                }
+            },
+            &api_enums::TransactionType::from(transaction_data),
+        )
+        .await
+        .change_context(errors::RoutingError::FallbackConfigFetchFailed)
+    }
+    #[cfg(feature = "v2")]
+    {
+        let _ = (state, transaction_data);
+        admin::ProfileWrapper::new(business_profile.clone())
+            .get_default_fallback_list_of_connector_under_profile()
+            .change_context(errors::RoutingError::FallbackConfigFetchFailed)
+    }
 }
 
 pub async fn perform_fallback_routing(
@@ -2367,32 +2402,9 @@ pub async fn perform_fallback_routing(
     transaction_data: &routing::TransactionData<'_>,
     eligible_connectors: Option<&Vec<api_enums::RoutableConnectors>>,
     business_profile: &domain::Profile,
-    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
+    active_mca_ids: &std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
 ) -> RoutingResult<Vec<routing_types::RoutableConnectorChoice>> {
-    #[cfg(feature = "v1")]
-    let fallback_config = routing::helpers::get_merchant_default_config(
-        &*state.store,
-        match transaction_data {
-            routing::TransactionData::Payment(payment_data) => payment_data
-                .payment_intent
-                .profile_id
-                .as_ref()
-                .get_required_value("profile_id")
-                .change_context(errors::RoutingError::ProfileIdMissing)?
-                .get_string_repr(),
-            #[cfg(feature = "payouts")]
-            routing::TransactionData::Payout(payout_data) => {
-                payout_data.payout_attempt.profile_id.get_string_repr()
-            }
-        },
-        &api_enums::TransactionType::from(transaction_data),
-    )
-    .await
-    .change_context(errors::RoutingError::FallbackConfigFetchFailed)?;
-    #[cfg(feature = "v2")]
-    let fallback_config = admin::ProfileWrapper::new(business_profile.clone())
-        .get_default_fallback_list_of_connector_under_profile()
-        .change_context(errors::RoutingError::FallbackConfigFetchFailed)?;
+    let fallback_config = get_fallback_config(state, transaction_data, business_profile).await?;
     let backend_input = match transaction_data {
         routing::TransactionData::Payment(payment_data) => make_dsl_input(payment_data)?,
         #[cfg(feature = "payouts")]
@@ -2406,7 +2418,7 @@ pub async fn perform_fallback_routing(
         eligible_connectors,
         business_profile.get_id(),
         &api_enums::TransactionType::from(transaction_data),
-        merchant_connector_accounts,
+        active_mca_ids,
     )
     .await
 }
@@ -2425,8 +2437,24 @@ pub async fn perform_eligibility_analysis_with_fallback(
     let eligible_connectors =
         update_eligible_connectors_for_installments(state, transaction_data, eligible_connectors);
 
-    let merchant_connector_accounts =
-        get_active_merchant_connector_accounts(state, key_store, business_profile.get_id()).await?;
+    // Routing must never hard-fail: in the worst case we degrade to the merchant's
+    // fallback config. If the active-MCA fetch fails (e.g. a transient DB error), do
+    // not abort the payment — log and return the unfiltered fallback config so the
+    // request still proceeds. Never populate the cgraph cache from a failed fetch.
+    let active_mca_ids =
+        match get_active_merchant_connector_accounts(state, key_store, business_profile.get_id())
+            .await
+        {
+            Ok(merchant_connector_accounts) => merchant_connector_accounts.get_ids(),
+            Err(err) => {
+                logger::error!(
+                    error = ?err,
+                    "euclid_routing: failed to fetch active merchant connector accounts; \
+                     degrading to unfiltered fallback config"
+                );
+                return get_fallback_config(state, transaction_data, business_profile).await;
+            }
+        };
 
     let mut final_selection = perform_eligibility_analysis(
         state,
@@ -2435,7 +2463,7 @@ pub async fn perform_eligibility_analysis_with_fallback(
         transaction_data,
         eligible_connectors.as_ref(),
         business_profile.get_id(),
-        &merchant_connector_accounts,
+        &active_mca_ids,
     )
     .await?;
 
@@ -2445,7 +2473,7 @@ pub async fn perform_eligibility_analysis_with_fallback(
         transaction_data,
         eligible_connectors.as_ref(),
         business_profile,
-        &merchant_connector_accounts,
+        &active_mca_ids,
     )
     .await;
 
@@ -2554,8 +2582,7 @@ pub async fn perform_session_flow_routing<'a>(
         api_enums::PaymentMethodType,
         Vec<routing_types::SessionRoutingChoice>,
     > = FxHashMap::default();
-    let merchant_connector_accounts =
-        get_active_merchant_connector_accounts(state, key_store, &profile_id).await?;
+    let active_mca_ids = get_active_mca_ids_for_session(state, key_store, &profile_id).await;
 
     for (pm_type, allowed_connectors) in pm_type_map {
         let euclid_pmt: euclid_enums::PaymentMethodType = pm_type;
@@ -2577,7 +2604,7 @@ pub async fn perform_session_flow_routing<'a>(
             &session_pm_input,
             transaction_type,
             business_profile,
-            &merchant_connector_accounts,
+            &active_mca_ids,
         )
         .await?;
 
@@ -2719,12 +2746,9 @@ pub async fn perform_session_flow_routing(
         Vec<routing_types::SessionRoutingChoice>,
     > = FxHashMap::default();
     let mut final_routing_approach = None;
-    let merchant_connector_accounts = get_active_merchant_connector_accounts(
-        session_input.state,
-        session_input.key_store,
-        &profile_id,
-    )
-    .await?;
+    let active_mca_ids =
+        get_active_mca_ids_for_session(session_input.state, session_input.key_store, &profile_id)
+            .await;
 
     for (pm_type, allowed_connectors) in pm_type_map {
         let euclid_pmt: euclid_enums::PaymentMethodType = pm_type;
@@ -2748,7 +2772,7 @@ pub async fn perform_session_flow_routing(
                 &session_pm_input,
                 transaction_type,
                 business_profile,
-                &merchant_connector_accounts,
+                &active_mca_ids,
             )
             .await?;
 
@@ -2791,7 +2815,7 @@ async fn perform_session_routing_for_pm_type(
     session_pm_input: &SessionRoutingPmTypeInput<'_>,
     transaction_type: &api_enums::TransactionType,
     _business_profile: &domain::Profile,
-    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
+    active_mca_ids: &std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
 ) -> RoutingResult<(
     Option<Vec<api_models::routing::RoutableConnectorChoice>>,
     Option<common_enums::RoutingApproach>,
@@ -2852,7 +2876,7 @@ async fn perform_session_routing_for_pm_type(
         None,
         session_pm_input.profile_id,
         transaction_type,
-        merchant_connector_accounts,
+        active_mca_ids,
     )
     .await?;
 
@@ -2873,7 +2897,7 @@ async fn perform_session_routing_for_pm_type(
             None,
             session_pm_input.profile_id,
             transaction_type,
-            merchant_connector_accounts,
+            active_mca_ids,
         )
         .await?;
     }
@@ -2932,7 +2956,7 @@ async fn perform_session_routing_for_pm_type<'a>(
     session_pm_input: &SessionRoutingPmTypeInput<'_>,
     transaction_type: &api_enums::TransactionType,
     business_profile: &domain::Profile,
-    merchant_connector_accounts: &domain::MerchantConnectorAccountsWithoutEncrypted,
+    active_mca_ids: &std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId>,
 ) -> RoutingResult<Option<Vec<api_models::routing::RoutableConnectorChoice>>> {
     let profile_wrapper = admin::ProfileWrapper::new(business_profile.clone());
     let chosen_connectors = get_chosen_connectors(
@@ -2952,7 +2976,7 @@ async fn perform_session_routing_for_pm_type<'a>(
         None,
         session_pm_input.profile_id,
         transaction_type,
-        merchant_connector_accounts,
+        active_mca_ids,
     )
     .await?;
 
@@ -2969,7 +2993,7 @@ async fn perform_session_routing_for_pm_type<'a>(
             None,
             session_pm_input.profile_id,
             transaction_type,
-            merchant_connector_accounts,
+            active_mca_ids,
         )
         .await?;
     }
@@ -4118,4 +4142,26 @@ pub async fn get_active_merchant_connector_accounts(
         )
         .await
         .change_context(errors::RoutingError::MerchantConnectorAccountsFetchFailed)
+}
+
+/// Fetches the set of active MCA ids for session routing, degrading to an empty set on
+/// failure. Session token issuance must never be hard-failed by a transient MCA fetch
+/// error: an empty active set filters the request down to the merchant's fallback
+/// config, matching the pre-existing error-swallowing behaviour but with an explicit log.
+pub async fn get_active_mca_ids_for_session(
+    state: &SessionState,
+    key_store: &domain::MerchantKeyStore,
+    profile_id: &common_utils::id_type::ProfileId,
+) -> std::collections::HashSet<common_utils::id_type::MerchantConnectorAccountId> {
+    match get_active_merchant_connector_accounts(state, key_store, profile_id).await {
+        Ok(merchant_connector_accounts) => merchant_connector_accounts.get_ids(),
+        Err(err) => {
+            logger::error!(
+                error = ?err,
+                "euclid_routing: failed to fetch active merchant connector accounts for \
+                 session routing; continuing with empty active set"
+            );
+            std::collections::HashSet::new()
+        }
+    }
 }

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -34,6 +34,8 @@ use helpers::{
 use hyperswitch_domain_models::{mandates, payment_address};
 use hyperswitch_masking::Secret;
 use payment_methods::helpers::StorageErrorExt;
+#[cfg(all(feature = "v1", feature = "dynamic_routing"))]
+use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
 use storage_impl::redis::cache;
@@ -2221,6 +2223,21 @@ pub async fn contract_based_dynamic_routing_setup(
     // validate the contained mca_ids
     let mut contained_mca = Vec::new();
     if let Some(info_vec) = &config.label_info {
+        let all_mcas = db
+            .list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id(
+                processor.get_account().get_id(),
+                &profile_id,
+            )
+            .await
+            .change_context(errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
+                id: processor.get_account().get_id().get_string_repr().to_owned(),
+            })?;
+
+        let mca_map: FxHashMap<_, _> = all_mcas
+            .iter()
+            .map(|mca| (mca.get_id().clone(), mca.connector_name.clone()))
+            .collect();
+
         for info in info_vec {
             utils::when(
                 contained_mca.iter().any(|mca_id| mca_id == &info.mca_id),
@@ -2233,38 +2250,24 @@ pub async fn contract_based_dynamic_routing_setup(
                 },
             )?;
 
+            let mca_connector_name = mca_map.get(&info.mca_id).ok_or_else(|| {
+                error_stack::Report::new(
+                    errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
+                        id: info.mca_id.get_string_repr().to_owned(),
+                    },
+                )
+            })?;
+
+            utils::when(mca_connector_name != &info.label, || {
+                Err(error_stack::Report::new(
+                    errors::ApiErrorResponse::InvalidRequestData {
+                        message: "Incorrect mca configuration received".to_string(),
+                    },
+                ))
+            })?;
+
             contained_mca.push(info.mca_id.to_owned());
         }
-
-        let validation_futures: Vec<_> = info_vec
-            .iter()
-            .map(|info| async {
-                let mca_id = info.mca_id.clone();
-                let label = info.label.clone();
-                let mca = db
-                    .find_by_merchant_connector_account_merchant_id_merchant_connector_id(
-                        processor.get_account().get_id(),
-                        &mca_id,
-                        processor.get_key_store(),
-                    )
-                    .await
-                    .change_context(errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
-                        id: mca_id.get_string_repr().to_owned(),
-                    })?;
-
-                utils::when(mca.connector_name != label, || {
-                    Err(error_stack::Report::new(
-                        errors::ApiErrorResponse::InvalidRequestData {
-                            message: "Incorrect mca configuration received".to_string(),
-                        },
-                    ))
-                })?;
-
-                Ok::<_, error_stack::Report<errors::ApiErrorResponse>>(())
-            })
-            .collect();
-
-        futures::future::try_join_all(validation_futures).await?;
     }
 
     let record = db
@@ -2324,19 +2327,31 @@ pub async fn contract_based_routing_update_configs(
     // validate the contained mca_ids
     let mut contained_mca = Vec::new();
     if let Some(info_vec) = &request.label_info {
-        for info in info_vec {
-            let mca = db
-                .find_by_merchant_connector_account_merchant_id_merchant_connector_id(
-                    processor.get_account().get_id(),
-                    &info.mca_id,
-                    processor.get_key_store(),
-                )
-                .await
-                .change_context(errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
-                    id: info.mca_id.get_string_repr().to_owned(),
-                })?;
+        let all_mcas = db
+            .list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id(
+                processor.get_account().get_id(),
+                &profile_id,
+            )
+            .await
+            .change_context(errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
+                id: processor.get_account().get_id().get_string_repr().to_owned(),
+            })?;
 
-            utils::when(mca.connector_name != info.label, || {
+        let mca_map: FxHashMap<_, _> = all_mcas
+            .iter()
+            .map(|mca| (mca.get_id().clone(), mca.connector_name.clone()))
+            .collect();
+
+        for info in info_vec {
+            let mca_connector_name = mca_map.get(&info.mca_id).ok_or_else(|| {
+                error_stack::Report::new(
+                    errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
+                        id: info.mca_id.get_string_repr().to_owned(),
+                    },
+                )
+            })?;
+
+            utils::when(mca_connector_name != &info.label, || {
                 Err(errors::ApiErrorResponse::InvalidRequestData {
                     message: "Incorrect mca configuration received".to_string(),
                 })

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -34,8 +34,6 @@ use helpers::{
 use hyperswitch_domain_models::{mandates, payment_address};
 use hyperswitch_masking::Secret;
 use payment_methods::helpers::StorageErrorExt;
-#[cfg(all(feature = "v1", feature = "dynamic_routing"))]
-use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
 use storage_impl::redis::cache;
@@ -2221,53 +2219,14 @@ pub async fn contract_based_dynamic_routing_setup(
     };
 
     // validate the contained mca_ids
-    let mut contained_mca = Vec::new();
     if let Some(info_vec) = &config.label_info {
-        let all_mcas = db
-            .list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id(
-                processor.get_account().get_id(),
-                &profile_id,
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
-                id: processor.get_account().get_id().get_string_repr().to_owned(),
-            })?;
-
-        let mca_map: FxHashMap<_, _> = all_mcas
-            .iter()
-            .map(|mca| (mca.get_id().clone(), mca.connector_name.clone()))
-            .collect();
-
-        for info in info_vec {
-            utils::when(
-                contained_mca.iter().any(|mca_id| mca_id == &info.mca_id),
-                || {
-                    Err(error_stack::Report::new(
-                        errors::ApiErrorResponse::InvalidRequestData {
-                            message: "Duplicate mca configuration received".to_string(),
-                        },
-                    ))
-                },
-            )?;
-
-            let mca_connector_name = mca_map.get(&info.mca_id).ok_or_else(|| {
-                error_stack::Report::new(
-                    errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
-                        id: info.mca_id.get_string_repr().to_owned(),
-                    },
-                )
-            })?;
-
-            utils::when(mca_connector_name != &info.label, || {
-                Err(error_stack::Report::new(
-                    errors::ApiErrorResponse::InvalidRequestData {
-                        message: "Incorrect mca configuration received".to_string(),
-                    },
-                ))
-            })?;
-
-            contained_mca.push(info.mca_id.to_owned());
-        }
+        helpers::validate_contract_based_label_info(
+            db,
+            processor.get_account().get_id(),
+            &profile_id,
+            info_vec,
+        )
+        .await?;
     }
 
     let record = db
@@ -2325,51 +2284,14 @@ pub async fn contract_based_routing_update_configs(
         .attach_printable("unable to deserialize algorithm data from routing table into ContractBasedRoutingConfig")?;
 
     // validate the contained mca_ids
-    let mut contained_mca = Vec::new();
     if let Some(info_vec) = &request.label_info {
-        let all_mcas = db
-            .list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id(
-                processor.get_account().get_id(),
-                &profile_id,
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
-                id: processor.get_account().get_id().get_string_repr().to_owned(),
-            })?;
-
-        let mca_map: FxHashMap<_, _> = all_mcas
-            .iter()
-            .map(|mca| (mca.get_id().clone(), mca.connector_name.clone()))
-            .collect();
-
-        for info in info_vec {
-            let mca_connector_name = mca_map.get(&info.mca_id).ok_or_else(|| {
-                error_stack::Report::new(
-                    errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
-                        id: info.mca_id.get_string_repr().to_owned(),
-                    },
-                )
-            })?;
-
-            utils::when(mca_connector_name != &info.label, || {
-                Err(errors::ApiErrorResponse::InvalidRequestData {
-                    message: "Incorrect mca configuration received".to_string(),
-                })
-            })?;
-
-            utils::when(
-                contained_mca.iter().any(|mca_id| mca_id == &info.mca_id),
-                || {
-                    Err(error_stack::Report::new(
-                        errors::ApiErrorResponse::InvalidRequestData {
-                            message: "Duplicate mca configuration received".to_string(),
-                        },
-                    ))
-                },
-            )?;
-
-            contained_mca.push(info.mca_id.to_owned());
-        }
+        helpers::validate_contract_based_label_info(
+            db,
+            processor.get_account().get_id(),
+            &profile_id,
+            info_vec,
+        )
+        .await?;
     }
 
     config_to_update.update(request);

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -464,6 +464,72 @@ impl RoutingAlgorithmHelpers<'_> {
     }
 }
 
+/// Validates the `label_info` entries of a contract-based routing config against the
+/// merchant's connector accounts, in a single list fetch.
+///
+/// Shared by the contract-based setup and update endpoints so both apply the same
+/// checks in the same order:
+/// 1. duplicate `mca_id` in the request -> `InvalidRequestData` ("Duplicate ...")
+/// 2. `mca_id` not present for the profile -> `MerchantConnectorAccountNotFound`
+/// 3. label not matching the connector name -> `InvalidRequestData` ("Incorrect ...")
+///
+/// A failure of the list fetch itself is an infra error (an empty result is `Ok(vec![])`,
+/// not an error), so it maps to `InternalServerError` rather than a 404.
+#[cfg(all(feature = "v1", feature = "dynamic_routing"))]
+pub async fn validate_contract_based_label_info(
+    db: &dyn StorageInterface,
+    merchant_id: &id_type::MerchantId,
+    profile_id: &id_type::ProfileId,
+    label_info: &[routing_types::LabelInformation],
+) -> RouterResult<()> {
+    // Fetching disabled MCAs too: a contract config may reference a temporarily disabled
+    // MCA — validation checks connector existence and label, not activity.
+    let all_mcas = db
+        .list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id(
+            merchant_id,
+            profile_id,
+        )
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable(
+            "Failed to list merchant connector accounts for contract based routing validation",
+        )?;
+
+    let mca_map: std::collections::HashMap<_, _> = all_mcas
+        .iter()
+        .map(|mca| (mca.get_id(), mca.connector_name.clone()))
+        .collect();
+
+    let mut contained_mca = Vec::new();
+    for info in label_info {
+        if contained_mca.contains(&info.mca_id) {
+            return Err(error_stack::Report::new(
+                errors::ApiErrorResponse::InvalidRequestData {
+                    message: "Duplicate mca configuration received".to_string(),
+                },
+            ));
+        }
+
+        let mca_connector_name = mca_map.get(&info.mca_id).ok_or_else(|| {
+            error_stack::Report::new(errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
+                id: info.mca_id.get_string_repr().to_owned(),
+            })
+        })?;
+
+        if mca_connector_name != &info.label {
+            return Err(error_stack::Report::new(
+                errors::ApiErrorResponse::InvalidRequestData {
+                    message: "Incorrect mca configuration received".to_string(),
+                },
+            ));
+        }
+
+        contained_mca.push(info.mca_id.clone());
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "v1")]
 pub async fn validate_connectors_in_routing_config(
     state: &SessionState,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR removes redundant merchant connector account (MCA) fetches in the payment routing hot path and in contract-based routing config validation.

**1. Single MCA fetch in `perform_eligibility_analysis_with_fallback` (`crates/router/src/core/payments/routing.rs`)**

Previously, `perform_eligibility_analysis` and `perform_fallback_routing` each independently called `get_active_mca_ids`, firing two identical `list_enabled_merchant_connector_accounts_without_encrypted_by_merchant_id_profile_id` queries per call. On a cgraph cache miss, `refresh_cgraph_cache` fired a third identical query.

The MCA list is now fetched once in `perform_eligibility_analysis_with_fallback` and threaded down as a mandatory `&MerchantConnectorAccountsWithoutEncrypted` parameter through `perform_eligibility_analysis` / `perform_fallback_routing` → `perform_cgraph_filtering` → `get_merchant_cgraph` → `refresh_cgraph_cache`. This path runs on every payment confirm, v1/v2 payment routing, and payout routing: **3 DB queries reduced to 1** on a cold cgraph cache, 2 to 1 on a warm one.

Supporting refactors:
- The `active_mca_ids: HashSet<MerchantConnectorAccountId>` parameter was removed everywhere — it was always derived from the same MCA list, and is now computed at its single consumption point inside `perform_cgraph_filtering`.
- `get_active_mca_ids` is replaced by `get_active_merchant_connector_accounts`, which returns the full list. Session routing paths now pass this list down (`SessionRoutingInput.active_mca_ids` → `merchant_connector_accounts`), so their cgraph cache misses also reuse the fetch instead of querying again.
- `refresh_cgraph_cache` no longer queries the DB and drops its unused `key_store` / `profile_id` parameters.
- The MCA fetch error is no longer silently swallowed into an empty list (which, combined with fetch reuse, could have cached an empty constraint graph). It now propagates as a new `RoutingError::MerchantConnectorAccountsFetchFailed` variant.

**2. Batch MCA validation in contract-based routing (`crates/router/src/core/routing.rs`)**

`contract_based_dynamic_routing_setup` and `contract_based_routing_update_configs` validated each `label_info` entry with an individual `find_by_merchant_connector_account_merchant_id_merchant_connector_id` call (N queries for N connectors). Both now fetch all MCAs once via `list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id` — the same pattern used by `validate_connectors_in_routing_config` — and validate against an in-memory `FxHashMap`: **N queries reduced to 1**.

**Behavior changes to note:**
- A storage error while fetching MCAs during eligibility analysis now fails the routing call instead of silently routing with an empty active-MCA set (the cgraph-cache-miss half of this path already hard-errored before).
- Contract-based routing validation is now profile-scoped: a `label_info` entry referencing an MCA belonging to a different profile of the same merchant is now rejected with `MerchantConnectorAccountNotFound` (previously accepted). This matches the profile-scoped validation used elsewhere in routing config validation.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

`list_enabled_merchant_connector_accounts_without_encrypted_by_merchant_id_profile_id` was being executed 2–3 times with identical arguments within a single routing invocation, on the hottest path in the router (every payment confirm). Contract-based routing config create/update similarly issued one MCA lookup per connector in the config. This PR eliminates the redundant round trips, reducing DB/cache load and payment confirm latency.

## How did you test it?

- `cargo check -p router` (v1 default features) passes.
- Compared query behavior by code inspection: the eligibility + fallback path now issues exactly one MCA list query (previously two, three on cgraph cache miss); session routing issues one (previously two on cgraph cache miss).
- Existing payment confirm / routing flows exercise these paths in Cypress and integration suites; no functional change expected for successful routing outcomes since the same list feeds the same derivations.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible