### PR TITLE
fix(core/connector): [CYBERSOURCE] Persist previous state in case of Void 2xx failures or 4xx

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -3042,6 +3042,12 @@ impl TryFrom<&CybersourceRouterData<&PaymentsIncrementalAuthorizationRouterData>
 }
 
 #[derive(Debug, Serialize)]
+pub enum CybersourceReversalReason {
+    #[serde(rename = "34")]
+    SuspectedFraud,
+}
+
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CybersourceVoidRequest {
     client_reference_information: ClientReferenceInformation,
@@ -3055,7 +3061,7 @@ pub struct CybersourceVoidRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ReversalInformation {
     amount_details: Amount,
-    reason: String,
+    reason: CybersourceReversalReason,
 }
 
 impl TryFrom<&CybersourceRouterData<&PaymentsCancelRouterData>> for CybersourceVoidRequest {
@@ -3085,14 +3091,7 @@ impl TryFrom<&CybersourceRouterData<&PaymentsCancelRouterData>> for CybersourceV
                         },
                     )?,
                 },
-                reason: value
-                    .router_data
-                    .request
-                    .cancellation_reason
-                    .clone()
-                    .ok_or(errors::ConnectorError::MissingRequiredField {
-                        field_name: "Cancellation Reason",
-                    })?,
+                reason: CybersourceReversalReason::SuspectedFraud,
             },
             merchant_defined_information,
         })

--- a/crates/hyperswitch_domain_models/src/router_data.rs
+++ b/crates/hyperswitch_domain_models/src/router_data.rs
@@ -2490,7 +2490,7 @@ impl
                     code,
                     message,
                     reason,
-                    status_code: _,
+                    status_code,
                     attempt_status: _,
                     connector_transaction_id,
                     connector_response_reference_id,
@@ -2500,14 +2500,22 @@ impl
                     connector_metadata: _,
                 } = error_response.clone();
 
-                // Handle errors exactly
-                let status = match error_response.attempt_status {
-                    // Use the status sent by connector in error_response if it's present
-                    Some(status) => status,
-                    None => match error_response.status_code {
-                        500..=511 => common_enums::AttemptStatus::Pending,
-                        _ => common_enums::AttemptStatus::VoidFailed,
-                    },
+                // Void failures should not overwrite the pre-Void status unless the
+                // connector failure is a 5xx, where the final state is uncertain.
+                let status = match status_code {
+                    500..=511 => common_enums::AttemptStatus::Pending,
+                    _ => payment_data.payment_attempt.status,
+                };
+                // When restoring the pre-Void status, preserve its capturable amount too.
+                let amount_capturable = if status == payment_data.payment_attempt.status {
+                    Some(
+                        payment_data
+                            .payment_attempt
+                            .amount_details
+                            .get_amount_capturable(),
+                    )
+                } else {
+                    Some(MinorUnit::zero())
                 };
 
                 let error_details = ErrorDetails {
@@ -2523,7 +2531,7 @@ impl
 
                 PaymentAttemptUpdate::ErrorUpdate {
                     status,
-                    amount_capturable: Some(MinorUnit::zero()),
+                    amount_capturable,
                     error: Box::new(error_details),
                     updated_by: storage_scheme.to_string(),
                     connector_payment_id: connector_transaction_id,
@@ -2532,7 +2540,7 @@ impl
                 }
             }
             Ok(ref _response) => PaymentAttemptUpdate::VoidUpdate {
-                status: self.status,
+                status: self.get_attempt_status_for_db_update(payment_data),
                 cancellation_reason: payment_data.payment_attempt.cancellation_reason.clone(),
                 updated_by: storage_scheme.to_string(),
             },
@@ -2557,17 +2565,16 @@ impl
 
     fn get_attempt_status_for_db_update(
         &self,
-        _payment_data: &payments::PaymentCancelData<router_flow_types::Void>,
+        payment_data: &payments::PaymentCancelData<router_flow_types::Void>,
     ) -> common_enums::AttemptStatus {
-        // For void operations, determine status based on response
         match &self.response {
-            Err(ref error_response) => match error_response.attempt_status {
-                Some(status) => status,
-                None => match error_response.status_code {
-                    500..=511 => common_enums::AttemptStatus::Pending,
-                    _ => common_enums::AttemptStatus::VoidFailed,
-                },
+            Err(ref error_response) => match error_response.status_code {
+                500..=511 => common_enums::AttemptStatus::Pending,
+                _ => payment_data.payment_attempt.status,
             },
+            Ok(ref _response) if self.status == common_enums::AttemptStatus::VoidFailed => {
+                payment_data.payment_attempt.status
+            }
             Ok(ref _response) => self.status,
         }
     }

--- a/crates/hyperswitch_domain_models/src/router_data.rs
+++ b/crates/hyperswitch_domain_models/src/router_data.rs
@@ -1262,7 +1262,7 @@ impl
             | common_enums::IntentStatus::PartiallyAuthorizedAndRequiresCapture => None,
             // If status is requires capture, get the total amount that can be captured
             // This is in cases where the capture method will be `manual` or `manual_multiple`
-            // We do not need to handle the case where amount_to_capture is provided here as it cannot be passed in authroize flow
+            // We do not need to handle the case where amount_to_capture is provided here as it cannot be passed in authorize flow
             common_enums::IntentStatus::RequiresCapture => {
                 let total_amount = payment_data.payment_attempt.amount_details.get_net_amount();
                 Some(total_amount)
@@ -2384,7 +2384,7 @@ impl
             | common_enums::IntentStatus::RequiresConfirmation => None,
             // If status is requires capture, get the total amount that can be captured
             // This is in cases where the capture method will be `manual` or `manual_multiple`
-            // We do not need to handle the case where amount_to_capture is provided here as it cannot be passed in authroize flow
+            // We do not need to handle the case where amount_to_capture is provided here as it cannot be passed in authorize flow
             common_enums::IntentStatus::RequiresCapture
             | common_enums::IntentStatus::PartiallyAuthorizedAndRequiresCapture => {
                 let total_amount = payment_data.payment_attempt.amount_details.get_net_amount();

--- a/crates/router/src/core/payments/operations/payment_cancel_v2.rs
+++ b/crates/router/src/core/payments/operations/payment_cancel_v2.rs
@@ -202,7 +202,7 @@ impl<F: Clone + Send + Sync>
         state: &'b SessionState,
         req_state: ReqState,
         processor: &domain::Processor,
-        mut payment_data: hyperswitch_domain_models::payments::PaymentCancelData<F>,
+        payment_data: hyperswitch_domain_models::payments::PaymentCancelData<F>,
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: hyperswitch_domain_models::payments::HeaderPayload,
         _dimensions: &dimension_state::DimensionsWithProcessorAndProviderMerchantId,
@@ -223,17 +223,17 @@ impl<F: Clone + Send + Sync>
             updated_by: storage_scheme.to_string(),
         };
 
-        let updated_payment_attempt = db
-            .update_payment_attempt(
-                merchant_key_store,
-                payment_data.payment_attempt.clone(),
-                payment_attempt_update,
-                storage_scheme,
-            )
-            .await
-            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)
-            .attach_printable("Failed to update payment attempt for cancellation")?;
-        payment_data.set_payment_attempt(updated_payment_attempt);
+        // Persist VoidInitiated before the connector call, but keep payment_data
+        // unchanged so post-connector handling can restore the real pre-Void status.
+        db.update_payment_attempt(
+            merchant_key_store,
+            payment_data.payment_attempt.clone(),
+            payment_attempt_update,
+            storage_scheme,
+        )
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)
+        .attach_printable("Failed to update payment attempt for cancellation")?;
 
         Ok((Box::new(self), payment_data))
     }

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -2325,31 +2325,40 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                         .await
                         .or(Some(unified_message));
 
-                    let status = match err.attempt_status {
-                        // Use the status sent by connector in error_response if it's present
-                        Some(status) => status,
-                        None =>
-                        // mark previous attempt status for technical failures in PSync and ExtendAuthorization flow
-                        {
-                            if sub_flow == "PSync" || sub_flow == "ExtendAuthorization" {
-                                match err.status_code {
-                                    // marking failure for 2xx because this is genuine payment failure
-                                    200..=299 => enums::AttemptStatus::Failure,
-                                    _ => router_data.status,
-                                }
-                            } else if sub_flow == "Capture" {
-                                match err.status_code {
-                                    500..=511 => enums::AttemptStatus::Pending,
-                                    // don't update the status for 429 error status
-                                    429 => router_data.status,
-                                    _ => enums::AttemptStatus::Failure,
-                                }
-                            } else if sub_flow == "CancelPostCapture" {
-                                router_data.status
-                            } else {
-                                match err.status_code {
-                                    500..=511 => enums::AttemptStatus::Pending,
-                                    _ => enums::AttemptStatus::Failure,
+                    let status = if sub_flow == "Void" {
+                        // Void failures should not overwrite the pre-Void status unless
+                        // the connector failure is a 5xx, where the final state is uncertain.
+                        match err.status_code {
+                            500..=511 => enums::AttemptStatus::Pending,
+                            _ => router_data.status,
+                        }
+                    } else {
+                        match err.attempt_status {
+                            // Use the status sent by connector in error_response if it's present
+                            Some(status) => status,
+                            None =>
+                            // mark previous attempt status for technical failures in PSync and ExtendAuthorization flow
+                            {
+                                if sub_flow == "PSync" || sub_flow == "ExtendAuthorization" {
+                                    match err.status_code {
+                                        // marking failure for 2xx because this is genuine payment failure
+                                        200..=299 => enums::AttemptStatus::Failure,
+                                        _ => router_data.status,
+                                    }
+                                } else if sub_flow == "Capture" {
+                                    match err.status_code {
+                                        500..=511 => enums::AttemptStatus::Pending,
+                                        // don't update the status for 429 error status
+                                        429 => router_data.status,
+                                        _ => enums::AttemptStatus::Failure,
+                                    }
+                                } else if sub_flow == "CancelPostCapture" {
+                                    router_data.status
+                                } else {
+                                    match err.status_code {
+                                        500..=511 => enums::AttemptStatus::Pending,
+                                        _ => enums::AttemptStatus::Failure,
+                                    }
                                 }
                             }
                         }
@@ -2449,11 +2458,17 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                 Ok(()) => {
                     let attempt_status = payment_data.payment_attempt.status.to_owned();
                     let connector_status = router_data.status.to_owned();
+                    let sub_flow = core_utils::get_flow_name::<F>()?;
                     let updated_attempt_status = match (
                         connector_status,
                         attempt_status,
                         payment_data.frm_message.to_owned(),
                     ) {
+                        (enums::AttemptStatus::VoidFailed, previous_attempt_status, _)
+                            if sub_flow == "Void" =>
+                        {
+                            previous_attempt_status
+                        }
                         (
                             enums::AttemptStatus::Authorized,
                             enums::AttemptStatus::Unresolved,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

In case of Void 2xx failures or 4xx => Preseve previous state of intent.status and attempt.status
In case of Void 5xx => Mark as Pending or Processing

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
For the cybersource hardcoding of fraud (34), [Ref](https://developer.cybersource.com/api-reference-assets/index.html#payments_reversal_process-an-authorization-reversal_responsefielddescription_201)

<img width="1728" height="967" alt="Screenshot 2026-07-20 at 17 55 14" src="https://github.com/user-attachments/assets/7342e336-fe63-4e07-90ef-0850a7d574f9" />


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Cybersource Void 

```
curl --location 'http://localhost:8080/payments/pay_WsGMCaau7YTiweK6CfIC/cancel' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_RVYY4Ljn2cjA9AsMfz96k39zPpvENzb3iBaqE6ed35QwaVspOVXD1A4fTiYThU0N' \
--data '{
      "cancellation_reason": "requested_by_customer"
}'
```

Response 

```
{
    "payment_id": "pay_WsGMCaau7YTiweK6CfIC",
    "merchant_id": "merchant_1784537343",
    "status": "cancelled",
    "amount": 10,
    "net_amount": 10,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "processor_merchant_id": "merchant_1784537343",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fY3dndmV4T3BwakFOd0lVTmlsTEgscHVibGlzaGFibGVfa2V5PXBrX2Rldl9mOTg1OWNhNGM1ZGY0ZWViODgwNWFlNWY5ODJjMWI3NixjbGllbnRfc2VjcmV0PXBheV9Xc0dNQ2FhdTdZVGl3ZUs2Q2ZJQ19zZWNyZXRfYWQ1b1g1bG5vcVdTd0EzVTBaaDksY3VzdG9tZXJfaWQ9Y3VzX1EzNVAyMHBjM1NYYUtlczVEbDl0LHBheW1lbnRfaWQ9cGF5X1dzR01DYWF1N1lUaXdlSzZDZklD",
    "connector": "cybersource",
    "state_metadata": null,
    "client_secret": "pay_WsGMCaau7YTiweK6CfIC_secret_ad5oX5lnoqWSwA3U0Zh9",
    "created": "2026-07-20T11:58:46.063Z",
    "modified_at": "2026-07-20T12:11:06.641Z",
    "connector_customer_id": null,
    "currency": "EUR",
    "customer_id": "cus_Q35P20pc3SXaKes5Dl9t",
    "customer": {
        "id": "cus_Q35P20pc3SXaKes5Dl9t",
        "name": "John Doe",
        "email": "dg@example.com",
        "phone": "999999999",
        "phone_country_code": "+1",
        "customer_document_details": {
            "document_type": "cnpj",
            "document_number": "20201210000155"
        }
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "4444",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "555555",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "payment_checks": {
                "avs_response": {
                    "code": "Y",
                    "codeRaw": "Y"
                },
                "card_verification": null
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": {
            "address": {
                "city": "Thise",
                "country": "FR",
                "line1": "1467",
                "line2": "CA",
                "line3": null,
                "zip": "94122",
                "state": "Alsace",
                "first_name": "HenryLouis",
                "last_name": "aa",
                "origin_zip": null
            },
            "phone": null,
            "email": "dg@example.com"
        }
    },
    "payment_token": "token_eSPacdvfNy2aGKxFt8O9",
    "shipping": null,
    "billing": null,
    "order_details": [
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        }
    ],
    "email": "dg@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": "abcd",
    "error_code": "INVALID_DATA",
    "error_message": "Declined - One or more fields in the request contains invalid data, detailed_error_information: reversalInformation.reason : INVALID_DATA",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "error_details": {
        "unified_details": {
            "category": "UE_9000",
            "message": "Something went wrong",
            "standardised_code": null,
            "description": null,
            "user_guidance_message": null,
            "recommended_action": null
        },
        "issuer_details": null,
        "connector_details": {
            "code": "INVALID_DATA",
            "message": "Declined - One or more fields in the request contains invalid data",
            "reason": "Declined - One or more fields in the request contains invalid data, detailed_error_information: reversalInformation.reason : INVALID_DATA"
        }
    },
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "7845494662976760303813",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "disable_avs": true,
        "new_customer": "true"
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "pay_WsGMCaau7YTiweK6CfIC_1",
    "payment_link": null,
    "profile_id": "pro_cwgvexOppjANwIUNilLH",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_wHcJ7OxsC3vxGdh7vlwX",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-07-20T12:13:46.063Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "208.127.127.193",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1280,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 720,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_CeHfWkTfL1UgaI49vQA8",
    "network_transaction_id": "0602MCC603474",
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-07-20T12:11:06.641Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": {
        "network_advice_code": null
    },
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
