### PR TITLE
fix(ucs): allow shadow event publishing

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2974,23 +2974,21 @@ where
         }
     };
 
-    if let ExecutionMode::Primary = execution_mode {
-        emit_ucs_connector_event(
-            state,
-            std::any::type_name::<T>(),
-            connector_name,
-            payment_id,
-            merchant_id,
-            refund_id,
-            dispute_id,
-            payout_id,
-            grpc_request_body,
-            status_code,
-            response_body,
-            external_latency,
-            execution_mode,
-        );
-    }
+    emit_ucs_connector_event(
+        state,
+        std::any::type_name::<T>(),
+        connector_name,
+        payment_id,
+        merchant_id,
+        refund_id,
+        dispute_id,
+        payout_id,
+        grpc_request_body,
+        status_code,
+        response_body,
+        external_latency,
+        execution_mode,
+    );
 
     // Set external latency on router data
     router_result.map(|mut router_data| {
@@ -3105,23 +3103,21 @@ where
         }
     };
 
-    if let ExecutionMode::Primary = execution_mode {
-        emit_ucs_connector_event(
-            state,
-            std::any::type_name::<T>(),
-            connector_name,
-            payment_id,
-            merchant_id,
-            refund_id,
-            dispute_id,
-            payout_id,
-            grpc_request_body,
-            status_code,
-            response_body,
-            external_latency,
-            execution_mode,
-        );
-    }
+    emit_ucs_connector_event(
+        state,
+        std::any::type_name::<T>(),
+        connector_name,
+        payment_id,
+        merchant_id,
+        refund_id,
+        dispute_id,
+        payout_id,
+        grpc_request_body,
+        status_code,
+        response_body,
+        external_latency,
+        execution_mode,
+    );
 
     // Set external latency on router data
     router_result.map(|mut router_data| {

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -197,23 +197,12 @@ impl SessionState {
             ExecutionMode::Shadow => Some("shadow"),
             ExecutionMode::NotApplicable => None,
         };
-        let config_override = match unified_connector_service_execution_mode {
-            ExecutionMode::Shadow => Some(
-                serde_json::json!({
-                    "events": {
-                        "enabled": false
-                    }
-                })
-                .to_string(),
-            ),
-            _ => None,
-        };
         GrpcHeadersUcs::builder()
             .tenant_id(tenant_id)
             .request_id(request_id)
             .shadow_mode(shadow_mode)
             .proxy_name(proxy_name)
-            .config_override(config_override)
+            .config_override(None)
     }
     #[cfg(all(feature = "revenue_recovery", feature = "v2"))]
     pub fn get_recovery_grpc_headers(&self) -> GrpcRecoveryHeaders {


### PR DESCRIPTION
## Summary
- remove the shadow-only `events.enabled=false` config override sent to UCS
- remove the HS-side `ExecutionMode::Primary` guards around UCS connector-event emission
- this fully reverts the shadow event suppressions introduced in #13069

## Why
- prod certification needs shadow connector events persisted in ClickHouse for both HS and Prism/UCS event streams
- HS analytics APIs still filter shadow connector events out of dashboard responses through `connector_events_core(...).filter(|event| !event.is_shadow())`

## Verification
- `cargo fmt --all --check`
- verified both connector-event API routes (`Hyperswitch` and `Prism`) go through the shared `connector_events_core` shadow filter
- verified HS shadow rows are tagged via `EventExecutionMode::from(execution_mode)`
- verified UCS still receives `x-shadow-mode` and no longer receives the events-disabled config override
