### PR TITLE
fix(openapi): correct list blocklist response schema and document pagination params

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -6483,6 +6483,40 @@
             "schema": {
               "$ref": "#/components/schemas/BlocklistDataKind"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of entries to return (default 10)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Zero-based offset for pagination (default 0)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "client_secret",
+            "in": "query",
+            "description": "Client secret, required when authenticating with a publishable key",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
           }
         ],
         "responses": {
@@ -6491,7 +6525,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BlocklistResponse"
+                  "$ref": "#/components/schemas/ListBlocklistResponse"
                 }
               }
             }
@@ -24339,6 +24373,33 @@
           "client_secret": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "ListBlocklistResponse": {
+        "type": "object",
+        "required": [
+          "count",
+          "total_count",
+          "data"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "description": "The number of blocked entries in the current response",
+            "minimum": 0
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "The total number of blocked entries for the given data_kind",
+            "minimum": 0
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlocklistResponse"
+            },
+            "description": "The list of blocked payment method entries"
           }
         }
       },

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -984,6 +984,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::PaymentLinkStatus,
         api_models::blocklist::BlocklistRequest,
         api_models::blocklist::BlocklistResponse,
+        api_models::blocklist::ListBlocklistResponse,
         api_models::blocklist::ToggleBlocklistResponse,
         api_models::blocklist::ListBlocklistQuery,
         api_models::blocklist::BatchBlocklistUploadResponse,

--- a/crates/openapi/src/routes/blocklist.rs
+++ b/crates/openapi/src/routes/blocklist.rs
@@ -47,9 +47,12 @@ pub async fn remove_entry_from_blocklist() {}
     path = "/blocklist",
     params (
         ("data_kind" = BlocklistDataKind, Query, description = "Kind of the fingerprint list requested"),
+        ("limit" = Option<u16>, Query, description = "Maximum number of entries to return (default 10)"),
+        ("offset" = Option<u16>, Query, description = "Zero-based offset for pagination (default 0)"),
+        ("client_secret" = Option<String>, Query, description = "Client secret, required when authenticating with a publishable key"),
     ),
     responses(
-        (status = 200, description = "Blocked Fingerprints", body = BlocklistResponse),
+        (status = 200, description = "Blocked Fingerprints", body = ListBlocklistResponse),
         (status = 400, description = "Invalid Data")
     ),
     tag = "Blocklist",

--- a/crates/router/src/routes/blocklist.rs
+++ b/crates/router/src/routes/blocklist.rs
@@ -105,6 +105,9 @@ pub async fn remove_entry_from_blocklist(
     path = "/blocklist",
     params (
         ("data_kind" = BlocklistDataKind, Query, description = "Kind of the fingerprint list requested"),
+        ("limit" = Option<u16>, Query, description = "Maximum number of entries to return (default 10)"),
+        ("offset" = Option<u16>, Query, description = "Zero-based offset for pagination (default 0)"),
+        ("client_secret" = Option<String>, Query, description = "Client secret, required when authenticating with a publishable key"),
     ),
     responses(
         (status = 200, description = "Blocked Fingerprints", body = ListBlocklistResponse),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

The published API reference for `GET /blocklist` does not match what the router returns.

The spec documents the 200 response as a single `BlocklistResponse` object (`fingerprint_id`,
`data_kind`, `created_at`), but the handler returns `ListBlocklistResponse` —
`{ count, total_count, data[] }`. It also documents only the `data_kind` query param, omitting
`limit`, `offset` and `client_secret`, all of which the endpoint accepts.

The effect is that `total_count` — the number of blocked entries for a given `data_kind` — is
invisible to anyone reading the API reference, along with the pagination params needed to use it.

The response type was already corrected in the router's own `utoipa` annotation, but the spec is
generated from the stub handlers in `crates/openapi/src/routes/`, which were never updated — so the
published spec never picked the change up.

Changes:

- `crates/openapi/src/routes/blocklist.rs` — `GET /blocklist` response body corrected to
  `ListBlocklistResponse`; documented the `limit`, `offset` and `client_secret` query params.
- `crates/openapi/src/openapi.rs` — registered `api_models::blocklist::ListBlocklistResponse` in
  `components(schemas(...))`. Without it the new `$ref` is dangling and `swagger-cli validate` fails.
- `crates/router/src/routes/blocklist.rs` — mirrored the same query params onto the router's
  annotation so the two copies stop drifting, which is what caused this in the first place.

The regenerated `api-reference/v1/openapi_spec_v1.json` follows in a subsequent commit on this
branch.

No runtime behaviour changes — this only corrects the generated documentation to describe the
response the endpoint has already been returning.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The blocklist APIs are being surfaced in the dashboard for BIN management. One of the required
capabilities is showing the total number of blocked BINs for a merchant. That count is already
returned by the API as `total_count`, but because the reference documents the wrong response type,
consumers cannot discover it and would otherwise assume it needs to be built.

## Linked Issues
<!-- Cloud issues are cross-repo + private, so `Fixes #` does NOT auto-close them. Use full URLs. -->
- Parent: https://github.com/juspay/hyperswitch-cloud/issues/22537
- Issue: https://github.com/juspay/hyperswitch-cloud/issues/22538

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Documentation-only change; there is no runtime code path to test.

Verified against the current behaviour: `list_blocklist_entries_for_merchant`
(`crates/router/src/core/blocklist/utils.rs`) builds and returns
`api_models::blocklist::ListBlocklistResponse { count, total_count, data }`, and
`ListBlocklistQuery` deserialises `data_kind`, `limit` (default 10), `offset` and `client_secret` —
which is what the spec now describes.

The generated spec is validated in CI by `validate-openapi-spec` (`cargo run -p openapi --features
v1` followed by `swagger-cli validate`), which also enforces that the committed spec matches the
annotations.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
