### PR TITLE
feat(vault): route HyperswitchVault calls through an optional egress proxy

### DIFF
--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -155,10 +155,11 @@ pub struct VaultConnectorAuth {
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
 pub enum ExternalVaultProxyMetadata {
+    /// HyperswitchVault data variant — must be first so serde matches vault_endpoint+vault_auth_data
+    /// before falling through to VgsMetadata (which only needs proxy_url+certificate)
+    HyperswitchVaultMetadata(HyperswitchVaultMetadata),
     /// VGS proxy data variant
     VgsMetadata(VgsMetadata),
-    /// HyperswitchVault data variant
-    HyperswitchVaultMetadata(HyperswitchVaultMetadata),
 }
 
 /// Complete external vault proxy configuration to be serialized and sent to UCS
@@ -179,6 +180,13 @@ pub struct HyperswitchVaultMetadata {
     pub vault_endpoint: Url,
     /// Authentication data for the vault connector
     pub vault_auth_data: VaultConnectorAuth,
+    /// Optional egress proxy URL (e.g. Squid). Absent for in-cluster deployments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_url: Option<Url>,
+    /// Optional CA certificate for TLS verification (required for MITM proxies like VGS,
+    /// not needed for CONNECT-tunnel proxies like Squid).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub certificate: Option<Secret<String>>,
 }
 
 /// Builds a gRPC client. `$connection_timeout` bounds connect; `$request_timeout` bounds each RPC.

--- a/crates/hyperswitch_domain_models/src/merchant_connector_account.rs
+++ b/crates/hyperswitch_domain_models/src/merchant_connector_account.rs
@@ -363,8 +363,10 @@ pub struct RevenueRecoveryMetadata {
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct ExternalVaultConnectorMetadata {
-    pub proxy_url: common_utils::types::Url,
-    pub certificate: Secret<String>,
+    #[serde(default)]
+    pub proxy_url: Option<common_utils::types::Url>,
+    #[serde(default)]
+    pub certificate: Option<Secret<String>>,
 }
 #[cfg(feature = "v2")]
 #[derive(Debug, Clone)]

--- a/crates/injector/src/injector.rs
+++ b/crates/injector/src/injector.rs
@@ -931,7 +931,13 @@ pub mod core {
                 .headers(vault_headers)
                 .set_body(RequestContent::Json(Box::new(vault_proxy_request)));
 
-            let http_request = request_builder.build();
+            let config = &request.connection_config;
+            let http_request = build_request_with_certificates(
+                request_builder,
+                None,
+                None,
+                config.ca_cert.clone(),
+            );
 
             let vault_endpoint_host = vault_endpoint.host_str().unwrap_or("unknown").to_string();
             metrics::INJECTOR_OUTGOING_CALLS_COUNT.add(
@@ -942,7 +948,10 @@ pub mod core {
                 ),
             );
 
-            let response = send_request(&Proxy::default(), http_request).await?;
+            let proxy = Proxy::from_optional_url(
+                config.proxy_url.clone().or_else(|| config.backup_proxy_url.clone()),
+            );
+            let response = send_request(&proxy, http_request).await?;
             response
                 .into_injector_response()
                 .await

--- a/crates/injector/src/injector.rs
+++ b/crates/injector/src/injector.rs
@@ -949,7 +949,10 @@ pub mod core {
             );
 
             let proxy = Proxy::from_optional_url(
-                config.proxy_url.clone().or_else(|| config.backup_proxy_url.clone()),
+                config
+                    .proxy_url
+                    .clone()
+                    .or_else(|| config.backup_proxy_url.clone()),
             );
             let response = send_request(&proxy, http_request).await?;
             response

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -2154,12 +2154,17 @@ struct VaultTokenDetailsResponse {
 /// targets `connectors.hyperswitch_vault.base_url` (which already includes the `/v2` prefix) and is
 /// authenticated as the merchant using the external vault connector account's credentials
 /// (`api-key` + profile id) — not the pay server's internal API key.
+///
+/// `proxy_url` — when `Some`, all traffic to the vault is routed through that HTTP CONNECT proxy
+/// (e.g. a Squid egress proxy required by self-hosted / non-PCI deployments). Falls back to the
+/// router-wide `[proxy]` config when `None`.
 #[cfg(feature = "v1")]
 pub async fn get_permanent_pm_id_from_temporary_token(
     state: &routes::SessionState,
     api_key: Secret<String>,
     vault_profile_id: Secret<String>,
     temporary_token: String,
+    proxy_url: Option<common_utils::types::Url>,
 ) -> CustomResult<String, errors::ApiErrorResponse> {
     let url = format!(
         "{}/payment-methods/token/{}/details",
@@ -2184,7 +2189,27 @@ pub async fn get_permanent_pm_id_from_temporary_token(
         ])
         .build();
 
-    let response = http_client::send_request(&state.conf.proxy, request, None)
+    // If the MCA supplies a per-merchant proxy URL, use it; otherwise fall back to the
+    // router-wide proxy config so the behaviour is unchanged for deployments that have
+    // not set a proxy on the vault connector account.
+    let effective_proxy;
+    let proxy = match proxy_url {
+        Some(url) => {
+            let url_str = url.get_string_repr().to_owned();
+            effective_proxy = hyperswitch_interfaces::types::Proxy {
+                http_url: Some(url_str.clone()),
+                https_url: Some(url_str),
+                idle_pool_connection_timeout: Some(90),
+                bypass_proxy_hosts: None,
+                mitm_ca_certificate: None,
+                mitm_enabled: None,
+            };
+            &effective_proxy
+        }
+        None => &state.conf.proxy,
+    };
+
+    let response = http_client::send_request(proxy, request, None)
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to call hyperswitch vault token details endpoint")?;

--- a/crates/router/src/core/payments/operations/payment_confirm_external_vault_proxy.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm_external_vault_proxy.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use api_models::{enums::FrmSuggestion, payments::PaymentsRequest};
 use async_trait::async_trait;
 use common_enums;
+use common_utils::ext_traits::ValueExt;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::payment_methods::VaultPaymentMethodData;
 use hyperswitch_masking::{ExposeInterface, Secret};
@@ -740,12 +741,27 @@ impl<F: Clone + Send + Sync> Domain<F, PaymentsRequest, PaymentData<F>>
                 )),
             }?;
 
+            // Parse optional proxy_url from vault MCA metadata so the detokenize call
+            // is also routed through the egress proxy (required for self-hosted / non-PCI
+            // deployments that must reach the SaaS vault via Squid).
+            let vault_proxy_url = vault_mca
+                .get_metadata()
+                .and_then(|m| {
+                    m.expose()
+                        .parse_value::<hyperswitch_domain_models::merchant_connector_account::ExternalVaultConnectorMetadata>(
+                            "ExternalVaultConnectorMetadata",
+                        )
+                        .ok()
+                })
+                .and_then(|meta| meta.proxy_url);
+
             let temporary_token = vault_card.card_number.clone().expose();
             let permanent_pm_id = pm_transformers::get_permanent_pm_id_from_temporary_token(
                 state,
                 api_key,
                 vault_profile_id,
                 temporary_token,
+                vault_proxy_url,
             )
             .await?;
             vault_card.card_number = Secret::new(permanent_pm_id);

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -1990,13 +1990,30 @@ pub fn build_unified_connector_service_external_vault_proxy_metadata_v1(
                 vault_connector_id: Some("vgs".to_string()),
                 metadata: external_services::grpc_client::unified_connector_service::ExternalVaultProxyMetadata::VgsMetadata(
                     external_services::grpc_client::unified_connector_service::VgsMetadata {
-                        proxy_url: external_vault_metadata_parsed.proxy_url,
-                        certificate: external_vault_metadata_parsed.certificate,
+                        proxy_url: external_vault_metadata_parsed.proxy_url
+                            .ok_or_else(|| error_stack::report!(UnifiedConnectorServiceError::ParsingFailed))
+                            .attach_printable("VGS requires proxy_url in MCA metadata")?,
+                        certificate: external_vault_metadata_parsed.certificate
+                            .ok_or_else(|| error_stack::report!(UnifiedConnectorServiceError::ParsingFailed))
+                            .attach_printable("VGS requires certificate in MCA metadata")?,
                     },
                 ),
             }
         }
         api_enums::VaultConnectors::HyperswitchVault => {
+            // Optional metadata — in-cluster setups have no metadata; proxy setups supply proxy_url.
+            let vault_meta = external_vault_merchant_connector_account
+                .get_metadata()
+                .map(|m| {
+                    m.expose()
+                        .parse_value::<ExternalVaultConnectorMetadata>(
+                            "ExternalVaultConnectorMetadata",
+                        )
+                        .change_context(UnifiedConnectorServiceError::ParsingFailed)
+                        .attach_printable("Failed to parse external vault connector metadata")
+                })
+                .transpose()?;
+
             let base = &connectors.hyperswitch_vault.base_url;
             let vault_endpoint_url = format!("{}/proxy", base)
                 .parse::<url::Url>()
@@ -2035,6 +2052,8 @@ pub fn build_unified_connector_service_external_vault_proxy_metadata_v1(
                             api_key,
                             profile_id,
                         },
+                        proxy_url: vault_meta.as_ref().and_then(|m| m.proxy_url.clone()),
+                        certificate: vault_meta.and_then(|m| m.certificate),
                     },
                 ),
             }
