### PR TITLE
fix(router): handle fallback in dispute connector-dispute-id lookup

### DIFF
--- a/crates/diesel_models/src/query/dispute.rs
+++ b/crates/diesel_models/src/query/dispute.rs
@@ -22,7 +22,7 @@ impl DisputeNew {
 }
 
 impl Dispute {
-    pub async fn find_by_processor_merchant_id_payment_id_connector_dispute_id(
+    pub async fn find_optional_by_processor_merchant_id_payment_id_connector_dispute_id(
         conn: &PgPooledConn,
         processor_merchant_id: &common_utils::id_type::MerchantId,
         payment_id: &common_utils::id_type::PaymentId,
@@ -78,7 +78,7 @@ impl Dispute {
     }
 
     // Fallback function for stagger release - finds by merchant_id when processor_merchant_id is NULL
-    pub async fn find_by_merchant_id_payment_id_connector_dispute_id(
+    pub async fn find_optional_by_merchant_id_payment_id_connector_dispute_id(
         conn: &PgPooledConn,
         processor_merchant_id: &common_utils::id_type::MerchantId,
         payment_id: &common_utils::id_type::PaymentId,

--- a/crates/router/src/db/dispute.rs
+++ b/crates/router/src/db/dispute.rs
@@ -100,7 +100,7 @@ mod storage_impl {
         ) -> CustomResult<Option<storage_types::Dispute>, errors::StorageError> {
             let conn = connection::pg_connection_read(self).await?;
             let result =
-                storage_types::Dispute::find_by_processor_merchant_id_payment_id_connector_dispute_id(
+                storage_types::Dispute::find_optional_by_processor_merchant_id_payment_id_connector_dispute_id(
                     &conn,
                     processor_merchant_id,
                     payment_id,
@@ -112,7 +112,7 @@ mod storage_impl {
             match result {
                 Some(dispute) => Ok(Some(dispute)),
                 None => {
-                    storage_types::Dispute::find_by_merchant_id_payment_id_connector_dispute_id(
+                    storage_types::Dispute::find_optional_by_merchant_id_payment_id_connector_dispute_id(
                         &conn,
                         processor_merchant_id,
                         payment_id,
@@ -384,7 +384,7 @@ mod storage_impl {
             let database_call = || async {
                 let conn = connection::pg_connection_read(self).await?;
                 let result =
-                    storage_types::Dispute::find_by_processor_merchant_id_payment_id_connector_dispute_id(
+                    storage_types::Dispute::find_optional_by_processor_merchant_id_payment_id_connector_dispute_id(
                         &conn,
                         processor_merchant_id,
                         payment_id,
@@ -393,24 +393,18 @@ mod storage_impl {
                     .await;
 
                 match result {
-                    Ok(dispute) => Ok(dispute),
-                    Err(error) => {
-                        if matches!(
-                            error.current_context(),
-                            diesel_models::errors::DatabaseError::NotFound
-                        ) {
-                            storage_types::Dispute::find_by_merchant_id_payment_id_connector_dispute_id(
-                                &conn,
-                                processor_merchant_id,
-                                payment_id,
-                                connector_dispute_id,
-                            )
-                            .await
-                            .map_err(|error| report!(errors::StorageError::from(error)))
-                        } else {
-                            Err(report!(errors::StorageError::from(error)))
-                        }
+                    Ok(Some(dispute)) => Ok(Some(dispute)),
+                    Ok(None) => {
+                        storage_types::Dispute::find_optional_by_merchant_id_payment_id_connector_dispute_id(
+                            &conn,
+                            processor_merchant_id,
+                            payment_id,
+                            connector_dispute_id,
+                        )
+                        .await
+                        .map_err(|error| report!(errors::StorageError::from(error)))
                     }
+                    Err(error) => Err(report!(errors::StorageError::from(error))),
                 }
             };
             let storage_scheme = Box::pin(decide_storage_scheme::<_, diesel_models::Dispute>(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The incoming dispute-webhook flow looks up an existing dispute by
`(processor_merchant_id, payment_id, connector_dispute_id)` before deciding
whether to **update** the existing dispute or **create** a new one
(`get_or_update_dispute_object`).

That primary lookup
(`Dispute::find_by_processor_merchant_id_payment_id_connector_dispute_id`) is
implemented with `generic_find_one_optional`, so a miss surfaces as `Ok(None)`
— **not** `Err(DatabaseError::NotFound)`.

The fallback logic in `db/dispute.rs`, however, only fired on
`Err(NotFound)`:

```rust
match result {
    Ok(dispute) => Ok(dispute),           // Ok(None) returned as-is -> fallback skipped
    Err(error) => {
        if matches!(error.current_context(), DatabaseError::NotFound) {
            // merchant_id fallback ...
        } else { Err(...) }
    }
}
```

For **legacy dispute rows that have a `NULL` `processor_merchant_id`**, the
primary lookup returns `Ok(None)`, the `merchant_id` fallback was never
reached, and the webhook handler treated the dispute as non-existent —
**creating a duplicate dispute** on every subsequent dispute-status webhook
instead of updating the original row.

This PR matches on `Ok(None)` explicitly so the `merchant_id` fallback runs
for legacy rows, while `Ok(Some(_))` (the normal, no-fallback path) and
`Err(_)` are preserved exactly as before:

```rust
match result {
    Ok(Some(dispute)) => Ok(Some(dispute)),
    Ok(None) => { /* merchant_id fallback for legacy NULL processor_merchant_id rows */ }
    Err(error) => Err(report!(errors::StorageError::from(error))),
}
```

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes juspay/hyperswitch-cloud#22415

The `processor_merchant_id` column was introduced for
platform/processor-merchant support. Disputes created before that column was
populated have `processor_merchant_id = NULL`. The fallback to the
`merchant_id`-based lookup exists precisely to keep those legacy rows working
during the staggered rollout, but it was gated on the wrong error condition
(`Err(NotFound)`) for an optional query that returns `Ok(None)` on a miss.

Impact: incoming dispute webhooks for legacy disputes silently created
duplicate dispute records instead of updating the existing one.

## How did you test it?

Verified with unit tests plus an end-to-end incoming-webhook test against a
locally running router (Postgres + Redis), driving the real Stripe dispute
webhook flow.

**Unit tests**

```
cargo test -p router --lib db::dispute::
# test result: ok. 8 passed; 0 failed
```

**End-to-end: signed Stripe `charge.dispute.updated` webhook →
`POST /webhooks/{merchant_id}/stripe`**

Setup: one charged Stripe payment with two pre-existing disputes at
`dispute_status = dispute_opened`, both anchored to the same payment:

| dispute | `processor_merchant_id` | path exercised |
| --- | --- | --- |
| `dp_modern_cltest` | set | primary lookup (current behavior) |
| `dp_legacy_cltest` | `NULL` | `Ok(None)` → `merchant_id` fallback (the fix) |

For each, a signature-verified `charge.dispute.updated` webhook (status
`under_review` → `DisputeChallenged`) was POSTed.

Result — both returned `HTTP 200` and **updated the existing dispute in place**;
**no duplicate rows** were created:

```
BEFORE:
 dp_modern_cltest | dispute_opened     | processor_merchant_id = offers_local_test
 dp_legacy_cltest | dispute_opened     | processor_merchant_id = NULL

AFTER:
 dp_modern_cltest | dispute_challenged | (1 row)
 dp_legacy_cltest | dispute_challenged | (1 row)   <-- fallback found & updated the legacy row
```

Server logs show the update path (`"Dispute Already exists, Updating the dispute
details"`) for **both** webhooks — confirming the legacy dispute was located via
the `merchant_id` fallback rather than being re-created.

Without this fix, the legacy webhook takes the `None` branch of
`get_or_update_dispute_object` and inserts a **duplicate** dispute (new `dp_…`
id) instead of updating the original, which was also reproduced at the query
level: the primary `processor_merchant_id` lookup returns 0 rows (`Ok(None)`) for
the legacy row, while the `merchant_id` fallback returns it.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
