### PR TITLE
fix(connector): [Nexixpay] mark 3DS auto-capture payments as Charged

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nexixpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nexixpay/transformers.rs
@@ -1700,8 +1700,8 @@ impl<F>
             Box::new(None)
         };
         let prev_status = item.data.status;
-        let status = if item.data.request.amount == 0
-            && item.response.operation.operation_result == NexixpayPaymentStatus::Authorized
+        let status = if item.response.operation.operation_result == NexixpayPaymentStatus::Authorized
+            && (item.data.request.amount == 0 || is_auto_capture)
         {
             AttemptStatus::Charged
         } else {

--- a/crates/hyperswitch_connectors/src/connectors/nexixpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nexixpay/transformers.rs
@@ -1700,7 +1700,8 @@ impl<F>
             Box::new(None)
         };
         let prev_status = item.data.status;
-        let status = if item.response.operation.operation_result == NexixpayPaymentStatus::Authorized
+        let status = if item.response.operation.operation_result
+            == NexixpayPaymentStatus::Authorized
             && (item.data.request.amount == 0 || is_auto_capture)
         {
             AttemptStatus::Charged


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Nexixpay 3DS payments with `capture_method: automatic` were getting stuck in `requires_capture` even though the connector had already captured the funds (Nexixpay is told `captureType: IMPLICIT` at authorization time and settles the payment server-side after the 3DS challenge completes).

The `CompleteAuthorize` response transformer already computed an `is_auto_capture` flag but only used it to populate `connector_metadata`, never to decide the resulting `AttemptStatus`. Nexixpay's `AUTHORIZED` status was always mapped to `AttemptStatus::Authorized`, which Hyperswitch's generic status mapping turns into `IntentStatus::RequiresCapture`. Since Nexixpay isn't in the connector allowlist that triggers an automatic chained capture call, and Nexixpay does not implement webhooks, the payment had no way to ever transition out of `requires_capture`.

Fix: when Nexixpay returns `AUTHORIZED` after 3DS completion and the payment was requested with automatic capture, resolve the status to `Charged` (mirroring the existing zero-amount special case), so Hyperswitch's status reflects what actually happened on the connector side. Manual-capture payments are unaffected.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Fixes #13470

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible