### PR TITLE
fix(connector): [datatrans] fix void flow

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/datatrans.rs
+++ b/crates/hyperswitch_connectors/src/connectors/datatrans.rs
@@ -560,6 +560,18 @@ impl ConnectorIntegration<Void, PaymentsCancelData, PaymentsResponseData> for Da
         Ok(format!("{base_url}v1/transactions/{transaction_id}/cancel"))
     }
 
+    fn get_request_body(
+        &self,
+        _req: &PaymentsCancelRouterData,
+        _connectors: &Connectors,
+    ) -> CustomResult<RequestContent, errors::ConnectorError> {
+        // Datatrans cancel takes no fields; send an empty JSON object `{}` so the
+        // application/json body is valid and avoids `INVALID_JSON_PAYLOAD`.
+        Ok(RequestContent::Json(Box::new(
+            datatrans::DatatransCancelRequest {},
+        )))
+    }
+
     fn build_request(
         &self,
         req: &PaymentsCancelRouterData,

--- a/crates/hyperswitch_connectors/src/connectors/datatrans/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/datatrans/transformers.rs
@@ -263,6 +263,12 @@ pub struct DataPaymentCaptureRequest {
     pub refno: String,
 }
 
+// Datatrans cancel expects an empty JSON object `{}` as the body when
+// Content-Type is application/json. Sending anything else (e.g. a bare JSON
+// string) triggers `INVALID_JSON_PAYLOAD`.
+#[derive(Debug, Serialize, Clone)]
+pub struct DatatransCancelRequest {}
+
 impl<T> TryFrom<(MinorUnit, T)> for DatatransRouterData<T> {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from((amount, item): (MinorUnit, T)) -> Result<Self, Self::Error> {

--- a/cypress-tests/cypress/e2e/configs/Payment/Datatrans.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Datatrans.js
@@ -48,8 +48,8 @@ const paymentMethodData3Ds = {
     last4: "1111",
     card_type: "DEBIT",
     card_network: "Visa",
-    card_issuer: 'CONOTOXIA SP Z OO',
-    card_issuing_country: 'POLAND',
+    card_issuer: "CONOTOXIA SP Z OO",
+    card_issuing_country: "POLAND",
     card_isin: "411111",
     card_extended_bin: null,
     card_exp_month: "06",
@@ -57,7 +57,7 @@ const paymentMethodData3Ds = {
     card_holder_name: "joseph Doe",
     payment_checks: null,
     authentication_data: null,
-    auth_code: null 
+    auth_code: null,
   },
   billing: null,
 };
@@ -313,7 +313,7 @@ export const connectorDetails = {
       },
     },
     MandateMultiUseNo3DSAutoCapture: {
-       Configs: {
+      Configs: {
         TRIGGER_SKIP: true,
       },
       Request: {
@@ -506,23 +506,23 @@ export const connectorDetails = {
         },
       },
     },
-        SaveCardUse3DSAutoCaptureOffSession: {
-          Request: {
-            payment_method: "card",
-            payment_method_data: {
-              card: successfulNo3DSCardDetails,
-            },
-            setup_future_usage: "off_session",
-            customer_acceptance: customerAcceptance,
-            billing: billingWithNewline,
-          },
-          Response: {
-            status: 200,
-            body: {
-              status: "requires_customer_action",
-            },
-          },
+    SaveCardUse3DSAutoCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
         },
+        setup_future_usage: "off_session",
+        customer_acceptance: customerAcceptance,
+        billing: billingWithNewline,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
     SaveCardUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",
@@ -762,7 +762,7 @@ export const connectorDetails = {
         },
       },
     },
-        PaymentWithBilling: {
+    PaymentWithBilling: {
       Request: {
         currency: "USD",
         setup_future_usage: "on_session",

--- a/cypress-tests/cypress/e2e/configs/Payment/Datatrans.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Datatrans.js
@@ -46,10 +46,10 @@ const multiUseMandateData = {
 const paymentMethodData3Ds = {
   card: {
     last4: "1111",
-    card_type: "CREDIT",
+    card_type: "DEBIT",
     card_network: "Visa",
-    card_issuer: "JP Morgan",
-    card_issuing_country: "INDIA",
+    card_issuer: 'CONOTOXIA SP Z OO',
+    card_issuing_country: 'POLAND',
     card_isin: "411111",
     card_extended_bin: null,
     card_exp_month: "06",
@@ -57,6 +57,7 @@ const paymentMethodData3Ds = {
     card_holder_name: "joseph Doe",
     payment_checks: null,
     authentication_data: null,
+    auth_code: null 
   },
   billing: null,
 };
@@ -66,7 +67,7 @@ const paymentMethodDataNo3Ds = {
     last4: "0018",
     card_type: "CREDIT",
     card_network: "Visa",
-    card_issuer: "Intl Hdqtrs Center Owned",
+    card_issuer: "INTL HDQTRS CENTER OWNED",
     card_issuing_country: "UNITED STATES OF AMERICA",
     card_isin: "400000",
     card_extended_bin: null,
@@ -312,6 +313,9 @@ export const connectorDetails = {
       },
     },
     MandateMultiUseNo3DSAutoCapture: {
+       Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "card",
         payment_method_data: {
@@ -493,6 +497,7 @@ export const connectorDetails = {
         currency: "USD",
         setup_future_usage: "on_session",
         customer_acceptance: customerAcceptance,
+        billing: billingWithNewline,
       },
       Response: {
         status: 200,
@@ -501,7 +506,23 @@ export const connectorDetails = {
         },
       },
     },
-
+        SaveCardUse3DSAutoCaptureOffSession: {
+          Request: {
+            payment_method: "card",
+            payment_method_data: {
+              card: successfulNo3DSCardDetails,
+            },
+            setup_future_usage: "off_session",
+            customer_acceptance: customerAcceptance,
+            billing: billingWithNewline,
+          },
+          Response: {
+            status: 200,
+            body: {
+              status: "requires_customer_action",
+            },
+          },
+        },
     SaveCardUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",
@@ -511,6 +532,7 @@ export const connectorDetails = {
         currency: "USD",
         setup_future_usage: "on_session",
         customer_acceptance: customerAcceptance,
+        billing: billingWithNewline,
       },
       Response: {
         status: 200,
@@ -532,6 +554,7 @@ export const connectorDetails = {
         },
         setup_future_usage: "off_session",
         customer_acceptance: customerAcceptance,
+        billing: billingWithNewline,
       },
       Response: {
         status: 200,
@@ -554,6 +577,7 @@ export const connectorDetails = {
         },
         setup_future_usage: "off_session",
         customer_acceptance: customerAcceptance,
+        billing: billingWithNewline,
       },
       Response: {
         status: 200,
@@ -735,6 +759,20 @@ export const connectorDetails = {
           message:
             "You cannot confirm this payment using `manual_retry` because the allowed duration has expired",
           code: "IR_16",
+        },
+      },
+    },
+        PaymentWithBilling: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "on_session",
+        billing: billingWithNewline,
+        email: "hyperswitch.example@gmail.com",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
         },
       },
     },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Fixes the Datatrans void / cancel flow, which was failing with a connector 
Added a DatatransCancelRequest struct (empty, serializes to {}) in datatrans/transformers.rs.
Overrode `get_request_body` in the Void ConnectorIntegration impl to send RequestContent::Json(DatatransCancelRequest {}), so the cancel request carries a valid empty JSON object.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

Void/cancel was unusable for Datatrans — every attempt was rejected by the connector before it reached transaction processing. This restores the manual-capture void flow.

## How did you test it?

<img width="272" height="1055" alt="image" src="https://github.com/user-attachments/assets/0f3e995b-b136-4323-8e2a-bfa5f5ec97bb" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
