### PR TITLE
feat(analytics): add organization user activity log for critical dashboard actions

### DIFF
--- a/crates/analytics/src/api_event.rs
+++ b/crates/analytics/src/api_event.rs
@@ -1,9 +1,13 @@
 mod core;
+pub mod critical_actions;
 pub mod events;
 pub mod filters;
 pub mod metrics;
+pub mod org;
 pub mod types;
 
 pub trait APIEventAnalytics: events::ApiLogsFilterAnalytics {}
 
-pub use self::core::{api_events_core, get_api_event_metrics, get_filters};
+pub use self::core::{
+    api_events_core, get_api_event_metrics, get_filters, get_org_user_activity_log_core,
+};

--- a/crates/analytics/src/api_event/core.rs
+++ b/crates/analytics/src/api_event/core.rs
@@ -65,19 +65,11 @@ pub async fn get_org_user_activity_log_core(
         ))
         .attach_printable("SQL Analytics is not implemented for the user activity log"),
         AnalyticsProvider::Clickhouse(pool) => {
-            get_org_user_activity_log(merchant_ids, &req.time_range, req.offset, req.limit, pool)
-                .await
+            get_org_user_activity_log(merchant_ids, &req, pool).await
         }
         AnalyticsProvider::CombinedSqlx(_sqlx_pool, ckh_pool)
         | AnalyticsProvider::CombinedCkh(_sqlx_pool, ckh_pool) => {
-            get_org_user_activity_log(
-                merchant_ids,
-                &req.time_range,
-                req.offset,
-                req.limit,
-                ckh_pool,
-            )
-            .await
+            get_org_user_activity_log(merchant_ids, &req, ckh_pool).await
         }
     }
     .switch()?;

--- a/crates/analytics/src/api_event/core.rs
+++ b/crates/analytics/src/api_event/core.rs
@@ -6,7 +6,7 @@ use api_models::analytics::{
         ApiMetricsBucketResponse,
     },
     AnalyticsMetadata, ApiEventFiltersResponse, GetApiEventFiltersRequest,
