### PR TITLE
chore(ci): split cashtocode and fiuu into new mock connectors batch 5

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -27,9 +27,10 @@ env:
   EXTENDED_PAYMENTS_CONNECTORS_BATCH_1: "bluesnap gigadat loonio nmi"
   EXTENDED_PAYMENTS_CONNECTORS_BATCH_2: "paypal redsys zift"
   EXTENDED_PAYOUTS_CONNECTORS: "adyenplatform wise"
-  MOCK_PAYMENTS_CONNECTORS_BATCH_1: "bluesnap gigadat zift loonio cashtocode"
-  MOCK_PAYMENTS_CONNECTORS_BATCH_2: "redsys worldpayxml cybersource braintree fiuu"
+  MOCK_PAYMENTS_CONNECTORS_BATCH_1: "bluesnap gigadat zift loonio"
+  MOCK_PAYMENTS_CONNECTORS_BATCH_2: "redsys worldpayxml cybersource braintree"
   MOCK_PAYMENTS_CONNECTORS_BATCH_3: "nmi calida adyen peachpayments"
+  MOCK_PAYMENTS_CONNECTORS_BATCH_5: "cashtocode fiuu"
   MOCK_PAYOUTS_CONNECTORS: "adyenplatform wise"
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
@@ -802,6 +803,15 @@ jobs:
                   "parallel": 5,
                   "report_artifact_name": "cypress-mock-test-results-payments-batch-3",
                   "server_logs_artifact": "mock-server-logs-payments-batch-3"
+                },
+                {
+                  "name": "mock-payments-batch-5",
+                  "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_5}"'",
+                  "payouts_connectors": "",
+                  "platform_connectors": "",
+                  "parallel": 5,
+                  "report_artifact_name": "cypress-mock-test-results-payments-batch-5",
+                  "server_logs_artifact": "mock-server-logs-payments-batch-5"
                 }
               ]
             }'


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] CI/CD

## Description

Splits `cashtocode` (from `MOCK_PAYMENTS_CONNECTORS_BATCH_1`) and `fiuu` (from `MOCK_PAYMENTS_CONNECTORS_BATCH_2`) out into a new `MOCK_PAYMENTS_CONNECTORS_BATCH_5`, and adds the corresponding matrix entry to the mock Cypress connector job, to rebalance CPU load across parallel CI batches.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables (`.github/workflows/cypress-tests-runner.yml`)

## Motivation and Context

`MOCK_PAYMENTS_CONNECTORS_BATCH_1` and `MOCK_PAYMENTS_CONNECTORS_BATCH_2` were overloaded, increasing CI runtime/CPU pressure on the mock Cypress connector jobs.

Fixes #13378

## How did you test it?

Verified the new batch renders correctly in the mock-matrix job JSON and that `cashtocode`/`fiuu` no longer appear in batches 1/2.

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible