### PR TITLE
feat(routing): make DE diff counter a lifetime total and add a reset API

### DIFF
--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -1126,6 +1126,26 @@ fn de_diff_count_key(profile_id: &id_type::ProfileId) -> String {
     )
 }
 
+/// Clears the per-profile routing diff counter, releasing the kill-switch overlay (reset API).
+pub async fn reset_de_diff_counter(
+    state: &SessionState,
+    profile_id: &id_type::ProfileId,
+) -> errors::RouterResult<()> {
+    let redis_conn = state
+        .store
+        .get_redis_conn()
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("failed to get redis connection to reset routing diff counter")?;
+
+    redis_conn
+        .delete_key(&de_diff_count_key(profile_id).as_str().into())
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("failed to delete routing diff counter key")?;
+
+    Ok(())
+}
+
 /// Counts a non-volume DE-vs-HS diff and cuts the profile over to Hyperswitch at the threshold.
 pub async fn record_de_diff_and_maybe_trip_kill_switch(
     state: &SessionState,

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -2531,6 +2531,22 @@ impl RoutableConnectors {
     }
 }
 
+/// Clears the Decision Engine routing diff kill-switch counter for a profile, so the switch can
+/// trip again after the profile is re-enabled for the Decision Engine.
+pub async fn reset_decision_engine_diff_counter(
+    state: SessionState,
+    profile_id: common_utils::id_type::ProfileId,
+) -> RouterResult<service_api::ApplicationResponse<()>> {
+    reset_de_diff_counter(&state, &profile_id).await?;
+
+    router_env::logger::info!(
+        profile_id=?profile_id.get_string_repr(),
+        "decision_engine_euclid: routing diff counter reset via api"
+    );
+
+    Ok(service_api::ApplicationResponse::StatusOk)
+}
+
 pub async fn migrate_rules_for_profile(
     state: SessionState,
     processor: domain::Processor,

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1171,6 +1171,10 @@ impl Routing {
             .app_data(web::Data::new(state.clone()))
             .service(web::resource("/entry").route(web::post().to(routing::routing_entry)))
             .service(
+                web::resource("/decision-engine/{profile_id}/diff-counter")
+                    .route(web::delete().to(routing::reset_decision_engine_diff_counter)),
+            )
+            .service(
                 web::resource("/active").route(web::get().to(|state, req, query_params| {
                     routing::routing_retrieve_linked_config(state, req, query_params, None)
                 })),

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -87,6 +87,7 @@ impl From<Flow> for ApiIdentifier {
             | Flow::UpdateDynamicRoutingConfigs
             | Flow::DecisionManagerUpsertConfig
             | Flow::RoutingEvaluateRule
+            | Flow::DecisionEngineDiffCounterReset
             | Flow::DecisionEngineRuleMigration
             | Flow::VolumeSplitOnRoutingType
             | Flow::DecisionEngineDecideGatewayCall

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -1748,6 +1748,26 @@ pub async fn migrate_routing_rules_for_profile(
     .await
 }
 
+#[instrument(skip_all, fields(flow = ?Flow::DecisionEngineDiffCounterReset))]
+pub async fn reset_decision_engine_diff_counter(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    path: web::Path<common_utils::id_type::ProfileId>,
+) -> impl Responder {
+    let flow = Flow::DecisionEngineDiffCounterReset;
+    let profile_id = path.into_inner();
+    Box::pin(oss_api::server_wrap(
+        flow,
+        state,
+        &req,
+        profile_id.clone(),
+        |state, _, profile_id, _| routing::reset_decision_engine_diff_counter(state, profile_id),
+        &auth::AdminApiAuth,
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
 async fn get_merchant_account(
     state: &super::SessionState,
     merchant_id: &common_utils::id_type::MerchantId,

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -659,6 +659,8 @@ pub enum Flow {
     VolumeSplitOnRoutingType,
     /// Routing evaluate rule flow
     RoutingEvaluateRule,
+    /// Reset the Decision Engine routing diff kill-switch counter for a profile
+    DecisionEngineDiffCounterReset,
     /// Relay flow
     Relay,
     /// Relay retrieve flow


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

> **Stacked on #13564** — this PR is based on the `feat/routing-de-diff-kill-switch` branch, so the diff below is exactly the reset-API change. Please review after (or alongside) #13564; it should be merged after the base.

## Description

Follow-up to the Decision Engine routing diff kill switch (#13564). Adds a self-service admin API to reset a profile's routing diff counter.

**New endpoint** — `DELETE /routing/decision-engine/{profile_id}/diff-counter` (AdminApiAuth) deletes the per-profile counter key `routing_decision_engine_{profile_id}_diff_count`.

The base PR's counter is a lifetime total and enforcement is a read-time overlay (`get_routing_result_source` returns `HyperswitchRouting` while the counter is at/over the threshold, without touching the stored `routing_result_source`). So a tripped profile stays overlaid onto Hyperswitch routing — for both payment routing and the dashboard — until the counter is cleared. This endpoint is how ops clears it to re-enable the Decision Engine for a profile, instead of asking infra to `DEL` the Redis key by hand. Clearing the counter drops it below the threshold, so the overlay releases and the profile follows its configured `routing_result_source` again.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes #13598.

With the base PR the kill switch trips automatically but only clears when the counter is reset, which today means a manual Redis operation for infra. This gives operators a self-service reset so re-enabling a profile is an authenticated API call.

## How did you test it?

- `cargo check -p router` (v1 + redis-rs, and v2) — clean; `cargo clippy -p router` — no warnings in touched files; `cargo +nightly fmt --all` applied.
- **Verified end-to-end against a live local stack** (router + real Decision Engine, kill switch at `threshold=2`, a cut-over profile with a divergent DE rule):
  - Two diverging payments → routed via the DE result, counter reached `2` (lifetime, `TTL -1`); the third payment was overlaid to the Hyperswitch result.
  - `DELETE /routing/decision-engine/{profile_id}/diff-counter` with the admin key → `HTTP 200`, counter key deleted, `routing diff counter reset via api` logged, and the next payment routed via the DE result again — the overlay released and routing/dashboard reverted to the Decision Engine.
  - Same call without the admin key → `HTTP 401` (AdminApiAuth).
  - `routing_result_source` stayed `decision_engine` throughout — the reset operates purely on the counter, never the config.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
