### PR TITLE
fix: mark UCS shadow gateway failures non-primary

### DIFF
--- a/crates/hyperswitch_interfaces/src/api/gateway.rs
+++ b/crates/hyperswitch_interfaces/src/api/gateway.rs
@@ -429,7 +429,12 @@ where
                         .attach_printable("Gateway execution failed");
 
                     if let Err(e) = &ucs_shadow_result {
-                        logger::error!(error=?e, "UCS shadow execution failed");
+                        logger::warn!(
+                            error=?e,
+                            execution_mode="shadow",
+                            primary_impact=false,
+                            "UCS shadow execution failed; primary execution result is unaffected"
+                        );
                     }
 
                     let ucs_for_compare = match ucs_shadow_result {
@@ -563,7 +568,12 @@ where
                         .attach_printable("Gateway execution failed");
 
                     if let Err(e) = &ucs_shadow_result {
-                        logger::error!(error=?e, "UCS shadow execution failed");
+                        logger::warn!(
+                            error=?e,
+                            execution_mode="shadow",
+                            primary_impact=false,
+                            "UCS shadow execution failed; primary execution result is unaffected"
+                        );
                     }
 
                     let ucs_for_compare = match ucs_shadow_result {


### PR DESCRIPTION
## Summary

This hotfix prevents UCS shadow-only gateway failures from being emitted as primary-traffic `ERROR` logs.

The shadow failure remains visible for validation/debugging, but is now logged as `WARN` with explicit structured fields:

- `execution_mode="shadow"`
- `primary_impact=false`
- message: `UCS shadow execution failed; primary execution result is unaffected`

This covers both payment and payout shadow gateway execution paths.

## Main PR

Original PR: https://github.com/juspay/hyperswitch/pull/13562

## Why

On 2026-08-05, the generic HS Sev1 log alert fired for a UCS shadow-only failure even though the merchant-facing primary/golden path returned HTTP 200.

Observed prod evidence:

- Alert: `5xx Logs [Past 1 min]`
- Last seen: `2026-08-05 12:28:26 IST`
- HS shadow error log time: `2026-08-05T06:57:31.259891634Z`
- Request ID: `019fd0b6-84cc-72f2-bf99-1e46d09b125b`
- Merchant: `reloadhero887`
- Flow: `PaymentsConfirm`
- Connector: `mifinity`
- Build: `2026.07.22.0-hotfix2-f1b1176-2026-07-29T06:09:58.000000000Z`
- Commit: `f1b1176a97322fbcccd36d12e4d8ffc974633cf4`
- Log site: `crates/hyperswitch_interfaces/src/api/gateway.rs:432`

For the same request, the merchant-facing completion log was:

- Time: `2026-08-05T06:57:31.883643215Z`
- Message: `[HTTP REQUEST - END]`
- HTTP status: `200`

The alert fired because the generic HS Sev1 rule matches HS `ERROR` logs containing `Something went wrong`. This shadow failure happened inside HS before the UCS request was sent:

```text
build_connector_config_header
-> mifinity missing from ConnectorSpecificConfig
-> ApiErrorResponse::InternalServerError
-> HE_00 / Something went wrong
```

So a shadow-only validation failure looked like primary traffic impact.

Fixes https://github.com/juspay/hyperswitch-cloud/issues/22505

## Change

Before:

```rust
logger::error!(error=?e, "UCS shadow execution failed");
```

After:

```rust
logger::warn!(
    error=?e,
    execution_mode="shadow",
    primary_impact=false,
    "UCS shadow execution failed; primary execution result is unaffected"
);
```

## Verification

- `cargo fmt --check --package hyperswitch_interfaces` passed.
- `git diff --check` passed.

`cargo check -p hyperswitch_interfaces` could not complete in this hotfix checkout due existing feature-gating errors unrelated to this patch, e.g. `diesel_models` / `api_models` types gated behind `v1`/`v2` features being unavailable. The failure occurred outside the edited file.




