### PR TITLE
ci(deja): trigger a Deja ART replay when the deja-art label is added 

### DIFF
--- a/.github/workflows/deja-art-replay.yml
+++ b/.github/workflows/deja-art-replay.yml
@@ -1,0 +1,30 @@
+name: Deja ART Replay
+
+on:
+  # This is a dangerous event trigger as it causes the workflow to run in the
+  # context of the target repository.
+  # Avoid checking out the head of the pull request or building code from the
+  # pull request whenever this trigger is used.
+  # Since this workflow only forwards the event payload to Jenkins and has no
+  # checkout step, this is an acceptable use of this trigger.
+  pull_request_target:
+    types:
+      - labeled
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-replay:
+    name: Trigger Jenkins Deja ART replay
+    if: ${{ github.event.label.name == 'deja-art' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Forward event to the Jenkins deja/art-replay job
+        run: |
+          curl -fsS --max-time 30 \
+            -H 'Content-Type: application/json' \
+            -H 'x-github-event: pull_request' \
+            --data @"$GITHUB_EVENT_PATH" \
+            "JENKINS_URL"


### PR DESCRIPTION


Forwards the pull_request labeled event payload to the Jenkins deja/art-replay job's generic-webhook-trigger endpoint, which filters on action=labeled, label=deja-art and PR state open. No PR code is checked out under the pull_request_target trigger; the workflow only relays the event JSON.



## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
