### PR TITLE
fix(common_utils): add TCP keepalive params to DB URL so pool connections recover from RDS failover

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -58,6 +58,10 @@ connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
 idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
 max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
+keepalives_idle = 5       # Idle seconds before the OS sends TCP keepalive probes (detects silently-dead connections, e.g. after an RDS failover)
+keepalives_interval = 2   # Seconds between keepalive probes when one goes unanswered
+keepalives_count = 3      # Unanswered keepalive probes tolerated before the OS declares the connection dead
+tcp_user_timeout_ms = 5000 # Milliseconds of unacknowledged sent data before the OS closes the connection; must stay well below connection_timeout
 
 # Replica SQL data store credentials
 [replica_database]
@@ -72,6 +76,10 @@ connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
 idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
 max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
+keepalives_idle = 5       # Idle seconds before the OS sends TCP keepalive probes (detects silently-dead connections, e.g. after an RDS failover)
+keepalives_interval = 2   # Seconds between keepalive probes when one goes unanswered
+keepalives_count = 3      # Unanswered keepalive probes tolerated before the OS declares the connection dead
+tcp_user_timeout_ms = 5000 # Milliseconds of unacknowledged sent data before the OS closes the connection; must stay well below connection_timeout
 
 # Accounts schema SQL data store credentials (merchant accounts, profiles, MCAs, key stores)
 [accounts_database]
@@ -86,6 +94,10 @@ connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
 idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
 max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
+keepalives_idle = 5       # Idle seconds before the OS sends TCP keepalive probes (detects silently-dead connections, e.g. after an RDS failover)
+keepalives_interval = 2   # Seconds between keepalive probes when one goes unanswered
+keepalives_count = 3      # Unanswered keepalive probes tolerated before the OS declares the connection dead
+tcp_user_timeout_ms = 5000 # Milliseconds of unacknowledged sent data before the OS closes the connection; must stay well below connection_timeout
 
 # Global tenant (users, roles) SQL data store credentials
 [global_database]
@@ -100,6 +112,10 @@ connection_timeout = 10   # Timeout for database connection in seconds
 queue_strategy = "Fifo"   # Add the queue strategy used by the database bb8 client
 idle_timeout = 300        # Maximum idle duration in seconds before a connection is closed
 max_lifetime = 1800       # Maximum lifetime in seconds before a connection is reaped
+keepalives_idle = 5       # Idle seconds before the OS sends TCP keepalive probes (detects silently-dead connections, e.g. after an RDS failover)
+keepalives_interval = 2   # Seconds between keepalive probes when one goes unanswered
+keepalives_count = 3      # Unanswered keepalive probes tolerated before the OS declares the connection dead
+tcp_user_timeout_ms = 5000 # Milliseconds of unacknowledged sent data before the OS closes the connection; must stay well below connection_timeout
 
 # Redis credentials
 [redis]

--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -301,6 +301,38 @@ pub fn generate_time_ordered_id_without_prefix() -> String {
 pub fn generate_id_with_len(length: usize) -> String {
     nanoid::nanoid!(length, &consts::ALPHABETS)
 }
+/// Seconds of idle time before the OS starts sending TCP keepalive probes on a
+/// database connection. Left to the OS this is commonly ~2 hours on Linux, far
+/// too slow to notice a connection silently killed by an RDS/Aurora failover.
+pub const DEFAULT_DB_KEEPALIVES_IDLE_SECS: u64 = 5;
+
+/// Seconds between successive TCP keepalive probes when one goes unanswered.
+/// The OS default is ~75s, which would make detection minutes-slow.
+pub const DEFAULT_DB_KEEPALIVES_INTERVAL_SECS: u64 = 2;
+
+/// Unanswered TCP keepalive probes tolerated before the OS declares a database
+/// connection dead. With the two values above, a connection that dies while a
+/// query is in flight is detected in ~idle + interval*count = ~11s instead of
+/// hanging indefinitely.
+pub const DEFAULT_DB_KEEPALIVES_COUNT: u32 = 3;
+
+/// Milliseconds of unacknowledged *transmitted* data before the OS forcibly
+/// closes a database connection. This bounds a fresh write -- notably the
+/// pool's own checkout health-check ping -- sent to a connection that went
+/// idle before dying silently; that path is governed by ordinary TCP
+/// retransmission timers rather than the keepalive mechanism above, so the
+/// keepalive settings alone do not cover it.
+///
+/// MUST stay comfortably below the pool's `connection_timeout` (10s by
+/// default). `connection_timeout` wraps the entire connection checkout,
+/// including the health-check ping this bounds. If the outer timeout wins the
+/// race, the pool never runs its "mark connection invalid" path and the dead
+/// connection is returned to the idle queue looking healthy. Measured against
+/// a real failover with an all-idle pool: at 10_000 (equal to
+/// `connection_timeout`) one checkout hard-failed at 10.002s and full recovery
+/// took ~16s; at 5_000 there were no failures and recovery took ~12s.
+pub const DEFAULT_DB_TCP_USER_TIMEOUT_MS: u64 = 5_000;
+
 #[allow(missing_docs)]
 pub trait DbConnectionParams {
     fn get_username(&self) -> &str;
@@ -309,44 +341,21 @@ pub trait DbConnectionParams {
     fn get_port(&self) -> u16;
     fn get_dbname(&self) -> &str;
 
-    /// Seconds of idle time before the OS starts sending TCP keepalive probes
-    /// on this connection. Without overriding this, it falls back to the OS
-    /// default (commonly ~2 hours on Linux), which is far too slow to detect
-    /// a connection silently killed by an RDS/Aurora failover.
+    /// See [`DEFAULT_DB_KEEPALIVES_IDLE_SECS`].
     fn get_pool_keepalives_idle(&self) -> u64 {
-        5
+        DEFAULT_DB_KEEPALIVES_IDLE_SECS
     }
-    /// Seconds between successive keepalive probes if no ACK is received.
+    /// See [`DEFAULT_DB_KEEPALIVES_INTERVAL_SECS`].
     fn get_pool_keepalives_interval(&self) -> u64 {
-        2
+        DEFAULT_DB_KEEPALIVES_INTERVAL_SECS
     }
-    /// Number of unacknowledged keepalive probes before the OS declares the
-    /// connection dead. With the values above, a connection that dies while a
-    /// query is in flight is detected in ~idle + interval*count = ~11s,
-    /// instead of hanging indefinitely. (A connection that dies while *idle*
-    /// is instead bounded by `get_pool_tcp_user_timeout_ms` below, which
-    /// governs a different kernel timer -- see its docs.)
+    /// See [`DEFAULT_DB_KEEPALIVES_COUNT`].
     fn get_pool_keepalives_count(&self) -> u32 {
-        3
+        DEFAULT_DB_KEEPALIVES_COUNT
     }
-    /// Milliseconds of unacknowledged *transmitted* data before the OS
-    /// forcibly closes the connection. This is what bounds a fresh write
-    /// (e.g. the pool's own `is_valid()` checkout ping) sent to a connection
-    /// that went idle before dying silently -- without this, that specific
-    /// path can hang far longer than the keepalive settings above would
-    /// suggest, since it's governed by normal TCP retransmission timers
-    /// instead of the keepalive mechanism.
-    ///
-    /// MUST stay comfortably below the pool's `connection_timeout` (currently
-    /// 10s). `connection_timeout` wraps the whole `pool.get()`, including the
-    /// `is_valid()` ping this bounds; if the outer timeout wins the race, bb8
-    /// never runs its `Err => mark Invalid` path and the dead connection goes
-    /// back into the idle queue looking healthy. Measured against a real
-    /// failover with all connections idle: at 10_000 (== connection_timeout)
-    /// a checkout hard-failed at 10.002s and full recovery took ~16s; at
-    /// 5_000 there were no failures and recovery took ~12s.
+    /// See [`DEFAULT_DB_TCP_USER_TIMEOUT_MS`].
     fn get_pool_tcp_user_timeout_ms(&self) -> u64 {
-        5_000
+        DEFAULT_DB_TCP_USER_TIMEOUT_MS
     }
 
     fn get_database_url(&self, schema: &str) -> String {

--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -308,9 +308,50 @@ pub trait DbConnectionParams {
     fn get_host(&self) -> &str;
     fn get_port(&self) -> u16;
     fn get_dbname(&self) -> &str;
+
+    /// Seconds of idle time before the OS starts sending TCP keepalive probes
+    /// on this connection. Without overriding this, it falls back to the OS
+    /// default (commonly ~2 hours on Linux), which is far too slow to detect
+    /// a connection silently killed by an RDS/Aurora failover.
+    fn get_pool_keepalives_idle(&self) -> u64 {
+        5
+    }
+    /// Seconds between successive keepalive probes if no ACK is received.
+    fn get_pool_keepalives_interval(&self) -> u64 {
+        2
+    }
+    /// Number of unacknowledged keepalive probes before the OS declares the
+    /// connection dead. With the values above, a connection that dies while a
+    /// query is in flight is detected in ~idle + interval*count = ~11s,
+    /// instead of hanging indefinitely. (A connection that dies while *idle*
+    /// is instead bounded by `get_pool_tcp_user_timeout_ms` below, which
+    /// governs a different kernel timer -- see its docs.)
+    fn get_pool_keepalives_count(&self) -> u32 {
+        3
+    }
+    /// Milliseconds of unacknowledged *transmitted* data before the OS
+    /// forcibly closes the connection. This is what bounds a fresh write
+    /// (e.g. the pool's own `is_valid()` checkout ping) sent to a connection
+    /// that went idle before dying silently -- without this, that specific
+    /// path can hang far longer than the keepalive settings above would
+    /// suggest, since it's governed by normal TCP retransmission timers
+    /// instead of the keepalive mechanism.
+    ///
+    /// MUST stay comfortably below the pool's `connection_timeout` (currently
+    /// 10s). `connection_timeout` wraps the whole `pool.get()`, including the
+    /// `is_valid()` ping this bounds; if the outer timeout wins the race, bb8
+    /// never runs its `Err => mark Invalid` path and the dead connection goes
+    /// back into the idle queue looking healthy. Measured against a real
+    /// failover with all connections idle: at 10_000 (== connection_timeout)
+    /// a checkout hard-failed at 10.002s and full recovery took ~16s; at
+    /// 5_000 there were no failures and recovery took ~12s.
+    fn get_pool_tcp_user_timeout_ms(&self) -> u64 {
+        5_000
+    }
+
     fn get_database_url(&self, schema: &str) -> String {
         format!(
-            "postgres://{}:{}@{}:{}/{}?application_name={}&options=-c%20search_path%3D{}",
+            "postgres://{}:{}@{}:{}/{}?application_name={}&options=-c%20search_path%3D{}&keepalives=1&keepalives_idle={}&keepalives_interval={}&keepalives_count={}&tcp_user_timeout={}",
             self.get_username(),
             self.get_password().peek(),
             self.get_host(),
@@ -318,6 +359,10 @@ pub trait DbConnectionParams {
             self.get_dbname(),
             schema,
             schema,
+            self.get_pool_keepalives_idle(),
+            self.get_pool_keepalives_interval(),
+            self.get_pool_keepalives_count(),
+            self.get_pool_tcp_user_timeout_ms(),
         )
     }
 }

--- a/crates/drainer/src/settings.rs
+++ b/crates/drainer/src/settings.rs
@@ -86,6 +86,10 @@ pub struct Database {
     pub dbname: String,
     pub pool_size: u32,
     pub connection_timeout: u64,
+    pub keepalives_idle: u64,
+    pub keepalives_interval: u64,
+    pub keepalives_count: u32,
+    pub tcp_user_timeout_ms: u64,
 }
 
 impl DbConnectionParams for Database {
@@ -103,6 +107,18 @@ impl DbConnectionParams for Database {
     }
     fn get_dbname(&self) -> &str {
         &self.dbname
+    }
+    fn get_pool_keepalives_idle(&self) -> u64 {
+        self.keepalives_idle
+    }
+    fn get_pool_keepalives_interval(&self) -> u64 {
+        self.keepalives_interval
+    }
+    fn get_pool_keepalives_count(&self) -> u32 {
+        self.keepalives_count
+    }
+    fn get_pool_tcp_user_timeout_ms(&self) -> u64 {
+        self.tcp_user_timeout_ms
     }
 }
 
@@ -212,6 +228,10 @@ impl Default for Database {
             dbname: String::new(),
             pool_size: 5,
             connection_timeout: 10,
+            keepalives_idle: common_utils::DEFAULT_DB_KEEPALIVES_IDLE_SECS,
+            keepalives_interval: common_utils::DEFAULT_DB_KEEPALIVES_INTERVAL_SECS,
+            keepalives_count: common_utils::DEFAULT_DB_KEEPALIVES_COUNT,
+            tcp_user_timeout_ms: common_utils::DEFAULT_DB_TCP_USER_TIMEOUT_MS,
         }
     }
 }

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -48,6 +48,10 @@ impl Default for super::settings::Database {
             min_idle_pool_size: 2,
             max_lifetime: 1800,
             idle_timeout: 300,
+            keepalives_idle: common_utils::DEFAULT_DB_KEEPALIVES_IDLE_SECS,
+            keepalives_interval: common_utils::DEFAULT_DB_KEEPALIVES_INTERVAL_SECS,
+            keepalives_count: common_utils::DEFAULT_DB_KEEPALIVES_COUNT,
+            tcp_user_timeout_ms: common_utils::DEFAULT_DB_TCP_USER_TIMEOUT_MS,
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -1065,6 +1065,10 @@ pub struct Database {
     pub min_idle_pool_size: u32,
     pub max_lifetime: u64,
     pub idle_timeout: u64,
+    pub keepalives_idle: u64,
+    pub keepalives_interval: u64,
+    pub keepalives_count: u32,
+    pub tcp_user_timeout_ms: u64,
 }
 
 impl From<Database> for storage_impl::config::Database {
@@ -1081,6 +1085,10 @@ impl From<Database> for storage_impl::config::Database {
             min_idle_pool_size: val.min_idle_pool_size,
             max_lifetime: val.max_lifetime,
             idle_timeout: val.idle_timeout,
+            keepalives_idle: val.keepalives_idle,
+            keepalives_interval: val.keepalives_interval,
+            keepalives_count: val.keepalives_count,
+            tcp_user_timeout_ms: val.tcp_user_timeout_ms,
         }
     }
 }

--- a/crates/storage_impl/src/config.rs
+++ b/crates/storage_impl/src/config.rs
@@ -21,6 +21,14 @@ pub struct Database {
     pub max_lifetime: u64,
     #[serde(default = "default_idle_timeout")]
     pub idle_timeout: u64,
+    #[serde(default = "default_keepalives_idle")]
+    pub keepalives_idle: u64,
+    #[serde(default = "default_keepalives_interval")]
+    pub keepalives_interval: u64,
+    #[serde(default = "default_keepalives_count")]
+    pub keepalives_count: u32,
+    #[serde(default = "default_tcp_user_timeout_ms")]
+    pub tcp_user_timeout_ms: u64,
 }
 
 const fn default_min_idle_pool_size() -> u32 {
@@ -33,6 +41,22 @@ const fn default_max_lifetime() -> u64 {
 
 const fn default_idle_timeout() -> u64 {
     300
+}
+
+const fn default_keepalives_idle() -> u64 {
+    common_utils::DEFAULT_DB_KEEPALIVES_IDLE_SECS
+}
+
+const fn default_keepalives_interval() -> u64 {
+    common_utils::DEFAULT_DB_KEEPALIVES_INTERVAL_SECS
+}
+
+const fn default_keepalives_count() -> u32 {
+    common_utils::DEFAULT_DB_KEEPALIVES_COUNT
+}
+
+const fn default_tcp_user_timeout_ms() -> u64 {
+    common_utils::DEFAULT_DB_TCP_USER_TIMEOUT_MS
 }
 
 impl DbConnectionParams for Database {
@@ -50,6 +74,18 @@ impl DbConnectionParams for Database {
     }
     fn get_dbname(&self) -> &str {
         &self.dbname
+    }
+    fn get_pool_keepalives_idle(&self) -> u64 {
+        self.keepalives_idle
+    }
+    fn get_pool_keepalives_interval(&self) -> u64 {
+        self.keepalives_interval
+    }
+    fn get_pool_keepalives_count(&self) -> u32 {
+        self.keepalives_count
+    }
+    fn get_pool_tcp_user_timeout_ms(&self) -> u64 {
+        self.tcp_user_timeout_ms
     }
 }
 
@@ -84,6 +120,10 @@ impl Default for Database {
             min_idle_pool_size: default_min_idle_pool_size(),
             max_lifetime: default_max_lifetime(),
             idle_timeout: default_idle_timeout(),
+            keepalives_idle: default_keepalives_idle(),
+            keepalives_interval: default_keepalives_interval(),
+            keepalives_count: default_keepalives_count(),
+            tcp_user_timeout_ms: default_tcp_user_timeout_ms(),
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
After an Aurora/RDS failover the router could require a manual restart to recover.

Root cause is in `async-bb8-diesel`: its `ConnectionManager` wraps `r2d2::ConnectionManager` in a single `Arc<Mutex<..>>` shared by the entire pool, and both `connect()` and `is_valid()` acquire it for the full duration of their blocking libpq call. Aurora failover leaves old connections silently unresponsive (no RST/FIN), so that call never returns, the shared lock is never released, and every subsequent connection check *and* new-connection attempt for the whole pool queues behind it indefinitely.

We can bound the failure at the OS layer: libpq passes these connection-string parameters straight to setsockopt(), so the kernel detects and tears down the dead socket on its own. bb8's existing "is_valid() errors -> mark invalid -> discard -> reconnect" logic then works unmodified.

Both `storage_impl::config::Database` and `drainer::settings::Database` implement `DbConnectionParams` without overriding `get_database_url`, so the router pool and the drainer's separate pool are both covered.

`tcp_user_timeout` is deliberately 5s, below the existing 10s bb8 `connection_timeout`. At 10s (equal) the outer timeout wins the race, bb8 never marks the connection invalid, and it returns to the idle queue looking healthy - measured as one hard checkout failure at 10.002s and ~16s to recover, versus zero failures and ~12s at 5s.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested manually
Validated on Linux against a genuine iptables partition of the old instance plus DNS re-point to a healthy replacement, using unmodified bb8 0.8.6 and async-bb8-diesel 0.2.1:
  - in-flight queries at failover: all fail cleanly at ~11s, pool fully recovered, 16/16 follow-up probes succeed
  - all-idle pool at failover: 20/20 probes succeed, no checkout timeouts



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible