### PR TITLE
feat(routing): authenticate Decision Engine calls with x-admin-secret

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1424,6 +1424,7 @@ dynamic_routing_enabled = true                          # Enable or disable Open
 static_routing_enabled = true           # Enable or disable Open Router for static routing
 url = "http://localhost:8080"           # Open Router URL
 dashboard_url = "http://localhost:5173" # Decision Engine dashboard (browser) URL for merchant SSO redirect
+admin_secret = ""                       # Shared secret sent as x-admin-secret on Decision Engine admin endpoints; empty disables the header
 
 [grpc_client.unified_connector_service]
 base_url = "http://localhost:8000"      # Unified Connector Service Base URL

--- a/config/development.toml
+++ b/config/development.toml
@@ -1560,6 +1560,7 @@ dynamic_routing_enabled = false
 static_routing_enabled = false
 url = "http://localhost:8080"
 dashboard_url = "http://localhost:5173"
+admin_secret = ""
 
 [l2_l3_data_config]
 enabled = "true"

--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -4,6 +4,7 @@ use hyperswitch_interfaces::secrets_interface::{
     secret_state::{RawSecret, SecretStateContainer, SecuredSecret},
     SecretManagementInterface, SecretsManagementError,
 };
+use hyperswitch_masking::PeekInterface;
 
 use crate::settings::{self, Settings};
 
@@ -630,6 +631,18 @@ pub(crate) async fn fetch_raw_secrets(
         None
     };
 
