### PR TITLE
fix(router): handle fallback in dispute connector-dispute-id lookup

### DIFF
--- a/crates/diesel_models/src/query/dispute.rs
+++ b/crates/diesel_models/src/query/dispute.rs
@@ -22,7 +22,7 @@ impl DisputeNew {
 }
 
 impl Dispute {
-    pub async fn find_by_processor_merchant_id_payment_id_connector_dispute_id(
+    pub async fn find_optional_by_processor_merchant_id_payment_id_connector_dispute_id(
         conn: &PgPooledConn,
         processor_merchant_id: &common_utils::id_type::MerchantId,
         payment_id: &common_utils::id_type::PaymentId,
@@ -78,7 +78,7 @@ impl Dispute {
     }
 
     // Fallback function for stagger release - finds by merchant_id when processor_merchant_id is NULL
-    pub async fn find_by_merchant_id_payment_id_connector_dispute_id(
+    pub async fn find_optional_by_merchant_id_payment_id_connector_dispute_id(
         conn: &PgPooledConn,
         processor_merchant_id: &common_utils::id_type::MerchantId,
         payment_id: &common_utils::id_type::PaymentId,

--- a/crates/router/src/db/dispute.rs
+++ b/crates/router/src/db/dispute.rs
@@ -100,7 +100,7 @@ mod storage_impl {
         ) -> CustomResult<Option<storage_types::Dispute>, errors::StorageError> {
             let conn = connection::pg_connection_read(self).await?;
             let result =
-                storage_types::Dispute::find_by_processor_merchant_id_payment_id_connector_dispute_id(
+                storage_types::Dispute::find_optional_by_processor_merchant_id_payment_id_connector_dispute_id(
                     &conn,
                     processor_merchant_id,
                     payment_id,
@@ -112,7 +112,7 @@ mod storage_impl {
             match result {
                 Some(dispute) => Ok(Some(dispute)),
                 None => {
-                    storage_types::Dispute::find_by_merchant_id_payment_id_connector_dispute_id(
+                    storage_types::Dispute::find_optional_by_merchant_id_payment_id_connector_dispute_id(
                         &conn,
                         processor_merchant_id,
                         payment_id,
@@ -384,7 +384,7 @@ mod storage_impl {
             let database_call = || async {
                 let conn = connection::pg_connection_read(self).await?;
                 let result =
-                    storage_types::Dispute::find_by_processor_merchant_id_payment_id_connector_dispute_id(
+                    storage_types::Dispute::find_optional_by_processor_merchant_id_payment_id_connector_dispute_id(
                         &conn,
                         processor_merchant_id,
                         payment_id,
@@ -393,24 +393,18 @@ mod storage_impl {
                     .await;
 
                 match result {
-                    Ok(dispute) => Ok(dispute),
-                    Err(error) => {
-                        if matches!(
-                            error.current_context(),
-                            diesel_models::errors::DatabaseError::NotFound
-                        ) {
-                            storage_types::Dispute::find_by_merchant_id_payment_id_connector_dispute_id(
-                                &conn,
-                                processor_merchant_id,
-                                payment_id,
-                                connector_dispute_id,
-                            )
-                            .await
-                            .map_err(|error| report!(errors::StorageError::from(error)))
-                        } else {
-                            Err(report!(errors::StorageError::from(error)))
-                        }
+                    Ok(Some(dispute)) => Ok(Some(dispute)),
+                    Ok(None) => {
+                        storage_types::Dispute::find_optional_by_merchant_id_payment_id_connector_dispute_id(
+                            &conn,
+                            processor_merchant_id,
+                            payment_id,
+                            connector_dispute_id,
+                        )
+                        .await
+                        .map_err(|error| report!(errors::StorageError::from(error)))
                     }
+                    Err(error) => Err(report!(errors::StorageError::from(error))),
                 }
             };
             let storage_scheme = Box::pin(decide_storage_scheme::<_, diesel_models::Dispute>(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Cherry-pick of #13502 onto `hotfix-2026.07.29.2`.

The incoming dispute-webhook flow looks up an existing dispute by
`(processor_merchant_id, payment_id, connector_dispute_id)` to decide whether to
**update** the existing dispute or **create** a new one
(`get_or_update_dispute_object`).

The primary lookup
(`Dispute::find_by_processor_merchant_id_payment_id_connector_dispute_id`) is
implemented with `generic_find_one_optional`, so a miss surfaces as `Ok(None)`
— not `Err(DatabaseError::NotFound)`. The `merchant_id` fallback, however, only
fired on `Err(NotFound)`, so it never ran when the primary lookup returned
`Ok(None)`.

For legacy dispute rows whose `processor_merchant_id` does not match the
processor id used at webhook time (NULL, or backfilled to a different value),
the primary lookup returns `Ok(None)`, the fallback is skipped, and the handler
takes the create path — which then collides with the unique index
`merchant_id_payment_id_connector_dispute_id_index` on `insert_dispute` and
surfaces as `500 Something went wrong` (`HE_00`).

This change matches on `Ok(None)` explicitly so the `merchant_id` fallback runs,
while `Ok(Some(_))` (the normal, no-fallback path) and `Err(_)` are preserved.
It also renames the two `Option`-returning finders to `find_optional_by_*` for
naming consistency.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Merged on `main` via #13502.
Closes juspay/hyperswitch-cloud#22415

This cherry-pick brings the fix into the `hotfix-2026.07.29.2` release line, where
production incoming dispute webhooks for affected merchants are failing with 500s
(unique-constraint violation on the create path).

## How did you test it?

Validated on the original PR (#13502):

- Unit tests: `cargo test -p router --lib db::dispute::` — 8 passed.
- End-to-end signed Stripe `charge.dispute.updated` webhook against a locally
  running router (Postgres + Redis): for both a dispute whose
  `processor_merchant_id` matches and one that does not, the existing dispute is
  updated in place via the `merchant_id` fallback (no duplicate insert, no 500).

Cherry-pick applied cleanly onto `hotfix-2026.07.29.2` with no conflicts; the
diff is identical to the merged commit.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
