### PR TITLE
test(currency_conversion): assert conversion results and fix swapped rate fixtures

### DIFF
--- a/crates/currency_conversion/src/conversion.rs
+++ b/crates/currency_conversion/src/conversion.rs
@@ -30,62 +30,60 @@ pub fn convert(
 mod tests {
     use std::collections::HashMap;
 
-    use crate::types::CurrencyFactors;
+    use common_enums::Currency;
+    use rust_decimal::Decimal;
+
+    use super::convert;
+    use crate::types::{CurrencyFactors, ExchangeRates};
+
+    // Base currency is USD for every case below. `CurrencyFactors::new` takes
+    // `(to_factor, from_factor)`, where `to_factor` converts base -> currency
+    // and `from_factor` converts currency -> base.
+    //   INR: 1 USD = 80 INR  -> to_factor = 80,  from_factor = 1/80 = 0.0125
+    //   SZL: 1 USD = 20 SZL  -> to_factor = 20,  from_factor = 1/20 = 0.05
+    fn inr_factors() -> CurrencyFactors {
+        CurrencyFactors::new(Decimal::new(80, 0), Decimal::new(125, 4))
+    }
+    fn szl_factors() -> CurrencyFactors {
+        CurrencyFactors::new(Decimal::new(20, 0), Decimal::new(5, 2))
+    }
+    fn usd_factors() -> CurrencyFactors {
+        CurrencyFactors::new(Decimal::new(1, 0), Decimal::new(1, 0))
+    }
+
     #[test]
     fn currency_to_currency_conversion() {
-        use super::*;
-        let mut conversion: HashMap<Currency, CurrencyFactors> = HashMap::new();
-        let inr_conversion_rates =
-            CurrencyFactors::new(Decimal::new(823173, 4), Decimal::new(1214, 5));
-        let szl_conversion_rates =
-            CurrencyFactors::new(Decimal::new(194423, 4), Decimal::new(514, 4));
-        let convert_from = Currency::SZL;
-        let convert_to = Currency::INR;
-        let amount = 2000;
-        let base_currency = Currency::USD;
-        conversion.insert(convert_from, inr_conversion_rates);
-        conversion.insert(convert_to, szl_conversion_rates);
-        let sample_rate = ExchangeRates::new(base_currency, conversion);
-        let res =
-            convert(&sample_rate, convert_from, convert_to, amount).expect("converted_currency");
-        println!("The conversion from {amount} {convert_from} to {convert_to} is {res:?}");
+        let mut conversion = HashMap::new();
+        conversion.insert(Currency::SZL, szl_factors());
+        conversion.insert(Currency::INR, inr_factors());
+        let rates = ExchangeRates::new(Currency::USD, conversion);
+
+        // 2000 minor SZL = 20 SZL -> 20 * 0.05 = 1 USD -> 1 * 80 = 80 INR
+        let res = convert(&rates, Currency::SZL, Currency::INR, 2000).expect("conversion failed");
+        assert_eq!(res, Decimal::from(80));
     }
 
     #[test]
     fn currency_to_base_conversion() {
-        use super::*;
-        let mut conversion: HashMap<Currency, CurrencyFactors> = HashMap::new();
-        let inr_conversion_rates =
-            CurrencyFactors::new(Decimal::new(823173, 4), Decimal::new(1214, 5));
-        let usd_conversion_rates = CurrencyFactors::new(Decimal::new(1, 0), Decimal::new(1, 0));
-        let convert_from = Currency::INR;
-        let convert_to = Currency::USD;
-        let amount = 2000;
-        let base_currency = Currency::USD;
-        conversion.insert(convert_from, inr_conversion_rates);
-        conversion.insert(convert_to, usd_conversion_rates);
-        let sample_rate = ExchangeRates::new(base_currency, conversion);
-        let res =
-            convert(&sample_rate, convert_from, convert_to, amount).expect("converted_currency");
-        println!("The conversion from {amount} {convert_from} to {convert_to} is {res:?}");
+        let mut conversion = HashMap::new();
+        conversion.insert(Currency::INR, inr_factors());
+        conversion.insert(Currency::USD, usd_factors());
+        let rates = ExchangeRates::new(Currency::USD, conversion);
+
+        // 2000 minor INR = 20 INR -> 20 * 0.0125 = 0.25 USD
+        let res = convert(&rates, Currency::INR, Currency::USD, 2000).expect("conversion failed");
+        assert_eq!(res, Decimal::new(25, 2));
     }
 
     #[test]
     fn base_to_currency_conversion() {
-        use super::*;
-        let mut conversion: HashMap<Currency, CurrencyFactors> = HashMap::new();
-        let inr_conversion_rates =
-            CurrencyFactors::new(Decimal::new(823173, 4), Decimal::new(1214, 5));
-        let usd_conversion_rates = CurrencyFactors::new(Decimal::new(1, 0), Decimal::new(1, 0));
-        let convert_from = Currency::USD;
-        let convert_to = Currency::INR;
-        let amount = 2000;
-        let base_currency = Currency::USD;
-        conversion.insert(convert_from, usd_conversion_rates);
-        conversion.insert(convert_to, inr_conversion_rates);
-        let sample_rate = ExchangeRates::new(base_currency, conversion);
-        let res =
-            convert(&sample_rate, convert_from, convert_to, amount).expect("converted_currency");
-        println!("The conversion from {amount} {convert_from} to {convert_to} is {res:?}");
+        let mut conversion = HashMap::new();
+        conversion.insert(Currency::USD, usd_factors());
+        conversion.insert(Currency::INR, inr_factors());
+        let rates = ExchangeRates::new(Currency::USD, conversion);
+
+        // 2000 minor USD = 20 USD -> 20 * 80 = 1600 INR
+        let res = convert(&rates, Currency::USD, Currency::INR, 2000).expect("conversion failed");
+        assert_eq!(res, Decimal::from(1600));
     }
 }


### PR DESCRIPTION
## Type of Change

- [x] Refactoring
- [x] Enhancement

## Description

The `currency_conversion` unit tests only `println!` their results and assert nothing, so `convert()` is exercised but its output is never verified. In addition, the `currency_to_currency_conversion` case inserts swapped fixtures (the `SZL` key gets the `INR` factors and vice versa), which went unnoticed precisely because there were no assertions.

This corrects the fixtures and adds explicit result assertions for all three conversion paths (currency to currency, currency to base, base to currency), using simple round factors so the expected amounts are exact.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Turns three no-op tests into real regression tests for the core money-conversion routine. With the assertions in place, the previously latent fixture swap is caught (the swapped map produces `5` instead of the expected `80`).

Fixes #13493

## How did you test it?

`cargo test -p currency_conversion` (all three cases pass; re-introducing the swapped fixtures makes `currency_to_currency_conversion` fail).

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
