### PR TITLE
ci(cypress): fix zero auth mandate for mollie connector

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/mollie.rs
+++ b/crates/hyperswitch_connectors/src/connectors/mollie.rs
@@ -1086,15 +1086,18 @@ impl ConnectorSpecifications for Mollie {
         &self,
         payment_attempt: &hyperswitch_domain_models::payments::payment_attempt::PaymentAttempt,
     ) -> api::ConnectorCustomerAction {
+        // Mollie registers a mandate by sending `sequenceType: first` with a `customerId`,
+        // so a connector customer is required for any off-session card setup (including
+        // zero-auth mandates). We intentionally don't gate on `customer_acceptance`: it may
+        // be supplied nested inside `mandate_data` (not surfaced on the attempt) and its
+        // placement doesn't change whether Mollie needs a customer.
         if matches!(
             payment_attempt.setup_future_usage_applied,
             Some(enums::FutureUsage::OffSession)
-        ) && payment_attempt.customer_acceptance.is_some()
-            && matches!(
-                payment_attempt.payment_method,
-                Some(enums::PaymentMethod::Card)
-            )
-        {
+        ) && matches!(
+            payment_attempt.payment_method,
+            Some(enums::PaymentMethod::Card)
+        ) {
             api::ConnectorCustomerAction::CallConnectorCustomer
         } else {
             api::ConnectorCustomerAction::NoAction

--- a/cypress-tests/cypress/e2e/configs/Payment/Mollie.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Mollie.js
@@ -9,7 +9,6 @@ const successfulNo3DSCardDetails = {
   card_cvc: "123",
 };
 
-
 const successfulThreeDSTestCardDetails = {
   card_number: "5555555555554444",
   card_exp_month: "01",
@@ -728,7 +727,7 @@ export const connectorDetails = {
         },
       },
     },
-      No3DSFailPayment: {
+    No3DSFailPayment: {
       Request: {
         amount: 6000,
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/configs/Payment/Mollie.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Mollie.js
@@ -9,6 +9,7 @@ const successfulNo3DSCardDetails = {
   card_cvc: "123",
 };
 
+
 const successfulThreeDSTestCardDetails = {
   card_number: "5555555555554444",
   card_exp_month: "01",
@@ -167,6 +168,7 @@ export const connectorDetails = {
     "3DSManualCapture": {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -185,6 +187,7 @@ export const connectorDetails = {
     "3DSAutoCapture": {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -722,6 +725,24 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+        },
+      },
+    },
+      No3DSFailPayment: {
+      Request: {
+        amount: 6000,
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        billing: billingAddress,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded", // There is no failure test cards for Mollie
         },
       },
     },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Fixes Mollie zero-auth mandate failing with Missing required param: connector_customer_id.

Mollie needs a connector customer to register a mandate. The creation was gated on payment_attempt.customer_acceptance being set, but that field is only populated from top-level customer_acceptance — so requests that send it nested inside mandate_data skipped customer creation and failed.

Removed the customer_acceptance check from Mollie's should_call_connector_customer. A connector customer is now created for any off-session card setup (setup_future_usage = off_session + card), which is what actually requires the customerId.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Zero-auth mandate requests that carry customer_acceptance under mandate_data (rather than at the top level) were unable to register a mandate with Mollie. This aligns the customer-creation trigger with Mollie's actual requirement instead of the consent field's location.

## How did you test it?
<img width="368" height="1297" alt="image" src="https://github.com/user-attachments/assets/cd477448-162b-4919-8d2e-ebc0120fef94" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
