### PR TITLE
feat(deja): [6] gRPC (UCS) egress record/replay boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,6 +2863,7 @@ dependencies = [
  "deja-core",
  "deja-derive",
  "deja-runtime",
+ "error-stack 0.4.1",
  "serde",
  "serde_json",
 ]
@@ -3545,6 +3546,7 @@ dependencies = [
  "error-stack 0.4.1",
  "hex",
  "http 0.2.12",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.32",
  "hyper-proxy",
@@ -3555,6 +3557,7 @@ dependencies = [
  "once_cell",
  "open-feature",
  "prost 0.14.3",
+ "prost-reflect",
  "prost-types 0.14.3",
  "quick-xml",
  "reqwest 0.11.27",
@@ -3569,6 +3572,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time 0.3.41",
  "tokio 1.48.0",
+ "tokio-stream",
  "tonic 0.14.5",
  "tonic-prost",
  "tonic-prost-build",
@@ -7452,6 +7456,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
+dependencies = [
+ "base64 0.22.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "serde",
+ "serde-value",
 ]
 
 [[package]]

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -20,7 +20,13 @@ superposition = [
 ]
 v1 = ["hyperswitch_interfaces/v1", "common_utils/v1"]
 v2 = ["hyperswitch_interfaces/v2", "common_utils/v2"]
-deja = ["dep:bytes", "dep:deja"]
+deja = [
+    "dep:bytes",
+    "dep:deja",
+    "dep:http-body",
+    "dep:http-body-util",
+    "dep:prost-reflect",
+]
 revenue_recovery = [
     "dep:prost",
     "dep:router_env",
@@ -69,6 +75,7 @@ serde_json = "1.0.140"
 serde_urlencoded = "0.7.1"
 vaultrs = { version = "0.7.4", optional = true }
 prost = { version = "0.14", optional = true }
+prost-reflect = { version = "0.16.5", features = ["serde"], optional = true }
 prost-types = { version = "0.14", optional = true }
 time = { version = "0.3.41", features = ["serde", "serde-well-known", "std"] }
 tokio = "1.48.0"
@@ -79,6 +86,7 @@ tonic-types = "0.13.1"
 typed-builder = "0.21.2"
 hyper-util = { version = "0.1.12", optional = true }
 http-body-util = { version = "0.1.3", optional = true }
+http-body = { version = "1.0.1", optional = true }
 reqwest = { version = "0.11.27", features = ["rustls-tls"] }
 http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
@@ -107,6 +115,11 @@ api_models = { version = "0.1.0", path = "../api_models", optional = true }
 [build-dependencies]
 router_env = { version = "0.1.0", path = "../router_env", default-features = false, optional = true }
 tonic-prost-build = "0.14"
+
+[dev-dependencies]
+# Test-only: the deja gRPC transport test drives a real tonic server over a
+# TcpListener via `tokio_stream::wrappers::TcpListenerStream` (the `net` feature).
+tokio-stream = { version = "0.1.17", features = ["net"] }
 
 [lints]
 workspace = true

--- a/crates/external_services/build.rs
+++ b/crates/external_services/build.rs
@@ -11,6 +11,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .out_dir(&out_dir)
             .compile_well_known_types(true)
             .extern_path(".google.protobuf.Timestamp", "::prost_types::Timestamp")
+            // The deja gRPC boundary decodes this descriptor set at runtime to
+            // render request/response messages structurally.
+            .file_descriptor_set_path(out_dir.join("deja_recovery_descriptor.bin"))
             .compile_protos(&recovery_proto_files, &[proto_base_path])
             .expect("Failed to compile revenue-recovery proto files");
     }
@@ -29,6 +32,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Compile the .proto file
         #[allow(clippy::expect_used, clippy::unwrap_in_result)]
         tonic_prost_build::configure()
+            // The deja gRPC boundary decodes this descriptor set at runtime to
+            // render request/response messages structurally.
+            .file_descriptor_set_path(out_dir.join("deja_dynamic_routing_descriptor.bin"))
             .out_dir(out_dir)
             .compile_protos(
                 &[

--- a/crates/external_services/src/grpc_client.rs
+++ b/crates/external_services/src/grpc_client.rs
@@ -10,6 +10,18 @@ pub mod revenue_recovery;
 
 /// gRPC based Unified Connector Service Client interface implementation
 pub mod unified_connector_service;
+
+/// Deja gRPC egress boundary: the transport-layer tower Service wrapper.
+/// Installed at transport construction
+/// sites so every unary rpc crosses one deja boundary; identity is rank-2
+/// span-path (no explicit call-site tag), routing hardcoded Substitute.
+#[cfg(feature = "deja")]
+pub mod deja_transport;
+/// Deja gRPC egress semantics: recorded result envelope, byte-faithful response
+/// reconstruction.
+#[cfg(feature = "deja")]
+pub mod semantic_boundary;
+
 use std::{fmt::Debug, sync::Arc};
 
 #[cfg(feature = "dynamic_routing")]
@@ -40,9 +52,25 @@ use crate::grpc_client::unified_connector_service::{
     UnifiedConnectorServiceClient, UnifiedConnectorServiceClientConfig,
 };
 
-#[cfg(any(feature = "dynamic_routing", feature = "revenue_recovery"))]
+#[cfg(all(
+    any(feature = "dynamic_routing", feature = "revenue_recovery"),
+    not(feature = "deja")
+))]
 /// Hyper based Client type for maintaining connection pool for all gRPC services
 pub type Client = hyper_util::client::legacy::Client<HttpConnector, Body>;
+
+#[cfg(all(
+    any(feature = "dynamic_routing", feature = "revenue_recovery"),
+    feature = "deja"
+))]
+/// Hyper based Client type for maintaining connection pool for all gRPC services.
+///
+/// Under the `deja` feature the pool is wrapped in the deja gRPC egress boundary
+/// at this single definition site — every unary rpc on every service client built
+/// over it (dynamic routing, health check, recovery decider, future) is
+/// recorded/substituted at the wire level with zero call-site changes.
+pub type Client =
+    deja_transport::DejaGrpcTransport<hyper_util::client::legacy::Client<HttpConnector, Body>>;
 
 /// Struct contains all the gRPC Clients
 #[derive(Debug, Clone)]
@@ -85,6 +113,13 @@ impl GrpcClientSettings {
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
                 .http2_only(true)
                 .build_http();
+        // deja: wrap the shared pool in the gRPC egress boundary at its one
+        // construction site.
+        #[cfg(all(
+            any(feature = "dynamic_routing", feature = "revenue_recovery"),
+            feature = "deja"
+        ))]
+        let client = deja_transport::DejaGrpcTransport::new(client);
 
         #[cfg(feature = "dynamic_routing")]
         let dynamic_routing_connection = self