-    GetApiEventMetricRequest, MetricsResponse,
+    GetApiEventMetricRequest, GetUserActivityLogRequest, MetricsResponse,
 };
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
@@ -18,6 +18,7 @@ use router_env::{
 use super::{
     events::{get_api_event, ApiLogsResult},
     metrics::ApiEventMetricRow,
+    org::{get_org_user_activity_log, OrgUserActivityLogRow},
 };
 use crate::{
     errors::{AnalyticsError, AnalyticsResult},
@@ -41,6 +42,42 @@ pub async fn api_events_core(
         AnalyticsProvider::CombinedSqlx(_sqlx_pool, ckh_pool)
         | AnalyticsProvider::CombinedCkh(_sqlx_pool, ckh_pool) => {
             get_api_event(merchant_id, req, ckh_pool).await
+        }
+    }
+    .switch()?;
+    Ok(data)
+}
+
+/// Fetches the org-scoped, curated critical-action user activity log for organization admins.
+///
+/// `merchant_ids` is every `merchant_id` resolved for the caller's organization via Postgres
+/// (`api_events` has no `organization_id` column, so org-scoping is expressed as a
+/// `merchant_id IN (...)` filter rather than the generic `AuthInfo` org filter).
+#[instrument(skip_all)]
+pub async fn get_org_user_activity_log_core(
+    pool: &AnalyticsProvider,
+    req: GetUserActivityLogRequest,
+    merchant_ids: &[common_utils::id_type::MerchantId],
+) -> AnalyticsResult<Vec<OrgUserActivityLogRow>> {
+    let data = match pool {
+        AnalyticsProvider::Sqlx(_) => Err(FiltersError::NotImplemented(
+            "User Activity Log not implemented for SQLX",
+        ))
+        .attach_printable("SQL Analytics is not implemented for the user activity log"),
+        AnalyticsProvider::Clickhouse(pool) => {
+            get_org_user_activity_log(merchant_ids, &req.time_range, req.offset, req.limit, pool)
+                .await
+        }
+        AnalyticsProvider::CombinedSqlx(_sqlx_pool, ckh_pool)
+        | AnalyticsProvider::CombinedCkh(_sqlx_pool, ckh_pool) => {
+            get_org_user_activity_log(
+                merchant_ids,
+                &req.time_range,
+                req.offset,
+                req.limit,
+                ckh_pool,
+            )
+            .await
         }
     }
     .switch()?;

--- a/crates/analytics/src/api_event/critical_actions.rs
+++ b/crates/analytics/src/api_event/critical_actions.rs
@@ -1,0 +1,52 @@
+//! Curated allowlist of critical `api_flow`s surfaced in the organization user activity log.
+//!
+//! The `api_flow` column in the `api_events` ClickHouse table stores the `Display`
+//! representation of `router_env::Flow` (e.g. `Flow::MerchantConnectorsCreate` is stored as
+//! the string `"MerchantConnectorsCreate"`). We match against these strings directly
+//! (rather than the `Flow` enum itself) since that is the exact representation persisted in
+//! ClickHouse and read back out of it.
+
+/// Flows considered "critical actions" for the purposes of the organization admin activity log.
+/// Only these flows are surfaced, and only when a `user_id` is present on the event.
+pub const CRITICAL_ACTION_FLOWS: &[&str] = &[
+    "MerchantConnectorsCreate",
+    "MerchantConnectorsUpdate",
+    "MerchantConnectorsDelete",
+    "ApiKeyCreate",
+    "ApiKeyUpdate",
+    "ApiKeyRevoke",
+    "RoutingCreateConfig",
+    "RoutingLinkConfig",
+    "RoutingUnlinkConfig",
+    "RoutingUpdateConfig",
+    "RoutingUpdateDefaultConfig",
+    "ProfileCreate",
+    "ProfileUpdate",
+    "ProfileDelete",
+    "MerchantsAccountUpdate",
+];
+
+/// Maps a raw `api_flow` string (as stored in ClickHouse) to a short, human-readable label
+/// suitable for display in the activity log. Falls back to the raw flow name when the flow
+/// is not part of the curated allowlist.
+pub fn action_label(api_flow: &str) -> String {
+    match api_flow {
+        "MerchantConnectorsCreate" => "Connector Created",
+        "MerchantConnectorsUpdate" => "Connector Updated",
+        "MerchantConnectorsDelete" => "Connector Deleted",
+        "ApiKeyCreate" => "API Key Created",
+        "ApiKeyUpdate" => "API Key Updated",
+        "ApiKeyRevoke" => "API Key Revoked",
+        "RoutingCreateConfig" => "Routing Config Created",
+        "RoutingLinkConfig" => "Routing Config Activated",
+        "RoutingUnlinkConfig" => "Routing Config Deactivated",
+        "RoutingUpdateConfig" => "Routing Config Updated",
+        "RoutingUpdateDefaultConfig" => "Default Routing Config Updated",
+        "ProfileCreate" => "Business Profile Created",
+        "ProfileUpdate" => "Business Profile Updated",
+        "ProfileDelete" => "Business Profile Deleted",
+        "MerchantsAccountUpdate" => "Merchant Account Updated",
+        other => other,
+    }
+    .to_string()
+}

--- a/crates/analytics/src/api_event/critical_actions.rs
+++ b/crates/analytics/src/api_event/critical_actions.rs
@@ -5,48 +5,72 @@
 //! the string `"MerchantConnectorsCreate"`). We match against these strings directly
 //! (rather than the `Flow` enum itself) since that is the exact representation persisted in
 //! ClickHouse and read back out of it.
+//!
+//! Flow name and display label are kept as a single `(flow, label)` list, rather than two
+//! separately maintained lists, so adding a new critical action can't drift out of sync
+//! between the filter allowlist and the display label.
 
-/// Flows considered "critical actions" for the purposes of the organization admin activity log.
-/// Only these flows are surfaced, and only when a `user_id` is present on the event.
-pub const CRITICAL_ACTION_FLOWS: &[&str] = &[
-    "MerchantConnectorsCreate",
-    "MerchantConnectorsUpdate",
-    "MerchantConnectorsDelete",
-    "ApiKeyCreate",
-    "ApiKeyUpdate",
-    "ApiKeyRevoke",
-    "RoutingCreateConfig",
-    "RoutingLinkConfig",
-    "RoutingUnlinkConfig",
-    "RoutingUpdateConfig",
-    "RoutingUpdateDefaultConfig",
-    "ProfileCreate",
-    "ProfileUpdate",
-    "ProfileDelete",
-    "MerchantsAccountUpdate",
+/// (raw `api_flow` string, human-readable label) pairs for flows considered "critical
+/// actions" for the purposes of the organization admin activity log. Only these flows are
+/// surfaced, and only when a `user_id` is present on the event.
+const CRITICAL_ACTIONS: &[(&str, &str)] = &[
+    ("MerchantConnectorsCreate", "Connector Created"),
+    ("MerchantConnectorsUpdate", "Connector Updated"),
+    ("MerchantConnectorsDelete", "Connector Deleted"),
+    ("ApiKeyCreate", "API Key Created"),
+    ("ApiKeyUpdate", "API Key Updated"),
+    ("ApiKeyRevoke", "API Key Revoked"),
+    ("RoutingCreateConfig", "Routing Config Created"),
+    ("RoutingLinkConfig", "Routing Config Activated"),
+    ("RoutingUnlinkConfig", "Routing Config Deactivated"),
+    ("RoutingUpdateConfig", "Routing Config Updated"),
+    ("RoutingUpdateDefaultConfig", "Default Routing Config Updated"),
+    ("ProfileCreate", "Business Profile Created"),
+    ("ProfileUpdate", "Business Profile Updated"),
+    ("ProfileDelete", "Business Profile Deleted"),
+    ("MerchantsAccountUpdate", "Merchant Account Updated"),
 ];
+
+/// The raw `api_flow` strings from [`CRITICAL_ACTIONS`], for use in the ClickHouse
+/// `api_flow IN (...)` filter.
+pub fn critical_action_flows() -> Vec<&'static str> {
+    CRITICAL_ACTIONS.iter().map(|(flow, _)| *flow).collect()
+}
 
 /// Maps a raw `api_flow` string (as stored in ClickHouse) to a short, human-readable label
 /// suitable for display in the activity log. Falls back to the raw flow name when the flow
 /// is not part of the curated allowlist.
 pub fn action_label(api_flow: &str) -> String {
-    match api_flow {
-        "MerchantConnectorsCreate" => "Connector Created",
-        "MerchantConnectorsUpdate" => "Connector Updated",
-        "MerchantConnectorsDelete" => "Connector Deleted",
-        "ApiKeyCreate" => "API Key Created",
-        "ApiKeyUpdate" => "API Key Updated",
-        "ApiKeyRevoke" => "API Key Revoked",
-        "RoutingCreateConfig" => "Routing Config Created",
-        "RoutingLinkConfig" => "Routing Config Activated",
-        "RoutingUnlinkConfig" => "Routing Config Deactivated",
-        "RoutingUpdateConfig" => "Routing Config Updated",
-        "RoutingUpdateDefaultConfig" => "Default Routing Config Updated",
-        "ProfileCreate" => "Business Profile Created",
-        "ProfileUpdate" => "Business Profile Updated",
-        "ProfileDelete" => "Business Profile Deleted",
-        "MerchantsAccountUpdate" => "Merchant Account Updated",
-        other => other,
+    CRITICAL_ACTIONS
+        .iter()
+        .find_map(|(flow, label)| (*flow == api_flow).then_some(*label))
+        .unwrap_or(api_flow)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_critical_action_flow_has_a_label() {
+        for (flow, _) in CRITICAL_ACTIONS {
+            assert_ne!(
+                action_label(flow),
+                *flow,
+                "flow {flow} is missing a real display label (falling back to the raw flow name)"
+            );
+        }
     }
-    .to_string()
+
+    #[test]
+    fn unknown_flow_falls_back_to_the_raw_flow_name() {
+        assert_eq!(action_label("SomeUnrelatedFlow"), "SomeUnrelatedFlow");
+    }
+
+    #[test]
+    fn critical_action_flows_matches_the_curated_list() {
+        assert_eq!(critical_action_flows().len(), CRITICAL_ACTIONS.len());
+        assert!(critical_action_flows().contains(&"MerchantConnectorsUpdate"));
+    }
 }

--- a/crates/analytics/src/api_event/critical_actions.rs
+++ b/crates/analytics/src/api_event/critical_actions.rs
@@ -24,7 +24,10 @@ const CRITICAL_ACTIONS: &[(&str, &str)] = &[
     ("RoutingLinkConfig", "Routing Config Activated"),
     ("RoutingUnlinkConfig", "Routing Config Deactivated"),
     ("RoutingUpdateConfig", "Routing Config Updated"),
-    ("RoutingUpdateDefaultConfig", "Default Routing Config Updated"),
+    (
+        "RoutingUpdateDefaultConfig",
+        "Default Routing Config Updated",
+    ),
     ("ProfileCreate", "Business Profile Created"),
     ("ProfileUpdate", "Business Profile Updated"),
     ("ProfileDelete", "Business Profile Deleted"),

--- a/crates/analytics/src/api_event/org.rs
+++ b/crates/analytics/src/api_event/org.rs
@@ -1,9 +1,9 @@
-use api_models::analytics::{Granularity, TimeRange};
+use api_models::analytics::{GetUserActivityLogRequest, Granularity};
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
 
-use super::critical_actions::CRITICAL_ACTION_FLOWS;
+use super::critical_actions;
 use crate::{
     query::{
         Aggregate, FilterTypes, GroupByClause, Order, QueryBuilder, QueryFilter, ToSql, Window,
@@ -24,12 +24,9 @@ pub trait OrgUserActivityLogFilterAnalytics: LoadRow<OrgUserActivityLogRow> {}
 ///
 /// Only metadata columns are selected; `request`/`response`/`error`/`authentication_data`
 /// are intentionally never read here since they may contain secrets.
-#[allow(clippy::too_many_arguments)]
 pub async fn get_org_user_activity_log<T>(
     merchant_ids: &[common_utils::id_type::MerchantId],
-    time_range: &TimeRange,
-    offset: Option<u64>,
-    limit: Option<u64>,
+    req: &GetUserActivityLogRequest,
     pool: &T,
 ) -> FiltersResult<Vec<OrgUserActivityLogRow>>
 where
@@ -54,13 +51,13 @@ where
         .attach_printable("Error adding merchant_id filter")
         .switch()?;
 
-    time_range
+    req.time_range
         .set_filter_clause(&mut query_builder)
         .attach_printable("Error filtering time range")
         .switch()?;
 
     query_builder
-        .add_filter_in_range_clause("api_flow", CRITICAL_ACTION_FLOWS)
+        .add_filter_in_range_clause("api_flow", &critical_actions::critical_action_flows())
         .attach_printable("Error adding api_flow allowlist filter")
         .switch()?;
 
@@ -74,7 +71,7 @@ where
         .attach_printable("Error adding order by created_at")
         .switch()?;
 
-    query_builder.set_limit_offset(limit, offset);
+    query_builder.set_limit_offset(req.limit, req.offset);
 
     query_builder
         .execute_query::<OrgUserActivityLogRow, _>(pool)

--- a/crates/analytics/src/api_event/org.rs
+++ b/crates/analytics/src/api_event/org.rs
@@ -1,0 +1,94 @@
+use api_models::analytics::{Granularity, TimeRange};
+use common_utils::errors::ReportSwitchExt;
+use error_stack::ResultExt;
+use time::PrimitiveDateTime;
+
+use super::critical_actions::CRITICAL_ACTION_FLOWS;
+use crate::{
+    query::{Aggregate, FilterTypes, GroupByClause, Order, QueryBuilder, QueryFilter, ToSql, Window},
+    types::{AnalyticsCollection, AnalyticsDataSource, FiltersError, FiltersResult, LoadRow},
+};
+
+pub trait OrgUserActivityLogFilterAnalytics: LoadRow<OrgUserActivityLogRow> {}
+
+/// Fetches the curated, org-scoped list of critical dashboard-user actions from the
+/// `api_events` ClickHouse table.
+///
+/// Org-scoping is done by the caller resolving every `merchant_id` in the organization
+/// via Postgres and passing them in here — we filter `merchant_id IN (...)` directly
+/// rather than going through the generic `AuthInfo` filter, since (unlike every other
+/// analytics table) `api_events` has no `organization_id` column; `AuthInfo::MerchantLevel`
+/// would otherwise add a filter on a column that doesn't exist on this table.
+///
+/// Only metadata columns are selected; `request`/`response`/`error`/`authentication_data`
+/// are intentionally never read here since they may contain secrets.
+#[allow(clippy::too_many_arguments)]
+pub async fn get_org_user_activity_log<T>(
+    merchant_ids: &[common_utils::id_type::MerchantId],
+    time_range: &TimeRange,
+    offset: Option<u64>,
+    limit: Option<u64>,
+    pool: &T,
+) -> FiltersResult<Vec<OrgUserActivityLogRow>>
+where
+    T: AnalyticsDataSource + OrgUserActivityLogFilterAnalytics,
+    PrimitiveDateTime: ToSql<T>,
+    AnalyticsCollection: ToSql<T>,
+    Granularity: GroupByClause<T>,
+    Aggregate<&'static str>: ToSql<T>,
+    Window<&'static str>: ToSql<T>,
+{
+    let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::ApiEvents);
+
+    query_builder.add_select_column("created_at").switch()?;
+    query_builder.add_select_column("user_id").switch()?;
+    query_builder.add_select_column("api_flow").switch()?;
+    query_builder.add_select_column("merchant_id").switch()?;
+    query_builder.add_select_column("ip_addr").switch()?;
+    query_builder.add_select_column("status_code").switch()?;
+
+    query_builder
+        .add_filter_in_range_clause("merchant_id", merchant_ids)
+        .attach_printable("Error adding merchant_id filter")
+        .switch()?;
+
+    time_range
+        .set_filter_clause(&mut query_builder)
+        .attach_printable("Error filtering time range")
+        .switch()?;
+
+    query_builder
+        .add_filter_in_range_clause("api_flow", CRITICAL_ACTION_FLOWS)
+        .attach_printable("Error adding api_flow allowlist filter")
+        .switch()?;
+
+    query_builder
+        .add_custom_filter_clause("user_id", "", FilterTypes::IsNotNull)
+        .attach_printable("Error adding user_id IS NOT NULL filter")
+        .switch()?;
+
+    query_builder
+        .add_order_by_clause("created_at", Order::Descending)
+        .attach_printable("Error adding order by created_at")
+        .switch()?;
+
+    query_builder.set_limit_offset(limit, offset);
+
+    query_builder
+        .execute_query::<OrgUserActivityLogRow, _>(pool)
+        .await
+        .change_context(FiltersError::QueryBuildingError)?
+        .change_context(FiltersError::QueryExecutionFailure)
+}
+
+/// A single critical-action row, scoped to metadata only — never the raw request/response.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OrgUserActivityLogRow {
+    pub merchant_id: common_utils::id_type::MerchantId,
+    pub user_id: Option<String>,
+    pub api_flow: String,
+    pub ip_addr: Option<String>,
+    pub status_code: u16,
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub created_at: PrimitiveDateTime,
+}

--- a/crates/analytics/src/api_event/org.rs
+++ b/crates/analytics/src/api_event/org.rs
@@ -5,7 +5,9 @@ use time::PrimitiveDateTime;
 
 use super::critical_actions::CRITICAL_ACTION_FLOWS;
 use crate::{
-    query::{Aggregate, FilterTypes, GroupByClause, Order, QueryBuilder, QueryFilter, ToSql, Window},
+    query::{
+        Aggregate, FilterTypes, GroupByClause, Order, QueryBuilder, QueryFilter, ToSql, Window,
+    },
     types::{AnalyticsCollection, AnalyticsDataSource, FiltersError, FiltersResult, LoadRow},
 };
 

--- a/crates/analytics/src/clickhouse.rs
+++ b/crates/analytics/src/clickhouse.rs
@@ -27,6 +27,7 @@ use crate::{
         events::ApiLogsResult,
         filters::ApiEventFilter,
         metrics::{latency::LatencyAvg, ApiEventMetricRow},
+        org::OrgUserActivityLogRow,
     },
     auth_events::filters::AuthEventFilterRow,
     connector_events::events::ConnectorEventsResult,
@@ -193,6 +194,7 @@ impl super::auth_events::filters::AuthEventFilterAnalytics for ClickhouseClient 
 impl super::api_event::events::ApiLogsFilterAnalytics for ClickhouseClient {}
 impl super::api_event::filters::ApiEventFilterAnalytics for ClickhouseClient {}
 impl super::api_event::metrics::ApiEventMetricAnalytics for ClickhouseClient {}
+impl super::api_event::org::OrgUserActivityLogFilterAnalytics for ClickhouseClient {}
 impl super::connector_events::events::ConnectorEventLogAnalytics for ClickhouseClient {}
 impl super::routing_events::events::RoutingEventLogAnalytics for ClickhouseClient {}
 impl super::outgoing_webhook_event::events::OutgoingWebhookLogsFilterAnalytics
@@ -369,6 +371,16 @@ impl TryInto<DisputeFilterRow> for serde_json::Value {
     fn try_into(self) -> Result<DisputeFilterRow, Self::Error> {
         serde_json::from_value(self).change_context(ParsingError::StructParseFailure(
             "Failed to parse DisputeFilterRow in clickhouse results",
+        ))
+    }
+}
+
+impl TryInto<OrgUserActivityLogRow> for serde_json::Value {
+    type Error = Report<ParsingError>;
+
+    fn try_into(self) -> Result<OrgUserActivityLogRow, Self::Error> {
+        serde_json::from_value(self).change_context(ParsingError::StructParseFailure(
+            "Failed to parse OrgUserActivityLogRow in clickhouse results",
         ))
     }
 }

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -1184,6 +1184,7 @@ pub enum AnalyticsFlow {
     GetSankey,
     GetRoutingEvents,
     GetPaymentListFromOpenSearch,
+    GetUserActivityLog,
 }
 
 impl FlowMetric for AnalyticsFlow {}

--- a/crates/analytics/src/query.rs
+++ b/crates/analytics/src/query.rs
@@ -412,6 +412,8 @@ where
     order_by: Vec<String>,
     having: Option<Vec<(String, FilterTypes, String)>>,
     limit_by: Option<LimitByClause>,
+    limit: Option<u64>,
+    offset: Option<u64>,
     outer_select: Vec<String>,
     top_n: Option<TopN>,
     table: AnalyticsCollection,
@@ -591,6 +593,8 @@ where
             order_by: Default::default(),
             having: Default::default(),
             limit_by: Default::default(),
+            limit: Default::default(),
+            offset: Default::default(),
             outer_select: Default::default(),
             top_n: Default::default(),
             table,
@@ -767,6 +771,12 @@ where
         Ok(())
     }
 
+    /// Sets the `LIMIT` and `OFFSET` clauses used for paginating results.
+    pub fn set_limit_offset(&mut self, limit: Option<u64>, offset: Option<u64>) {
+        self.limit = limit;
+        self.offset = offset;
+    }
+
     pub fn add_granularity_in_mins(&mut self, granularity: Granularity) -> QueryResult<()> {
         let interval = match granularity {
             Granularity::OneMin => "1",
@@ -907,6 +917,14 @@ where
 
         if let Some(limit_by) = &self.limit_by {
             query.push_str(&format!(" {limit_by}"));
+        }
+
+        if let Some(limit) = self.limit {
+            query.push_str(&format!(" LIMIT {limit}"));
+        }
+
+        if let Some(offset) = self.offset {
+            query.push_str(&format!(" OFFSET {offset}"));
         }
 
         if !self.outer_select.is_empty() {

--- a/crates/api_models/src/analytics.rs
+++ b/crates/api_models/src/analytics.rs
@@ -482,6 +482,43 @@ pub struct GetApiEventMetricRequest {
     pub delta: bool,
 }
 
+/// Request payload for fetching the organization-scoped, curated critical-action user
+/// activity log, used by organization admins to audit which dashboard user performed
+/// which critical action across every merchant account in the organization.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetUserActivityLogRequest {
+    pub time_range: TimeRange,
+    /// Number of records to skip, for pagination.
+    #[serde(default)]
+    pub offset: Option<u64>,
+    /// Maximum number of records to return, for pagination.
+    #[serde(default)]
+    pub limit: Option<u64>,
+}
+
+/// A single critical-action entry performed by a dashboard user, scoped to metadata only.
+/// Deliberately excludes the raw request/response/error/authentication_data, since those
+/// may contain secrets.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserActivityLogEntry {
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub timestamp: time::PrimitiveDateTime,
+    pub user_id: Option<String>,
+    pub user_email: Option<String>,
+    pub action: String,
+    pub merchant_id: common_utils::id_type::MerchantId,
+    pub ip_addr: Option<String>,
+    pub status_code: i64,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetUserActivityLogResponse {
+    pub data: Vec<UserActivityLogEntry>,
+}
+
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetDisputeFilterRequest {

--- a/crates/api_models/src/analytics.rs
+++ b/crates/api_models/src/analytics.rs
@@ -497,6 +497,8 @@ pub struct GetUserActivityLogRequest {
     pub limit: Option<u64>,
 }
 
+impl ApiEventMetric for GetUserActivityLogRequest {}
+
 /// A single critical-action entry performed by a dashboard user, scoped to metadata only.
 /// Deliberately excludes the raw request/response/error/authentication_data, since those
 /// may contain secrets.
@@ -518,6 +520,8 @@ pub struct UserActivityLogEntry {
 pub struct GetUserActivityLogResponse {
     pub data: Vec<UserActivityLogEntry>,
 }
+
+impl ApiEventMetric for GetUserActivityLogResponse {}
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -9450,6 +9450,7 @@ pub enum PermissionGroup {
     ReconTransactionsManage,
     ReconRulesView,
     ReconRulesManage,
+    AuditLogView,
 }
 
 #[derive(
@@ -9471,6 +9472,7 @@ pub enum ParentGroup {
     ReconExceptions,
     ReconTransactions,
     ReconRules,
+    AuditLog,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
@@ -9503,6 +9505,7 @@ pub enum Resource {
     ReconTransaction,
     ReconRule,
     SuperpositionConfig,
+    AuditLog,
 }
 
 #[derive(

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -3254,15 +3254,24 @@ pub mod routes {
                         .change_context(AnalyticsError::UnknownError)
                         .attach_printable("Failed to resolve dashboard users for activity log")?
                         .into_iter()
-                        .map(|user| {
-                            let email = UserEmail::from_pii_email(user.email)
-                                .change_context(AnalyticsError::MissingEmail)?
-                                .get_secret()
-                                .expose()
-                                .to_string();
-                            Ok((user.user_id, email))
+                        .filter_map(|user| {
+                            let user_id = user.user_id.clone();
+                            match UserEmail::from_pii_email(user.email) {
+                                Ok(email) => {
+                                    Some((user_id, email.get_secret().expose().to_string()))
+                                }
+                                Err(err) => {
+                                    logger::warn!(
+                                        ?err,
+                                        %user_id,
+                                        "Failed to resolve email for user in activity log; \
+                                         showing user_id without an email for this row"
+                                    );
+                                    None
+                                }
+                            }
                         })
-                        .collect::<Result<HashMap<_, _>, error_stack::Report<AnalyticsError>>>()?
+                        .collect::<HashMap<_, _>>()
                 };
 
                 let data = rows

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -8,7 +8,7 @@ pub mod routes {
 
     use actix_web::{web, Responder, Scope};
     use analytics::{
-        api_event::api_events_core,
+        api_event::{api_events_core, critical_actions, get_org_user_activity_log_core},
         connector_events::{connector_events_core, ConnectorEventSource},
         enums::AuthInfo,
         errors::AnalyticsError,
@@ -30,7 +30,8 @@ pub mod routes {
         GetAuthEventMetricRequest, GetDisputeMetricRequest, GetFrmFilterRequest,
         GetFrmMetricRequest, GetPaymentFiltersRequest, GetPaymentIntentFiltersRequest,
         GetPaymentIntentMetricRequest, GetPaymentMetricRequest, GetRefundFilterRequest,
-        GetRefundMetricRequest, GetSdkEventFiltersRequest, GetSdkEventMetricRequest, ReportRequest,
+        GetRefundMetricRequest, GetSdkEventFiltersRequest, GetSdkEventMetricRequest,
+        GetUserActivityLogRequest, GetUserActivityLogResponse, ReportRequest, UserActivityLogEntry,
     };
     use common_enums::EntityType;
     use common_utils::{pii::Email, types::TimeRange};
@@ -391,6 +392,10 @@ pub mod routes {
                                 .service(
                                     web::resource("metrics/auth_events/sankey")
                                         .route(web::post().to(get_org_auth_event_sankey)),
+                                )
+                                .service(
+                                    web::resource("user_activity_log")
+                                        .route(web::post().to(get_org_user_activity_log)),
                                 ),
                         )
                         .service(
@@ -3186,6 +3191,115 @@ pub mod routes {
                 allow_connected: true,
                 allow_platform: true,
             },
+            api_locking::LockAction::NotApplicable,
+        ))
+        .await
+    }
+
+    /// Lets an organization admin see which dashboard user (via merchant_jwt/user_jwt)
+    /// performed which critical action (e.g. modified a connector, revoked an API key)
+    /// across every merchant account in their organization.
+    ///
+    /// Org-scoping is done by resolving the caller's `organization_id` to every
+    /// `merchant_id` in that organization via Postgres, then filtering the existing
+    /// `api_events` ClickHouse table by `merchant_id IN (...)` — no ClickHouse schema
+    /// change is required. Only a curated allowlist of critical `api_flow`s is surfaced,
+    /// and only metadata columns are returned (never the raw request/response/error).
+    pub async fn get_org_user_activity_log(
+        state: web::Data<AppState>,
+        req: actix_web::HttpRequest,
+        json_payload: web::Json<GetUserActivityLogRequest>,
+    ) -> impl Responder {
+        let flow = AnalyticsFlow::GetUserActivityLog;
+        Box::pin(api::server_wrap(
+            flow,
+            state.clone(),
+            &req,
+            json_payload.into_inner(),
+            |state, auth: AuthenticationData, payload, _| async move {
+                let org_id = auth
+                    .platform
+                    .get_processor()
+                    .get_account()
+                    .get_org_id()
+                    .clone();
+
+                let merchant_ids = state
+                    .store
+                    .list_merchant_accounts_by_organization_id(&org_id)
+                    .await
+                    .change_context(AnalyticsError::UnknownError)
+                    .attach_printable("Failed to list merchant accounts for organization")?
+                    .into_iter()
+                    .map(|merchant_account| merchant_account.get_id().clone())
+                    .collect::<Vec<_>>();
+
+                let rows =
+                    get_org_user_activity_log_core(&state.pool, payload, &merchant_ids).await?;
+
+                let user_ids = rows
+                    .iter()
+                    .filter_map(|row| row.user_id.clone())
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>();
+
+                let user_email_by_id = if user_ids.is_empty() {
+                    HashMap::new()
+                } else {
+                    state
+                        .global_store
+                        .find_active_users_by_user_ids(user_ids)
+                        .await
+                        .change_context(AnalyticsError::UnknownError)
+                        .attach_printable("Failed to resolve dashboard users for activity log")?
+                        .into_iter()
+                        .map(|user| {
+                            let email = UserEmail::from_pii_email(user.email)
+                                .change_context(AnalyticsError::MissingEmail)?
+                                .get_secret()
+                                .expose()
+                                .to_string();
+                            Ok((user.user_id, email))
+                        })
+                        .collect::<Result<HashMap<_, _>, error_stack::Report<AnalyticsError>>>()?
+                };
+
+                let data = rows
+                    .into_iter()
+                    .map(|row| {
+                        let user_email = row
+                            .user_id
+                            .as_ref()
+                            .and_then(|user_id| user_email_by_id.get(user_id).cloned());
+                        UserActivityLogEntry {
+                            timestamp: row.created_at,
+                            user_id: row.user_id,
+                            user_email,
+                            action: critical_actions::action_label(&row.api_flow),
+                            merchant_id: row.merchant_id,
+                            ip_addr: row.ip_addr,
+                            status_code: i64::from(row.status_code),
+                        }
+                    })
+                    .collect();
+
+                Ok(ApplicationResponse::Json(GetUserActivityLogResponse {
+                    data,
+                }))
+            },
+            auth::auth_type(
+                &auth::PlatformOrgAdminAuth {
+                    is_admin_auth_allowed: false,
+                    organization_id: None,
+                },
+                &auth::JWTAuth {
+                    permission: Permission::OrganizationAuditLogRead,
+                    allow_connected: true,
+                    allow_platform: true,
+                },
+                req.headers(),
+            ),
             api_locking::LockAction::NotApplicable,
         ))
         .await

--- a/crates/router/src/services/authorization/info.rs
+++ b/crates/router/src/services/authorization/info.rs
@@ -61,6 +61,7 @@ fn get_group_description(group: PermissionGroup) -> Option<&'static str> {
         PermissionGroup::ReconTransactionsManage => Some("View and edit recon staging entries and transactions"),
         PermissionGroup::ReconRulesView => Some("View reconciliation rules"),
         PermissionGroup::ReconRulesManage => Some("Create and edit reconciliation rules"),
+        PermissionGroup::AuditLogView => Some("View the organization's user activity log"),
     }
 }
 
@@ -82,5 +83,6 @@ pub fn get_parent_group_description(group: ParentGroup) -> Option<&'static str> 
         ParentGroup::ReconExceptions => Some("Recon exception investigation and resolution"),
         ParentGroup::ReconTransactions => Some("Recon staging entries and transactions"),
         ParentGroup::ReconRules => Some("Reconciliation rules"),
+        ParentGroup::AuditLog => Some("Organization user activity log"),
     }
 }

--- a/crates/router/src/services/authorization/permission_groups.rs
+++ b/crates/router/src/services/authorization/permission_groups.rs
@@ -30,7 +30,8 @@ impl PermissionGroupExt for PermissionGroup {
             | Self::ReconSourcesView
             | Self::ReconTransactionsView
             | Self::ReconExceptionsView
-            | Self::ReconRulesView => PermissionScope::Read,
+            | Self::ReconRulesView
+            | Self::AuditLogView => PermissionScope::Read,
 
             Self::OperationsManage
             | Self::ConnectorsManage
@@ -69,6 +70,7 @@ impl PermissionGroupExt for PermissionGroup {
                 ParentGroup::ReconTransactions
             }
             Self::ReconRulesView | Self::ReconRulesManage => ParentGroup::ReconRules,
+            Self::AuditLogView => ParentGroup::AuditLog,
         }
     }
 
@@ -157,13 +159,16 @@ impl PermissionGroupExt for PermissionGroup {
                 Self::ReconRulesView,
                 Self::ReconTransactionsView,
             ],
+            Self::AuditLogView => vec![Self::AuditLogView],
         }
     }
 
     fn get_role_product_category(&self) -> RoleProductCategory {
         match self {
             // Common across every product — not validated against the merchant's category.
-            Self::UsersView | Self::UsersManage => RoleProductCategory::Dashboard,
+            Self::UsersView | Self::UsersManage | Self::AuditLogView => {
+                RoleProductCategory::Dashboard
+            }
 
             // Orchestration-only groups.
             Self::OperationsView
@@ -225,6 +230,7 @@ impl ParentGroupExt for ParentGroup {
             Self::ReconExceptions => RECON_EXCEPTIONS.to_vec(),
             Self::ReconTransactions => RECON_TRANSACTIONS.to_vec(),
             Self::ReconRules => RECON_RULES.to_vec(),
+            Self::AuditLog => AUDIT_LOG.to_vec(),
         }
     }
 
@@ -316,3 +322,5 @@ pub static RECON_TRANSACTIONS: [Resource; 3] = [
 ];
 
 pub static RECON_RULES: [Resource; 2] = [Resource::ReconRule, Resource::Account];
+
+pub static AUDIT_LOG: [Resource; 1] = [Resource::AuditLog];

--- a/crates/router/src/services/authorization/permissions.rs
+++ b/crates/router/src/services/authorization/permissions.rs
@@ -111,6 +111,10 @@ generate_permissions! {
             scopes: [Read, Write],
             entities: [Profile]
         },
+        AuditLog: {
+            scopes: [Read],
+            entities: [Organization]
+        },
     ]
 }
 
@@ -148,6 +152,7 @@ pub fn get_resource_name(resource: Resource, entity_type: EntityType) -> Option<
         (Resource::ReconTransaction, _) => Some("Recon Transactions"),
         (Resource::ReconRule, _) => Some("Recon Rules"),
         (Resource::SuperpositionConfig, _) => Some("Superposition Configs"),
+        (Resource::AuditLog, _) => Some("Activity Log"),
     }
 }
 

--- a/crates/router/src/services/authorization/roles/predefined_roles.rs
+++ b/crates/router/src/services/authorization/roles/predefined_roles.rs
@@ -136,6 +136,7 @@ pub static PREDEFINED_ROLES: LazyLock<HashMap<&'static str, RoleInfo>> = LazyLoc
                 PermissionGroup::ReconTransactionsManage,
                 PermissionGroup::ReconRulesView,
                 PermissionGroup::ReconRulesManage,
+                PermissionGroup::AuditLogView,
             ],
             role_id: common_utils::consts::ROLE_ID_ORGANIZATION_ADMIN.to_string(),
             role_name: "organization_admin".to_string(),


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds an "organization user activity log" so an organization admin can see which dashboard user (via `merchant_jwt`/`user_jwt`) performed which critical action — e.g. modified a payment connector, revoked an API key, changed routing config — across every merchant account in their organization. This builds on `api_events`' now-reliable top-level `user_id` column (#13462).

