### PR TITLE
fix(refunds): serialize concurrent refund creation to prevent over-refund (TOCTOU

### DIFF
--- a/crates/router/src/compatibility/stripe/refunds.rs
+++ b/crates/router/src/compatibility/stripe/refunds.rs
@@ -6,7 +6,10 @@ use router_env::{instrument, tracing, Flow, Tag};
 
 use crate::{
     compatibility::{stripe::errors, wrap},
-    core::{api_locking, refunds},
+    core::{
+        api_locking::{self, GetLockingInput},
+        refunds,
+    },
     logger, routes,
     services::{api, authentication as auth},
     types::api::refunds as refund_types,
@@ -34,6 +37,7 @@ pub async fn refund_create(
     let create_refund_req: refund_types::RefundRequest = payload.into();
 
     let flow = Flow::RefundsCreate;
+    let locking_action = create_refund_req.get_locking_input(flow.clone());
 
     Box::pin(wrap::compatibility_api_wrap::<
         _,
@@ -56,7 +60,7 @@ pub async fn refund_create(
             allow_connected_scope_operation: false,
             allow_platform_self_operation: false,
         }),
-        api_locking::LockAction::NotApplicable,
+        locking_action,
     ))
     .await
 }

--- a/crates/router/src/core/utils/refunds_validator.rs
+++ b/crates/router/src/core/utils/refunds_validator.rs
@@ -299,3 +299,115 @@ pub fn validate_xendit_charge_refund(
         }
     }
 }
+
+#[cfg(all(test, feature = "v1"))]
+mod refund_amount_validation_tests {
+    use common_utils::types::{ConnectorTransactionId, MinorUnit};
+    use diesel_models::refund as diesel_refund;
+
+    use super::*;
+
+    /// Builds a `Refund` row with the given amount and status; all other fields are irrelevant to
+    /// `validate_refund_amount` and are filled with placeholders.
+    fn refund(amount: i64, status: enums::RefundStatus) -> diesel_refund::Refund {
+        let now = common_utils::date_time::now();
+        diesel_refund::Refund {
+            internal_reference_id: "ref_internal".to_string(),
+            refund_id: "ref_1".to_string(),
+            payment_id: common_utils::id_type::PaymentId::default(),
+            merchant_id: common_utils::id_type::MerchantId::default(),
+            connector_transaction_id: ConnectorTransactionId::from("txn_1".to_string()),
+            connector: "stripe".to_string(),
+            connector_refund_id: None,
+            external_reference_id: None,
+            refund_type: enums::RefundType::InstantRefund,
+            total_amount: MinorUnit::new(amount),
+            currency: enums::Currency::USD,
+            refund_amount: MinorUnit::new(amount),
+            refund_status: status,
+            sent_to_gateway: false,
+            refund_error_message: None,
+            metadata: None,
+            refund_arn: None,
+            created_at: now,
+            modified_at: now,
+            description: None,
+            attempt_id: "att_1".to_string(),
+            refund_reason: None,
+            refund_error_code: None,
+            profile_id: None,
+            updated_by: String::new(),
+            merchant_connector_id: None,
+            charges: None,
+            organization_id: common_utils::id_type::OrganizationId::default(),
+            connector_refund_data: None,
+            connector_transaction_data: None,
+            split_refunds: None,
+            unified_code: None,
+            unified_message: None,
+            processor_refund_data: None,
+            processor_transaction_data: None,
+            issuer_error_code: None,
+            issuer_error_message: None,
+            processor_merchant_id: None,
+            created_by: None,
+        }
+    }
+
+    #[test]
+    fn full_refund_at_boundary_is_allowed() {
+        // captured 100, nothing refunded yet, refund exactly 100 -> allowed
+        assert!(validate_refund_amount(100, &[], 100).is_ok());
+    }
+
+    #[test]
+    fn refund_one_over_captured_is_rejected() {
+        // captured 100, refund 101 -> rejected
+        assert!(validate_refund_amount(100, &[], 101).is_err());
+    }
+
+    #[test]
+    fn partial_refunds_summing_to_captured_are_allowed() {
+        // captured 100, already refunded 70 (Success), refund remaining 30 -> allowed
+        let existing = [refund(70, enums::RefundStatus::Success)];
+        assert!(validate_refund_amount(100, &existing, 30).is_ok());
+    }
+
+    #[test]
+    fn partial_refund_exceeding_remaining_is_rejected() {
+        // captured 100, already refunded 70, refund 31 (>30 remaining) -> rejected
+        let existing = [refund(70, enums::RefundStatus::Success)];
+        assert!(validate_refund_amount(100, &existing, 31).is_err());
+    }
+
+    #[test]
+    fn pending_refunds_count_toward_the_total() {
+        // A not-yet-settled (Pending) refund must still reserve balance, otherwise concurrent
+        // in-flight refunds could both pass. captured 100, pending 100, refund 1 -> rejected.
+        let existing = [refund(100, enums::RefundStatus::Pending)];
+        assert!(validate_refund_amount(100, &existing, 1).is_err());
+    }
+
+    #[test]
+    fn failed_refunds_are_excluded_from_the_total() {
+        // Failed and TransactionFailure refunds free up balance again.
+        let existing = [
+            refund(100, enums::RefundStatus::Failure),
+            refund(100, enums::RefundStatus::TransactionFailure),
+        ];
+        assert!(validate_refund_amount(100, &existing, 100).is_ok());
+    }
+
+    #[test]
+    fn mixed_statuses_only_non_failed_reserve_balance() {
+        // captured 100: 40 Success + 100 Failure(excluded) + 30 Pending => reserved 70,
+        // remaining 30. Refund 30 -> allowed, 31 -> rejected.
+        let existing = [
+            refund(40, enums::RefundStatus::Success),
+            refund(100, enums::RefundStatus::Failure),
+            refund(30, enums::RefundStatus::Pending),
+        ];
+        assert!(validate_refund_amount(100, &existing, 30).is_ok());
+        assert!(validate_refund_amount(100, &existing, 31).is_err());
+    }
+}