@@ -2088,13 +2107,30 @@ pub fn build_unified_connector_service_external_vault_proxy_metadata(
                 vault_connector_id: Some("vgs".to_string()),
                 metadata: external_services::grpc_client::unified_connector_service::ExternalVaultProxyMetadata::VgsMetadata(
                     external_services::grpc_client::unified_connector_service::VgsMetadata {
-                        proxy_url: external_vault_metadata_parsed.proxy_url,
-                        certificate: external_vault_metadata_parsed.certificate,
+                        proxy_url: external_vault_metadata_parsed.proxy_url
+                            .ok_or_else(|| error_stack::report!(UnifiedConnectorServiceError::ParsingFailed))
+                            .attach_printable("VGS requires proxy_url in MCA metadata")?,
+                        certificate: external_vault_metadata_parsed.certificate
+                            .ok_or_else(|| error_stack::report!(UnifiedConnectorServiceError::ParsingFailed))
+                            .attach_printable("VGS requires certificate in MCA metadata")?,
                     },
                 ),
             }
         }
         api_enums::VaultConnectors::HyperswitchVault => {
+            // Optional metadata — in-cluster setups have no metadata; proxy setups supply proxy_url.
+            let vault_meta = external_vault_merchant_connector_account
+                .get_metadata()
+                .map(|m| {
+                    m.expose()
+                        .parse_value::<ExternalVaultConnectorMetadata>(
+                            "ExternalVaultConnectorMetadata",
+                        )
+                        .change_context(UnifiedConnectorServiceError::ParsingFailed)
+                        .attach_printable("Failed to parse external vault connector metadata")
+                })
+                .transpose()?;
+
             let base = &connectors.hyperswitch_vault.base_url;
             let vault_endpoint_url = format!("{}/proxy", base)
                 .parse::<url::Url>()
@@ -2132,6 +2168,8 @@ pub fn build_unified_connector_service_external_vault_proxy_metadata(
                             api_key,
                             profile_id,
                         },
+                        proxy_url: vault_meta.as_ref().and_then(|m| m.proxy_url.clone()),
+                        certificate: vault_meta.and_then(|m| m.certificate),
                     },
                 ),
             }


