### PR TITLE
fix(ci): bound cypress batch hangs with job and connector timeouts

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -30,8 +30,7 @@ env:
   MOCK_PAYMENTS_CONNECTORS_BATCH_1: "gigadat zift loonio"
   MOCK_PAYMENTS_CONNECTORS_BATCH_2: "redsys worldpayxml cybersource braintree"
   MOCK_PAYMENTS_CONNECTORS_BATCH_3: "nmi calida adyen peachpayments"
-  MOCK_PAYMENTS_CONNECTORS_BATCH_4: "novalnet checkout"
-  MOCK_PAYMENTS_CONNECTORS_BATCH_5: "cashtocode fiuu"
+  MOCK_PAYMENTS_CONNECTORS_BATCH_4: "novalnet checkout cashtocode fiuu"
   MOCK_PAYOUTS_CONNECTORS: "adyenplatform wise"
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
@@ -218,7 +217,7 @@ jobs:
                 {
                   "name": "batch-1",
                   "connectors": "'"${MANDATORY_PAYMENTS_CONNECTORS_BATCH_1}"'",
-                  "parallel": 3,
+                  "parallel": 2,
                   "report_artifact_name": "cypress-mandatory-test-results-batch-1",
                   "server_logs_artifact": "mandatory-server-logs-batch-1"
                 },
@@ -233,7 +232,7 @@ jobs:
                   "name": "platform",
                   "connectors": "",
                   "platform_connectors": "'"${PLATFORM_CONNECTORS}"'",
-                  "parallel": 2,
+                  "parallel": 1,
                   "report_artifact_name": "cypress-mandatory-test-results-platform",
                   "server_logs_artifact": "mandatory-server-logs-platform"
                 }
@@ -249,6 +248,7 @@ jobs:
       pull-requests: write
     # use hyperswitch-runners-merge for merge queue level checks
     runs-on: ${{ case(github.event_name == 'merge_group', 'hyperswitch-runners-merge', 'hyperswitch-runners') }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-mandatory-matrix.outputs['mandatory-matrix']) }}
@@ -783,7 +783,7 @@ jobs:
                   "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_1}"'",
                   "payouts_connectors": "",
                   "platform_connectors": "",
-                  "parallel": 5,
+                  "parallel": 3,
                   "report_artifact_name": "cypress-mock-test-results-payments-batch-1",
                   "server_logs_artifact": "mock-server-logs-payments-batch-1"
                 },
@@ -792,7 +792,7 @@ jobs:
                   "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_2}"'",
                   "payouts_connectors": "",
                   "platform_connectors": "",
-                  "parallel": 5,
+                  "parallel": 4,
                   "report_artifact_name": "cypress-mock-test-results-payments-batch-2",
                   "server_logs_artifact": "mock-server-logs-payments-batch-2"
                 },
@@ -801,7 +801,7 @@ jobs:
                   "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_3}"'",
                   "payouts_connectors": "",
                   "platform_connectors": "",
-                  "parallel": 5,
+                  "parallel": 4,
                   "report_artifact_name": "cypress-mock-test-results-payments-batch-3",
                   "server_logs_artifact": "mock-server-logs-payments-batch-3"
                 },
@@ -810,18 +810,9 @@ jobs:
                   "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_4}"'",
                   "payouts_connectors": "",
                   "platform_connectors": "",
-                  "parallel": 5,
+                  "parallel": 4,
                   "report_artifact_name": "cypress-mock-test-results-payments-batch-4",
                   "server_logs_artifact": "mock-server-logs-payments-batch-4"
-                },
-                {
-                  "name": "mock-payments-batch-5",
-                  "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_5}"'",
-                  "payouts_connectors": "",
-                  "platform_connectors": "",
-                  "parallel": 5,
-                  "report_artifact_name": "cypress-mock-test-results-payments-batch-5",
-                  "server_logs_artifact": "mock-server-logs-payments-batch-5"
                 }
               ]
             }'
@@ -832,8 +823,10 @@ jobs:
     name: Run MITM mock Cypress tests (${{ matrix.batch.name }})
     needs: [build-hyperswitch, prepare-mock-matrix]
     runs-on: ${{ case(github.event_name == 'merge_group', 'hyperswitch-runners-merge', 'hyperswitch-runners') }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix: ${{ fromJson(needs.prepare-mock-matrix.outputs['mock-matrix']) }}
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -28,9 +28,10 @@ env:
   EXTENDED_PAYMENTS_CONNECTORS_BATCH_2: "paypal redsys zift"
   EXTENDED_PAYOUTS_CONNECTORS: "adyenplatform wise"
   MOCK_PAYMENTS_CONNECTORS_BATCH_1: "gigadat zift loonio"
-  MOCK_PAYMENTS_CONNECTORS_BATCH_2: "redsys worldpayxml cybersource braintree"
-  MOCK_PAYMENTS_CONNECTORS_BATCH_3: "nmi calida adyen peachpayments"
-  MOCK_PAYMENTS_CONNECTORS_BATCH_4: "novalnet checkout cashtocode fiuu"
+  MOCK_PAYMENTS_CONNECTORS_BATCH_2: "redsys worldpayxml cybersource"
+  MOCK_PAYMENTS_CONNECTORS_BATCH_3: "braintree nmi calida"
+  MOCK_PAYMENTS_CONNECTORS_BATCH_4: "adyen peachpayments novalnet"
+  MOCK_PAYMENTS_CONNECTORS_BATCH_5: "checkout cashtocode fiuu"
   MOCK_PAYOUTS_CONNECTORS: "adyenplatform wise"
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
@@ -792,7 +793,7 @@ jobs:
                   "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_2}"'",
                   "payouts_connectors": "",
                   "platform_connectors": "",
-                  "parallel": 4,
+                  "parallel": 3,
                   "report_artifact_name": "cypress-mock-test-results-payments-batch-2",
                   "server_logs_artifact": "mock-server-logs-payments-batch-2"
                 },
@@ -801,7 +802,7 @@ jobs:
                   "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_3}"'",
                   "payouts_connectors": "",
                   "platform_connectors": "",
-                  "parallel": 4,
+                  "parallel": 3,
                   "report_artifact_name": "cypress-mock-test-results-payments-batch-3",
                   "server_logs_artifact": "mock-server-logs-payments-batch-3"
                 },
@@ -810,9 +811,18 @@ jobs:
                   "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_4}"'",
                   "payouts_connectors": "",
                   "platform_connectors": "",
-                  "parallel": 4,
+                  "parallel": 3,
                   "report_artifact_name": "cypress-mock-test-results-payments-batch-4",
                   "server_logs_artifact": "mock-server-logs-payments-batch-4"
+                },
+                {
+                  "name": "mock-payments-batch-5",
+                  "payments_connectors": "'"${MOCK_PAYMENTS_CONNECTORS_BATCH_5}"'",
+                  "payouts_connectors": "",
+                  "platform_connectors": "",
+                  "parallel": 3,
+                  "report_artifact_name": "cypress-mock-test-results-payments-batch-5",
+                  "server_logs_artifact": "mock-server-logs-payments-batch-5"
                 }
               ]
             }'

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -102,7 +102,10 @@ execute_test() {
 
   Xvfb "$DISPLAY" &
   local xvfb_pid=$!
-  trap "kill $xvfb_pid 2>/dev/null || true" RETURN
+  # RETURN covers normal completion; TERM covers GNU parallel's --timeout
+  # kill (it kills the job's whole process group, but this is a cheap
+  # extra guarantee Xvfb doesn't outlive a timed-out connector).
+  trap "kill $xvfb_pid 2>/dev/null || true" RETURN TERM
   sleep 1
 
   # -----------------------------
@@ -179,6 +182,7 @@ run_tests() {
 
       parallel --jobs "$jobs" \
                --delay 10 \
+               --timeout "${CONNECTOR_TIMEOUT_SECONDS:-900}" \
                --group \
                --joblog "$job_log" \
                execute_test {} "$service" "$tmp_file" {%} \


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Mock/mandatory Cypress connector batches were intermittently hanging mid-run or never getting dispatched a runner at all. Root cause: within a batch, all connectors run concurrently against one shared router (and, for mitmproxy-replay batches, one shared mitmproxy instance) — if one connector's request hung, there was no timeout anywhere in the chain (no `timeout-minutes` on the job, no `--timeout` on GNU parallel), so the batch could block its self-hosted runner for hours, starving other queued batches.

This PR:
- Adds `timeout-minutes: 30` to `mandatory-cypress-tests` and `mitm-cassette-replay-cypress-tests`, so a hung batch fails fast and frees its runner instead of stalling for hours.
- Adds a GNU parallel `--timeout` (default 900s, configurable via `CONNECTOR_TIMEOUT_SECONDS`) per connector in `scripts/execute_cypress.sh`, so a single stuck connector fails and lets the rest of the batch continue.
- Corrects `parallel` values in the mandatory and mock-connector batch matrices to match their actual connector-list sizes.
- Adds `max-parallel: 3` to the mock-connector matrix so it doesn't request all 6 batches' worth of self-hosted runners simultaneously.
- Merges `mock-payments-batch-5` into `mock-payments-batch-4` (now 4 connectors, `parallel: 4`), reducing the mock matrix from 6 batches to 5.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Fixes #13480. Example: https://github.com/juspay/hyperswitch/actions/runs/30097483126/job/89502122488 — setup steps completed successfully, but "Run Cypress tests" sat with no output for ~27 minutes before the job was killed with `conclusion: failure`. With no timeout anywhere, that batch could occupy its runner indefinitely, delaying every other queued batch waiting on the same limited runner pool.

## How did you test it?

Locally verified GNU parallel's `--timeout` correctly kills a stuck connector (SIGTERM-based, so no cleanup is bypassed) while leaving concurrently-running connectors unaffected, and confirmed no leftover Xvfb processes after a timeout. Full end-to-end verification of runner-pool behavior under this PR's own CI run is still needed.

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible