### PR TITLE
feat(tsys_transit): add billing line1 + zip as required dynamic fields (CIT + MIT)

### DIFF
--- a/crates/payment_methods/src/configs/payment_connector_required_fields.rs
+++ b/crates/payment_methods/src/configs/payment_connector_required_fields.rs
@@ -4267,9 +4267,7 @@ fn test_required_fields_to_json() {
                     .fields
                     .get(&Connector::TsysTransit)
                     .expect("tsys_transit required fields should be present");
-                assert!(tsys_fields
-                    .common
-                    .contains_key("billing.address.line1"));
+                assert!(tsys_fields.common.contains_key("billing.address.line1"));
                 assert!(tsys_fields.common.contains_key("billing.address.zip"));
                 assert!(tsys_fields
                     .common

--- a/crates/payment_methods/src/configs/payment_connector_required_fields.rs
+++ b/crates/payment_methods/src/configs/payment_connector_required_fields.rs
@@ -1756,6 +1756,24 @@ fn get_cards_required_fields() -> HashMap<Connector, RequiredFieldFinal> {
         ),
         (Connector::Tsys, fields(vec![], card_basic(), vec![])),
         (
+            // TSYS Transit hard-requires billing addressLine1 + zip on every
+            // card authorization (AVS), for both CIT and MIT flows. Surface
+            // them as dynamic required fields so the SDK collects them.
+            Connector::TsysTransit,
+            fields(
+                vec![],
+                vec![],
+                [
+                    card_basic(),
+                    vec![
+                        RequiredField::BillingAddressLine1,
+                        RequiredField::BillingAddressZip,
+                    ],
+                ]
+                .concat(),
+            ),
+        ),
+        (
             Connector::Wellsfargo,
             fields(
                 vec![],
@@ -4233,6 +4251,32 @@ fn test_required_fields_to_json() {
                 }
             }
         }
+        // Verify TSYS Transit surfaces billing addressLine1 + zip (AVS) as
+        // required fields on both credit and debit cards, so the SDK collects
+        // them for CIT and MIT.
+        if let Some(card_method) = default_fields.0.get(&enums::PaymentMethod::Card) {
+            for pmt in [
+                enums::PaymentMethodType::Credit,
+                enums::PaymentMethodType::Debit,
+            ] {
+                let type_fields = card_method
+                    .0
+                    .get(&pmt)
+                    .expect("card payment method type should be present");
+                let tsys_fields = type_fields
+                    .fields
+                    .get(&Connector::TsysTransit)
+                    .expect("tsys_transit required fields should be present");
+                assert!(tsys_fields
+                    .common
+                    .contains_key("billing.address.line1"));
+                assert!(tsys_fields.common.contains_key("billing.address.zip"));
+                assert!(tsys_fields
+                    .common
+                    .contains_key("payment_method_data.card.card_number"));
+            }
+        }
+
         // print the result of default required fields as json in new file
         serde_json::to_writer_pretty(
             std::fs::File::create("default_required_fields.json").unwrap(),


### PR DESCRIPTION
## Summary

`tsys_transit` hard-requires `billing.address.line1` and `billing.address.zip`
(AVS) on **every** card authorization — for both CIT and MIT — but had **no
entry** in the connector required-fields config. As a result the SDK never
collected them and payments failed at the connector with:

```
UCS_400: Missing required field: billing.address.line1
```

This adds a `TsysTransit` entry to `payment_connector_required_fields.rs` with
`card_basic()` + `BillingAddressLine1` + `BillingAddressZip` (common fields), so
the SDK surfaces and collects them for both credit and debit cards.

## Why line1 + zip (and only these)

The connector's `extract_for_authorize` extracts `billing.address.line1` and
`billing.address.zip` unconditionally (no channel gate) and errors if absent —
they map to the TSYS `<addressLine1>` / `<zip>` AVS fields. City/state/country
are not sent on the wire, so they are intentionally not required.

Verified against the TSYS cert script (Test Card Data → AVS data: Address 8320,
Zip 85284) and live: a CIT/MIT without billing fails with the missing-field
error; with line1 + zip it returns `A0000`.

## Test

Extends `test_required_fields_to_json` to assert `TsysTransit` exposes
`billing.address.line1` + `billing.address.zip` (and card fields) on both the
Credit and Debit payment method types.
