### PR TITLE
feat(locker): create locker entity during merchant account creation

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -233,6 +233,7 @@ mock_locker = true                  # Emulate a locker locally using Postgres
 locker_signing_key_id = "1"         # Key_id to sign basilisk hs locker
 locker_enabled = true               # Boolean to enable or disable saving cards in locker
 ttl_for_storage_in_secs = 220752000 # Time to live for storage entries in locker
+create_entity_on_merchant_create = false # Boolean to call the locker's entity-create API during merchant account creation, aborting creation on locker failure
 
 [delayed_session_response]
 connectors_with_delayed_session_response = "trustpay,payme" # List of connectors which has delayed session response

--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -140,6 +140,7 @@ locker_signing_key_id = "1"                                           # Key_id t
 locker_enabled = true                                                 # Boolean to enable or disable saving cards in locker
 redis_temp_locker_encryption_key = "redis_temp_locker_encryption_key" # Encryption key for redis temp locker
 ttl_for_storage_in_secs = 220752000                                   # Time to live for storage entries in locker
+create_entity_on_merchant_create = false                              # Boolean to call the locker's entity-create API during merchant account creation, aborting creation on locker failure
 
 
 

--- a/config/development.toml
+++ b/config/development.toml
@@ -153,6 +153,7 @@ host = "http://127.0.0.1:3000"
 mock_locker = true
 locker_enabled = true
 ttl_for_storage_in_secs = 220752000
+create_entity_on_merchant_create = false
 
 [forex_api]
 api_key = ""

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -150,6 +150,7 @@ host = ""
 mock_locker = true
 locker_enabled = true
 ttl_for_storage_in_secs = 220752000
+create_entity_on_merchant_create = false
 
 [jwekey]
 vault_encryption_key = ""

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -62,6 +62,7 @@ impl Default for super::settings::Locker {
             //Time to live for storage entries in locker
             ttl_for_storage_in_secs: 60 * 60 * 24 * 365 * 7,
             decryption_scheme: Default::default(),
+            create_entity_on_merchant_create: false,
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -994,6 +994,7 @@ pub struct Locker {
     pub locker_enabled: bool,
     pub ttl_for_storage_in_secs: i64,
     pub decryption_scheme: DecryptionScheme,
+    pub create_entity_on_merchant_create: bool,
 }
 
 impl Locker {

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -215,6 +215,12 @@ pub const V2_VAULT_DELETE_FLOW_TYPE: &str = "delete_from_vault";
 /// Vault Fingerprint fetch flow type
 pub const V2_VAULT_GET_FINGERPRINT_FLOW_TYPE: &str = "get_fingerprint_vault";
 
+/// Locker entity create request url
+pub const LOCKER_ENTITY_CREATE_REQUEST_URL: &str = "/entity";
+
+/// Locker entity create flow type
+pub const LOCKER_ENTITY_CREATE_FLOW_TYPE: &str = "create_entity";
+
 /// Max volume split for Dynamic routing
 pub const DYNAMIC_ROUTING_MAX_VOLUME: u8 = 100;
 

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -38,7 +38,7 @@ use crate::{
         disputes,
         encryption::transfer_encryption_key,
         errors::{self, RouterResponse, RouterResult, StorageErrorExt},
-        payment_methods::{cards, transformers},
+        payment_methods::{cards, transformers, vault},
         payments::helpers::{self},
         pm_auth::helpers::PaymentAuthConnectorDataExt,
         routing, utils as core_utils,
@@ -313,6 +313,14 @@ pub async fn create_merchant_account(
 
     let key_manager_state: &KeyManagerState = &(&state).into();
     let merchant_id = req.get_merchant_reference_id();
+
+    if state.conf.locker.locker_enabled && state.conf.locker.create_entity_on_merchant_create {
+        vault::create_entity_in_locker(&state, &merchant_id)
+            .await
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Failed to create entity in locker for merchant")?;
+    }
+
     let identifier = km_types::Identifier::Merchant(merchant_id.clone());
     keymanager::transfer_key_to_key_manager(
         key_manager_state,

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -2026,6 +2026,27 @@ pub async fn call_to_vault<V: pm_types::VaultingInterface>(
     Ok(decrypted_payload)
 }
 
+pub async fn create_entity_in_locker(
+    state: &routes::SessionState,
+    entity_id: &id_type::MerchantId,
+) -> CustomResult<pm_types::EntityCreateResponse, errors::VaultError> {
+    let payload = pm_types::EntityCreateRequest {
+        entity_id: entity_id.get_string_repr().to_owned(),
+    }
+    .encode_to_vec()
+    .change_context(errors::VaultError::RequestEncodingFailed)?;
+
+    let response = call_to_vault::<pm_types::EntityCreate>(state, payload, None, None)
+        .await
+        .change_context(errors::VaultError::VaultAPIError)
+        .attach_printable("Call to vault failed while creating locker entity")?;
+
+    response
+        .parse_struct("EntityCreateResponse")
+        .change_context(errors::VaultError::ResponseDeserializationFailed)
+        .attach_printable("Failed to parse EntityCreateResponse")
+}
+
 #[cfg(feature = "v2")]
 pub async fn get_fingerprint_id_for_payment_method(
     state: &routes::SessionState,

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -2031,7 +2031,7 @@ pub async fn create_entity_in_locker(
     entity_id: &id_type::MerchantId,
 ) -> CustomResult<pm_types::EntityCreateResponse, errors::VaultError> {
     let payload = pm_types::EntityCreateRequest {
-        entity_id: entity_id.get_string_repr().to_owned(),
+        entity_id: entity_id.clone(),
     }
     .encode_to_vec()
     .change_context(errors::VaultError::RequestEncodingFailed)?;

--- a/crates/router/src/types/payment_methods.rs
+++ b/crates/router/src/types/payment_methods.rs
@@ -182,7 +182,7 @@ impl VaultingInterface for EntityCreate {
 
 #[derive(Debug, serde::Serialize)]
 pub struct EntityCreateRequest {
-    pub entity_id: String,
+    pub entity_id: id_type::MerchantId,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/crates/router/src/types/payment_methods.rs
+++ b/crates/router/src/types/payment_methods.rs
@@ -167,6 +167,30 @@ impl VaultingInterface for VaultDelete {
     }
 }
 
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct EntityCreate;
+
+impl VaultingInterface for EntityCreate {
+    fn get_vaulting_request_url() -> &'static str {
+        consts::LOCKER_ENTITY_CREATE_REQUEST_URL
+    }
+
+    fn get_vaulting_flow_name() -> &'static str {
+        consts::LOCKER_ENTITY_CREATE_FLOW_TYPE
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct EntityCreateRequest {
+    pub entity_id: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct EntityCreateResponse {
+    pub entity_id: String,
+    pub created_at: String,
+}
+
 #[cfg(feature = "v2")]
 pub struct SavedPMLPaymentsInfo {
     pub payment_intent: storage::PaymentIntent,

--- a/crates/router/src/types/payment_methods.rs
+++ b/crates/router/src/types/payment_methods.rs
@@ -167,7 +167,7 @@ impl VaultingInterface for VaultDelete {
     }
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Debug)]
 pub struct EntityCreate;
 
 impl VaultingInterface for EntityCreate {
@@ -188,7 +188,8 @@ pub struct EntityCreateRequest {
 #[derive(Debug, serde::Deserialize)]
 pub struct EntityCreateResponse {
     pub entity_id: String,
-    pub created_at: String,
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub created_at: time::PrimitiveDateTime,
 }
 
 #[cfg(feature = "v2")]

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -84,6 +84,7 @@ host = ""
 mock_locker = true
 locker_enabled = true
 ttl_for_storage_in_secs = 220752000
+create_entity_on_merchant_create = false
 
 [forex_api]
 api_key = ""


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Adds a `locker.create_entity_on_merchant_create` config flag (default `false`). When enabled alongside the existing `locker.locker_enabled`, merchant account creation calls the locker's entity-create API (`POST /entity`) before any DB writes or key-manager transfer — a locker failure aborts the merchant creation entirely, so a merchant account is never left without a locker entity.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
New key `create_entity_on_merchant_create` under `[locker]` in `config/development.toml`, `config/config.example.toml`, `config/docker_compose.toml`, `config/deployments/env_specific.toml`, `loadtest/config/development.toml`, and `crates/router/src/configs/settings.rs`/`defaults.rs`. Defaults to `false` everywhere, so existing environments are unaffected unless explicitly opted in.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Ensures every merchant has a corresponding locker entity from the moment it's created, instead of relying on a separate backfill/migration step.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually, against a local router + real (JWE-enabled) locker + Postgres, with `create_entity_on_merchant_create = true`:

Success path:
```bash
curl -s -X POST http://localhost:8080/accounts \
  -H "api-key: test_admin" \
  -H "content-type: application/json" \
  -d '{"merchant_id": "entity_on_create_test_merchant"}'
# -> 200, merchant created; locker entity confirmed to exist (idempotent re-check returns the same created_at)
```

Failure path (locker killed before the call):
```bash
curl -s -X POST http://localhost:8080/accounts \
  -H "api-key: test_admin" \
  -H "content-type: application/json" \
  -d '{"merchant_id": "entity_on_create_should_fail"}'
# -> 500, "Failed to create entity in locker for merchant" in the error chain
```
Confirmed via direct SQL that the failure path leaves **zero rows** in `merchant_account`, `merchant_key_store`, and `business_profile` for that merchant_id — no partial state on locker failure.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