--- a/crates/external_services/src/grpc_client/deja_transport.rs
+++ b/crates/external_services/src/grpc_client/deja_transport.rs
@@ -1,0 +1,428 @@
+//! The deja gRPC egress boundary — a tower `Service` wrapper around the
+//! transport under every generated tonic client.
+//!
+//! The wrapper is installed at the transport CONSTRUCTION sites (the shared
+//! hyper pool `Client` type alias and the UCS channels), so every unary rpc —
+//! current and future, on any service client built over the wrapped transport
+//! — crosses one deja boundary with zero changes to how gRPC client code is
+//! written or called.
+//!
+//! Identity carries NO explicit call-site id: this is a generic transport
+//! wrapper, so there is no per-call-site literal to name. It is
+//! `CallsiteSource::SyntacticHash` with `scope = "grpc::/package.Service/Method"`
+//! — the rpc path is the most version-independent name an egress call has, and
+//! it rides in the scope rather than as a rank-1 id — plus the span path as the
+//! calling-context disambiguator. Routing is HARDCODED
+//! `ReplayStrategy::Substitute` — egress is never re-issued.
+//!
+//! Substitution replays the recorded wire bytes through tonic's own decoder
+//! (see [`super::semantic_boundary`]), so typed `Status` errors, trailers-only
+//! shapes, and metadata partitioning reproduce by construction.
+
+use std::{
+    future::Future,
+    panic::Location,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tonic::{body::Body as TonicBody, codegen::http};
+
+use super::semantic_boundary::{self, BufferedBody, GrpcResultEnvelope};
+
+/// Boxed error type matching the `GrpcService` transport-error bound.
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+const BOUNDARY: &str = "grpc";
+const COMPONENT: &str = "external_services::grpc_client::deja_transport";
+const OPERATION: &str = "unary";
+
+/// The transport wrapper. Generic over the inner tower service so the same
+/// type serves the shared hyper pool (dynamic routing / health / recovery)
+/// and the UCS `tonic::transport::Channel`s.
+#[derive(Debug, Clone)]
+pub struct DejaGrpcTransport<S> {
+    inner: S,
+}
+
+impl<S> DejaGrpcTransport<S> {
+    /// Wraps a transport. Call at the construction site, never per request.
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+/// Envelope smuggled through `http::Extensions` from the buffering `run`
+/// closure to the recording `extract` closure — the same trick the HTTP
+/// boundary uses for its response body (`CapturedResponseBody`).
+#[derive(Clone)]
+struct CapturedEnvelope(GrpcResultEnvelope);
+
+/// A substituted transport error: the recorded display chain of the original
+/// failure. Approximate by design (the original error struct is gone); tonic
+/// maps it through `Status::from_error` exactly as it would a live failure.
+#[derive(Debug)]
+pub struct ReplayedTransportError(pub String);
+
+impl std::fmt::Display for ReplayedTransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "deja replayed transport error: {}", self.0)
+    }
+}
+
+impl std::error::Error for ReplayedTransportError {}
+
+impl<S, RB> tonic::codegen::Service<http::Request<TonicBody>> for DejaGrpcTransport<S>
+where
+    S: tonic::codegen::Service<http::Request<TonicBody>, Response = http::Response<RB>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+    RB: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    RB::Error: Into<BoxError>,
+{
+    type Response = http::Response<TonicBody>;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, BoxError>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    #[track_caller]
+    fn call(&mut self, request: http::Request<TonicBody>) -> Self::Future {
+        // Standard tower clone-dance: `self.inner` was driven to readiness by
+        // poll_ready, so hand THAT instance to the future and keep the fresh
+        // clone (which will be polled to readiness before its own use).
+        let clone = self.inner.clone();
+        let inner = std::mem::replace(&mut self.inner, clone);
+
+        // Boundary engaged only when a deja hook is live (record or replay);
+        // otherwise pure passthrough — no buffering, no dispatch, streaming
+        // untouched.
+        if !is_active() {
+            return Box::pin(passthrough(inner, request));
+        }
+        let caller = Location::caller();
+        Box::pin(boundary_call(inner, request, caller))
+    }
+}
+
+fn is_active() -> bool {
+    // Covers BOTH worlds: replay/record via the runtime hook (runtime_mode)
+    // and record via the recording hook — substitution must engage in replay,
+    // so this must never be a record-only check.
+    deja::__private::observation_is_active()
+}
+
+async fn passthrough<S, RB>(
+    mut inner: S,
+    request: http::Request<TonicBody>,
+) -> Result<http::Response<TonicBody>, BoxError>
+where
+    S: tonic::codegen::Service<http::Request<TonicBody>, Response = http::Response<RB>>,
+    S::Error: Into<BoxError>,
+    RB: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    RB::Error: Into<BoxError>,
+{
+    let response = inner.call(request).await.map_err(Into::into)?;
+    Ok(response.map(TonicBody::new))
+}
+
+/// One unary gRPC exchange as one deja boundary crossing.
+async fn boundary_call<S, RB>(
+    inner: S,
+    request: http::Request<TonicBody>,
+    caller: &'static Location<'static>,
+) -> Result<http::Response<TonicBody>, BoxError>
+where
+    S: tonic::codegen::Service<http::Request<TonicBody>, Response = http::Response<RB>>
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+    RB: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    RB::Error: Into<BoxError>,
+{
+    let (parts, body) = request.into_parts();
+
+    // Unary request: buffer the frames before forwarding — args identity
+    // needs the message bytes, and the rebuilt body is what the inner
+    // transport actually sends.
+    let request_bytes = match http_body_util::BodyExt::collect(body).await {
+        Ok(collected) => collected.to_bytes(),
+        Err(error) => return Err(error.into()),
+    };
+
+    let rpc: String = parts.uri.path().to_owned();
+    let authority = parts.uri.authority().map(ToString::to_string);
+
+    // Descriptor-decoded proto3-JSON for the local protos; UCS (unknown
+    // schema) falls back to the canonical wire identity inside `grpc_args`.
+    #[cfg(any(feature = "dynamic_routing", feature = "revenue_recovery"))]
+    let decoded_request =
+        semantic_boundary::descriptors::decode_unary_request(&rpc, &request_bytes);
+    #[cfg(not(any(feature = "dynamic_routing", feature = "revenue_recovery")))]
+    let decoded_request: Option<serde_json::Value> = None;
+
+    let args_value = semantic_boundary::grpc_args(
+        &rpc,
+        authority.as_deref(),
+        &parts.headers,
+        &request_bytes,
+        decoded_request,
+    );
+    let correlation = semantic_boundary::correlation(&parts.headers);
+
+    // Identity: rank-2 span-path (from the ambient tracing context) — NO explicit
+    // call-site id. rank-1 Explicit is a hand-out tag, not a burden to stamp on
+    // call-sites; the rpc path lives in the ARGS (grpc_args), not the identity, so
+    // replay matches within a span by occurrence + args — exactly like the
+    // db / redis / superposition boundaries. The syntactic hash of "grpc::<path>"
+    // is the rank-3 fallback (each in-span call is still disambiguated by
+    // occurrence, so distinct rpcs never collapse onto one identity).
+    let scope = format!("grpc::{rpc}");
+    let identity = deja::__private::CallsiteIdentity {
+        version: 1,
+        source: deja::__private::CallsiteSource::SyntacticHash,
+        id: None,
+        scope: Some(scope.clone()),
+        occurrence: deja::__private::next_boundary_occurrence(
+            correlation.as_deref(),
+            deja::__private::CallsiteSource::SyntacticHash,
+            Some(&scope),
+        ),
+        caller_function: Some(COMPONENT.to_string()),
+        lexical_path: Some(scope.clone()),
+        syntax_hash: Some(deja::__private::stable_callsite_hash(&scope)),
+        span_path: deja::__private::current_span_path(),
+    };
+
+    // Egress routing is hardcoded: never re-issued on replay.
+    let semantics = deja::__private::BoundarySemantics {
+        replay_strategy: deja::ReplayStrategy::Substitute,
+        kind: Some(BOUNDARY.to_string()),
+        declaration: Some(
+            deja::BoundaryDeclaration::default().operation(deja::OperationKind::ExternalCall),
+        ),
+    };
+    let spec =
+        deja::__private::BoundarySpec::with_semantics(BOUNDARY, COMPONENT, OPERATION, semantics);
+    let observation =
+        deja::__private::CrossingObservation::with_correlation(spec, identity, caller, correlation);
+
+    let rebuilt_request = http::Request::from_parts(
+        parts,
+        TonicBody::new(BufferedBody::new(request_bytes, None)),
+    );
+
+    deja::__private::dispatch_async(
+        observation,
+        move || args_value,
+        move || run_and_capture(inner, rebuilt_request),
+        reconstruct_from_recorded,
+        extract_envelope,
+    )
+    .await
+}
+
+/// The `run` thunk: forward to the real transport, buffer the response
+/// verbatim (data frames + trailers), and hand tonic a response rebuilt over
+/// the SAME buffer the tape captures — byte-identical parity. The envelope
+/// rides `http::Extensions` to the extractor.
+async fn run_and_capture<S, RB>(
+    mut inner: S,
+    request: http::Request<TonicBody>,
+) -> Result<http::Response<TonicBody>, BoxError>
+where
+    S: tonic::codegen::Service<http::Request<TonicBody>, Response = http::Response<RB>>,
+    S::Error: Into<BoxError>,
+    RB: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    RB::Error: Into<BoxError>,
+{
+    let response = match inner.call(request).await {
+        Ok(response) => response,
+        Err(error) => return Err(error.into()),
+    };
+    let (parts, body) = response.into_parts();
+    let collected = match http_body_util::BodyExt::collect(body).await {
+        Ok(collected) => collected,
+        Err(error) => return Err(error.into()),
+    };
+    let trailers = collected.trailers().cloned();
+    let data = collected.to_bytes();
+
+    let envelope = GrpcResultEnvelope::from_response_parts(
+        parts.status.as_u16(),
+        &parts.headers,
+        &data,
+        trailers.as_ref(),
+    );
+    let mut rebuilt =
+        http::Response::from_parts(parts, TonicBody::new(BufferedBody::new(data, trailers)));
+    rebuilt.extensions_mut().insert(CapturedEnvelope(envelope));
+    Ok(rebuilt)
+}
+
+/// The `extract` closure: envelope out of the extensions (record path), or a
+/// transport-error envelope from the `Err` arm.
+fn extract_envelope(
+    result: &Result<http::Response<TonicBody>, BoxError>,
+) -> (serde_json::Value, bool) {
+    let envelope = match result {
+        Ok(response) => match response.extensions().get::<CapturedEnvelope>() {
+            Some(CapturedEnvelope(envelope)) => envelope.clone(),
+            // Unreachable on the record path (run_and_capture always stamps
+            // it); recorded loudly rather than silently if it ever happens.
+            None => GrpcResultEnvelope::TransportError {
+                error: "deja: response envelope was not captured".to_owned(),
+            },
+        },
+        Err(error) => GrpcResultEnvelope::TransportError {
+            error: format!("{error}"),
+        },
+    };
+    let is_error = envelope.is_err();
+    let value = serde_json::to_value(&envelope).unwrap_or_else(
+        |error| serde_json::json!({ "deja_grpc_capture_error": error.to_string() }),
+    );
+    (value, is_error)
+}
+
+/// The `reconstruct` closure: recorded envelope → the identical wire response
+/// through tonic's own decoder, or the recorded transport failure.
+fn reconstruct_from_recorded(
+    recorded: serde_json::Value,
+) -> deja::__private::Reconstructed<Result<http::Response<TonicBody>, BoxError>> {
+    let Ok(envelope) = serde_json::from_value::<GrpcResultEnvelope>(recorded) else {
+        return deja::__private::Reconstructed::Failed;
+    };
+    match &envelope {
+        GrpcResultEnvelope::Response { .. } => {
+            match semantic_boundary::reconstruct_response(&envelope) {
+                Some(response) => {
+                    deja::__private::Reconstructed::Value(Ok(response.map(TonicBody::new)))
+                }
+                None => deja::__private::Reconstructed::Failed,
+            }
+        }
+        GrpcResultEnvelope::TransportError { error } => deja::__private::Reconstructed::Value(Err(
+            Box::new(ReplayedTransportError(error.clone())),
+        )),
+    }
+}
+
+#[cfg(all(test, feature = "dynamic_routing"))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{
+        super::dynamic_routing::{
+            success_rate_client::success_rate::{
+                success_rate_calculator_server::{
+                    SuccessRateCalculator, SuccessRateCalculatorServer,
+                },
+                CalGlobalSuccessRateRequest, CalGlobalSuccessRateResponse, CalSuccessRateRequest,
+                CalSuccessRateResponse, InvalidateWindowsRequest, InvalidateWindowsResponse,
+                LabelWithScore, UpdateSuccessRateWindowRequest, UpdateSuccessRateWindowResponse,
+            },
+            SuccessRateCalculatorClient,
+        },
+        *,
+    };
+
+    /// Canned scorer: a deterministic Ok and a typed decline.
+    pub(crate) struct CannedScorer;
+
+    #[tonic::async_trait]
+    impl SuccessRateCalculator for CannedScorer {
+        async fn fetch_success_rate(
+            &self,
+            request: tonic::Request<CalSuccessRateRequest>,
+        ) -> Result<tonic::Response<CalSuccessRateResponse>, tonic::Status> {
+            let id = request.into_inner().id;
+            Ok(tonic::Response::new(CalSuccessRateResponse {
+                labels_with_score: vec![LabelWithScore {
+                    score: 0.75,
+                    label: format!("stripe:{id}"),
+                }],
+                routing_approach: 0,
+            }))
+        }
+
+        async fn update_success_rate_window(
+            &self,
+            _request: tonic::Request<UpdateSuccessRateWindowRequest>,
+        ) -> Result<tonic::Response<UpdateSuccessRateWindowResponse>, tonic::Status> {
+            Err(tonic::Status::invalid_argument("window rejected"))
+        }
+
+        async fn invalidate_windows(
+            &self,
+            _request: tonic::Request<InvalidateWindowsRequest>,
+        ) -> Result<tonic::Response<InvalidateWindowsResponse>, tonic::Status> {
+            Err(tonic::Status::unimplemented("not in this test"))
+        }
+
+        async fn fetch_entity_and_global_success_rate(
+            &self,
+            _request: tonic::Request<CalGlobalSuccessRateRequest>,
+        ) -> Result<tonic::Response<CalGlobalSuccessRateResponse>, tonic::Status> {
+            Err(tonic::Status::unimplemented("not in this test"))
+        }
+    }
+
+    /// Inactive-hook passthrough: real tonic server + wrapped hyper pool,
+    /// traffic must be untouched in both arms. (The RECORD side needs a
+    /// separate process, because the global hook OnceLock latches on first
+    /// read and this test must observe the pre-install state.)
+    #[tokio::test]
+    async fn inactive_wrapper_is_a_pure_passthrough() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(SuccessRateCalculatorServer::new(CannedScorer))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+
+        let pool =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                .http2_only(true)
+                .build_http();
+        let transport = DejaGrpcTransport::new(pool);
+        let uri: http::Uri = format!("http://127.0.0.1:{port}").parse().unwrap();
+        let mut client = SuccessRateCalculatorClient::with_origin(transport, uri);
+
+        assert!(!is_active(), "no deja hook may be active in the lib tests");
+        let response = client
+            .fetch_success_rate(tonic::Request::new(CalSuccessRateRequest {
+                id: "m1".to_owned(),
+                params: "card".to_owned(),
+                labels: vec![],
+                config: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.labels_with_score.len(), 1);
+        assert_eq!(
+            response.labels_with_score.first().unwrap().label,
+            "stripe:m1"
+        );
+
+        let status = client
+            .update_success_rate_window(UpdateSuccessRateWindowRequest {
+                id: "m1".to_owned(),
+                params: String::new(),
+                labels_with_status: vec![],
+                global_labels_with_status: vec![],
+                config: None,
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.message(), "window rejected");
+    }
+}

--- a/crates/external_services/src/grpc_client/semantic_boundary.rs
+++ b/crates/external_services/src/grpc_client/semantic_boundary.rs
@@ -1,0 +1,715 @@
+//! Deja gRPC egress semantics — the capture/reconstruct half of the gRPC
+//! boundary.
+//!
+//! Mirrors `http_client::semantic_boundary` one layer down: the boundary sits
+//! on the tonic *transport* (a tower `Service`), so everything here operates
+//! on wire-level values — http/2 response parts, length-prefixed gRPC frames,
+//! trailers — and never interprets gRPC framing. Recorded bytes are replayed
+//! verbatim through tonic's own decoder, which is what makes substitution
+//! byte-faithful: typed `Status` (including `grpc-status-details-bin`),
+//! trailers-only error shapes, and compression all reproduce by construction.
+//!
+//! Lookup identity note: undecoded (descriptor-less) request messages MUST be
+//! keyed by [`wire_canon`], never by raw bytes — prost encodes `map<..>`
+//! fields in per-process `HashMap` iteration order, so the same logical
+//! request produces different bytes across the recording and candidate
+//! processes. Responses are never hashed: they replay verbatim.
+
+use base64::Engine;
+use tonic::codegen::http;
+
+/// General purpose base64 engine used for wire payload capture.
+const B64: base64::engine::GeneralPurpose = base64::engine::general_purpose::STANDARD;
+
+/// Correlation for a gRPC egress call: the `x-request-id` request metadata,
+/// attached by all three client families (mirrors the HTTP boundary's
+/// `X-Request-Id` extractor).
+pub fn correlation(headers: &http::HeaderMap) -> Option<String> {
+    headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+/// Canonical boundary args for a unary gRPC call.
+///
+/// `decoded_request` is the descriptor-decoded proto3-JSON of the request
+/// message when the rpc's schema is known (local protos); when `None` the
+/// args instead carry the [`wire_canon`] form of each request message and an
+/// `undecoded: true` marker (UCS — field-level diffs deferred by design D2).
+pub fn grpc_args(
+    rpc: &str,
+    authority: Option<&str>,
+    headers: &http::HeaderMap,
+    request_body: &[u8],
+    decoded_request: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut args = serde_json::Map::new();
+    args.insert("rpc".to_owned(), serde_json::Value::from(rpc));
+    args.insert("authority".to_owned(), serde_json::Value::from(authority));
+    args.insert(
+        "metadata".to_owned(),
+        serde_json::json!(header_pairs(headers)),
+    );
+    match decoded_request {
+        Some(decoded) => {
+            args.insert("request".to_owned(), decoded);
+        }
+        None => {
+            // Canonicalize per message so the identity is stable under
+            // prost's map-entry encode-order nondeterminism. A body that does
+            // not parse as clean gRPC framing (or carries compressed frames)
+            // falls back to canonicalizing the whole body — still
+            // deterministic, weaker only in precision.
+            let canon: Vec<String> = match unframe_messages(request_body) {
+                Some(messages) => messages
+                    .iter()
+                    .map(|message| wire_canon::canonical_b64(message))
+                    .collect(),
+                None => vec![wire_canon::canonical_b64(request_body)],
+            };
+            args.insert("request_canon_b64".to_owned(), serde_json::json!(canon));
+            args.insert("undecoded".to_owned(), serde_json::Value::from(true));
+        }
+    }
+    serde_json::Value::Object(args)
+}
+
+/// Splits a raw gRPC message-stream body into its length-prefixed messages
+/// (`[compressed: u8][len: u32 BE][payload]`*). Returns `None` on malformed
+/// framing or any compressed frame (canonicalization cannot see inside
+/// compressed bytes; hyperswitch clients never negotiate compression).
+pub fn unframe_messages(body: &[u8]) -> Option<Vec<&[u8]>> {
+    let mut out = Vec::new();
+    let mut rest = body;
+    while !rest.is_empty() {
+        let (head, tail) = rest.split_at_checked(5)?;
+        if *head.first()? != 0 {
+            return None;
+        }
+        let len_bytes: [u8; 4] = head.get(1..5)?.try_into().ok()?;
+        let len = usize::try_from(u32::from_be_bytes(len_bytes)).ok()?;
+        let (message, remaining) = tail.split_at_checked(len)?;
+        out.push(message);
+        rest = remaining;
+    }
+    Some(out)
+}
+
+/// Schema-free canonicalization of protobuf wire bytes, used ONLY to derive
+/// stable lookup identity for undecoded messages.
+///
+/// The contract is DETERMINISM, not schema-correctness: both the lookup
+/// renderer and the replay hook apply the same procedure to their respective
+/// bytes, so any parse heuristic is fine as long as identical payloads make
+/// identical decisions. Canonicalization sorts repeated occurrences of the
+/// same field number (map entries are repeated messages on the wire), which
+/// erases order-sensitivity of genuinely ordered repeated fields FOR THE KEY
+/// — an accepted, documented trade-off (order-only changes substitute instead
+/// of re-keying).
+pub mod wire_canon {
+    use base64::Engine;
+
+    /// Nesting cap: beyond this the level is kept verbatim (still
+    /// deterministic — depth is a function of the data).
+    const MAX_DEPTH: usize = 32;
+
+    /// Canonical form of `bytes`; input that does not parse as protobuf wire
+    /// format is returned verbatim.
+    pub fn canonical(bytes: &[u8]) -> Vec<u8> {
+        canon_level(bytes, 0).unwrap_or_else(|| bytes.to_vec())
+    }
+
+    /// Base64 of [`canonical`] — the shape embedded in boundary args.
+    pub fn canonical_b64(bytes: &[u8]) -> String {
+        super::B64.encode(canonical(bytes))
+    }
+
+    fn canon_level(bytes: &[u8], depth: usize) -> Option<Vec<u8>> {
+        if depth >= MAX_DEPTH {
+            return None;
+        }
+        let mut items: Vec<(u64, u8, Vec<u8>)> = Vec::new();
+        let mut rest = bytes;
+        while !rest.is_empty() {
+            let (tag, remaining) = varint(rest)?;
+            rest = remaining;
+            let field = tag >> 3;
+            let wire_type = u8::try_from(tag & 7).ok()?;
+            if field == 0 {
+                return None;
+            }
+            let payload: Vec<u8> = match wire_type {
+                0 => {
+                    let (raw, remaining) = varint_raw(rest)?;
+                    rest = remaining;
+                    raw.to_vec()
+                }
+                1 => take(&mut rest, 8)?.to_vec(),
+                5 => take(&mut rest, 4)?.to_vec(),
+                2 => {
+                    let (len, remaining) = varint(rest)?;
+                    rest = remaining;
+                    let raw = take(&mut rest, usize::try_from(len).ok()?)?;
+                    // Recurse when the payload itself parses as wire format.
+                    // The decision depends only on the payload bytes, so it is
+                    // identical on both sides of a record/replay pair.
+                    canon_level(raw, depth.checked_add(1)?).unwrap_or_else(|| raw.to_vec())
+                }
+                // Groups (3/4) are deprecated and unused; anything else is
+                // malformed — keep the whole level verbatim.
+                _ => return None,
+            };
+            items.push((field, wire_type, payload));
+        }
+        items.sort();
+        let mut out = Vec::with_capacity(bytes.len());
+        for (field, wire_type, payload) in items {
+            put_varint(field.checked_shl(3)? | u64::from(wire_type), &mut out);
+            if wire_type == 2 {
+                put_varint(u64::try_from(payload.len()).ok()?, &mut out);
+            }
+            out.extend_from_slice(&payload);
+        }
+        Some(out)
+    }
+
+    fn take<'a>(rest: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+        let (head, tail) = rest.split_at_checked(n)?;
+        *rest = tail;
+        Some(head)
+    }
+
+    /// Decodes a varint, returning (value, rest). Rejects >10-byte runs.
+    fn varint(bytes: &[u8]) -> Option<(u64, &[u8])> {
+        let (raw, rest) = varint_raw(bytes)?;
+        let mut value: u64 = 0;
+        for (index, byte) in raw.iter().enumerate() {
+            let shift = u32::try_from(index).ok()?.checked_mul(7)?;
+            value |= u64::from(byte & 0x7f).checked_shl(shift)?;
+        }
+        Some((value, rest))
+    }
+
+    /// Splits off the raw encoded bytes of one varint (preserved verbatim so
+    /// re-emission never normalizes what the producer wrote).
+    fn varint_raw(bytes: &[u8]) -> Option<(&[u8], &[u8])> {
+        let end = bytes
+            .iter()
+            .take(10)
+            .position(|byte| byte & 0x80 == 0)?
+            .checked_add(1)?;
+        bytes.split_at_checked(end)
+    }
+
+    fn put_varint(mut value: u64, out: &mut Vec<u8>) {
+        loop {
+            let byte = u8::try_from(value & 0x7f).unwrap_or(0x7f);
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+}
+
+/// The recorded result of one unary gRPC exchange — everything needed to hand
+/// tonic's decoder a byte-identical response on replay.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GrpcResultEnvelope {
+    /// An HTTP/2 response arrived (any grpc-status, including declines —
+    /// gRPC errors are just recorded trailers, replayed verbatim).
+    Response {
+        /// HTTP status (gRPC uses 200 even for declines; transport-mapped
+        /// failures may differ).
+        http_status: u16,
+        /// Response headers, sorted by (name, value). gRPC metadata is ASCII
+        /// by spec (binary metadata rides base64 in `-bin` keys); non-UTF-8
+        /// values are captured lossily.
+        headers: Vec<(String, String)>,
+        /// Raw gRPC body frames exactly as received — length prefixes,
+        /// compression flags and all. Never parsed, never re-framed.
+        body_b64: String,
+        /// HTTP/2 trailers; `None` preserves the trailers-only/headers-only
+        /// error shape so `Status::metadata()` partitions identically.
+        trailers: Option<Vec<(String, String)>>,
+    },
+    /// The transport itself failed (connect refused, h2 reset, timeout).
+    /// Replays approximately: the recorded display chain, not the original
+    /// error struct.
+    TransportError {
+        /// Display chain of the transport error.
+        error: String,
+    },
+}
+
+impl GrpcResultEnvelope {
+    /// Captures a buffered response into its recorded envelope.
+    pub fn from_response_parts(
+        http_status: u16,
+        headers: &http::HeaderMap,
+        body: &[u8],
+        trailers: Option<&http::HeaderMap>,
+    ) -> Self {
+        Self::Response {
+            http_status,
+            headers: header_pairs(headers),
+            body_b64: B64.encode(body),
+            trailers: trailers.map(header_pairs),
+        }
+    }
+
+    /// Whether this result is an error in gRPC terms: transport failure,
+    /// non-zero `grpc-status` (trailers first, then the headers-only shape),
+    /// or a missing status on a non-200 response.
+    pub fn is_err(&self) -> bool {
+        match self {
+            Self::TransportError { .. } => true,
+            Self::Response {
+                http_status,
+                headers,
+                trailers,
+                ..
+            } => {
+                let grpc_status = trailers
+                    .as_ref()
+                    .and_then(|pairs| find_pair(pairs, "grpc-status"))
+                    .or_else(|| find_pair(headers, "grpc-status"));
+                match grpc_status {
+                    Some(status) => status != "0",
+                    None => *http_status != 200,
+                }
+            }
+        }
+    }
+}
+
+fn find_pair<'a>(pairs: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    pairs
+        .iter()
+        .find(|(key, _)| key == name)
+        .map(|(_, value)| value.as_str())
+}
+
+/// ALL request metadata, sorted by (name, value) so the serialized args are
+/// canonical (`args_hash` is order-sensitive).
+///
+/// Full-fidelity capture BY POLICY: everything the request carried is recorded
+/// — including connector auth metadata — exactly as the HTTP boundary records
+/// all request headers. Tape protection/redaction is a separate, deferred
+/// workstream; the capture layer never drops data. Replay stability holds
+/// because the candidate rebuilds requests from SEEDED state, so recorded
+/// values reproduce; a metadata change (auth, transport version, anything)
+/// re-keys the lookup and surfaces as an honest divergence — same semantics
+/// as HTTP.
+fn header_pairs(headers: &http::HeaderMap) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_owned(),
+                String::from_utf8_lossy(value.as_bytes()).into_owned(),
+            )
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn headers_from_pairs(pairs: &[(String, String)]) -> Option<http::HeaderMap> {
+    let mut map = http::HeaderMap::with_capacity(pairs.len());
+    for (name, value) in pairs {
+        map.append(
+            http::header::HeaderName::from_bytes(name.as_bytes()).ok()?,
+            http::header::HeaderValue::from_str(value).ok()?,
+        );
+    }
+    Some(map)
+}
+
+/// Rebuilds the `http::Response` a substituted call returns — tonic's own
+/// client stack decodes it exactly as it would a network response. `None`
+/// (malformed recorded data, or the transport-error arm which the seam
+/// handles separately) maps to a reconstruction failure at the boundary.
+pub fn reconstruct_response(envelope: &GrpcResultEnvelope) -> Option<http::Response<BufferedBody>> {
+    let GrpcResultEnvelope::Response {
+        http_status,
+        headers,
+        body_b64,
+        trailers,
+    } = envelope
+    else {
+        return None;
+    };
+    let data = B64.decode(body_b64).ok()?;
+    let trailer_map = match trailers {
+        Some(pairs) => Some(headers_from_pairs(pairs)?),
+        None => None,
+    };
+    let mut response =
+        http::Response::new(BufferedBody::new(bytes::Bytes::from(data), trailer_map));
+    *response.status_mut() = http::StatusCode::from_u16(*http_status).ok()?;
+    *response.headers_mut() = headers_from_pairs(headers)?;
+    Some(response)
+}
+
+/// A fully buffered http body: one data frame, then optional trailers, then
+/// end-of-stream. Serves both sides of the boundary — the record path hands
+/// tonic a response rebuilt over the same buffer it taped (byte-identical
+/// parity), and the replay path reconstructs from the recorded envelope.
+#[derive(Debug)]
+pub struct BufferedBody {
+    data: Option<bytes::Bytes>,
+    trailers: Option<http::HeaderMap>,
+}
+
+impl BufferedBody {
+    /// A body yielding `data` (skipped when empty) then `trailers`.
+    pub fn new(data: bytes::Bytes, trailers: Option<http::HeaderMap>) -> Self {
+        Self {
+            data: (!data.is_empty()).then_some(data),
+            trailers,
+        }
+    }
+}
+
+impl http_body::Body for BufferedBody {
+    type Data = bytes::Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        if let Some(data) = this.data.take() {
+            return std::task::Poll::Ready(Some(Ok(http_body::Frame::data(data))));
+        }
+        if let Some(trailers) = this.trailers.take() {
+            return std::task::Poll::Ready(Some(Ok(http_body::Frame::trailers(trailers))));
+        }
+        std::task::Poll::Ready(None)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.data.is_none() && self.trailers.is_none()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        match &self.data {
+            Some(data) => {
+                http_body::SizeHint::with_exact(u64::try_from(data.len()).unwrap_or(u64::MAX))
+            }
+            None => http_body::SizeHint::with_exact(0),
+        }
+    }
+}
+
+/// Descriptor-pool decoding for the local protos (dynamic routing, revenue
+/// recovery, health) — the readable-JSON projection and field-level diffs.
+/// UCS descriptors are deferred by design decision D2; UCS rpcs simply return
+/// `None` here and fall back to the wire-canonical identity.
+#[cfg(any(feature = "dynamic_routing", feature = "revenue_recovery"))]
+pub mod descriptors {
+    use std::sync::OnceLock;
+
+    use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
+
+    static POOLS: OnceLock<Vec<DescriptorPool>> = OnceLock::new();
+
+    /// One pool per emitted descriptor set (kept separate so shared
+    /// well-known files can never collide across sets).
+    fn pools() -> &'static [DescriptorPool] {
+        POOLS.get_or_init(|| {
+            let mut pools = Vec::new();
+            #[cfg(feature = "dynamic_routing")]
+            if let Ok(pool) = DescriptorPool::decode(
+                &include_bytes!(concat!(
+                    env!("OUT_DIR"),
+                    "/deja_dynamic_routing_descriptor.bin"
+                ))[..],
+            ) {
+                pools.push(pool);
+            }
+            #[cfg(feature = "revenue_recovery")]
+            if let Ok(pool) = DescriptorPool::decode(
+                &include_bytes!(concat!(env!("OUT_DIR"), "/deja_recovery_descriptor.bin"))[..],
+            ) {
+                pools.push(pool);
+            }
+            pools
+        })
+    }
+
+    /// `(input, output)` message descriptors for an rpc path of the form
+    /// `/package.Service/Method`, when the schema is known.
+    pub fn method_descriptors(rpc: &str) -> Option<(MessageDescriptor, MessageDescriptor)> {
+        let (service, method) = rpc.strip_prefix('/')?.split_once('/')?;
+        pools().iter().find_map(|pool| {
+            let service = pool
+                .services()
+                .find(|candidate| candidate.full_name() == service)?;
+            let method = service
+                .methods()
+                .find(|candidate| candidate.name() == method)?;
+            Some((method.input(), method.output()))
+        })
+    }
+
+    /// Proto3-JSON projection of one wire message.
+    pub fn decode_to_json(
+        descriptor: &MessageDescriptor,
+        message: &[u8],
+    ) -> Option<serde_json::Value> {
+        let decoded = DynamicMessage::decode(descriptor.clone(), message).ok()?;
+        serde_json::to_value(&decoded).ok()
+    }
+
+    /// Decodes a single-message request body (unary) into proto3-JSON using
+    /// the rpc's input descriptor. `None` = unknown schema or malformed body;
+    /// callers fall back to the wire-canonical identity.
+    pub fn decode_unary_request(rpc: &str, request_body: &[u8]) -> Option<serde_json::Value> {
+        let (input, _) = method_descriptors(rpc)?;
+        let messages = super::unframe_messages(request_body)?;
+        let (message, rest) = messages.split_first()?;
+        if !rest.is_empty() {
+            return None;
+        }
+        decode_to_json(&input, message)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    /// Minimal wire-format writer for test fixtures.
+    fn field(out: &mut Vec<u8>, number: u64, wire_type: u64, payload: &[u8]) {
+        put_test_varint(number << 3 | wire_type, out);
+        if wire_type == 2 {
+            put_test_varint(u64::try_from(payload.len()).unwrap(), out);
+        }
+        out.extend_from_slice(payload);
+    }
+
+    fn put_test_varint(mut value: u64, out: &mut Vec<u8>) {
+        loop {
+            let byte = u8::try_from(value & 0x7f).unwrap();
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    /// One `map<string, string>` entry: nested message {1: key, 2: value}.
+    fn map_entry(key: &str, value: &str) -> Vec<u8> {
+        let mut entry = Vec::new();
+        field(&mut entry, 1, 2, key.as_bytes());
+        field(&mut entry, 2, 2, value.as_bytes());
+        entry
+    }
+
+    fn frame(message: &[u8]) -> Vec<u8> {
+        let mut framed = vec![0u8];
+        framed.extend_from_slice(&u32::try_from(message.len()).unwrap().to_be_bytes());
+        framed.extend_from_slice(message);
+        framed
+    }
+
+    #[test]
+    fn map_reorder_is_canonically_stable() {
+        // message { 1: "id", map<string,string> 2 } with entries in both orders
+        let (mut ab, mut ba) = (Vec::new(), Vec::new());
+        field(&mut ab, 1, 2, b"payment_123");
+        field(&mut ab, 2, 2, &map_entry("alpha", "1"));
+        field(&mut ab, 2, 2, &map_entry("beta", "2"));
+        field(&mut ba, 1, 2, b"payment_123");
+        field(&mut ba, 2, 2, &map_entry("beta", "2"));
+        field(&mut ba, 2, 2, &map_entry("alpha", "1"));
+        assert_ne!(ab, ba, "fixtures must differ before canonicalization");
+        assert_eq!(wire_canon::canonical(&ab), wire_canon::canonical(&ba));
+    }
+
+    #[test]
+    fn value_changes_change_the_canonical_form() {
+        let (mut left, mut right) = (Vec::new(), Vec::new());
+        field(&mut left, 2, 2, &map_entry("alpha", "1"));
+        field(&mut right, 2, 2, &map_entry("alpha", "CHANGED"));
+        assert_ne!(wire_canon::canonical(&left), wire_canon::canonical(&right));
+    }
+
+    #[test]
+    fn nested_map_reorder_is_canonically_stable() {
+        // outer message { 3: inner } where inner carries the reordered map
+        let (mut inner_ab, mut inner_ba) = (Vec::new(), Vec::new());
+        field(&mut inner_ab, 2, 2, &map_entry("alpha", "1"));
+        field(&mut inner_ab, 2, 2, &map_entry("beta", "2"));
+        field(&mut inner_ba, 2, 2, &map_entry("beta", "2"));
+        field(&mut inner_ba, 2, 2, &map_entry("alpha", "1"));
+        let (mut outer_ab, mut outer_ba) = (Vec::new(), Vec::new());
+        field(&mut outer_ab, 3, 2, &inner_ab);
+        field(&mut outer_ba, 3, 2, &inner_ba);
+        assert_eq!(
+            wire_canon::canonical(&outer_ab),
+            wire_canon::canonical(&outer_ba)
+        );
+    }
+
+    #[test]
+    fn non_protobuf_input_passes_through_verbatim() {
+        let text = b"hello world! this is not protobuf";
+        assert_eq!(wire_canon::canonical(text), text.to_vec());
+        assert_eq!(wire_canon::canonical(&[]), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn unframe_roundtrip_and_rejections() {
+        let message = b"\x0a\x02hi".to_vec();
+        let mut body = frame(&message);
+        body.extend_from_slice(&frame(b"more"));
+        let messages = unframe_messages(&body).unwrap();
+        assert_eq!(messages, vec![&message[..], &b"more"[..]]);
+
+        // compressed flag and truncation are both rejected
+        let mut compressed = frame(&message);
+        compressed[0] = 1;
+        assert!(unframe_messages(&compressed).is_none());
+        assert!(unframe_messages(&body[..body.len() - 1]).is_none());
+    }
+
+    #[test]
+    fn args_capture_everything_sorted_full_fidelity() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-tenant-id", "t1".parse().unwrap());
+        headers.insert("x-request-id", "req_9".parse().unwrap());
+        headers.insert("x-api-key", "SECRET".parse().unwrap());
+        headers.insert("content-type", "application/grpc".parse().unwrap());
+
+        let args = grpc_args(
+            "/success_rate.SuccessRateCalculator/FetchSuccessRate",
+            Some("dyn-routing:7000"),
+            &headers,
+            &frame(b"\x0a\x02id"),
+            None,
+        );
+        // Full fidelity: EVERYTHING the request carried is on the tape —
+        // auth metadata included (protection is a deferred workstream, and
+        // the HTTP boundary records all headers identically). Sorted for a
+        // canonical args_hash.
+        assert_eq!(
+            args["metadata"],
+            serde_json::json!([
+                ["content-type", "application/grpc"],
+                ["x-api-key", "SECRET"],
+                ["x-request-id", "req_9"],
+                ["x-tenant-id", "t1"]
+            ])
+        );
+        assert_eq!(args["undecoded"], serde_json::json!(true));
+        assert_eq!(correlation(&headers).as_deref(), Some("req_9"));
+    }
+
+    #[test]
+    fn envelope_roundtrips_through_serde() {
+        let envelope = GrpcResultEnvelope::Response {
+            http_status: 200,
+            headers: vec![("content-type".to_owned(), "application/grpc".to_owned())],
+            body_b64: B64.encode(frame(b"\x08\x01")),
+            trailers: Some(vec![("grpc-status".to_owned(), "0".to_owned())]),
+        };
+        let json = serde_json::to_value(&envelope).unwrap();
+        let back: GrpcResultEnvelope = serde_json::from_value(json).unwrap();
+        assert_eq!(envelope, back);
+        assert!(!envelope.is_err());
+        assert!(GrpcResultEnvelope::TransportError {
+            error: "connect refused".to_owned()
+        }
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn buffered_body_emits_data_then_trailers() {
+        use http_body_util::BodyExt;
+
+        let mut trailers = http::HeaderMap::new();
+        trailers.insert("grpc-status", "0".parse().unwrap());
+        let body = BufferedBody::new(bytes::Bytes::from_static(b"payload"), Some(trailers));
+        let collected = body.collect().await.unwrap();
+        assert_eq!(
+            collected.trailers().and_then(|t| t.get("grpc-status")),
+            Some(&"0".parse().unwrap())
+        );
+        assert_eq!(collected.to_bytes().as_ref(), b"payload");
+    }
+
+    #[tokio::test]
+    async fn recorded_decline_reconstructs_the_same_typed_status() {
+        use http_body_util::BodyExt;
+
+        // A recorded decline: grpc-status 3 (InvalidArgument) in trailers.
+        let envelope = GrpcResultEnvelope::Response {
+            http_status: 200,
+            headers: vec![("content-type".to_owned(), "application/grpc".to_owned())],
+            body_b64: String::new(),
+            trailers: Some(vec![
+                ("grpc-message".to_owned(), "card declined".to_owned()),
+                ("grpc-status".to_owned(), "3".to_owned()),
+            ]),
+        };
+        assert!(envelope.is_err());
+
+        let response = reconstruct_response(&envelope).unwrap();
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let collected = response.into_body().collect().await.unwrap();
+        let status = tonic::Status::from_header_map(collected.trailers().unwrap()).unwrap();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.message(), "card declined");
+    }
+
+    #[test]
+    fn trailers_only_shape_is_preserved() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("grpc-status", "14".parse().unwrap());
+        let envelope = GrpcResultEnvelope::from_response_parts(200, &headers, &[], None);
+        assert!(envelope.is_err());
+        let response = reconstruct_response(&envelope).unwrap();
+        // Status stays in the HEADERS — no synthesized trailers frame.
+        let status = tonic::Status::from_header_map(response.headers()).unwrap();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+    }
+
+    #[cfg(feature = "dynamic_routing")]
+    #[test]
+    fn descriptor_decode_by_rpc_path() {
+        use prost_reflect::prost::Message;
+
+        let rpc = "/success_rate.SuccessRateCalculator/FetchSuccessRate";
+        let (input, output) = descriptors::method_descriptors(rpc).unwrap();
+        assert_eq!(input.full_name(), "success_rate.CalSuccessRateRequest");
+        assert_eq!(output.full_name(), "success_rate.CalSuccessRateResponse");
+
+        // Round-trip a request through the descriptor: set fields dynamically,
+        // encode, decode back to proto3-JSON.
+        let mut message = prost_reflect::DynamicMessage::new(input.clone());
+        message.set_field_by_name("id", prost_reflect::Value::String("m1:gateway".to_owned()));
+        message.set_field_by_name(
+            "params",
+            prost_reflect::Value::String("card&credit".to_owned()),
+        );
+        let wire = message.encode_to_vec();
+
+        let json = descriptors::decode_unary_request(rpc, &frame(&wire)).unwrap();
+        assert_eq!(json["id"], serde_json::json!("m1:gateway"));
+        assert_eq!(json["params"], serde_json::json!("card&credit"));
+
+        // Unknown schema (UCS) falls back to None — the wire-canonical path.
+        assert!(descriptors::method_descriptors("/types.PaymentService/Authorize").is_none());
+    }
+}

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -21,33 +21,45 @@ use crate::{
 
 /// Result type for Dynamic Routing
 pub type UnifiedConnectorServiceResult<T> = CustomResult<T, UnifiedConnectorServiceError>;
+
+/// The transport under every UCS service client. Under the `deja` feature it is
+/// the gRPC egress boundary wrapper — every unary rpc (payment, refund, …) is
+/// recorded/substituted at the wire level with rank-2 span-path identity;
+/// otherwise it is the raw tonic channel. Threading this alias through the
+/// client fields + their construction keeps the feature-off build byte-identical.
+#[cfg(feature = "deja")]
+pub type UcsChannel = super::deja_transport::DejaGrpcTransport<tonic::transport::Channel>;
+/// The transport under every UCS service client (raw tonic channel; see the
+/// `deja`-gated definition above for the recording/substituting variant).
+#[cfg(not(feature = "deja"))]
+pub type UcsChannel = tonic::transport::Channel;
 /// Contains the  Unified Connector Service client
 #[derive(Debug, Clone)]
 pub struct UnifiedConnectorServiceClient {
     /// The Payment Service Client
-    pub payment_service_client: payments_grpc::payment_service_client::PaymentServiceClient<tonic::transport::Channel>,
+    pub payment_service_client: payments_grpc::payment_service_client::PaymentServiceClient<UcsChannel>,
     /// The Refund Service Client
-    pub refund_service_client: payments_grpc::refund_service_client::RefundServiceClient<tonic::transport::Channel>,
+    pub refund_service_client: payments_grpc::refund_service_client::RefundServiceClient<UcsChannel>,
     /// The Event Service Client
-    pub event_service_client: payments_grpc::event_service_client::EventServiceClient<tonic::transport::Channel>,
+    pub event_service_client: payments_grpc::event_service_client::EventServiceClient<UcsChannel>,
     /// The Recurring Payment Service Client
-    pub recurring_payment_service_client: payments_grpc::recurring_payment_service_client::RecurringPaymentServiceClient<tonic::transport::Channel>,
+    pub recurring_payment_service_client: payments_grpc::recurring_payment_service_client::RecurringPaymentServiceClient<UcsChannel>,
     /// The Dispute Service Client
-    pub dispute_service_client: payments_grpc::dispute_service_client::DisputeServiceClient<tonic::transport::Channel>,
+    pub dispute_service_client: payments_grpc::dispute_service_client::DisputeServiceClient<UcsChannel>,
     /// The Payment Method Service Client
-    pub payment_method_service_client: payments_grpc::payment_method_service_client::PaymentMethodServiceClient<tonic::transport::Channel>,
+    pub payment_method_service_client: payments_grpc::payment_method_service_client::PaymentMethodServiceClient<UcsChannel>,
     /// The Customer Service Client
-    pub customer_service_client: payments_grpc::customer_service_client::CustomerServiceClient<tonic::transport::Channel>,
+    pub customer_service_client: payments_grpc::customer_service_client::CustomerServiceClient<UcsChannel>,
     /// The Merchant Authentication Service Client
     pub merchant_authentication_service_client:
-        payments_grpc::merchant_authentication_service_client::MerchantAuthenticationServiceClient<tonic::transport::Channel>,
+        payments_grpc::merchant_authentication_service_client::MerchantAuthenticationServiceClient<UcsChannel>,
     /// The Payment Method Authentication Service Client
     pub payment_method_authentication_service_client:
-        payments_grpc::payment_method_authentication_service_client::PaymentMethodAuthenticationServiceClient<tonic::transport::Channel>,
+        payments_grpc::payment_method_authentication_service_client::PaymentMethodAuthenticationServiceClient<UcsChannel>,
         /// The Payout Service Client
-    pub payout_service_client: payments_grpc::payout_service_client::PayoutServiceClient<tonic::transport::Channel>,
+    pub payout_service_client: payments_grpc::payout_service_client::PayoutServiceClient<UcsChannel>,
     /// The Surcharge Service Client
-    pub surcharge_service_client: payments_grpc::surcharge_service_client::SurchargeServiceClient<tonic::transport::Channel>,
+    pub surcharge_service_client: payments_grpc::surcharge_service_client::SurchargeServiceClient<UcsChannel>,
 }
 
 /// Contains the Unified Connector Service Client config
@@ -188,7 +200,15 @@ macro_rules! build_grpc_client {
         let endpoint = tonic::transport::Channel::builder($uri.clone())
             .timeout($request_timeout.as_duration());
         match timeout($connection_timeout.as_duration(), endpoint.connect()).await {
-            Ok(Ok(channel)) => <$client>::new(channel),
+            Ok(Ok(channel)) => {
+                // deja: wrap the UCS channel in the gRPC egress boundary at its
+                // construction site so every unary rpc is recorded/substituted at
+                // the wire level (rank-2 identity). Feature-off passes the raw
+                // channel unchanged.
+                #[cfg(feature = "deja")]
+                let channel = $crate::grpc_client::deja_transport::DejaGrpcTransport::new(channel);
+                <$client>::new(channel)
+            }
             Ok(Err(err)) => {
                 router_env::logger::error!(
                     "Failed to connect to Unified Connector Service for {}: {:?}",
@@ -240,7 +260,7 @@ impl UnifiedConnectorServiceClient {
 
                 let payment_service_client = build_grpc_client!(
                     payments_grpc::payment_service_client::PaymentServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "payment_service_client",
                     uri,
@@ -250,7 +270,7 @@ impl UnifiedConnectorServiceClient {
 
                 let refund_service_client = build_grpc_client!(
                     payments_grpc::refund_service_client::RefundServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "refund_service_client",
                     uri,
@@ -260,7 +280,7 @@ impl UnifiedConnectorServiceClient {
 
                 let event_service_client = build_grpc_client!(
                     payments_grpc::event_service_client::EventServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "event_service_client",
                     uri,
@@ -270,7 +290,7 @@ impl UnifiedConnectorServiceClient {
 
                 let recurring_payment_service_client = build_grpc_client!(
                     payments_grpc::recurring_payment_service_client::RecurringPaymentServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "recurring_payment_service_client",
                     uri,
@@ -280,7 +300,7 @@ impl UnifiedConnectorServiceClient {
 
                 let dispute_service_client = build_grpc_client!(
                     payments_grpc::dispute_service_client::DisputeServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "dispute_service_client",
                     uri,
@@ -290,7 +310,7 @@ impl UnifiedConnectorServiceClient {
 
                 let payment_method_service_client = build_grpc_client!(
                     payments_grpc::payment_method_service_client::PaymentMethodServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "payment_method_service_client",
                     uri,
@@ -300,7 +320,7 @@ impl UnifiedConnectorServiceClient {
 
                 let customer_service_client = build_grpc_client!(
                     payments_grpc::customer_service_client::CustomerServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "customer_service_client",
                     uri,
@@ -309,7 +329,7 @@ impl UnifiedConnectorServiceClient {
                 );
 
                 let merchant_authentication_service_client = build_grpc_client!(
-                    payments_grpc::merchant_authentication_service_client::MerchantAuthenticationServiceClient<tonic::transport::Channel>,
+                    payments_grpc::merchant_authentication_service_client::MerchantAuthenticationServiceClient<UcsChannel>,
                     "merchant_authentication_service_client",
                     uri,
                     connection_timeout,
@@ -317,7 +337,7 @@ impl UnifiedConnectorServiceClient {
                 );
 
                 let payment_method_authentication_service_client = build_grpc_client!(
-                    payments_grpc::payment_method_authentication_service_client::PaymentMethodAuthenticationServiceClient<tonic::transport::Channel>,
+                    payments_grpc::payment_method_authentication_service_client::PaymentMethodAuthenticationServiceClient<UcsChannel>,
                     "payment_method_authentication_service_client",
                     uri,
                     connection_timeout,
@@ -326,7 +346,7 @@ impl UnifiedConnectorServiceClient {
 
                 let payout_service_client = build_grpc_client!(
                     payments_grpc::payout_service_client::PayoutServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "payout_service_client",
                     uri,
@@ -336,7 +356,7 @@ impl UnifiedConnectorServiceClient {
 
                 let surcharge_service_client = build_grpc_client!(
                     payments_grpc::surcharge_service_client::SurchargeServiceClient<
-                        tonic::transport::Channel,
+                        UcsChannel,
                     >,
                     "surcharge_service_client",
                     uri,


### PR DESCRIPTION
Closes #13436

# feat(deja): [6] gRPC (UCS) egress record/replay boundary

## TL;DR
Follow-up to the 5-PR deja stack (#13285–#13289), stacked on #13289. The unified-connector-service (UCS) gRPC egress becomes a full record/replay boundary: every unary RPC is recorded with full metadata fidelity and replays by **substitution from the tape** — egress is never re-issued against a live connector. All deja surface stays `#[cfg(feature = "deja")]`; feature-off remains byte-identical.

> **What deja is:** a deterministic record/replay harness for service boundaries; see #13285.

---

## What's in this PR — `external_services/src/grpc_client/`

- **`DejaGrpcTransport`** (`deja_transport.rs`): a tower-`Service` wrapper installed at the transport-construction sites — the shared hyper pool (dynamic routing / health check / revenue recovery) and the UCS channels — so every unary RPC crosses one deja boundary at the wire level with **zero call-site changes**.
- **`semantic_boundary.rs`**: the wire codec — captures request/response bytes plus metadata on record; reconstructs the recorded response on replay.
- **`unified_connector_service.rs`**: a `UcsChannel` alias — `DejaGrpcTransport<Channel>` under the feature, the raw `tonic` channel otherwise — threaded through the UCS service clients; the `build_grpc_client!` macro wraps the channel at construction.
- **Identity** is span-path based (syntactic hash + occurrence; the rpc path travels in the captured args), so concurrent identical RPCs pair deterministically on replay — the same identity scheme as the database / redis / config-read boundaries. No per-call-site tags to maintain.
- **Replay strategy is fixed to Substitute**: a replayed process never opens a live connector connection through this path.

## Evidence

- **Record fidelity:** in a recorded payment flow with UCS enabled, the UCS unary RPCs were captured on the tape with full metadata, alongside the database / redis / crypto / HTTP boundaries.
- **Replay substitution:** an end-to-end record then replay with UCS enabled substituted the gRPC calls from the tape — **2/2 matched, zero divergences**, metadata included.
- Caveat (not specific to this boundary): a recorded confirm flow can diverge on replay if the replay build runs under a *different effective configuration* than record — e.g. a differently-resolved `ucs_enabled` sending confirm down a different gateway path. That is a general replay config-consistency concern (record and replay must run under the same effective config) and is tracked as a separate follow-up.

## Feature-off guarantee

Same regime as the rest of the stack: both new modules and the transport wrap compile away feature-off; the `#[cfg(not(feature = "deja"))]` arms are the pre-existing types verbatim (the raw `tonic` channel). The `deja` feature additionally pulls `http-body` + `http-body-util` in `external_services` (optional deps, feature-gated).

## How to review

- `DejaGrpcTransport`: metadata-capture completeness on record and the substitution path on replay.
- The `UcsChannel` type split: confirm the feature-off arm is the pre-existing channel type verbatim.
- The identity choice (span-path + occurrence + args, no explicit call-site tag): confirm zero call-site edits.

## Verification

- `cargo check -p router --features deja,v1` ✅ · `cargo check -p router --features v1` (feature-off) ✅ — both on this branch against the pinned deja revision.
- End-to-end record then replay with UCS enabled: gRPC boundaries substituted from tape, zero gRPC divergences.

