### PR TITLE
perf(migrations): add partial created_at indexes on events table

### DIFF
--- a/migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/down.sql
+++ b/migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX CONCURRENTLY IF EXISTS events_initiator_merchant_id_created_at_initial_index;

--- a/migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/metadata.toml
+++ b/migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/up.sql
+++ b/migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/up.sql
@@ -1,0 +1,12 @@
+-- Your SQL goes here
+-- Supports the webhook events list/count queries, which filter by initiator
+-- merchant, restrict `created_at` to a time range and sort by `created_at DESC`.
+-- Partial on the initial-attempt predicate so retry rows are excluded from the
+-- index entirely.
+--
+-- NOTE: `initiator_merchant_id` is NULL on the majority of existing rows. Until
+-- that column is backfilled, the list query's `initiator_merchant_id IS NULL AND
+-- merchant_id = ...` fallback branch is not served by this index.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS events_initiator_merchant_id_created_at_initial_index
+ON events (initiator_merchant_id, created_at)
+WHERE event_id = initial_attempt_id;

--- a/migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/up.sql
+++ b/migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/up.sql
@@ -1,12 +1,4 @@
 -- Your SQL goes here
--- Supports the webhook events list/count queries, which filter by initiator
--- merchant, restrict `created_at` to a time range and sort by `created_at DESC`.
--- Partial on the initial-attempt predicate so retry rows are excluded from the
--- index entirely.
---
--- NOTE: `initiator_merchant_id` is NULL on the majority of existing rows. Until
--- that column is backfilled, the list query's `initiator_merchant_id IS NULL AND
--- merchant_id = ...` fallback branch is not served by this index.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS events_initiator_merchant_id_created_at_initial_index
 ON events (initiator_merchant_id, created_at)
 WHERE event_id = initial_attempt_id;

--- a/migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/down.sql
+++ b/migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX CONCURRENTLY IF EXISTS events_business_profile_id_created_at_initial_index;

--- a/migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/metadata.toml
+++ b/migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/up.sql
+++ b/migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here
+-- Supports the profile-scoped webhook events list/count queries, which filter by
+-- business profile, restrict `created_at` to a time range and sort by
+-- `created_at DESC`. Partial on the initial-attempt predicate so retry rows are
+-- excluded from the index entirely.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS events_business_profile_id_created_at_initial_index
+ON events (business_profile_id, created_at)
+WHERE event_id = initial_attempt_id;

--- a/migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/up.sql
+++ b/migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/up.sql
@@ -1,8 +1,4 @@
 -- Your SQL goes here
--- Supports the profile-scoped webhook events list/count queries, which filter by
--- business profile, restrict `created_at` to a time range and sort by
--- `created_at DESC`. Partial on the initial-attempt predicate so retry rows are
--- excluded from the index entirely.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS events_business_profile_id_created_at_initial_index
 ON events (business_profile_id, created_at)
 WHERE event_id = initial_attempt_id;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

No index on the `events` table contains `created_at`, so the webhook events list and count
queries cannot seek on their time range and have to sort the full matched set before
applying `LIMIT`.

Adds two partial indexes:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS events_initiator_merchant_id_created_at_initial_index
ON events (initiator_merchant_id, created_at)
WHERE event_id = initial_attempt_id;

CREATE INDEX CONCURRENTLY IF NOT EXISTS events_business_profile_id_created_at_initial_index
ON events (business_profile_id, created_at)
WHERE event_id = initial_attempt_id;
```

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

- `migrations/2026-08-07-000001_add_events_initiator_merchant_id_created_at_index/`
- `migrations/2026-08-07-000002_add_events_business_profile_id_created_at_index/`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

`POST /events/profile/list` takes ~3 seconds even when it returns a single record.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

No Rust changes, so `fmt` / `clippy` / unit tests do not apply.
