### PR TITLE
feat(connector): [CYBERSOURCE] Persist previous state for Void in case of 2xx failures and 4xx

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/cybersource.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource.rs
@@ -2007,6 +2007,10 @@ impl ConnectorIntegration<Void, PaymentsCancelData, PaymentsResponseData> for Cy
         event_builder: Option<&mut ConnectorEvent>,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res, event_builder)
+            .map(|mut error| {
+                error.attempt_status = Some(common_enums::AttemptStatus::Authorized);
+                error
+            })
     }
 
     fn get_5xx_error_response(

--- a/crates/hyperswitch_connectors/src/connectors/cybersource.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource.rs
@@ -2007,10 +2007,6 @@ impl ConnectorIntegration<Void, PaymentsCancelData, PaymentsResponseData> for Cy
         event_builder: Option<&mut ConnectorEvent>,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res, event_builder)
-            .map(|mut error| {
-                error.attempt_status = Some(common_enums::AttemptStatus::Authorized);
-                error
-            })
     }
 
     fn get_5xx_error_response(

--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -4334,6 +4334,16 @@ impl TryFrom<PaymentsCancelResponseRouterData<CybersourcePaymentsResponse>>
         );
         let response =
             get_payment_response((&item.response, status, item.http_code)).map_err(|err| *err);
+        let (status, response) = if utils::is_payment_failure(status) {
+            let new_status = enums::AttemptStatus::Authorized;
+            let new_response = response.map_err(|err| ErrorResponse {
+                attempt_status: Some(new_status),
+                ..err
+            });
+            (new_status, new_response)
+        } else {
+            (status, response)
+        };
         Ok(Self {
             status,
             response,

--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -4335,7 +4335,7 @@ impl TryFrom<PaymentsCancelResponseRouterData<CybersourcePaymentsResponse>>
         let response =
             get_payment_response((&item.response, status, item.http_code)).map_err(|err| *err);
         let (status, response) = if utils::is_payment_failure(status) {
-            let new_status = enums::AttemptStatus::Authorized;
+            let new_status = item.data.status;
             let new_response = response.map_err(|err| ErrorResponse {
                 attempt_status: Some(new_status),
                 ..err

--- a/crates/hyperswitch_domain_models/src/router_data.rs
+++ b/crates/hyperswitch_domain_models/src/router_data.rs
@@ -2476,7 +2476,10 @@ impl
         error
             .attempt_status
             .map(common_enums::IntentStatus::from)
-            .unwrap_or(common_enums::IntentStatus::Failed)
+            .unwrap_or_else(|| match error.status_code {
+                500..=511 => common_enums::IntentStatus::Processing,
+                _ => common_enums::IntentStatus::from(payment_data.payment_attempt.status),
+            })
     }
 
     fn get_payment_attempt_update(
@@ -2506,7 +2509,7 @@ impl
                     Some(status) => status,
                     None => match error_response.status_code {
                         500..=511 => common_enums::AttemptStatus::Pending,
-                        _ => common_enums::AttemptStatus::VoidFailed,
+                        _ => payment_data.payment_attempt.status,
                     },
                 };
 
@@ -2557,7 +2560,7 @@ impl
 
     fn get_attempt_status_for_db_update(
         &self,
-        _payment_data: &payments::PaymentCancelData<router_flow_types::Void>,
+        payment_data: &payments::PaymentCancelData<router_flow_types::Void>,
     ) -> common_enums::AttemptStatus {
         // For void operations, determine status based on response
         match &self.response {
@@ -2565,7 +2568,7 @@ impl
                 Some(status) => status,
                 None => match error_response.status_code {
                     500..=511 => common_enums::AttemptStatus::Pending,
-                    _ => common_enums::AttemptStatus::VoidFailed,
+                    _ => payment_data.payment_attempt.status,
                 },
             },
             Ok(ref _response) => self.status,

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -2344,7 +2344,7 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                                     429 => router_data.status,
                                     _ => enums::AttemptStatus::Failure,
                                 }
-                            } else if sub_flow == "CancelPostCapture" {
+                            } else if sub_flow == "Void" || sub_flow == "CancelPostCapture" {
                                 router_data.status
                             } else {
                                 match err.status_code {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

In case of Void flow : 

- 2xx success : Voided or Cancelled
- 2xx failure : Persist previous status of attempt & intent
- 4xx : Persist previous status of attempt & intent
- 5xx : Pending or Processing


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Payments Cancel - 2xx success 

```
curl --location 'http://localhost:8080/payments/pay_VBBXdYk0yrgurEVyX98M/cancel' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_hJRvKzl45ohz45seLEjDmgZHyFsaqgEii0DnmCQ8Y9O1Pv4ZrUm0G8TJ5OIZfcw5' \
--data '{
    "cancellation_reason": "requested_by_customer"
    
}'
```

Response 

```
{
    "payment_id": "pay_VBBXdYk0yrgurEVyX98M",
    "merchant_id": "merchant_1785490189",
    "status": "cancelled",
    "amount": 10,
    "net_amount": 10,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "processor_merchant_id": "merchant_1785490189",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fVFN6UmhqbExFRFJ6TWtjSlhtaFYscHVibGlzaGFibGVfa2V5PXBrX2Rldl9hZWQyYTE4Zjc1ODM0M2EwYjcxMTE1ZTNjYjBkMWEzNCxjbGllbnRfc2VjcmV0PXBheV9WQkJYZFlrMHlyZ3VyRVZ5WDk4TV9zZWNyZXRfWWIyQnlsajduaXBTakx1VEZOQ1csY3VzdG9tZXJfaWQ9Y3VzX1EzNVAyMHBjM1NYYUtlczVEbDl0LHBheW1lbnRfaWQ9cGF5X1ZCQlhkWWsweXJndXJFVnlYOThN",
    "connector": "cybersource",
    "state_metadata": null,
    "client_secret": "pay_VBBXdYk0yrgurEVyX98M_secret_Yb2Bylj7nipSjLuTFNCW",
    "created": "2026-08-04T09:59:38.172Z",
    "modified_at": "2026-08-04T09:59:58.732Z",
    "connector_customer_id": null,
    "currency": "EUR",
    "customer_id": "cus_Q35P20pc3SXaKes5Dl9t",
    "customer": {
        "id": "cus_Q35P20pc3SXaKes5Dl9t",
        "name": "John Doe",
        "email": "dg@example.com",
        "phone": "999999999",
        "phone_country_code": "+1",
        "customer_document_details": {
            "document_type": "cnpj",
            "document_number": "20201210000155"
        }
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "HenryLouis aa",
            "payment_checks": {
                "avs_response": {
                    "code": "Y",
                    "codeRaw": "Y"
                },
                "card_verification": null
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": {
            "address": {
                "city": "Thise",
                "country": "FR",
                "line1": "1467",
                "line2": "CA",
                "line3": null,
                "zip": "94122",
                "state": "Alsace",
                "first_name": "HenryLouis",
                "last_name": "aa",
                "origin_zip": null
            },
            "phone": null,
            "email": "dg@example.com"
        }
    },
    "payment_token": "token_osyP55ojZ4xSVyv0lbk0",
    "shipping": null,
    "billing": null,
    "order_details": [
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        }
    ],
    "email": "dg@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": "requested_by_customer",
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "7858375985476117804805",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "disable_avs": true,
        "new_customer": "true"
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "pay_VBBXdYk0yrgurEVyX98M_1",
    "payment_link": null,
    "profile_id": "pro_TSzRhjlLEDRzMkcJXmhV",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_neGh1mIMNqWIqazPH2V2",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-08-04T10:14:38.172Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "208.127.127.193",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1280,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 720,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_VkrRd95OqMgEPZEqeFRg",
    "network_transaction_id": "016150703802094",
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-08-04T09:59:58.732Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": true,
    "force_3ds_challenge_trigger": true,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

2. Payments Cancel - 4xx

Note : to simulate a 2xx failure i altered the connector_transaction_id from db before voiding it

```
curl --location 'http://localhost:8080/payments/pay_VEnsgSmcL0THqedRnEYO/cancel' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_hJRvKzl45ohz45seLEjDmgZHyFsaqgEii0DnmCQ8Y9O1Pv4ZrUm0G8TJ5OIZfcw5' \
--data '{
    "cancellation_reason": "requested_by_customer"
    
}'
```

Response 

```
{
    "payment_id": "pay_VEnsgSmcL0THqedRnEYO",
    "merchant_id": "merchant_1785490189",
    "status": "requires_capture",
    "amount": 10,
    "net_amount": 10,
    "shipping_cost": null,
    "amount_capturable": 10,
    "amount_received": null,
    "processor_merchant_id": "merchant_1785490189",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fVFN6UmhqbExFRFJ6TWtjSlhtaFYscHVibGlzaGFibGVfa2V5PXBrX2Rldl9hZWQyYTE4Zjc1ODM0M2EwYjcxMTE1ZTNjYjBkMWEzNCxjbGllbnRfc2VjcmV0PXBheV9WRW5zZ1NtY0wwVEhxZWRSbkVZT19zZWNyZXRfam5SRlpxaFN1Yk9sNU82WlluelEsY3VzdG9tZXJfaWQ9Y3VzX1EzNVAyMHBjM1NYYUtlczVEbDl0LHBheW1lbnRfaWQ9cGF5X1ZFbnNnU21jTDBUSHFlZFJuRVlP",
    "connector": "cybersource",
    "state_metadata": null,
    "client_secret": "pay_VEnsgSmcL0THqedRnEYO_secret_jnRFZqhSubOl5O6ZYnzQ",
    "created": "2026-08-04T09:56:40.765Z",
    "modified_at": "2026-08-04T09:57:50.353Z",
    "connector_customer_id": null,
    "currency": "EUR",
    "customer_id": "cus_Q35P20pc3SXaKes5Dl9t",
    "customer": {
        "id": "cus_Q35P20pc3SXaKes5Dl9t",
        "name": "John Doe",
        "email": "dg@example.com",
        "phone": "999999999",
        "phone_country_code": "+1",
        "customer_document_details": {
            "document_type": "cnpj",
            "document_number": "20201210000155"
        }
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "HenryLouis aa",
            "payment_checks": {
                "avs_response": {
                    "code": "Y",
                    "codeRaw": "Y"
                },
                "card_verification": null
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": {
            "address": {
                "city": "Thise",
                "country": "FR",
                "line1": "1467",
                "line2": "CA",
                "line3": null,
                "zip": "94122",
                "state": "Alsace",
                "first_name": "HenryLouis",
                "last_name": "aa",
                "origin_zip": null
            },
            "phone": null,
            "email": "dg@example.com"
        }
    },
    "payment_token": "token_u3EdQoeVWPdQi5ip8j8E",
    "shipping": null,
    "billing": null,
    "order_details": [
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        }
    ],
    "email": "dg@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": "requested_by_customer",
    "error_code": "INVALID_DATA",
    "error_message": "Declined - One or more fields in the request contains invalid data, detailed_error_information: id : INVALID_DATA",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "error_details": {
        "unified_details": {
            "category": "UE_9000",
            "message": "Something went wrong",
            "standardised_code": null,
            "description": null,
            "user_guidance_message": null,
            "recommended_action": null
        },
        "issuer_details": null,
        "connector_details": {
            "code": "INVALID_DATA",
            "message": "Declined - One or more fields in the request contains invalid data",
            "reason": "Declined - One or more fields in the request contains invalid data, detailed_error_information: id : INVALID_DATA"
        }
    },
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "7858374024316023204900",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "disable_avs": true,
        "new_customer": "true"
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "pay_VEnsgSmcL0THqedRnEYO_1",
    "payment_link": null,
    "profile_id": "pro_TSzRhjlLEDRzMkcJXmhV",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_neGh1mIMNqWIqazPH2V2",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-08-04T10:11:40.764Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "208.127.127.193",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1280,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 720,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_RzUJAIrn79U6av7seoAM",
    "network_transaction_id": "016150703802094",
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-08-04T09:57:50.353Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": true,
    "force_3ds_challenge_trigger": true,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": {
        "network_advice_code": null
    },
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

3. Payments Cancel - 2xx failure 

Note : got a 2xx failure by mutating the connector response and changing the status to Declined. 

```
curl --location 'http://localhost:8080/payments/pay_nhNyaXv2yryNOA6AT8UL/cancel' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_hJRvKzl45ohz45seLEjDmgZHyFsaqgEii0DnmCQ8Y9O1Pv4ZrUm0G8TJ5OIZfcw5' \
--data '{
    "cancellation_reason": "fraud"
    
}'
```

Response 

```
{
    "payment_id": "pay_nhNyaXv2yryNOA6AT8UL",
    "merchant_id": "merchant_1785490189",
    "status": "requires_capture",
    "amount": 10,
    "net_amount": 10,
    "shipping_cost": null,
    "amount_capturable": 10,
    "amount_received": null,
    "processor_merchant_id": "merchant_1785490189",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fVFN6UmhqbExFRFJ6TWtjSlhtaFYscHVibGlzaGFibGVfa2V5PXBrX2Rldl9hZWQyYTE4Zjc1ODM0M2EwYjcxMTE1ZTNjYjBkMWEzNCxjbGllbnRfc2VjcmV0PXBheV9uaE55YVh2MnlyeU5PQTZBVDhVTF9zZWNyZXRfM3d4emtRcTlXT3VhQ2hNZ2EyMm0sY3VzdG9tZXJfaWQ9Y3VzX1EzNVAyMHBjM1NYYUtlczVEbDl0LHBheW1lbnRfaWQ9cGF5X25oTnlhWHYyeXJ5Tk9BNkFUOFVM",
    "connector": "cybersource",
    "state_metadata": null,
    "client_secret": "pay_nhNyaXv2yryNOA6AT8UL_secret_3wxzkQq9WOuaChMga22m",
    "created": "2026-08-04T10:51:00.130Z",
    "modified_at": "2026-08-04T10:51:13.869Z",
    "connector_customer_id": null,
    "currency": "EUR",
    "customer_id": "cus_Q35P20pc3SXaKes5Dl9t",
    "customer": {
        "id": "cus_Q35P20pc3SXaKes5Dl9t",
        "name": "John Doe",
        "email": "dg@example.com",
        "phone": "999999999",
        "phone_country_code": "+1",
        "customer_document_details": {
            "document_type": "cnpj",
            "document_number": "20201210000155"
        }
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "HenryLouis aa",
            "payment_checks": {
                "avs_response": {
                    "code": "Y",
                    "codeRaw": "Y"
                },
                "card_verification": null
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": {
            "address": {
                "city": "Thise",
                "country": "FR",
                "line1": "1467",
                "line2": "CA",
                "line3": null,
                "zip": "94122",
                "state": "Alsace",
                "first_name": "HenryLouis",
                "last_name": "aa",
                "origin_zip": null
            },
            "phone": null,
            "email": "dg@example.com"
        }
    },
    "payment_token": "token_tFTzdcGHyS6aJiMmxk0K",
    "shipping": null,
    "billing": null,
    "order_details": [
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        }
    ],
    "email": "dg@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": "fraud",
    "error_code": null,
    "error_message": "",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "error_details": {
        "unified_details": {
            "category": "UE_9000",
            "message": "Something went wrong",
            "standardised_code": null,
            "description": null,
            "user_guidance_message": null,
            "recommended_action": null
        },
        "issuer_details": {
            "code": "00",
            "message": null,
            "network_details": null
        },
        "connector_details": {
            "code": "No error code",
            "message": "No error message",
            "reason": ""
        }
    },
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "7858406736486853004807",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "disable_avs": true,
        "new_customer": "true"
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "pay_nhNyaXv2yryNOA6AT8UL_1",
    "payment_link": null,
    "profile_id": "pro_TSzRhjlLEDRzMkcJXmhV",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_neGh1mIMNqWIqazPH2V2",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-08-04T11:06:00.130Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "208.127.127.193",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1280,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 720,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_tNtRAm9TWwM7TDnjqQxq",
    "network_transaction_id": "016150703802094",
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-08-04T10:51:13.869Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": true,
    "force_3ds_challenge_trigger": true,
    "issuer_error_code": "00",
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": {
        "network_advice_code": null
    },
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
