### PR TITLE
fix(router): normalize wallet card_network so payments list filter matches

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,49 @@
+# SPEC — Normalize wallet card_network so the payments-list filter matches
+
+## Problem statement
+In the V1 payments list, wallet transactions (Apple Pay / Google Pay / Samsung Pay)
+display their card network as the raw provider string (e.g. `AmEx`, `AMEX`), but
+filtering the list by "American Express" returns none of them. The POST payments
+list filter matches on the `payment_attempt.card_network` **column** (a canonical
+`CardNetwork` enum, `dsl::card_network.eq_any(...)`). That column is only written
+for card payments — for wallets it stays NULL — so wallet rows can never match a
+card-network filter, and the value surfaced to the UI is a non-canonical string.
+
+## Root cause
+`payment_attempt.card_network` is populated at write time from
+`PaymentAttempt::extract_card_network()` → `AdditionalPaymentData::get_additional_card_info()`,
+which only matches the `Card` variant and returns `None` for the `Wallet` variant.
+So wallets never write the filterable column.
+
+- `crates/api_models/src/payments.rs` — `AdditionalPaymentData::get_additional_card_info()` (Card-only).
+- `crates/hyperswitch_domain_models/src/payments/payment_attempt.rs` — V1 `extract_card_network()`.
+- Filter match: `crates/diesel_models/src/query/payment_attempt.rs:478,537` and
+  `crates/storage_impl/src/payments/payment_intent.rs:1276,1500` — `card_network.eq_any(...)`.
+
+## Acceptance criteria
+- For wallet payments, `extract_card_network()` returns the canonical `CardNetwork`
+  enum, normalized case-insensitively (`AmEx`/`AMEX`/`amex` → `AmericanExpress`).
+- The `payment_attempt.card_network` column is written for new wallet payments.
+- Filtering the payments list by a card network returns matching wallet payments.
+- Card-payment behaviour is unchanged (card path evaluated first).
+- `cargo check --features v1` passes.
+
+## Affected files
+- `crates/api_models/src/payments.rs` — add `AdditionalPaymentData::get_wallet_card_network()`:
+  reads the wallet provider network string (google_pay/samsung_pay `card_network`,
+  apple_pay `network`) and normalizes it to `CardNetwork` via its UPPERCASE serde
+  aliases. Case-insensitive, no bespoke mapping table.
+- `crates/hyperswitch_domain_models/src/payments/payment_attempt.rs` — V1
+  `extract_card_network()` now falls back to `get_wallet_card_network()` when the
+  card path yields nothing.
+
+## Risks & out of scope
+- Write-path only: fixes **new** wallet payments. Existing rows have a NULL
+  `card_network` column and need a separate backfill to be filterable — out of scope.
+- V2 `extract_card_network()` (`todo!()`) is untouched.
+- No API schema change; `WalletAdditionalDataForCard.card_network` stays `Option<String>`.
+
+## Test plan
+- `cargo check -p api_models -p hyperswitch_domain_models --features v1` — GREEN.
+- Manual: create a Google Pay / Apple Pay payment, confirm `payment_attempt.card_network`
+  is set, then filter the payments list by that network and confirm the payment appears.

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4232,6 +4232,40 @@ impl AdditionalPaymentData {
             _ => None,
         }
     }
+
+    /// Extract the card network for wallet payments.
+    ///
+    /// For wallet payments the underlying card network is persisted as a plain
+    /// provider string (e.g. `AMEX`, `AmEx`, `VISA`) rather than the canonical
+    /// [`common_enums::CardNetwork`] enum used for card payments. Normalize it
+    /// case-insensitively so it lines up with card payments and, crucially, with
+    /// the `card_network` column used by the payments list filter.
+    pub fn get_wallet_card_network(&self) -> Option<common_enums::CardNetwork> {
+        let raw_network = match self {
+            Self::Wallet {
+                apple_pay,
+                google_pay,
+                samsung_pay,
+            } => google_pay
+                .as_ref()
+                .and_then(|wallet| wallet.card_network.clone())
+                .or_else(|| {
+                    samsung_pay
+                        .as_ref()
+                        .and_then(|wallet| wallet.card_network.clone())
+                })
+                .or_else(|| apple_pay.as_ref().map(|wallet| wallet.network.clone())),
+            _ => None,
+        }?;
+
+        // `CardNetwork` carries serde aliases in UPPERCASE (e.g. `AMEX`, `VISA`),
+        // so upper-casing the raw provider string lets us reuse them for a
+        // case-insensitive match without a bespoke mapping table.
+        serde_json::from_value::<common_enums::CardNetwork>(serde_json::Value::String(
+            raw_network.to_uppercase(),
+        ))
+        .ok()
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -1758,18 +1758,21 @@ impl PaymentAttempt {
     }
 
     pub fn extract_card_network(&self) -> Option<common_enums::CardNetwork> {
-        self.payment_method_data
-            .as_ref()
-            .and_then(|value| {
-                value
-                    .clone()
-                    .parse_value::<api_models::payments::AdditionalPaymentData>(
-                        "AdditionalPaymentData",
-                    )
-                    .ok()
-            })
-            .and_then(|data| data.get_additional_card_info())
+        let additional_payment_data = self.payment_method_data.as_ref().and_then(|value| {
+            value
+                .clone()
+                .parse_value::<api_models::payments::AdditionalPaymentData>("AdditionalPaymentData")
+                .ok()
+        })?;
+
+        // Cards carry the network as a typed enum; wallets persist it as a plain
+        // provider string, so fall back to the normalized wallet network. This
+        // ensures the `card_network` column is populated for wallet payments and
+        // the payments list card-network filter matches them.
+        additional_payment_data
+            .get_additional_card_info()
             .and_then(|card_info| card_info.card_network)
+            .or_else(|| additional_payment_data.get_wallet_card_network())
     }
 
     pub fn get_payment_method_data(&self) -> Option<api_models::payments::AdditionalPaymentData> {


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
Wallet payments (Apple Pay / Google Pay / Samsung Pay) persisted their `card_network` only inside `payment_method_data` as a raw provider string (e.g. `AmEx`, `AMEX`), leaving the filterable `payment_attempt.card_network` column empty. The V1 payments list filter matches on that column (`card_network.eq_any(...)`), so filtering the list by a card network never returned wallet payments, and the value surfaced to the dashboard was non-canonical (shown as `AmEx`).

`PaymentAttempt::extract_card_network()` (V1) now falls back to a normalized wallet network. New `AdditionalPaymentData::get_wallet_card_network()` reads the wallet provider network string (Google/Samsung Pay `card_network`, Apple Pay `network`) and maps it case-insensitively to the canonical `CardNetwork` enum via its uppercase serde aliases. Card behaviour is unchanged (the card path is evaluated first).

## Root cause
`AdditionalPaymentData::get_additional_card_info()` only matches the `Card` variant → returns `None` for `Wallet` → `extract_card_network()` returned `None` for wallets → the filterable `payment_attempt.card_network` column was never written for wallet payments.

## Files
- `crates/api_models/src/payments.rs` — add `AdditionalPaymentData::get_wallet_card_network()`.
- `crates/hyperswitch_domain_models/src/payments/payment_attempt.rs` — V1 `extract_card_network()` wallet fallback.

## Scope / limitations
- Write-path fix: applies to **new** wallet payments. Existing rows have a NULL `card_network` column and need a separate backfill to become filterable (out of scope).
- V2 `extract_card_network()` (`todo!()`) untouched. No API schema change.

## How did you test it?
`cargo check -p api_models -p hyperswitch_domain_models --features v1` — passes clean. `cargo fmt` applied.