--- a/crates/router/src/routes/refunds.rs
+++ b/crates/router/src/routes/refunds.rs
@@ -7,10 +7,32 @@ use crate::core::refunds::*;
 #[cfg(feature = "v2")]
 use crate::core::refunds_v2::*;
 use crate::{
-    core::api_locking,
+    core::api_locking::{self, GetLockingInput},
+    routes::lock_utils,
     services::{api, authentication as auth, authorization::permissions::Permission},
     types::api::refunds,
 };
+
+/// Locks refund creation on the target payment so concurrent refund requests against the
+/// same payment are serialized. Without this, two refunds can both pass the
+/// `amount_refunded <= amount_captured` check before either is persisted (TOCTOU), letting the
+/// total refunded amount exceed the captured amount.
+#[cfg(feature = "v1")]
+impl GetLockingInput for refunds::RefundRequest {
+    fn get_locking_input<F>(&self, flow: F) -> api_locking::LockAction
+    where
+        F: router_env::types::FlowMetric,
+        lock_utils::ApiIdentifier: From<F>,
+    {
+        api_locking::LockAction::Hold {
+            input: api_locking::LockingInput {
+                unique_locking_key: self.payment_id.get_string_repr().to_owned(),
+                api_identifier: lock_utils::ApiIdentifier::from(flow),
+                override_lock_retries: None,
+            },
+        }
+    }
+}
 
 #[cfg(feature = "v2")]
 /// A private module to hold internal types to be used in route handlers.
@@ -41,6 +63,28 @@ mod internal_payload_types {
             })
         }
     }
+
+    /// Serializes concurrent refund creations against the same payment. Prevents the TOCTOU race
+    /// where two refunds each pass the `amount_refunded <= amount_captured` check before either is
+    /// persisted, letting the total refunded amount exceed the captured amount.
+    impl<T: serde::Serialize> GetLockingInput for RefundsGenericRequestWithResourceId<T> {
+        fn get_locking_input<F>(&self, flow: F) -> api_locking::LockAction
+        where
+            F: router_env::types::FlowMetric,
+            lock_utils::ApiIdentifier: From<F>,
+        {
+            match self.payment_id.as_ref() {
+                Some(payment_id) => api_locking::LockAction::Hold {
+                    input: api_locking::LockingInput {
+                        unique_locking_key: payment_id.get_string_repr().to_owned(),
+                        api_identifier: lock_utils::ApiIdentifier::from(flow),
+                        override_lock_retries: None,
+                    },
+                },
+                None => api_locking::LockAction::NotApplicable,
+            }
+        }
+    }
 }
 
 /// Refunds - Create
@@ -55,11 +99,13 @@ pub async fn refunds_create(
     json_payload: web::Json<refunds::RefundRequest>,
 ) -> HttpResponse {
     let flow = Flow::RefundsCreate;
+    let payload = json_payload.into_inner();
+    let locking_action = payload.get_locking_input(flow.clone());
     Box::pin(api::server_wrap(
         flow,
         state,
         &req,
-        json_payload.into_inner(),
+        payload,
         |state, auth: auth::AuthenticationData, req, _| {
             let profile_id = auth.profile.map(|profile| profile.get_id().clone());
             refund_create_core(state, auth.platform, profile_id, req)
@@ -76,7 +122,7 @@ pub async fn refunds_create(
             },
             req.headers(),
         ),
-        api_locking::LockAction::NotApplicable,
+        locking_action,
     ))
     .await
 }
@@ -101,6 +147,8 @@ pub async fn refunds_create(
             payment_id: Some(payload.payment_id.clone()),
             payload,
         };
+
+    let locking_action = internal_refund_create_payload.get_locking_input(flow.clone());
 
     let auth_type = if state.conf.merchant_id_auth.merchant_id_auth_enabled {
         &auth::MerchantIdAuth
@@ -128,7 +176,7 @@ pub async fn refunds_create(
             refund_create_core(state, auth.platform, req.payload, global_refund_id.clone())
         },
         auth_type,
-        api_locking::LockAction::NotApplicable,
+        locking_action,
     ))
     .await
 }
