### PR TITLE
feat(deja): fold sampler.enabled into mode = "record"

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -199,7 +199,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -189,7 +189,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/development.toml
+++ b/config/development.toml
@@ -37,7 +37,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -49,7 +49,6 @@ lookup_dir = ""
 observed_sink = ""
 
 [deja.sampler]
-enabled = false
 record_key = "deja_record"
 timeout_ms = 25
 fail_closed = true

--- a/config/superposition_seed.toml
+++ b/config/superposition_seed.toml
@@ -13,7 +13,7 @@ overrides = []
 [default-configs.deja_record]
 value = true
 schema = { type = "boolean" }
-description = "Whether Deja request recording is enabled for matching request contexts (inert unless deja.sampler.enabled is set)"
+description = "Whether Deja request recording is enabled for matching request contexts (inert unless deja.mode is set to record)"
 change_reason = "Initial setup"
 
 

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -321,7 +321,6 @@ pub struct DejaReplaySettings {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct DejaSamplerSettings {
-    pub enabled: bool,
     pub record_key: Option<String>,
     pub timeout_ms: u64,
     pub fail_closed: bool,
@@ -331,7 +330,6 @@ pub struct DejaSamplerSettings {
 impl Default for DejaSamplerSettings {
     fn default() -> Self {
         Self {
-            enabled: false,
             record_key: None,
             timeout_ms: 25,
             fail_closed: true,

--- a/crates/router/tests/feature_off_config_purity.rs
+++ b/crates/router/tests/feature_off_config_purity.rs
@@ -63,7 +63,6 @@ lookup_dir = "ignored"
 observed_sink = "ignored"
 
 [deja.sampler]
-enabled = true
 record_key = "ignored"
 timeout_ms = 1
 fail_closed = true
@@ -158,7 +157,6 @@ fn settings_debug(path: PathBuf) -> String {
         "ROUTER__DEJA__REPLAY__SOURCE",
         "ROUTER__DEJA__REPLAY__LOOKUP_DIR",
         "ROUTER__DEJA__REPLAY__OBSERVED_SINK",
-        "ROUTER__DEJA__SAMPLER__ENABLED",
         "ROUTER__DEJA__WRITER__QUEUE_CAPACITY",
     ] {
         std::env::remove_var(key);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Simplifies the Deja configuration surface by folding the separate `[deja.sampler] enabled` flag into `mode = "record"`. A process running in `mode = "record"` now implicitly enables the sampler. This avoids a footgun state where `mode = "record"` but the sampler is disabled.

Key changes:
- Dropped the `enabled` field from `DejaSamplerSettings` struct and its default implementation inside [settings.rs](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/crates/router/src/configs/settings.rs).
- Removed the `enabled = false` lines from under `[deja.sampler]` in all configuration TOML files ([development.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/development.toml), [config.example.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/config.example.toml), [docker_compose.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/docker_compose.toml), and [env_specific.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/deployments/env_specific.toml)).
- Updated `deja_record` config description in [superposition_seed.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/superposition_seed.toml).
- Cleaned up config purity tests in [feature_off_config_purity.rs](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/crates/router/tests/feature_off_config_purity.rs).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
- [config/config.example.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/config.example.toml#L201)
- [config/deployments/env_specific.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/deployments/env_specific.toml#L191)
- [config/development.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/development.toml#L39)
- [config/docker_compose.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/docker_compose.toml#L51)
- [config/superposition_seed.toml](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/config/superposition_seed.toml#L16)
- [crates/router/src/configs/settings.rs](file:///Users/dhruvilpatel/Developer-OpenSource/hyperswitch/crates/router/src/configs/settings.rs#L323)


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fixes #13435

Record mode is meaningless without the per-request sampler: a record-mode process with the sampler disabled should not be representable. This change removes the redundant configuration option and derives the state implicitly, eliminating a misconfiguration footgun for recording fleets.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Validated correct compilation for all targets:
- Built and checked with default features: `cargo check`
- Built and checked test targets with all features (including `deja`) enabled: `cargo check --tests --all-features`


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
