### PR TITLE
fix(payment_methods): match vault delete entity_id to the add-flow scheme

### DIFF
--- a/crates/hyperswitch_domain_models/src/errors/api_error_response.rs
+++ b/crates/hyperswitch_domain_models/src/errors/api_error_response.rs
@@ -203,6 +203,8 @@ pub enum ApiErrorResponse {
     MandateActive,
     #[error(error_type = ErrorType::InvalidRequestError, code = "IR_11", message = "Customer has already been redacted")]
     CustomerRedacted,
+    #[error(error_type = ErrorType::InvalidRequestError, code = "IR_11", message = "Payment method has already been redacted")]
+    PaymentMethodRedacted,
     #[error(error_type = ErrorType::InvalidRequestError, code = "IR_12", message = "Reached maximum refund attempts")]
     MaximumRefundCount,
     #[error(error_type = ErrorType::InvalidRequestError, code = "IR_13", message = "The refund amount exceeds the amount captured")]
@@ -594,6 +596,9 @@ impl ErrorSwitch<api_models::errors::types::ApiErrorResponse> for ApiErrorRespon
             }
             Self::CustomerRedacted => {
                 AER::BadRequest(ApiError::new("IR", 11, "Customer has already been redacted", None))
+            }
+            Self::PaymentMethodRedacted => {
+                AER::BadRequest(ApiError::new("IR", 11, "Payment method has already been redacted", None))
             }
             Self::MaximumRefundCount => AER::BadRequest(ApiError::new("IR", 12, "Reached maximum refund attempts", None)),
             Self::RefundAmountExceedsPaymentAmount => {

--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -78,6 +78,9 @@ pub enum StripeErrorCode {
     #[error(error_type = StripeErrorType::InvalidRequestError, code = "customer_redacted", message = "Customer has redacted")]
     CustomerRedacted,
 
+    #[error(error_type = StripeErrorType::InvalidRequestError, code = "payment_method_redacted", message = "Payment method has already been redacted")]
+    PaymentMethodRedacted,
+
     #[error(error_type = StripeErrorType::InvalidRequestError, code = "customer_already_exists", message = "Customer with the given customer_id already exists")]
     DuplicateCustomer,
 
@@ -541,6 +544,7 @@ impl From<errors::ApiErrorResponse> for StripeErrorCode {
             }
             errors::ApiErrorResponse::MandateActive => Self::MandateActive, //not a stripe code
             errors::ApiErrorResponse::CustomerRedacted => Self::CustomerRedacted, //not a stripe code
+            errors::ApiErrorResponse::PaymentMethodRedacted => Self::PaymentMethodRedacted, //not a stripe code
             errors::ApiErrorResponse::ConfigNotFound => Self::ConfigNotFound, // not a stripe code
             errors::ApiErrorResponse::DuplicateConfig => Self::DuplicateConfig, // not a stripe code
             errors::ApiErrorResponse::DuplicateRefundRequest => Self::DuplicateRefundRequest,
@@ -798,6 +802,7 @@ impl actix_web::ResponseError for StripeErrorCode {
             | Self::InternalServerError
             | Self::MandateActive
             | Self::CustomerRedacted
+            | Self::PaymentMethodRedacted
             | Self::WebhookProcessingError
             | Self::InvalidTenant
             | Self::ExternalVaultFailed

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -6144,6 +6144,11 @@ pub async fn delete_payment_method_core(
         || Err(errors::ApiErrorResponse::PaymentMethodNotFound),
     )?;
 
+    when(
+        payment_method.status == enums::PaymentMethodStatus::Redacted,
+        || Err(errors::ApiErrorResponse::PaymentMethodRedacted),
+    )?;
+
     let _customer = db
         .find_customer_by_global_id_merchant_id(
             customer_id,

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -1907,17 +1907,35 @@ impl LockerOperations for GenericLocker {
     async fn delete_payment_method_from_locker(
         &self,
         state: &SessionState,
-        _platform: &domain::Platform,
+        platform: &domain::Platform,
         vault_id: domain::VaultId,
         customer_id: &id_type::GlobalCustomerId,
     ) -> CustomResult<pm_types::VaultDeleteResponse, errors::VaultError> {
-        let payload = pm_types::VaultDeleteRequest {
-            entity_id: customer_id.to_owned(),
-            vault_id,
-        }
-        .encode_to_vec()
-        .change_context(errors::VaultError::RequestEncodingFailed)
-        .attach_printable("Failed to encode VaultDeleteRequest")?;
+        let should_trigger_fingerprint_migration =
+            payment_method_utils::get_should_trigger_fingerprint_migration(
+                state,
+                None,
+                platform.get_provider().get_provider_merchant_id(),
+            )
+            .await;
+
+        let payload = if should_trigger_fingerprint_migration {
+            pm_types::VaultDeleteRequestNew {
+                entity_id: platform.get_provider().get_account().get_id().clone(),
+                vault_id,
+            }
+            .encode_to_vec()
+            .change_context(errors::VaultError::RequestEncodingFailed)
+            .attach_printable("Failed to encode VaultDeleteRequestNew")?
+        } else {
+            pm_types::VaultDeleteRequest {
+                entity_id: customer_id.to_owned(),
+                vault_id,
+            }
+            .encode_to_vec()
+            .change_context(errors::VaultError::RequestEncodingFailed)
+            .attach_printable("Failed to encode VaultDeleteRequest")?
+        };
 
         let resp = vault::call_to_vault::<pm_types::VaultDelete>(state, payload, None, None)
             .await

--- a/crates/router/src/types/payment_methods.rs
+++ b/crates/router/src/types/payment_methods.rs
@@ -208,6 +208,12 @@ pub struct VaultDeleteRequest {
     pub vault_id: domain::VaultId,
 }
 
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct VaultDeleteRequestNew {
+    pub entity_id: id_type::MerchantId,
+    pub vault_id: domain::VaultId,
+}
+
 #[cfg(feature = "v2")]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct VaultDeleteResponse {


### PR DESCRIPTION
## Summary
- `delete_payment_method_from_locker` (GenericLocker, v2) always sent `entity_id=customer_id` to the vault delete endpoint, but the add flow (`encode_add_vault_request`) sends `entity_id=merchant_id` when `should_trigger_fingerprint_migration` is enabled for the merchant.
- Payment methods vaulted under the merchant-scoped entity could therefore not be deleted — the vault can't resolve the record by the wrong entity_id — surfacing to callers as a generic `InternalServerError` (`HE_00` "Something went wrong").
- Delete now checks the same `should_trigger_fingerprint_migration` flag as add and picks the matching `entity_id` (`VaultDeleteRequestNew { entity_id: merchant_id }` vs `VaultDeleteRequest { entity_id: customer_id }`).

- Additionally, `delete_payment_method_core` only guarded against `status == Inactive`, but a successful delete sets `status = Redacted` (not `Inactive`), so the guard never caught an already-deleted payment method. Repeated `DELETE` calls on the same id kept returning `200`, silently re-running the status update and re-issuing a vault delete request with the stale `locker_id`.
- Added `ApiErrorResponse::PaymentMethodRedacted` (code `IR_11`, reusing the code already used by `CustomerRedacted` for the analogous customer-redaction case, following the existing pattern of `ClientSecretNotGiven`/`ClientSecretExpired` sharing `IR_08`) and reject re-deletion once the payment method is `Redacted`:
```json
{"error":{"type":"invalid_request","message":"Payment method has already been redacted","code":"IR_11"}}
```

### Testing
```
curl --location 'http://localhost:3030/v1/customers' \
--header 'x-profile-id: pro_SQcBva3w8owBPVIQLe2T' \
--header 'Authorization: api-key=dev_jxDvTqNc3XTFWfZryIn2hxJ0wkkoc4IDzYOFSuKus1oMnhfnujh3H17pnG1wS7sH' \
--header 'Content-Type: application/json' \
--data-raw '{   
    
    "name": "John Doe",
    "email": "guest@example.com"
    }'
```
```
{
    "id": "0a_cus_019f896aa8d77fc3ba02054f4edef4ce",
    "merchant_reference_id": null,
    "connector_customer_ids": null,
    "name": "John Doe",
    "email": "guest@example.com",
    "phone": null,
    "phone_country_code": null,
    "description": null,
    "default_billing_address": null,
    "default_shipping_address": null,
    "created_at": "2026-07-22T10:41:36.473Z",
    "metadata": null,
    "default_payment_method_id": null,
    "tax_registration_id": null,
    "document_details": null
}
```
-> pm create
```
curl --location 'http://localhost:3030/v1/payment-methods' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'X-Profile-Id: pro_SQcBva3w8owBPVIQLe2T' \
--header 'Authorization: api-key=dev_jxDvTqNc3XTFWfZryIn2hxJ0wkkoc4IDzYOFSuKus1oMnhfnujh3H17pnG1wS7sH' \
--data '
{
    "customer_id": "0a_cus_019f896aa8d77fc3ba02054f4edef4ce",
    "payment_method_type": "card",
    "payment_method_subtype": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "03",
            "card_exp_year": "2031",
            "card_holder_name": "joseph Doe",
            "card_cvc": "737"
        }
    },
    "storage_type": "persistent"
}'
```
```
{
    "id": "0a_pm_019f896ba5247f328e92f5f2edff76b9",
    "merchant_id": "merchant_1784652523",
    "customer_id": "0a_cus_019f896aa8d77fc3ba02054f4edef4ce",
    "payment_method_type": "card",
    "payment_method_subtype": "credit",
    "recurring_enabled": false,
    "created": "2026-07-22T10:42:41.237Z",
    "last_used_at": "2026-07-22T10:42:41.237Z",
    "payment_method_data": {
        "card": {
            "issuer_country": null,
            "last4_digits": "4242",
            "expiry_month": "03",
            "expiry_year": "2031",
            "card_holder_name": "joseph Doe",
            "card_fingerprint": null,
            "nick_name": null,
            "card_network": null,
            "card_isin": null,
            "card_issuer": null,
            "card_type": null,
            "saved_to_locker": true
        }
    },
    "connector_tokens": null,
    "network_token": null,
    "storage_type": "persistent",
    "card_cvc_token_storage": {
        "is_stored": true,
        "expires_at": "2026-07-22T10:57:41.265Z"
    },
    "network_transaction_id": null,
    "raw_payment_method_data": null,
    "billing": null,
    "acknowledgement_status": null
}
```
-> delete pm
```
curl --request DELETE \               
  --url http://localhost:3030/v1/payment-methods/0a_pm_019f896ba5247f328e92f5f2edff76b9 \
  --header 'Authorization: api-key=dev_jxDvTqNc3XTFWfZryIn2hxJ0wkkoc4IDzYOFSuKus1oMnhfnujh3H17pnG1wS7sH' \
  --header 'X-Profile-Id: pro_SQcBva3w8owBPVIQLe2T'
```

```
{"id":"0a_pm_019f896ba5247f328e92f5f2edff76b9"}
```

-> delete the same payment method again
```
curl --request DELETE \
  --url http://localhost:3030/v1/payment-methods/0a_pm_019f896ba5247f328e92f5f2edff76b9 \
  --header 'Authorization: api-key=dev_jxDvTqNc3XTFWfZryIn2hxJ0wkkoc4IDzYOFSuKus1oMnhfnujh3H17pnG1wS7sH' \
  --header 'X-Profile-Id: pro_SQcBva3w8owBPVIQLe2T'
```
```
{"error":{"type":"invalid_request","message":"Payment method has already been redacted","code":"IR_11"}}
```





## Test plan
- [ ] Delete a payment method vaulted under `should_trigger_fingerprint_migration = false` (existing behavior, entity_id = customer_id) — still succeeds.
- [ ] Delete a payment method vaulted under `should_trigger_fingerprint_migration = true` (entity_id = merchant_id at add time) — previously failed with `HE_00`, now succeeds.
- [ ] Delete the same payment method again — now returns the `IR_11` error instead of a phantom `200`.