@@ -728,4 +776,74 @@ pub async fn get_refunds_aggregate_profile(
         api_locking::LockAction::NotApplicable,
     ))
     .await
+}
+
+#[cfg(all(test, feature = "v1"))]
+mod refund_locking_tests {
+    use std::borrow::Cow;
+
+    use common_utils::id_type::PaymentId;
+    use router_env::Flow;
+
+    use super::*;
+
+    #[test]
+    fn refund_create_locks_on_its_payment_id() {
+        let req = refunds::RefundRequest {
+            payment_id: PaymentId::try_from(Cow::Borrowed("pay_test_lock_123")).unwrap(),
+            ..Default::default()
+        };
+
+        match req.get_locking_input(Flow::RefundsCreate) {
+            api_locking::LockAction::Hold { input } => {
+                // Lock key must be the payment id so all refunds on that payment serialize.
+                assert_eq!(input.unique_locking_key, "pay_test_lock_123");
+            }
+            other => panic!("expected LockAction::Hold, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "v2"))]
+mod refund_locking_tests_v2 {
+    use common_utils::id_type::{CellId, GlobalPaymentId, GlobalRefundId};
+    use router_env::Flow;
+
+    use super::{internal_payload_types::RefundsGenericRequestWithResourceId, *};
+
+    fn cell() -> CellId {
+        CellId::from_string("12").unwrap()
+    }
+
+    #[test]
+    fn refund_create_locks_on_its_payment_id() {
+        let c = cell();
+        let payment_id = GlobalPaymentId::generate(&c);
+        let payload = RefundsGenericRequestWithResourceId {
+            global_refund_id: GlobalRefundId::generate(&c),
+            payment_id: Some(payment_id.clone()),
+            payload: (),
+        };
+
+        match payload.get_locking_input(Flow::RefundsCreate) {
+            api_locking::LockAction::Hold { input } => {
+                assert_eq!(input.unique_locking_key, payment_id.get_string_repr());
+            }
+            other => panic!("expected LockAction::Hold, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refund_create_without_payment_id_is_not_locked() {
+        let payload = RefundsGenericRequestWithResourceId {
+            global_refund_id: GlobalRefundId::generate(&cell()),
+            payment_id: None,
+            payload: (),
+        };
+
+        assert!(matches!(
+            payload.get_locking_input(Flow::RefundsCreate),
+            api_locking::LockAction::NotApplicable
+        ));
+    }
 }


### PR DESCRIPTION
Fixes a TOCTOU race in refund creation that can let the total refunded amount exceed the captured amount.

`validate_and_create_refund` performs three unsynchronized steps: (1) read all existing refunds, (2) validate `refund_amount <= amount_captured - Σ(non-failed refunds)`, (3) insert the new refund. No lock, DB transaction, `SELECT … FOR UPDATE`, or idempotency guard sits between steps 1 and 3. Two concurrent refunds for the same payment interleave between the read and the insert, both see the same stale balance, both pass validation, and both insert — a double payout. With `refund_id` omitted it is auto-generated per request, so the unique key gives no dedup either.

Payments already serialize per `payment_id` via `api_locking::LockAction::Hold` (`server_wrap_util` acquires before the handler and frees after, on success and error paths). All three refund-create entry points instead passed `LockAction::NotApplicable`.

### Fix
- Implement `GetLockingInput` for `RefundRequest` (v1) and `RefundsGenericRequestWithResourceId` (v2), keyed on `payment_id`.
- Wire the lock into all three create routes: native v1, native v2 (`routes/refunds.rs`), and stripe-compat (`compatibility/stripe/refunds.rs`).

Concurrent refunds on the same payment now serialize; the second request re-reads the balance (including the first, still-`Pending` refund) and is rejected if it would exceed captured. The insert is inside the locked section and before the connector call, so the critical section is DB-only and stays within the redis lock TTL. Retrieve/list/update/aggregate endpoints are unchanged (reads / non-amount mutations).

Closes #13182

## How did you test it?

Unit tests (all passing):

**`validate_refund_amount` edge cases** — boundary allow, +1 reject, partial sums, Pending reserves balance, Failure/TransactionFailure excluded, mixed statuses.
**Lock wiring** — v1 key == payment_id; v2 Some→Hold, None→NotApplicable.
cargo test -p router --lib refund

test result: ok. 8 passed; 0 failed
cargo test -p router --lib --no-default-features --features "v2,redis-rs" refund_locking

test result: ok. 2 passed; 0 failed
Manual E2E (running stack): create a succeeded payment, fire two full-amount refunds concurrently with no `refund_id`. Before: both can succeed (Σ > captured). After: one succeeds, one 4xx (`ResourceBusy` / `RefundAmountExceedsPaymentAmount`).
## Checklist
- [x] `cargo fmt --all`
- [x] `cargo clippy`
- [x] Added unit tests
- [ ] Modified API contract (no — internal locking only)