### PR TITLE
fix(router): register MultipartFormConfig so per-field multipart limits are reachable

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -6589,7 +6589,7 @@
         ],
         "operationId": "Upload a batch blocklist CSV",
         "requestBody": {
-          "description": "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MB). The CSV must have a header row: `type,data,metadata`. `type`: one of `card_bin` (6 digits), `extended_card_bin` (8 digits), `fingerprint`. `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). Maximum 100,000 data rows.",
+          "description": "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). The CSV must have a header row: `type,data,metadata`. `type`: one of `card_bin` (6 digits), `extended_card_bin` (8 digits), `fingerprint`. `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). Maximum 100,000 data rows.",
           "content": {
             "multipart/form-data": {
               "schema": {
@@ -6611,7 +6611,7 @@
             }
           },
           "400": {
-            "description": "CSV validation error or file exceeds 5 MB limit"
+            "description": "CSV validation error or file exceeds 5 MiB limit"
           }
         },
         "security": [

--- a/crates/openapi/src/routes/blocklist.rs
+++ b/crates/openapi/src/routes/blocklist.rs
@@ -64,7 +64,7 @@ pub async fn list_blocked_payment_methods() {}
     request_body(
         content = String,
         content_type = "multipart/form-data",
-        description = "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MB). \
+        description = "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). \
             The CSV must have a header row: `type,data,metadata`. \
             `type`: one of `card_bin` (6 digits), `extended_card_bin` (8 digits), `fingerprint`. \
             `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). \
@@ -72,7 +72,7 @@ pub async fn list_blocked_payment_methods() {}
     ),
     responses(
         (status = 202, description = "Batch blocklist job initiated", body = BatchBlocklistUploadResponse),
-        (status = 400, description = "CSV validation error or file exceeds 5 MB limit"),
+        (status = 400, description = "CSV validation error or file exceeds 5 MiB limit"),
     ),
     tag = "Blocklist",
     operation_id = "Upload a batch blocklist CSV",

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -41,6 +41,8 @@ pub const FINGERPRINT_SECRET_LENGTH: usize = 64;
 
 pub const DEFAULT_LIST_API_LIMIT: u16 = 10;
 
+pub const MULTIPART_MEMORY_LIMIT: usize = 6 * 1024 * 1024;
+
 // String literals
 pub(crate) const UNSUPPORTED_ERROR_MESSAGE: &str = "Unsupported response type";
 

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -506,6 +506,9 @@ pub fn get_application_builder(
         .content_type_required(true)
         .error_handler(utils::error_parser::custom_json_error_handler);
 
+    let multipart_cfg = actix_multipart::form::MultipartFormConfig::default()
+        .memory_limit(consts::MULTIPART_MEMORY_LIMIT);
+
     let request_identifier = router_env::RequestIdentifier::new(&trace_header.header_name)
         .use_incoming_id({
             #[cfg(feature = "deja")]
@@ -530,6 +533,7 @@ pub fn get_application_builder(
 
     actix_web::App::new()
         .app_data(json_cfg)
+        .app_data(multipart_cfg)
         .wrap(ErrorHandlers::new().handler(
             StatusCode::NOT_FOUND,
             errors::error_handlers::custom_error_handlers,

--- a/crates/router/src/routes/blocklist.rs
+++ b/crates/router/src/routes/blocklist.rs
@@ -208,7 +208,9 @@ pub async fn toggle_blocklist_guard(
 
 #[derive(Debug, MultipartForm)]
 pub struct BatchBlocklistUploadForm {
-    #[multipart(limit = "5MB")]
+    // Also charged against `consts::MULTIPART_MEMORY_LIMIT`, the global in-memory budget for
+    // multipart fields. That global must stay >= this limit, or this one is unreachable.
+    #[multipart(limit = "5MiB")]
     pub file: MultipartBytes,
 }
 
@@ -218,7 +220,7 @@ pub struct BatchBlocklistUploadForm {
     request_body(
         content = String,
         content_type = "multipart/form-data",
-        description = "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MB). \
+        description = "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). \
             The CSV must have a header row: `type,data,metadata`. \
             `type`: one of `card_bin` (6 digits), `extended_card_bin` (8 digits), `fingerprint`. \
             `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). \
@@ -226,7 +228,7 @@ pub struct BatchBlocklistUploadForm {
     ),
     responses(
         (status = 202, description = "Batch blocklist job initiated", body = BatchBlocklistUploadResponse),
-        (status = 400, description = "CSV validation error or file exceeds 5 MB limit"),
+        (status = 400, description = "CSV validation error or file exceeds 5 MiB limit"),
     ),
     tag = "Blocklist",
     operation_id = "Upload a batch blocklist CSV",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

`MultipartFormConfig` was never registered in actix app data, so every `MultipartForm` extractor
in the router fell back to the value compiled into `actix-multipart`:

```rust
// actix-multipart-0.6.2/src/form/mod.rs:382
const DEFAULT_CONFIG: MultipartFormConfig = MultipartFormConfig {
    total_limit: 52_428_800, // 50 MiB
    memory_limit: 2_097_152, // 2 MiB
    err_handler: None,
};
```

`Limits::try_consume_limits` charges each chunk against the global `memory_limit` **and** the
per-field `#[multipart(limit = "...")]`, and the smaller of the two wins. A `Bytes` field is an
in-memory field (`form/bytes.rs:35` passes `in_memory = true`), so the real ceiling was 2 MiB no
matter what the field declared. Overflowing any of the counters produces the same
`MultipartError::Payload(PayloadError::Overflow)`, surfaced as a 400 `payload reached size limit`
with no indication of which limit was hit.

Effect before this change:

| Endpoint | declared field limit | effective |
|---|---|---|
| `POST /blocklist/batch` | 5 MB | 2 MiB |

Changes:

- Register a `MultipartFormConfig` with a 6 MiB `memory_limit` (`consts::MULTIPART_MEMORY_LIMIT`)
  so the per-field limits become the binding constraint. The six forms declaring `1MB` are
  untouched — their own field limit still binds, so nothing is loosened for them.
- Switch the batch blocklist field to `"5MiB"`. `"5MB"` is parsed as decimal `5_000_000` by
  `parse-size`, which does not line up with a MiB-denominated global.
- Correct the OpenAPI descriptions on the endpoint to say MiB.

Note that `MAX_BATCH_CSV_ROWS = 100_000` against the old 2 MiB budget implied ≤ 21 bytes per row,
so only the narrowest possible CSV (`card_bin,411111,`) could ever reach the documented row limit.
At 5 MiB the row cap is reachable for `card_bin` and `extended_card_bin` rows with metadata; a
100,000-row `fingerprint` CSV (~78 bytes/row) would still need a larger limit.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

No contract, schema, or config changes. The limit is a code-level constant rather than a config
value deliberately: it must stay >= the largest `#[multipart(limit = "...")]` in the codebase, and
those are compile-time attributes — making it operator-tunable would let a deployment silently
render a declared field limit unreachable. Only the utoipa `description` strings on the batch
endpoint changed, so `api-reference/v1/openapi_spec_v1.json` will pick that up on regeneration.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Fixes #13503

Uploading a batch blocklist CSV of ~99,000 rows (3,481,871 bytes) returned
400 `payload reached size limit` even though the endpoint advertises 5 MB and 100,000 rows. The
request died in the extractor (`flow: "UNKNOWN"`, never reaching the handler), so no
`batch_blocklist_jobs` row was written and the failure was visible only in application logs:

```
POST /blocklist/batch   Content-Length: 3481871
→ 400  exception.details: Payload(Overflow)
       exception.message: "payload reached size limit"
```

Smaller uploads on the same build succeeded (56,794 narrow rows ≈ 1.9 MB), which is what made the
2 MiB boundary hard to spot — the limit is not referenced anywhere in this repo, it lives as a
`const` inside the dependency.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Manually, against a local server:

- Before: `POST /blocklist/batch` with a 3,481,871-byte CSV → 400 `payload reached size limit`,
  `exception.details: Payload(Overflow)`, `flow: "UNKNOWN"`.
- After: the same file is accepted and the job is created; `flow` becomes `BatchBlocklistUpload`
  instead of `UNKNOWN`, which is the signal the extractor no longer rejects the body.

No automated test added — exercising this needs an integration test that POSTs a >2 MiB
`multipart/form-data` body, which the current Rust test setup does not cover for this route.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
