### PR TITLE
fix(core): Store encrypted profile in application cache

### DIFF
--- a/crates/storage_impl/src/business_profile.rs
+++ b/crates/storage_impl/src/business_profile.rs
@@ -25,13 +25,6 @@ use crate::{
 #[cfg(feature = "accounts_cache")]
 use crate::{metrics, RedisConnInterface};
 
-/// Time to live for the redis copy of a profile, in seconds.
-///
-/// Tuned independently of the in-memory cache's TTL, and deliberately longer than it, so that an
-/// expired in-memory entry can be refilled from redis instead of the database.
-#[cfg(feature = "accounts_cache")]
-const PROFILE_REDIS_CACHE_TTL: i64 = 60 * 60;
-
 /// Cache key for a profile, shared by both the profile-scoped and merchant-scoped lookups.
 #[cfg(feature = "accounts_cache")]
 fn profile_cache_key(profile_id: &common_utils::id_type::ProfileId) -> String {
@@ -201,12 +194,12 @@ impl<T: DatabaseStore> ProfileInterface for RouterStore<T> {
                 .await
                 .map_err(|error| report!(StorageError::from(error)))
         };
+        let state = self
+            .get_keymanager_state()
+            .attach_printable("Missing KeyManagerState")?;
 
         #[cfg(not(feature = "accounts_cache"))]
         {
-            let state = self
-                .get_keymanager_state()
-                .attach_printable("Missing KeyManagerState")?;
             fetch_func()
                 .await?
                 .convert(
@@ -220,27 +213,20 @@ impl<T: DatabaseStore> ProfileInterface for RouterStore<T> {
 
         #[cfg(feature = "accounts_cache")]
         {
-            let state = self
-                .get_keymanager_state()
-                .attach_printable("Missing KeyManagerState")?
-                .clone();
-
-            let identifier = merchant_key_store.merchant_id.clone().into();
-
-            cache::get_or_populate_in_memory_with_transform(
+            cache::get_or_populate_in_memory(
                 self,
                 &profile_cache_key(profile_id),
-                Some(PROFILE_REDIS_CACHE_TTL),
                 fetch_func,
-                |diesel_profile| async move {
-                    diesel_profile
-                        .convert(&state, &merchant_key_store.key, identifier)
-                        .await
-                        .change_context(StorageError::DecryptionError)
-                },
                 &ACCOUNTS_CACHE,
             )
+            .await?
+            .convert(
+                state,
+                merchant_key_store.key.get_inner(),
+                merchant_key_store.merchant_id.clone().into(),
+            )
             .await
+            .change_context(StorageError::DecryptionError)
         }
     }
 
@@ -256,12 +242,12 @@ impl<T: DatabaseStore> ProfileInterface for RouterStore<T> {
                 .await
                 .map_err(|error| report!(StorageError::from(error)))
         };
+        let state = self
+            .get_keymanager_state()
+            .attach_printable("Missing KeyManagerState")?;
 
         #[cfg(not(feature = "accounts_cache"))]
         {
-            let state = self
-                .get_keymanager_state()
-                .attach_printable("Missing KeyManagerState")?;
             fetch_func()
                 .await?
                 .convert(
@@ -275,27 +261,20 @@ impl<T: DatabaseStore> ProfileInterface for RouterStore<T> {
 
         #[cfg(feature = "accounts_cache")]
         {
-            let state = self
-                .get_keymanager_state()
-                .attach_printable("Missing KeyManagerState")?
-                .clone();
-
-            let identifier = merchant_key_store.merchant_id.clone().into();
-
-            cache::get_or_populate_in_memory_with_transform(
+            cache::get_or_populate_in_memory(
                 self,
                 &profile_cache_key(profile_id),
-                Some(PROFILE_REDIS_CACHE_TTL),
                 fetch_func,
-                |diesel_profile| async move {
-                    diesel_profile
-                        .convert(&state, &merchant_key_store.key, identifier)
-                        .await
-                        .change_context(StorageError::DecryptionError)
-                },
                 &ACCOUNTS_CACHE,
             )
+            .await?
+            .convert(
+                state,
+                merchant_key_store.key.get_inner(),
+                merchant_key_store.merchant_id.clone().into(),
+            )
             .await
+            .change_context(StorageError::DecryptionError)
         }
     }
 

--- a/crates/storage_impl/src/redis/cache.rs
+++ b/crates/storage_impl/src/redis/cache.rs
@@ -454,67 +454,6 @@ where
     }
 }
 
-/// Two-tier cache where redis (L2) holds type `R` — typically the encrypted diesel model — and
-/// the in-memory cache (L1) holds type `T` — typically the decrypted domain model.
-/// `transform_func` converts the redis representation into the in-memory one, so that the
-/// (potentially expensive) decryption is paid once per in-memory population rather than once per
-/// read.
-///
-/// `redis_ttl` is the time to live for the redis entry in seconds; `None` stores it without an
-/// expiry. It is deliberately independent of the in-memory cache's TTL so the two tiers can be
-/// tuned separately — set it longer than the in-memory TTL to let an expired in-memory entry be
-/// refilled from redis instead of the database.
-#[instrument(skip_all)]
-pub async fn get_or_populate_in_memory_with_transform<T, R, F, Fut, TransF, TransFut>(
-    store: &(dyn RedisConnInterface + Send + Sync),
-    key: &str,
-    redis_ttl: Option<i64>,
-    fetch_func: F,
-    transform_func: TransF,
-    cache: &Cache,
-) -> CustomResult<T, StorageError>
-where
-    T: Cacheable + Debug + Clone,
-    R: serde::Serialize + serde::de::DeserializeOwned + Debug + Send,
-    F: FnOnce() -> Fut + Send,
-    Fut: futures::Future<Output = CustomResult<R, StorageError>> + Send,
-    TransF: FnOnce(R) -> TransFut + Send,
-    TransFut: futures::Future<Output = CustomResult<T, StorageError>> + Send,
-{
-    let redis = &store
-        .get_redis_conn()
-        .change_context(StorageError::RedisError(
-            RedisError::RedisConnectionError.into(),
-        ))
-        .attach_printable("Failed to get redis connection")?;
-
-    let cache_val = cache
-        .get_val::<T>(CacheKey {
-            key: key.to_string(),
-            prefix: redis.redis_conn.key_prefix.clone(),
-        })
-        .await;
-    if let Some(val) = cache_val {
-        return Ok(val);
-    }
-
-    let redis_model = get_or_populate_redis(redis, key, redis_ttl, fetch_func).await?;
-
-    let domain_model = transform_func(redis_model).await?;
-
-    cache
-        .push(
-            CacheKey {
-                key: key.to_string(),
-                prefix: redis.redis_conn.key_prefix.clone(),
-            },
-            domain_model.clone(),
-        )
-        .await;
-
-    Ok(domain_model)
-}
-
 #[instrument(skip_all)]
 pub async fn redact_from_redis_and_publish<
     'a,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Make the in-memory cache for business profile encrypted. This is a conservative step until we get clarity on the PCI restrictions on decrypted in-memory caches.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Locally tested Payments Create + Confirm
Verified the business_profile cache was created in redis

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