### PR DESCRIPTION
## Summary
- Self-hosted Hyperswitch deployments without direct internet egress need the injector's HyperswitchVault detokenize and charge calls to route through an egress proxy (e.g. Squid), the same way VGS traffic already does via `proxy_url`.
- Adds optional `proxy_url` / `certificate` fields to the `hyperswitch_vault` connector's MCA metadata (`ExternalVaultConnectorMetadata`), threads them through the gRPC `x-external-vault-metadata` header into UCS, and into the injector's HTTP client for both the detokenize call (`transformers.rs::get_permanent_pm_id_from_temporary_token`) and the injector's own proxy request (`injector.rs::make_hyperswitch_vault_request`).
- Falls back to direct/global-proxy behavior when `proxy_url` is unset, so existing in-cluster deployments are unaffected.
- Reorders the untagged `ExternalVaultProxyMetadata` enum (HyperswitchVault before VGS) to avoid deserialization ambiguity now that both variants can structurally overlap.

Companion PR in connector-service: juspay/hyperswitch-prism#<fill-in>

## Test plan
- [x] `cargo check -p injector`, `cargo check -p router --features v1` — clean
- [x] Verified locally end-to-end against a mock SaaS vault behind a local Squid proxy: both the detokenize `GET` and the injector's charge `POST` appear in Squid's access log, authenticated with the credentials from the vault MCA's `proxy_url` metadata
- [ ] Backward-compat check (no `proxy_url` set → no Squid traffic, direct call) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)