### PR TITLE
fix(ucs): send payment_channel on repeat/MIT charge (MOTO MIT → PHONE)

### DIFF
--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2143,6 +2143,7 @@ impl
                 .map(|data| Secret::new(data.peek().to_string())),
             l2_l3_data: None,
             setup_mandate_details: None,
+            partner_merchant_identifier_details: None,
         })
     }
 }
@@ -2350,6 +2351,13 @@ impl
                 .mit_category
                 .map(payments_grpc::MitCategory::foreign_from)
                 .map(|mit_category| mit_category.into()),
+            payment_channel: router_data
+                .request
+                .payment_channel
+                .as_ref()
+                .map(payments_grpc::PaymentChannel::foreign_try_from)
+                .transpose()?
+                .map(|payment_channel| payment_channel.into()),
             shipping_cost: router_data
                 .request
                 .shipping_cost
@@ -2419,6 +2427,7 @@ impl
                     }),
                 }),
             auth_type: Some(auth_type.into()),
+            complete_authorize_url: None,
         })
     }
 }


### PR DESCRIPTION
## Summary

A `payment_method_id` MIT is executed via the **RepeatPayment** grpc flow
(`RecurringPaymentServiceChargeRequest`), which did **not** carry
`payment_channel`. So a merchant-initiated transaction lost the MOTO signal and
channel-sensitive connectors (`tsys_transit`) defaulted to
`cardDataSource=INTERNET` — even when the merchant sent
`payment_channel: telephone_order`. A CIT (which goes through the `Authorize`
grpc that *does* carry `payment_channel`) was unaffected.

This populates `payment_channel` on the outgoing
`RecurringPaymentServiceChargeRequest` from `PaymentsAuthorizeData.payment_channel`,
mirroring the `Authorize` builder.

## Root cause (debugged live)

| Flow | grpc method | proto has `payment_channel`? | result |
|------|-------------|------------------------------|--------|
| CIT | `Authorize` | ✅ | `cardDataSource=PHONE` ✅ |
| MIT (`payment_method_id`) | `RepeatPayment` | ❌ (before) | `cardDataSource=INTERNET` ❌ |

After the fix the MIT's outgoing TSYS request carries `<cardDataSource>PHONE</cardDataSource>` /
`CARDHOLDER_NOT_PRESENT_PHONE_TRANSACTION` and TSYS returns `A0000`. An MIT with no
`payment_channel` still defaults to `INTERNET` (no regression).

## ⚠️ Dependency

Requires the connector-service change that adds `payment_channel` (field 38) to
`RecurringPaymentServiceChargeRequest`: **juspay/hyperswitch-prism#1988**.

Once that merges and a new `rust-grpc-client` tag is cut, bump
`unified-connector-service-client` / `unified-connector-service-cards` to it.
Until then CI will not compile (the proto field, and the two `None`-initialised
fields `complete_authorize_url` / `partner_merchant_identifier_details` that ship
with that newer proto version, are not in the currently pinned tag).
