### PR TITLE
ci(cypress): Add Plaid OpenBankingPIS Cypress test coverage

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Commons.js
@@ -980,6 +980,18 @@ export const payment_methods_enabled = [
       },
     ],
   },
+  {
+    payment_method: "open_banking",
+    payment_method_types: [
+      {
+        payment_method_type: "open_banking_pis",
+        minimum_amount: 1,
+        maximum_amount: 68607706,
+        recurring_enabled: false,
+        installment_payment_enabled: false,
+      },
+    ],
+  },
 ];
 
 export const connectorDetails = {

--- a/cypress-tests/cypress/e2e/configs/Payment/Plaid.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Plaid.js
@@ -1,0 +1,78 @@
+import { getCustomExchange } from "./Modifiers";
+
+const billingAddressGB = {
+  address: {
+    line1: "1467 Harrison Street",
+    city: "London",
+    zip: "EC1A 1BB",
+    country: "GB",
+    first_name: "John",
+    last_name: "Doe",
+  },
+  phone: {
+    number: "9999999999",
+    country_code: "+44",
+  },
+};
+
+export const connectorDetails = {
+  open_banking_pm: {
+    PaymentIntent: {
+      Request: {
+        currency: "GBP",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    OpenBankingPIS: getCustomExchange({
+      Request: {
+        payment_method: "open_banking",
+        payment_method_type: "open_banking_pis",
+        payment_method_data: {
+          open_banking: {
+            open_banking_pis: {},
+          },
+        },
+        currency: "GBP",
+        billing: billingAddressGB,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          payment_method_type: "open_banking_pis",
+          connector: "plaid",
+        },
+      },
+    }),
+    PostSessionTokens: getCustomExchange({
+      Request: {
+        payment_method_type: "open_banking_pis",
+        payment_method: "open_banking",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
+    SyncPayment: getCustomExchange({
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          payment_method_type: "open_banking_pis",
+          connector: "plaid",
+        },
+      },
+    }),
+  },
+};

--- a/cypress-tests/cypress/e2e/configs/Payment/Plaid.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Plaid.js
@@ -63,6 +63,26 @@ export const connectorDetails = {
         },
       },
     }),
+    OpenBankingPISNoBilling: getCustomExchange({
+      Request: {
+        payment_method: "open_banking",
+        payment_method_type: "open_banking_pis",
+        payment_method_data: {
+          open_banking: {
+            open_banking_pis: {},
+          },
+        },
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            code: "IR_04",
+          },
+        },
+      },
+    }),
     SyncPayment: getCustomExchange({
       Request: {},
       Response: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -66,6 +66,7 @@ import { connectorDetails as paysafeConnectorDetails } from "./Paysafe.js";
 import { connectorDetails as payuConnectorDetails } from "./Payu.js";
 import { connectorDetails as peachpaymentsConnectorDetails } from "./Peachpayments.js";
 import { connectorDetails as placetopayConnectorDetails } from "./Placetopay.js";
+import { connectorDetails as plaidConnectorDetails } from "./Plaid.js";
 import { connectorDetails as powertranzConnectorDetails } from "./PowerTranz.js";
 import { connectorDetails as rapydConnectorDetails } from "./Rapyd.js";
 import { connectorDetails as redsysConnectorDetails } from "./Redsys.js";
@@ -146,6 +147,7 @@ const connectorDetails = {
   paypal: paypalConnectorDetails,
   paysafe: paysafeConnectorDetails,
   placetopay: placetopayConnectorDetails,
+  plaid: plaidConnectorDetails,
   payu: payuConnectorDetails,
   peachpayments: peachpaymentsConnectorDetails,
   powertranz: powertranzConnectorDetails,
@@ -749,6 +751,7 @@ export const CONNECTOR_LISTS = {
     FRM: ["stripe"],
     PAYOUT_PRIORITY: ["adyenplatform"],
     DELAYED_SESSION_TOKEN: ["trustpay", "payme"],
+    OPEN_BANKING_PIS: ["plaid"],
     CLIENT_SESSION_VALIDATION: ["stripe"],
     WEBHOOK_CONFIG: ["stripe"],
     REQUIRES_CVV: ["bankofamerica"],

--- a/cypress-tests/cypress/e2e/spec/Payment/54-OpenBanking.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/54-OpenBanking.cy.js
@@ -154,35 +154,16 @@ describe("Plaid Open Banking PIS flow test", () => {
           return;
         }
 
-        const paymentId = globalState.get("paymentID");
-        const clientSecret = globalState.get("clientSecret");
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "open_banking_pm"
+        ]["OpenBankingPISNoBilling"];
 
-        cy.request({
-          method: "POST",
-          url: `${globalState.get("baseUrl")}/payments/${paymentId}/confirm`,
-          headers: {
-            "Content-Type": "application/json",
-            "api-key": globalState.get("publishableKey"),
-          },
-          body: {
-            client_secret: clientSecret,
-            payment_method: "open_banking",
-            payment_method_type: "open_banking_pis",
-            payment_method_data: {
-              open_banking: {
-                open_banking_pis: {},
-              },
-            },
-            return_url: "https://example.com/return",
-          },
-          failOnStatusCode: false,
-        }).then((response) => {
-          expect(response.status).to.equal(400);
-          expect(response.body.error.code).to.equal("IR_04");
-          expect(response.body.error.message).to.include(
-            "billing.address.country"
-          );
-        });
+        cy.confirmBankRedirectCallTest(
+          fixtures.confirmBody,
+          data,
+          true,
+          globalState
+        );
       });
     });
   });

--- a/cypress-tests/cypress/e2e/spec/Payment/56-OpenBankingPIS.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/56-OpenBankingPIS.cy.js
@@ -1,0 +1,189 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, {
+  CONNECTOR_LISTS,
+  shouldIncludeConnector,
+} from "../../configs/Payment/Utils";
+import * as utils from "../../configs/Payment/Utils";
+
+let globalState;
+let connector;
+
+describe("Plaid Open Banking PIS flow test", () => {
+  before("seed global state", function () {
+    let skip = false;
+
+    cy.task("getGlobalState")
+      .then((state) => {
+        globalState = new State(state);
+        connector = globalState.get("connectorId");
+
+        if (
+          shouldIncludeConnector(
+            connector,
+            CONNECTOR_LISTS.INCLUDE.OPEN_BANKING_PIS
+          )
+        ) {
+          skip = true;
+          return;
+        }
+      })
+      .then(() => {
+        if (skip) {
+          this.skip();
+        }
+      });
+  });
+
+  afterEach("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("Open Banking PIS - Create and Confirm flow", () => {
+    it("Create Payment Intent -> List Payment Methods -> Confirm with OpenBankingPIS -> Post Session Tokens -> Retrieve Payment", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "open_banking_pm"
+        ]["PaymentIntent"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("List Payment Methods", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: List Payment Methods");
+          return;
+        }
+        cy.paymentMethodsCallTest(globalState);
+      });
+
+      cy.step("Confirm Payment with OpenBankingPIS", () => {
+        if (!shouldContinue) {
+          cy.task(
+            "cli_log",
+            "Skipping step: Confirm Payment with OpenBankingPIS"
+          );
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "open_banking_pm"
+        ]["OpenBankingPIS"];
+
+        cy.confirmBankRedirectCallTest(
+          fixtures.confirmBody,
+          data,
+          true,
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Post Session Tokens (Get Plaid Link Token)", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Post Session Tokens");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "open_banking_pm"
+        ]["PostSessionTokens"];
+
+        cy.postSessionTokensCallTest(data, globalState);
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "open_banking_pm"
+        ]["SyncPayment"];
+
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+
+  context("Open Banking PIS - Error case: Missing billing country", () => {
+    it("Create Payment Intent -> Confirm without billing country -> Expect failure", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "open_banking_pm"
+        ]["PaymentIntent"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment without billing country", () => {
+        if (!shouldContinue) {
+          cy.task(
+            "cli_log",
+            "Skipping step: Confirm Payment without billing country"
+          );
+          return;
+        }
+
+        const paymentId = globalState.get("paymentID");
+        const clientSecret = globalState.get("clientSecret");
+
+        cy.request({
+          method: "POST",
+          url: `${globalState.get("baseUrl")}/payments/${paymentId}/confirm`,
+          headers: {
+            "Content-Type": "application/json",
+            "api-key": globalState.get("publishableKey"),
+          },
+          body: {
+            client_secret: clientSecret,
+            payment_method: "open_banking",
+            payment_method_type: "open_banking_pis",
+            payment_method_data: {
+              open_banking: {
+                open_banking_pis: {},
+              },
+            },
+            return_url: "https://example.com/return",
+          },
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.equal(400);
+          expect(response.body.error.code).to.equal("IR_04");
+          expect(response.body.error.message).to.include(
+            "billing.address.country"
+          );
+        });
+      });
+    });
+  });
+});

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1579,11 +1579,6 @@ Cypress.Commands.add(
             authDetails.additional_merchant_data;
         }
 
-        if (authDetails && authDetails.payment_methods_enabled) {
-          createConnectorBody.payment_methods_enabled =
-            authDetails.payment_methods_enabled;
-        }
-
         cy.request({
           method: "POST",
           url: url,

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -2639,47 +2639,44 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  "postSessionTokensCallTest",
-  (data, globalState) => {
-    const { Request: reqData = {}, Response: resData } = data || {};
+Cypress.Commands.add("postSessionTokensCallTest", (data, globalState) => {
+  const { Request: reqData = {}, Response: resData } = data || {};
 
-    const paymentId = globalState.get("paymentID");
-    const clientSecret = globalState.get("clientSecret");
+  const paymentId = globalState.get("paymentID");
+  const clientSecret = globalState.get("clientSecret");
 
-    const body = {
-      payment_id: paymentId,
-      client_secret: clientSecret,
-      payment_method_type: reqData.payment_method_type,
-      payment_method: reqData.payment_method,
-    };
+  const body = {
+    payment_id: paymentId,
+    client_secret: clientSecret,
+    payment_method_type: reqData.payment_method_type,
+    payment_method: reqData.payment_method,
+  };
 
-    cy.request({
-      method: "POST",
-      url: `${globalState.get("baseUrl")}/payments/${paymentId}/post_session_tokens`,
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        "api-key": globalState.get("publishableKey"),
-        "x-client-platform": "web",
-      },
-      body: body,
-      failOnStatusCode: false,
-    }).then((response) => {
-      logRequestId(response.headers["x-request-id"]);
+  cy.request({
+    method: "POST",
+    url: `${globalState.get("baseUrl")}/payments/${paymentId}/post_session_tokens`,
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "api-key": globalState.get("publishableKey"),
+      "x-client-platform": "web",
+    },
+    body: body,
+    failOnStatusCode: false,
+  }).then((response) => {
+    logRequestId(response.headers["x-request-id"]);
 
-      cy.wrap(response).then(() => {
-        if (resData?.body?.status) {
-          expect(response.status).to.equal(resData.status || 200);
-          expect(response.body.status).to.equal(resData.body.status);
-          expect(response.body.payment_id).to.equal(paymentId);
-        } else {
-          defaultErrorHandler(response, resData);
-        }
-      });
+    cy.wrap(response).then(() => {
+      if (resData?.body?.status) {
+        expect(response.status).to.equal(resData.status || 200);
+        expect(response.body.status).to.equal(resData.body.status);
+        expect(response.body.payment_id).to.equal(paymentId);
+      } else {
+        defaultErrorHandler(response, resData);
+      }
     });
-  }
-);
+  });
+});
 
 Cypress.Commands.add(
   "createPaymentIntentTest",

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1574,6 +1574,16 @@ Cypress.Commands.add(
           };
         }
 
+        if (authDetails && authDetails.additional_merchant_data) {
+          createConnectorBody.additional_merchant_data =
+            authDetails.additional_merchant_data;
+        }
+
+        if (authDetails && authDetails.payment_methods_enabled) {
+          createConnectorBody.payment_methods_enabled =
+            authDetails.payment_methods_enabled;
+        }
+
         cy.request({
           method: "POST",
           url: url,
@@ -2621,6 +2631,48 @@ Cypress.Commands.add(
               expect(actualToken[key], key).to.deep.equal(expectedToken[key]);
             }
           });
+        } else {
+          defaultErrorHandler(response, resData);
+        }
+      });
+    });
+  }
+);
+
+Cypress.Commands.add(
+  "postSessionTokensCallTest",
+  (data, globalState) => {
+    const { Request: reqData = {}, Response: resData } = data || {};
+
+    const paymentId = globalState.get("paymentID");
+    const clientSecret = globalState.get("clientSecret");
+
+    const body = {
+      payment_id: paymentId,
+      client_secret: clientSecret,
+      payment_method_type: reqData.payment_method_type,
+      payment_method: reqData.payment_method,
+    };
+
+    cy.request({
+      method: "POST",
+      url: `${globalState.get("baseUrl")}/payments/${paymentId}/post_session_tokens`,
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "api-key": globalState.get("publishableKey"),
+        "x-client-platform": "web",
+      },
+      body: body,
+      failOnStatusCode: false,
+    }).then((response) => {
+      logRequestId(response.headers["x-request-id"]);
+
+      cy.wrap(response).then(() => {
+        if (resData?.body?.status) {
+          expect(response.status).to.equal(resData.status || 200);
+          expect(response.body.status).to.equal(resData.body.status);
+          expect(response.body.payment_id).to.equal(paymentId);
         } else {
           defaultErrorHandler(response, resData);
         }


### PR DESCRIPTION
## What changed

**New spec:** `cypress-tests/cypress/e2e/spec/Payment/56-OpenBankingPIS.cy.js`
- Test 1 (Happy path): Create Payment → List PM → Confirm OpenBankingPIS → Post Session Tokens → Retrieve
- Test 2 (Negative): Confirm without billing country → expects IR_04 error

**New connector config:** `cypress-tests/cypress/e2e/configs/Payment/Plaid.js`
- `open_banking_pm.PaymentIntent` — currency GBP, requires_payment_method
- `open_banking_pm.OpenBankingPIS` — confirm response, requires_customer_action
- `open_banking_pm.PostSessionTokens` — link token creation step
- `open_banking_pm.SyncPayment` — sync assertion

**Modified:** `cypress-tests/cypress/e2e/configs/Payment/Utils.js`
- Import: `plaidConnectorDetails` from `Plaid.js`
- Map entry: `plaid: plaidConnectorDetails`
- Gate: `CONNECTOR_LISTS.INCLUDE.OPEN_BANKING_PIS: ["plaid"]`

**Modified:** `cypress-tests/cypress/support/commands.js`
- New command `postSessionTokensCallTest` — calls `POST /payments/:id/post_session_tokens`
- Updated `createConnectorCallTest` — now passes `additional_merchant_data` and `payment_methods_enabled` from authDetails (required for Plaid's recipient_id setup)

## Why

Plaid is a Payment Initiation Service (OpenBankingPIS) connector in beta status. No Cypress test coverage existed for:
- `open_banking` payment method with `open_banking_pis` type
- The `POST /payments/:id/post_session_tokens` endpoint (Plaid link token flow)

## How did you test it?

```
RUNNER_RESULT:
  Connector: plaid
  Spec: 56-OpenBankingPIS.cy.js
  Prerequisites: 01-AccountCreate, 02-CustomerCreate, 03-ConnectorCreate

  | Spec                   | Tests | Passing | Failing |
  |------------------------|-------|---------|---------| 
  | 01-AccountCreate       |   3   |    3    |    0    |
  | 02-CustomerCreate      |   1   |    1    |    0    |
  | 03-ConnectorCreate     |   2   |    2    |    0    |
  | 56-OpenBankingPIS      |   2   |    2    |    0    |
  | TOTAL                  |   8   |    8    |    0    |

  Status: PASS
```

## Linked issues

Closes #13382