### PR TITLE
fix(connector_cloning): strip wallet-specific keys from metadata when cloning connectors

### DIFF
--- a/crates/router/src/utils/user.rs
+++ b/crates/router/src/utils/user.rs
@@ -404,6 +404,30 @@ pub fn get_base_url(state: &SessionState) -> &str {
 }
 
 #[cfg(feature = "v1")]
+const WALLET_METADATA_KEYS_TO_STRIP: [&str; 5] = [
+    "apple_pay",
+    "google_pay",
+    "samsung_pay",
+    "paze",
+    "paypal_sdk",
+];
+
+#[cfg(feature = "v1")]
+fn strip_wallet_metadata(
+    metadata: Option<common_utils::pii::SecretSerdeValue>,
+) -> Option<common_utils::pii::SecretSerdeValue> {
+    metadata.map(|metadata| {
+        let mut value = metadata.expose();
+        if let serde_json::Value::Object(map) = &mut value {
+            for key in WALLET_METADATA_KEYS_TO_STRIP {
+                map.remove(key);
+            }
+        }
+        Secret::new(value)
+    })
+}
+
+#[cfg(feature = "v1")]
 #[instrument(skip_all)]
 pub async fn build_cloned_connector_create_request(
     source_mca: DomainMerchantConnectorAccount,
@@ -475,7 +499,7 @@ pub async fn build_cloned_connector_create_request(
         test_mode: source_mca.test_mode,
         disabled: source_mca.disabled,
         payment_methods_enabled,
-        metadata: source_mca.metadata,
+        metadata: strip_wallet_metadata(source_mca.metadata),
         business_country: source_mca.business_country,
         business_label: source_mca.business_label.clone(),
         business_sub_label: source_mca.business_sub_label.clone(),


### PR DESCRIPTION
## Summary
- The connector-cloning flow (#12660, `build_cloned_connector_create_request` in `crates/router/src/utils/user.rs`) copies `source_mca.metadata` verbatim to the destination merchant connector account.
- `connector_wallets_details` is already correctly excluded (set to `None`), but the generic `metadata` JSON blob can also carry wallet-specific configuration under keys `apple_pay`, `google_pay`, `samsung_pay`, `paze`, and `paypal_sdk` — these are scoped to the source profile's registered domains/certs and should not be silently duplicated to a new profile.
- Rather than skipping `metadata` cloning wholesale (which would also drop unrelated connector config such as currency settings or account ids), this strips only the known wallet keys and leaves everything else intact.

## Changes
- Added `strip_wallet_metadata` helper in `crates/router/src/utils/user.rs` that removes `apple_pay`, `google_pay`, `samsung_pay`, `paze`, and `paypal_sdk` keys from the metadata JSON object if present.
- Applied it to the `metadata` field in `build_cloned_connector_create_request`.

## Test plan
- [ ] `cargo check -p router` / relevant feature flags
- [ ] Manually clone a connector whose metadata contains `apple_pay`/`google_pay`/`paypal_sdk` entries and confirm those keys are absent on the destination MCA while other metadata keys (e.g. currency config) are preserved
- [ ] Clone a connector with no wallet keys in metadata and confirm metadata is copied unchanged