### PR TITLE
fix(events): map PaymentPartiallyAuthorized to the payments event class

### DIFF
--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -1855,6 +1855,7 @@ pub enum EventObjectType {
     serde::Deserialize,
     serde::Serialize,
     strum::Display,
+    strum::EnumIter,
     strum::EnumString,
     ToSchema,
 )]
@@ -1882,6 +1883,7 @@ impl EventClass {
                 EventType::PaymentCancelled,
                 EventType::PaymentCancelledPostCapture,
                 EventType::PaymentAuthorized,
+                EventType::PaymentPartiallyAuthorized,
                 EventType::PaymentCaptured,
                 EventType::PaymentExpired,
                 EventType::ActionRequired,
@@ -1917,6 +1919,35 @@ impl EventClass {
     }
 }
 
+#[cfg(test)]
+mod event_class_event_type_tests {
+    use std::collections::HashSet;
+
+    use strum::IntoEnumIterator;
+
+    use super::{EventClass, EventType};
+
+    // Enforces the invariant documented on `EventType`: every variant must be
+    // reachable from some `EventClass::event_types()` set. A variant missing
+    // here causes webhook subscriptions for that event type to be rejected as
+    // not a subset of the selected event classes.
+    #[test]
+    fn every_event_type_belongs_to_an_event_class() {
+        let mapped: HashSet<EventType> = EventClass::iter()
+            .flat_map(|class| class.event_types())
+            .collect();
+
+        let unmapped: Vec<EventType> = EventType::iter()
+            .filter(|event_type| !mapped.contains(event_type))
+            .collect();
+
+        assert!(
+            unmapped.is_empty(),
+            "these EventType variants are not mapped to any EventClass: {unmapped:?}"
+        );
+    }
+}
+
 #[derive(
     Clone,
     Copy,
@@ -1927,6 +1958,7 @@ impl EventClass {
     serde::Deserialize,
     serde::Serialize,
     strum::Display,
+    strum::EnumIter,
     strum::EnumString,
     ToSchema,
 )]


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

`EventType::PaymentPartiallyAuthorized` was not included in any `EventClass::event_types()` set. This adds it to the `payments` class, and adds a test that enforces the invariant documented on `EventType` ("Whenever an `EventType` variant is added or removed, make sure to update the `event_types` method in `EventClass`") by iterating every variant and asserting it maps to some class. `strum::EnumIter` is now derived on `EventClass` and `EventType` to support the test.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Webhook subscription validation (`crates/router/src/core/webhooks/webhook_events.rs`) derives the set of allowed event types from `EventClass::event_types()`. With `payment_partially_authorized` missing from the `payments` class:

- Subscribing with `event_types = ["payment_partially_authorized"]` and `event_classes = ["payments"]` was rejected with `"event_types must be a subset of event_classes"`.
- Subscribing to the whole `payments` class silently excluded the event.

Fixes #13492

## How did you test it?

`cargo test -p common_enums`. The new test `every_event_type_belongs_to_an_event_class` passes with the fix and fails without it (reporting `[PaymentPartiallyAuthorized]` as unmapped).

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