### Design decisions

- **No ClickHouse schema change.** `api_events` has no `organization_id` column (unlike every other analytics table). Org-scoping is done by resolving the caller's `organization_id` to its `merchant_id`s via Postgres (`state.store.list_merchant_accounts_by_organization_id`, an existing helper already used elsewhere), then filtering `api_events` by `merchant_id IN (...)` directly. This deliberately bypasses the generic `AuthInfo::MerchantLevel` filter, since that filter also unconditionally adds an `organization_id` clause that `api_events` can't satisfy.
- **Curated allowlist, not raw `api_events`.** Only a hand-picked set of "critical" `api_flow`s are surfaced (`crates/analytics/src/api_event/critical_actions.rs`): connector create/update/delete, API key create/update/revoke, routing config create/link/unlink/update/update-default, business profile create/update/delete, and merchant account update. Filtered together with `user_id IS NOT NULL` (excludes API-key/system traffic — only dashboard-authenticated actions show up).
- **Dedicated, narrow permission.** New `Permission::OrganizationAuditLogRead` (via a new `Resource::AuditLog`, `entities: [Organization]`), granted only to the `organization_admin` predefined role — mirroring exactly how `Theme` (the other Organization-only resource) is scoped, i.e. **not** granted to `merchant_admin` or general analytics-viewer roles. This is an oversight/accountability feature and shouldn't inherit a broader viewer list by accident.
- **Metadata only.** The response returns timestamp, user (id + resolved email), action label, merchant_id, ip_addr, status_code — never the raw `request`/`response`/`error`/`authentication_data`, since those can contain secrets (e.g. an API-key-creation request body).

### New endpoint

`POST analytics/v1/org/user_activity_log`, gated by `Permission::OrganizationAuditLogRead`, supports a time range plus offset/limit pagination (new generic `LIMIT`/`OFFSET` support added to the shared `QueryBuilder`).

## Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Enables org admins to audit "who did what" for critical dashboard actions, without requiring a ClickHouse migration or exposing raw event payloads.

## How did you test it?

Reviewed end-to-end against existing conventions in the codebase (permission macro expansion, `AuthInfo`/`QueryFilter` behavior against the actual `api_events` schema, existing org-scoped route/handler patterns, existing user-email-resolution helper). Manual/integration testing pending.

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible