### PR TITLE
fix(payment_methods): reject delete for already-redacted payment methods

### DIFF
--- a/crates/hyperswitch_domain_models/src/errors/api_error_response.rs
+++ b/crates/hyperswitch_domain_models/src/errors/api_error_response.rs
@@ -203,6 +203,8 @@ pub enum ApiErrorResponse {
     MandateActive,
     #[error(error_type = ErrorType::InvalidRequestError, code = "IR_11", message = "Customer has already been redacted")]
     CustomerRedacted,
+    #[error(error_type = ErrorType::InvalidRequestError, code = "IR_11", message = "Payment method has already been redacted")]
+    PaymentMethodRedacted,
     #[error(error_type = ErrorType::InvalidRequestError, code = "IR_12", message = "Reached maximum refund attempts")]
     MaximumRefundCount,
     #[error(error_type = ErrorType::InvalidRequestError, code = "IR_13", message = "The refund amount exceeds the amount captured")]
@@ -594,6 +596,9 @@ impl ErrorSwitch<api_models::errors::types::ApiErrorResponse> for ApiErrorRespon
             }
             Self::CustomerRedacted => {
                 AER::BadRequest(ApiError::new("IR", 11, "Customer has already been redacted", None))
+            }
+            Self::PaymentMethodRedacted => {
+                AER::BadRequest(ApiError::new("IR", 11, "Payment method has already been redacted", None))
             }
             Self::MaximumRefundCount => AER::BadRequest(ApiError::new("IR", 12, "Reached maximum refund attempts", None)),
             Self::RefundAmountExceedsPaymentAmount => {

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -6126,6 +6126,11 @@ pub async fn delete_payment_method_core(
         || Err(errors::ApiErrorResponse::PaymentMethodNotFound),
     )?;
 
+    when(
+        payment_method.status == enums::PaymentMethodStatus::Redacted,
+        || Err(errors::ApiErrorResponse::PaymentMethodRedacted),
+    )?;
+
     let _customer = db
         .find_customer_by_global_id_merchant_id(
             customer_id,


### PR DESCRIPTION
## Summary
- `delete_payment_method_core` only guarded against `status == Inactive`, but a successful delete sets `status = Redacted` (not `Inactive`), so the guard never caught an already-deleted payment method.
- Repeated `DELETE /v1/payment-methods/{id}` calls on the same id kept returning `200`, silently re-running the status update and re-issuing a vault delete request with the stale `locker_id`.
- Added `ApiErrorResponse::PaymentMethodRedacted` (code `IR_11`, reusing the code already used by `CustomerRedacted` for the analogous customer-redaction case, following the existing pattern of `ClientSecretNotGiven`/`ClientSecretExpired` sharing `IR_08`) and reject re-deletion once the payment method is `Redacted`:
```json
{"error":{"type":"invalid_request","message":"Payment method has already been redacted","code":"IR_11"}}
```

## Test plan
- [ ] `DELETE` an active payment method — succeeds (200), status becomes `Redacted`.
- [ ] `DELETE` the same payment method again — now returns the `IR_11` error instead of a phantom `200`.