+    #[allow(clippy::expect_used)]
+    let open_router = {
+        let mut open_router = conf.open_router;
+        if !open_router.admin_secret.peek().is_empty() {
+            open_router.admin_secret = secret_management_client
+                .get_secret(open_router.admin_secret)
+                .await
+                .expect("Failed to decrypt open router admin secret");
+        }
+        open_router
+    };
+
     Settings {
         server: conf.server,
         application_source: conf.application_source,
@@ -734,7 +747,7 @@ pub(crate) async fn fetch_raw_secrets(
         platform: conf.platform,
         l2_l3_data_config: conf.l2_l3_data_config,
         authentication_providers: conf.authentication_providers,
-        open_router: conf.open_router,
+        open_router,
         #[cfg(feature = "v2")]
         revenue_recovery: conf.revenue_recovery,
         merchant_advice_codes: conf.merchant_advice_codes,

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -421,6 +421,12 @@ pub struct OpenRouter {
     /// Browser-facing Decision Engine dashboard base URL, used for the merchant SSO redirect.
     #[serde(default)]
     pub dashboard_url: String,
+    /// Shared secret sent as the `x-admin-secret` header on Decision Engine requests. The DE
+    /// verifies it on admin endpoints (merchant provisioning, SSO code mint) and accepts it as
+    /// service-to-service auth on its protected routes. Decrypted via secrets management when
+    /// enabled; empty disables the header.
+    #[serde(default)]
+    pub admin_secret: Secret<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -312,9 +312,10 @@ where
             .trigger_event(state, closure)
             .await?
     } else {
-        let resp = closure()
-            .await
-            .change_context(errors::RoutingError::OpenRouterCallFailed)?;
+        // Keep the closure's error context (e.g. `RoutingEventsError` carrying the DE status
+        // code) so callers can react to specific statuses, like the 404-gated merchant
+        // provisioning in the SSO mint flow.
+        let resp = closure().await?;
 
         RoutingEventsResponse::new(None, resp)
     };

--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -29,6 +29,7 @@ use euclid::{
 use external_services::grpc_client::dynamic_routing as ir_client;
 use hyperswitch_domain_models::business_profile;
 use hyperswitch_interfaces::events::routing_api_logs as routing_events;
+use hyperswitch_masking::{Mask, PeekInterface};
 use router_env::RequestId;
 use serde::{Deserialize, Serialize};
 
@@ -158,6 +159,8 @@ impl DecisionEngineEndpoint {
     }
 }
 
+const DECISION_ENGINE_ADMIN_SECRET_HEADER: &str = "x-admin-secret";
+
 pub async fn build_and_send_decision_engine_http_request<Req, Res, ErrRes>(
     state: &SessionState,
     http_method: services::Method,
@@ -179,6 +182,18 @@ where
     let mut request_builder = services::RequestBuilder::new()
         .method(http_method)
         .url(&url);
+
+    // The Decision Engine authenticates Hyperswitch via a shared admin secret: its admin
+    // endpoints (merchant provisioning, SSO code mint) verify the header in the handler, and
+    // its protected router accepts it as service-to-service auth. Attach it on every call
+    // when configured; an empty secret omits the header.
+    let admin_secret = &state.conf.open_router.admin_secret;
+    if !admin_secret.peek().is_empty() {
+        request_builder = request_builder.headers(vec![(
+            DECISION_ENGINE_ADMIN_SECRET_HEADER.to_string(),
+            admin_secret.clone().into_masked(),
+        )]);
+    }
 
     if let Some(body_content) = request_body {
         let body = common_utils::request::RequestContent::Json(Box::new(body_content));


### PR DESCRIPTION
Closes #13538

## Type of Change

- [x] New feature

## Description

An audit of every Hyperswitch → Decision Engine call against the DE route table shows Hyperswitch sends no credentials on any of them, while the DE authenticates on two levels:

| HS calls | DE router | Auth DE requires |
|---|---|---|
| `decide-gateway`, `update-gateway-score` (payment-time) | protected | merchant api-key / dashboard JWT (when `api_key_auth_enabled`) |
| `routing/evaluate`, `routing/create`, `routing/activate`, `routing/list/*`, `routing/hybrid` | protected | same |
| `rule/create` / `update` / `get` / `delete` | protected | same |
| `merchant-account/{id}` (delete) | protected | same |
| `merchant-account/create` | public | `x-admin-secret` (verified in handler) |
| `auth/admin/merchant-token` (SSO mint, #13452) | public | `x-admin-secret` (verified in handler) |

On deployments where the DE runs with real credentials this 401s the dashboard cutover redirect, merchant provisioning, and — once `api_key_auth_enabled` is on — the payment-time routing calls as well.

This PR:

1. Adds `open_router.admin_secret` (`Secret<String>`, `#[serde(default)]` → empty). Decrypted through the configured secrets-management backend (e.g. AWS KMS) at startup, guarded so an unset/empty value skips decryption and cannot fail startup on existing deployments.
2. Attaches `x-admin-secret` on **every** Decision Engine request in `build_and_send_decision_engine_http_request`. The DE verifies it on admin endpoints and (with juspay/decision-engine#345) accepts it as service-to-service auth on its protected router. An empty secret omits the header, preserving current behaviour for local setups.

The header value is `Maskable`-masked, so it is redacted in the request logs.

Companion PR: juspay/decision-engine#345.

## Motivation and Context

Sandbox/production Decision Engine deployments are provisioned with a real (KMS-encrypted) admin secret and `api_key_auth_enabled = true`. Without HS-side support the SSO mint returns `401 Invalid or expired token`, and protected-route calls (e.g. `routing/list`, payment-time `decide-gateway`) are rejected the same way. This also removes the need to run the DE with an empty admin secret (i.e. an unauthenticated public mint endpoint) to make the flow work.

## How did you test it?

- `cargo check -p router` clean.
- Locally against a DE with `[admin_secret] secret = "test_admin"` and `api_key_auth_enabled = true`: with `open_router.admin_secret = "test_admin"`, `POST /routing/entry?target=rule` mints the SSO code and returns the redirect URL, and `decide-gateway` / `routing/*` calls pass the DE middleware; with the wrong/missing secret the DE rejects with 401 as expected.
- With `admin_secret = ""` (default): requests carry no `x-admin-secret` header — identical to current behaviour.

## Checklist

- [x] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
