### PR TITLE
fix(core): Prevent Partial Registrations for Any Scope Identifier for Connector Webhook Register API

### DIFF
--- a/crates/api_models/src/merchant_connector_webhook_management.rs
+++ b/crates/api_models/src/merchant_connector_webhook_management.rs
@@ -28,7 +28,7 @@ pub enum ScopeType {
     EventType,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(into = "String", try_from = "String")]
 pub enum ScopeIdentifier {
     NotSpecific,

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -7640,7 +7640,7 @@ type="Text"
 label="Webhook Registration & Workspace Creation"
 webhook_auto_configuration_supported=true 
 scope_type="payment_method_type"
-payment_method_types=["pix_emv", "pix_automatico_push", "pix_automatico_qr", "boleto"]
+payment_method_types=["pix_qr", "pix_automatico_push", "pix_automatico_qr", "boleto"]
 
 [blackhawknetwork]
 [[blackhawknetwork.gift_card]]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -6655,7 +6655,7 @@ type="Text"
 label="Webhook Registration & Workspace Creation"
 webhook_auto_configuration_supported=true 
 scope_type="payment_method_type"
-payment_method_types=["pix_emv", "pix_automatico_push", "pix_automatico_qr", "boleto"]
+payment_method_types=["pix_qr", "pix_automatico_push", "pix_automatico_qr", "boleto"]
 
 [blackhawknetwork]
 [[blackhawknetwork.gift_card]]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -7616,7 +7616,7 @@ type="Text"
 label="Webhook Registration & Workspace Creation"
 webhook_auto_configuration_supported=true 
 scope_type="payment_method_type"
-payment_method_types=["pix_emv", "pix_automatico_push", "pix_automatico_qr", "boleto"]
+payment_method_types=["pix_qr", "pix_automatico_push", "pix_automatico_qr", "boleto"]
 
 [blackhawknetwork]
 [[blackhawknetwork.gift_card]]

--- a/crates/router/src/core/merchant_connector_webhook_management.rs
+++ b/crates/router/src/core/merchant_connector_webhook_management.rs
@@ -233,6 +233,14 @@ pub async fn register_connector_webhook(
         Option<common_utils::pii::SecretSerdeValue>,
         Option<String>,
     );
+    type GroupedRegistrationOutcomes = HashMap<
+        ScopeIdentifier,
+        Vec<(
+            WebhookRegistrationResult,
+            Option<common_utils::pii::SecretSerdeValue>,
+            Option<String>,
+        )>,
+    >;
 
     let registration_futures = registration_plan.into_iter().map(|(identifier, base_url)| {
         let state = &state;
@@ -386,14 +394,7 @@ pub async fn register_connector_webhook(
         .into_iter()
         .collect::<errors::RouterResult<Vec<RegistrationOutcome>>>()?;
     let mut results = Vec::with_capacity(registration_outcomes.len());
-    let mut grouped_outcomes: HashMap<
-        ScopeIdentifier,
-        Vec<(
-            WebhookRegistrationResult,
-            Option<common_utils::pii::SecretSerdeValue>,
-            Option<String>,
-        )>,
-    > = HashMap::new();
+    let mut grouped_outcomes: GroupedRegistrationOutcomes = HashMap::new();
 
     for (identifier, result, metadata, connector_webhook_id) in registration_outcomes {
         results.push(result.clone());

--- a/crates/router/src/core/merchant_connector_webhook_management.rs
+++ b/crates/router/src/core/merchant_connector_webhook_management.rs
@@ -1,4 +1,6 @@
 mod transformers;
+use std::collections::{HashMap, HashSet};
+
 use api_models::merchant_connector_webhook_management::{
     ConnectorWebhookRegisterRequest as ApiConnectorWebhookRegisterRequest, ScopeIdentifier,
     WebhookRegistrationResult,
@@ -384,24 +386,70 @@ pub async fn register_connector_webhook(
         .into_iter()
         .collect::<errors::RouterResult<Vec<RegistrationOutcome>>>()?;
     let mut results = Vec::with_capacity(registration_outcomes.len());
+    let mut grouped_outcomes: HashMap<
+        ScopeIdentifier,
+        Vec<(
+            WebhookRegistrationResult,
+            Option<common_utils::pii::SecretSerdeValue>,
+            Option<String>,
+        )>,
+    > = HashMap::new();
+
+    for (identifier, result, metadata, connector_webhook_id) in registration_outcomes {
+        results.push(result.clone());
+        grouped_outcomes.entry(identifier).or_default().push((
+            result,
+            metadata,
+            connector_webhook_id,
+        ));
+    }
+
+    // An identifier is considered fully registered only when every planned
+    // registration call for that identifier succeeds. Partially-failed
+    // identifiers are not persisted (and any existing entries for them are
+    // removed) so that the list API does not surface an incomplete scope.
     let mut registration_entries = Vec::new();
     let mut metadata_patches = Vec::new();
     let mut first_successful_webhook_id = None;
+    let mut successful_identifiers = HashSet::new();
+    let mut scopes_to_remove = Vec::new();
 
-    for (identifier, result, metadata, connector_webhook_id) in registration_outcomes {
-        if let Some(metadata) = metadata {
-            metadata_patches.push(metadata);
-        }
+    for identifier in &requested {
+        let all_succeeded = grouped_outcomes
+            .get(identifier)
+            .map(|outcomes| {
+                outcomes.iter().all(|(result, _, webhook_id)| {
+                    matches!(
+                        result.status,
+                        common_enums::WebhookRegistrationStatus::Success
+                    ) && webhook_id.is_some()
+                })
+            })
+            .unwrap_or(false);
 
-        if let Some(webhook_id) = connector_webhook_id {
-            if first_successful_webhook_id.is_none() {
-                first_successful_webhook_id = Some(webhook_id.clone());
+        if all_succeeded {
+            successful_identifiers.insert(identifier.clone());
+            if let Some(outcomes) = grouped_outcomes.get(identifier) {
+                for (_, metadata, connector_webhook_id) in outcomes {
+                    if let Some(webhook_id) = connector_webhook_id {
+                        if first_successful_webhook_id.is_none() {
+                            first_successful_webhook_id = Some(webhook_id.clone());
+                        }
+                        registration_entries.push((webhook_id.clone(), identifier.clone()));
+                    }
+                    if let Some(metadata) = metadata {
+                        metadata_patches.push(metadata.clone());
+                    }
+                }
             }
-            registration_entries.push((webhook_id, identifier));
+        } else {
+            scopes_to_remove.push(identifier.clone());
         }
-
-        results.push(result);
     }
+
+    // Fully successful re-registrations should also replace any stale entries
+    // for the same scope so the list API does not show duplicate/outdated IDs.
+    scopes_to_remove.extend(successful_identifiers.iter().cloned());
 
     // Run the GenerateSecret flow only when the connector requires it (e.g. Adyen) AND the
     // register step returned a connector_webhook_id to operate on. A failure here does not
@@ -431,6 +479,7 @@ pub async fn register_connector_webhook(
             registration_entries,
             generated_secret,
             metadata_patches,
+            &scopes_to_remove,
         )?;
 
     let should_update_db = matches!(

--- a/crates/router/src/core/merchant_connector_webhook_management/transformers.rs
+++ b/crates/router/src/core/merchant_connector_webhook_management/transformers.rs
@@ -218,6 +218,8 @@ pub async fn construct_generate_secret_router_data<'a>(
     })
 }
 
+/// Recursively merges `patch` into `base`.
+/// Nested objects are merged key-by-key; non-object values are overwritten.
 fn deep_merge_json_values(base: &mut serde_json::Value, patch: serde_json::Value) {
     match (base, patch) {
         (serde_json::Value::Object(base_map), serde_json::Value::Object(patch_map)) => {
@@ -234,16 +236,45 @@ fn deep_merge_json_values(base: &mut serde_json::Value, patch: serde_json::Value
     }
 }
 
+/// Checks whether a stored scope matches the given scope identifier.
+fn scope_matches_identifier(identifier: &ScopeIdentifier, scope: &ConnectorWebhookScope) -> bool {
+    match (identifier, scope) {
+        (ScopeIdentifier::NotSpecific, ConnectorWebhookScope::NotSpecific) => true,
+        (
+            ScopeIdentifier::PaymentMethodType(pmt),
+            ConnectorWebhookScope::PaymentMethodType { value },
+        ) => pmt == value,
+        (ScopeIdentifier::EventType(evt), ConnectorWebhookScope::EventType { value }) => {
+            evt == value
+        }
+        _ => false,
+    }
+}
+
 #[cfg(feature = "v1")]
+/// Builds the DB update for connector webhook registration.
+///
+/// - `registration_entries`: `(connector_webhook_id, scope)` pairs that fully succeeded
+///   and must be persisted.
+/// - `scopes_to_remove`: scopes whose existing stored entries must be removed before
+///   inserting the new ones. This covers partially-failed scopes (so they are not
+///   persisted) and scopes that are being re-registered (so stale webhook IDs are
+///   replaced rather than duplicated).
 pub fn construct_connector_webhook_registration_details(
     merchant_connector_account: &domain::MerchantConnectorAccount,
     registration_entries: Vec<(String, ScopeIdentifier)>,
     generated_secret: Option<Secret<String>>,
     metadata_patches: Vec<common_utils::pii::SecretSerdeValue>,
+    scopes_to_remove: &[ScopeIdentifier],
 ) -> RouterResult<domain::MerchantConnectorAccountUpdate> {
-    let connector_webhook_registration_details = if registration_entries.is_empty() {
+    // Only touch stored registration details if we have something to add or remove.
+    let has_registration_changes = !registration_entries.is_empty() || !scopes_to_remove.is_empty();
+    let performed_removals = !scopes_to_remove.is_empty();
+
+    let connector_webhook_registration_details = if !has_registration_changes {
         None
     } else {
+        // Start from existing registrations, or an empty object if none exist.
         let mut connector_webhook_registration_details = merchant_connector_account
             .get_connector_webhook_registration_details()
             .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
@@ -252,6 +283,24 @@ pub fn construct_connector_webhook_registration_details(
             .as_object_mut()
             .ok_or(errors::ApiErrorResponse::InternalServerError)?;
 
+        // Step 1: Remove stored entries for scopes that failed or are being replaced.
+        // Legacy (event_type based) and unparseable entries are kept unchanged.
+        if performed_removals {
+            let scopes_to_remove = scopes_to_remove.to_vec();
+            map.retain(|_, entry_value| {
+                let stored: Result<StoredConnectorWebhookEntry, _> =
+                    serde_json::from_value(entry_value.clone());
+                match stored {
+                    Ok(StoredConnectorWebhookEntry::New(scope)) => !scopes_to_remove
+                        .iter()
+                        .any(|identifier| scope_matches_identifier(identifier, &scope)),
+                    Ok(StoredConnectorWebhookEntry::Legacy(_)) => true,
+                    Err(_) => true,
+                }
+            });
+        }
+
+        // Step 2: Persist the new webhook IDs for fully-successful scopes.
         for (connector_webhook_id, scope) in registration_entries {
             let entry_value = match &scope {
                 ScopeIdentifier::NotSpecific => {
@@ -269,9 +318,18 @@ pub fn construct_connector_webhook_registration_details(
             map.insert(connector_webhook_id, entry_value);
         }
 
-        Some(connector_webhook_registration_details)
+        if map.is_empty() {
+            // If we intentionally removed every entry, return an empty object so the
+            // DB update is still written. Returning None here would skip the update
+            // and leave stale registrations behind.
+            performed_removals.then(|| serde_json::Value::Object(Default::default()))
+        } else {
+            Some(connector_webhook_registration_details)
+        }
     };
 
+    // Merge connector-returned metadata patches into the existing metadata,
+    // creating a fresh metadata object if none exists yet.
     let metadata = if metadata_patches.is_empty() {
         None
     } else {
@@ -287,6 +345,8 @@ pub fn construct_connector_webhook_registration_details(
         Some(common_utils::pii::SecretSerdeValue::new(merged_metadata))
     };
 
+    // If the connector requires a generated webhook secret, persist it while preserving
+    // any existing additional_secret already stored for this merchant connector.
     let connector_webhook_details = generated_secret
         .map(|secret| {
             build_connector_webhook_details_with_secret(merchant_connector_account, secret)
@@ -303,6 +363,8 @@ pub fn construct_connector_webhook_registration_details(
 }
 
 #[cfg(feature = "v1")]
+/// Encodes the generated webhook secret into `MerchantConnectorWebhookDetails`,
+/// preserving any existing `additional_secret` instead of overwriting it.
 fn build_connector_webhook_details_with_secret(
     merchant_connector_account: &domain::MerchantConnectorAccount,
     secret: Secret<String>,
@@ -404,6 +466,10 @@ pub fn extract_requested_identifiers(scope: &Scope) -> Vec<ScopeIdentifier> {
 
 #[cfg(feature = "v1")]
 #[allow(deprecated)]
+/// Builds the response for the connector webhook register API.
+///
+/// Legacy requests receive a flattened single-status response. Non-legacy requests
+/// receive the full list of requested scope identifiers and one result per connector call.
 pub fn construct_connector_webhook_registration_response(
     results: Vec<WebhookRegistrationResult>,
     scope_type: ScopeType,
@@ -411,6 +477,7 @@ pub fn construct_connector_webhook_registration_response(
     generate_secret_response: Option<&ConnectorWebhookGenerateSecretResponse>,
     is_legacy_request: bool,
 ) -> RouterResult<RegisterConnectorWebhookResponse> {
+    // Extract the optional webhook-secret generation status/error to include in the response.
     let (secret_generation_status, secret_error) = generate_secret_response
         .map(|resp| {
             let secret_error =
@@ -424,6 +491,8 @@ pub fn construct_connector_webhook_registration_response(
         })
         .unwrap_or((None, None));
 
+    // Legacy callers only see one top-level status/id/error.
+    // Non-legacy callers receive the detailed per-call results below.
     let (connector_webhook_id, webhook_registration_status, error_code, error_message) =
         if is_legacy_request {
             if let Some(success) = results
@@ -508,6 +577,10 @@ enum StoredConnectorWebhookEntry {
 
 #[cfg(feature = "v1")]
 #[allow(deprecated)]
+/// Converts the persisted `connector_webhook_registration_details` blob into a list response.
+///
+/// Supports both the old event_type-based entries and the new scope-based entries so that
+/// webhooks registered before this change continue to be listed correctly.
 pub fn get_connector_webhook_list_response(
     register_webhook_response: &Option<serde_json::Value>,
 ) -> RouterResult<Vec<ConnectorWebhookResponse>> {

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1376,10 +1376,9 @@ pub fn create_webhook_url(
     merchant_id: &id_type::MerchantId,
     merchant_connector_id_or_connector_name: &str,
 ) -> String {
-    const base: &str = "https://play.svix.com/in/fH5mgnw6XQ1FvhofR72pkWHpk7c/";
     format!(
         "{}/webhooks/{}/{}",
-        base,
+        router_base_url,
         merchant_id.get_string_repr(),
         merchant_connector_id_or_connector_name,
     )

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1376,9 +1376,10 @@ pub fn create_webhook_url(
     merchant_id: &id_type::MerchantId,
     merchant_connector_id_or_connector_name: &str,
 ) -> String {
+    const base: &str = "https://play.svix.com/in/fH5mgnw6XQ1FvhofR72pkWHpk7c/";
     format!(
         "{}/webhooks/{}/{}",
-        router_base_url,
+        base,
         merchant_id.get_string_repr(),
         merchant_connector_id_or_connector_name,
     )


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
There exists identifiers for which multiple connector calls are required to complete each of its registrations. Like for example : `PixAutomaticoQr` required 3 registrations calls : 

- recurrence registration
- mit registration
- upfront or one-off payment registration (non 0$ mandates)

In such cases if any of the 3 registrations fails, we donot persist them in the db for partial updates. 
A scope is persisted only when every planned registration call for that scope succeeds. Partially-failed scopes are not persisted and any existing entries for them are removed, so the list API never shows incomplete registrations for any identifier. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Connector Webhook Registration 

```
curl --location 'http://localhost:8080/account/merchant_1785100286/connectors/webhooks/mca_I6YfU8ZmZTu3htkxoho7' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_zfEsK4Qri14OSCFOlA1cJGn9HoBnevwUW4Kfp9xyZ1PKOA1HZvaJq1EceJDoKhZr' \
--data '{
    "scope": {
        "type": "payment_method_types",
        "values": [
            "pix_qr",
            "boleto",
            "pix_automatico_push",
            "pix_automatico_qr"
        ]
    }
}'
```

Response 

```
{
    "scope_type": "payment_method_type",
    "requested": [
        "pix_qr",
        "boleto",
        "pix_automatico_push",
        "pix_automatico_qr"
    ],
    "results": [
        {
            "identifier": "pix_qr",
            "status": "Success",
            "connector_webhook_id": "santander_pixqr_81121151000108"
        },
        {
            "identifier": "boleto",
            "status": "Failure",
            "connector_webhook_id": null,
            "error": {
                "code": "10000",
                "message": "Validation error"
            }
        },
        {
            "identifier": "pix_automatico_push",
            "status": "Success",
            "connector_webhook_id": "santander_pixautomaticopush_84ecf736-001b-4037-837e-0e0fe3ed84b4"
        },
        {
            "identifier": "pix_automatico_push",
            "status": "Failure",
            "connector_webhook_id": null,
            "error": {
                "code": "500",
                "message": "No error message"
            }
        },
        {
            "identifier": "pix_automatico_qr",
            "status": "Success",
            "connector_webhook_id": "santander_pixautomaticoqr_81121151000108"
        },
        {
            "identifier": "pix_automatico_qr",
            "status": "Success",
            "connector_webhook_id": "santander_pixautomaticoqr_7bc2fcb2-28c1-49a3-9ebf-9ae19ed480e8"
        },
        {
            "identifier": "pix_automatico_qr",
            "status": "Success",
            "connector_webhook_id": "santander_pixautomaticoqr_8d596a84-dd3c-464c-a186-c8f210fd522d"
        }
    ]
}
```

Registration for `boleto` and 1/2 `pix_automatico_push` failed so it should not be persisted in the db or the list api call. 

<img width="1728" height="379" alt="Screenshot 2026-07-30 at 10 18 25" src="https://github.com/user-attachments/assets/d00b16a9-69ff-44d1-ba1d-2a4b25890fdc" />


2. List API 

```
curl --location 'http://localhost:8080/account/merchant_1785100286/connectors/webhooks/mca_I6YfU8ZmZTu3htkxoho7' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_zfEsK4Qri14OSCFOlA1cJGn9HoBnevwUW4Kfp9xyZ1PKOA1HZvaJq1EceJDoKhZr'
```

Response 

```
{
    "connector": "santander",
    "webhooks": [
        {
            "connector_webhook_id": "santander_pixqr_81121151000108",
            "scope": {
                "type": "payment_method_type",
                "value": "pix_qr"
            }
        },
        {
            "connector_webhook_id": "santander_pixautomaticoqr_7bc2fcb2-28c1-49a3-9ebf-9ae19ed480e8",
            "scope": {
                "type": "payment_method_type",
                "value": "pix_automatico_qr"
            }
        },
        {
            "connector_webhook_id": "santander_pixautomaticoqr_8d596a84-dd3c-464c-a186-c8f210fd522d",
            "scope": {
                "type": "payment_method_type",
                "value": "pix_automatico_qr"
            }
        },
        {
            "connector_webhook_id": "santander_pixautomaticoqr_81121151000108",
            "scope": {
                "type": "payment_method_type",
                "value": "pix_automatico_qr"
            }
        }
    ]
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
