### PR TITLE
fix(authentication): fixed race condition for authentication cavv update and authentication status update

### DIFF
--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -2222,13 +2222,29 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
                  )
                     .update_storage_scheme(platform.get_processor().get_account().storage_scheme);
 
-                let cryptogram = sync_response.authentication_details.and_then(|authentication_details| authentication_details.three_ds_data.and_then(|data| data.authentication_cryptogram)).ok_or(errors::ApiErrorResponse::MissingRequiredField{field_name:"authentication_cryptogram"})?;
+                let cavv = if updated_authentication_status
+                    == api_models::enums::AuthenticationStatus::Success
+                {
+                    let cryptogram = sync_response
+                        .authentication_details
+                        .and_then(|authentication_details| authentication_details.three_ds_data)
+                        .and_then(|data| data.authentication_cryptogram)
+                        .ok_or(errors::ApiErrorResponse::MissingRequiredField {
+                            field_name: "authentication_cryptogram",
+                        })?;
+
+                    match cryptogram {
+                        api_models::authentication::Cryptogram::Cavv {
+                            authentication_cryptogram,
+                        } => Some(authentication_cryptogram),
+                    }
+                } else {
+                    None
+                };
 
                 let authentication_store =
                         hyperswitch_domain_models::router_request_types::authentication::AuthenticationStore {
-                            cavv: match cryptogram {
-                                api_models::authentication::Cryptogram::Cavv { authentication_cryptogram } => Some(authentication_cryptogram),
-                            },
+                            cavv,
                             authentication:authentication_domain_model
                         };
 

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1938,6 +1938,28 @@ async fn external_authentication_incoming_webhook_flow(
                     "received a non-external-authentication id for retrieving authentication",
                 )
             }?;
+
+        // Store the authentication value before publishing the successful authentication state.
+        // Otherwise, the browser callback can observe `Success` and attempt authorization before
+        // the CAVV is available in Redis.
+        authentication_details
+            .authentication_value
+            .async_map(|auth_val| {
+                payment_methods::vault::create_tokenize_without_configurable_expiry(
+                    &state,
+                    auth_val.expose(),
+                    None,
+                    authentication
+                        .authentication_id
+                        .clone()
+                        .get_string_repr()
+                        .to_string(),
+                    platform.get_processor().get_key_store().key.get_inner(),
+                )
+            })
+            .await
+            .transpose()?;
+
         let updated_authentication = state
             .store
             .update_authentication_by_processor_merchant_id_authentication_id(
@@ -1951,23 +1973,6 @@ async fn external_authentication_incoming_webhook_flow(
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Error while updating authentication")?;
 
-        authentication_details
-            .authentication_value
-            .async_map(|auth_val| {
-                payment_methods::vault::create_tokenize_without_configurable_expiry(
-                    &state,
-                    auth_val.expose(),
-                    None,
-                    updated_authentication
-                        .authentication_id
-                        .clone()
-                        .get_string_repr()
-                        .to_string(),
-                    platform.get_processor().get_key_store().key.get_inner(),
-                )
-            })
-            .await
-            .transpose()?;
         // Check if it's a payment authentication flow, payment_id would be there only for payment authentication flows
         if let Some(payment_id) = updated_authentication.payment_id {
             let is_pull_mechanism_enabled = helper_utils::check_if_pull_mechanism_for_external_3ds_enabled_from_connector_metadata(merchant_connector_account.metadata.map(|metadata| metadata.expose()));


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring


## Description
<!-- Describe your changes in detail -->
fixed race condition for authentication cavv update and authentication status update


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

This PR (#13386) introduces two important fixes related to 3D Secure (3DS) external authentication flows:

1. **Fixes a missing cryptogram error during payment confirmation ([payment_confirm.rs](file:///Users/sahkal.poddar/hyperswitch/crates/router/src/core/payments/operations/payment_confirm.rs))**:
   - **Before:** The system would unconditionally attempt to extract the `authentication_cryptogram` (CAVV) from the 3DS sync response. If it was missing (which happens when authentication fails or is still pending), it would result in a `MissingRequiredField` error.
   - **After:** The code now first checks if the `updated_authentication_status` is `Success`. It only requires and extracts the cryptogram for successful authentications, gracefully falling back to `None` for other statuses without throwing an error.

2. **Resolves a race condition in incoming webhooks ([incoming.rs](file:///Users/sahkal.poddar/hyperswitch/crates/router/src/core/webhooks/incoming.rs))**:
   - **Before:** When handling an external authentication webhook, the system updated the authentication record in the database to a `Success` state *before* it stored the `authentication_value` (CAVV) into Redis.
   - **After:** The order of operations has been swapped. The `authentication_value` is now stored in Redis *first*. This prevents a race condition where a browser callback might observe the `Success` state and attempt to proceed with the authorization before the CAVV is actually available for use.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

There is a race condition in sandbox for netcetera

```shell
Browser/ACS calls /authorize
        ↓
perform_post_authentication tries Redis
        ↓
Netcetera webhook has not arrived yet
        ↓
LOCKER_PM_TOKEN_<authentication_id> does not exist
```
Previously we were marking authentication status as Success  and then storing value to redis due to which a simultaneous /authorise  would observe authentication status as success and try to get the value which is still yet to be put in redis. Resulting to value not found.

To mitigate this we will first store the value in redis and then update authentication status!

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

https://github.com/user-attachments/assets/a00ee6cc-0a37-45c8-b8aa-dbec494e9f6a



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
