### PR TITLE
fix(cypress): correct expected status for EURNo3DSAutoCapture adyen

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Routing/Adyen.js
+++ b/cypress-tests/cypress/e2e/configs/Routing/Adyen.js
@@ -150,7 +150,7 @@ export const connectorDetails = {
       Response: {
         status: 200,
         body: {
-          status: "processing",
+          status: "succeeded",
           connector: "adyen",
         },
       },


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
EURNo3DSAutoCapture expected status "processing" while every other Adyen auto-capture fixture (No3DSAutoCapture, mandate cases, etc.) expects "succeeded" for the same auto-capture flow. The integ run for payment-routing-test-EUR-to-adyen confirmed the actual response status is "succeeded", so the fixture was stale.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/c9157335-fa86-41a8-8e55-af57ae77d8bf" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
