### PR TITLE
fix(superposition): fixed payouts superposition foldering options for max_retries

### DIFF
--- a/config/superposition_seed.toml
+++ b/config/superposition_seed.toml
@@ -2552,11 +2552,16 @@ client_session_validation_enabled = { value = true, schema = { type = "boolean" 
 "dynamic_fields.wallet.mifinity.language_preference._validation_regex_pattern" = { value = ".*", schema = { type = "string" } }
 "dynamic_fields.wallet.mifinity.language_preference._validation_rule_type" = { value = "no_validation", schema = { type = "string" } }
 "payments.enable_extended_card_bin" = { value = false, schema = { type = "boolean" }, description = "Whether to use extended card BIN (8-digit) for payment method data", change_reason = "Initial setup" }
+"payments.card_only_mit_supported_connector" = { value = false, schema = { type = "boolean" }, description = "Whether the connector supports card-only merchant-initiated transactions", change_reason = "Initial setup" }
+"payments.network_transaction_id_supported_connector" = { value = false, schema = { type = "boolean" }, description = "Whether the connector supports network transaction IDs", change_reason = "Initial setup" }
+"payments.installment_config_supported" = { value = false, schema = { type = "boolean" }, description = "Whether installment payment configuration is supported", change_reason = "Initial setup" }
 "payouts.gsm_payout_call" = { value = false, schema = { type = "boolean" }, description = "Whether to call GSM for payout retries", change_reason = "Initial setup" }
 "payments.implicit_customer_update" = { value = false, schema = { type = "boolean" }, description = "Whether to implicitly update customer details on payment", change_reason = "Initial setup" }
 "payments.block_implicit_customer_creation" = { value = false, schema = { type = "boolean" }, description = "Whether payments must reject implicit creation of a missing customer for an organization", change_reason = "Decouple implicit customer creation from PM modular eligibility" }
 "webhooks.incoming_webhook_disabled_events" = { value = false, schema = { type = "boolean" }, description = "Whether a specific incoming webhook event is disabled for a given connector", change_reason = "Initial setup" }
-"payouts.max_auto_payout_retries" = { value = 0, schema = { maximum = 4294967295, minimum = 0, type = "integer" }, description = "Maximum auto payout retries, differentiated by payout_retry_type dimension (single_connector or multi_connector)", change_reason = "Initial setup" }
+"webhooks.webhooks" = { value = { outgoing_enabled = true, redis_lock_expiry_seconds = 180 }, schema = { type = "object" }, description = "Outgoing webhook configuration", change_reason = "Initial setup" }
+"payouts.max_auto_single_connector_payout_retries_enabled" = { value = 3, schema = { maximum = 4294967295, minimum = 0, type = "integer" }, description = "Maximum auto payout retries for a single connector", change_reason = "Initial setup" }
+"payouts.max_auto_multiple_connector_payout_retries_enabled" = { value = 2, schema = { maximum = 4294967295, minimum = 0, type = "integer" }, description = "Maximum auto payout retries across multiple connectors", change_reason = "Initial setup" }
 "payouts.payout_tracker_mapping" = { value = { frequencies = [
     [
         300,
@@ -2635,19 +2640,17 @@ pt_mapping_outgoing_connector_webhooks = { value = { default_mapping = { frequen
     ],
 ], start_after = 60 } }, schema = { type = "object" }, description = "Revenue recovery (PCR) payment retry process tracker mapping configuration", change_reason = "Initial setup" }
 "process_tracker.pt_mapping_refund_sync" = { value = { default_mapping = { frequencies = [
-    [1800, 4],   # 30 min  *  4  =  2 hours
-    [7200, 2],   # 2 hour  *  2  =  4 hours
-    [21600, 3],  # 6 hour  *  3  = 18 hours
-    [43200, 4],  # 12 hour *  4  = 48 hours
-    [86400, 4],  # 24 hour *  4  = 96 hours
-], start_after = 60 }, max_retries_count = 17 }, schema = { type = "object" }, description = "Refund sync retry process tracker mapping configuration", change_reason = "Initial setup" }
+    [
+        300,
+        5,
+    ],
+], start_after = 60 }, max_retries_count = 5 }, schema = { type = "object" }, description = "Refund sync retry process tracker mapping configuration", change_reason = "Initial setup" }
 "payments.requires_cvv" = { value = true, schema = { type = "boolean" }, description = "Whether CVV is required for payments", change_reason = "Initial setup" }
 "routing.routing_result_source" = { value = "hyperswitch_routing", schema = { enum = [
     "decision_engine",
     "hyperswitch_routing",
 ], type = "string" }, description = "Source of routing result: decision_engine (external DE) or hyperswitch_routing (inbuilt)", change_reason = "Initial setup" }
 "vaulting.save_wallet_decrypted_data" = { value = false, schema = { type = "boolean" }, description = "Whether to save wallet decrypted data", change_reason = "Initial setup" }
-"vaulting.fingerprint_secret" = { value = "", schema = { type = "string" }, description = "Fingerprint secret used as a migration fallback for merchant accounts", change_reason = "Retain during merchant account migration" }
 "payments.should_call_gsm" = { value = false, schema = { type = "boolean" }, description = "Whether to call GSM (Global Status Mapping) for auto-retries on payment failure", change_reason = "Initial setup" }
 "system.should_call_pm_modular_service" = { value = false, schema = { type = "boolean" }, description = "Whether to call the PM modular service for a provider merchant, with organization fallback", change_reason = "Initial setup" }
 "vaulting.should_disable_vault_tokenization" = { value = false, schema = { type = "boolean" }, description = "Whether to disable vault tokenization for a merchant", change_reason = "Initial setup" }
@@ -2659,12 +2662,15 @@ should_schedule_modular_backward_compat = { value = false, schema = { type = "bo
 "system.should_schedule_modular_forward_compat" = { value = false, schema = { type = "boolean" }, description = "Whether to schedule PM modular forward compatibility PT for a provider merchant, with organization fallback", change_reason = "Initial setup" }
 "payments.should_store_eligibility_check_data_for_authentication" = { value = false, schema = { type = "boolean" }, description = "Whether to store eligibility check data during authentication", change_reason = "Initial setup" }
 "system.should_trigger_backwards_compatibility_inline" = { value = false, schema = { type = "boolean" }, description = "Whether to trigger PM modular backward compatibility inline for a provider merchant, with organization fallback", change_reason = "Initial setup" }
-"vaulting.should_trigger_fingerprint_migration" = { value = false, schema = { type = "boolean" }, description = "Whether to trigger fingerprint and entity_id migration for a merchant", change_reason = "Initial setup" }
-"routing.threeds_routing_region_uas" = { value = "region1", schema = { enum = [
+"vaulting.should_trigger_fingerprint_migration" = { value = true, schema = { type = "boolean" }, description = "Whether to trigger fingerprint and entity_id migration for a merchant", change_reason = "Initial setup" }
+"system.threeds_routing_region_uas" = { value = "region1", schema = { enum = [
     "region1",
     "region2",
 ], type = "string" }, description = "3DS routing region for UAS (Unified Authentication Service) per organization", change_reason = "Initial setup" }
 "vaulting.should_perform_sdk_vaulting" = { value = true, schema = { type = "boolean" }, description = "Org level override on top of should_call_pm_modular_service; when false the SDK skips vaulting", change_reason = "Initial setup" }
+"refunds_and_disputes.refund" = { value = { max_age = 365, max_attempts = 10 }, schema = { type = "object" }, description = "Refund age and attempt limits", change_reason = "Initial setup" }
+"refunds_and_disputes.dispute_supported_connector" = { value = false, schema = { type = "boolean" }, description = "Whether the connector supports disputes", change_reason = "Initial setup" }
+"session_misc.eph_key_validity" = { value = { validity = 1 }, schema = { type = "object" }, description = "Ephemeral key validity configuration", change_reason = "Initial setup" }
 
 
 [dimensions]

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -439,8 +439,7 @@ pub mod superposition {
         "payments.should_store_eligibility_check_data_for_authentication";
     /// Extended card BIN configuration key
     pub const ENABLE_EXTENDED_CARD_BIN: &str = "payments.enable_extended_card_bin";
-    /// Max auto payout retries configuration key
-    pub const MAX_AUTO_PAYOUT_RETRIES: &str = "payouts.max_auto_payout_retries";
+
     /// GSM payout call configuration key (scoped by merchant, profile, and payout retry type)
     pub const GSM_PAYOUT_CALL: &str = "payouts.gsm_payout_call";
     /// Disable vault tokenization configuration key
@@ -485,6 +484,12 @@ pub mod superposition {
     pub const INCOMING_WEBHOOK_DISABLED_EVENTS: &str = "webhooks.incoming_webhook_disabled_events";
     /// save wallet decrypted data in locker
     pub const SAVE_WALLET_DECRYPTED_DATA: &str = "vaulting.save_wallet_decrypted_data";
+    /// max auto single connector payout retries enabled configuration key
+    pub const MAX_AUTO_SINGLE_CONNECTOR_PAYOUT_RETRIES_ENABLED: &str =
+        "payouts.max_auto_single_connector_payout_retries_enabled";
+    /// max auto multiple connector payout retries enabled configuration key
+    pub const MAX_AUTO_MULTIPLE_CONNECTOR_PAYOUT_RETRIES_ENABLED: &str =
+        "payouts.max_auto_multiple_connector_payout_retries_enabled";
 }
 
 #[cfg(test)]

--- a/crates/router/src/core/configs/dimension_config.rs
+++ b/crates/router/src/core/configs/dimension_config.rs
@@ -113,6 +113,47 @@ macro_rules! config {
         }
     };
 
+    // Primitive config variant with an explicit legacy Superposition key.
+    // Use this when the first-degree key is not simply the final segment of
+    // the new foldered key.
+    (
+        superposition_key = $key:ident,
+        legacy_superposition_key = $legacy_key:literal,
+        output = $output:ty,
+        default = $default:expr,
+        requires = $requirement:ty,
+        targeting_key = $targeting_type:ty
+    ) => {
+        paste::paste! {
+            pub struct [<$key:camel>];
+
+            impl superposition::Config for [<$key:camel>] {
+                type Output = $output;
+                type TargetingKey = $targeting_type;
+                const SUPERPOSITION_KEY: &'static str = superposition_consts::$key;
+
+                fn legacy_superposition_key() -> Option<&'static str> {
+                    Some($legacy_key)
+                }
+
+                fn default_value() -> Self::Output {
+                    $default
+                }
+            }
+
+            impl $requirement {
+                pub async fn [<get_ $key:lower>](
+                    &self,
+                    storage: &dyn StorageInterface,
+                    superposition_client: &superposition::SuperpositionClient,
+                    targeting_key: Option<&$targeting_type>,
+                ) -> $output {
+                    fetch_db_config_for_dimensions::<[<$key:camel>]>(storage, superposition_client, self, targeting_key).await
+                }
+            }
+        }
+    };
+
     // Primitive config variant (no helper function - use get_{{key_name}}() directly on Dimensions)
     (
         superposition_key = $key:ident,
@@ -543,32 +584,68 @@ impl DatabaseBackedConfig for ClientSessionValidationEnabled {
 }
 
 config! {
-    superposition_key = MAX_AUTO_PAYOUT_RETRIES,
+    superposition_key = MAX_AUTO_SINGLE_CONNECTOR_PAYOUT_RETRIES_ENABLED,
+    legacy_superposition_key = "max_auto_single_connector_payout_retries",
     output = u32,
-    default = 0u32,
+    default = 3u32,
     requires = dimension_state::DimensionsWithProcessorAndProviderMerchantIdAndPayoutRetryType,
     targeting_key = id_type::CustomerId
 }
 
-impl DatabaseBackedConfig for MaxAutoPayoutRetries {
-    const KEY: &'static str = "max_auto_payout_retries";
+impl DatabaseBackedConfig for MaxAutoSingleConnectorPayoutRetriesEnabled {
+    const KEY: &'static str = "max_auto_single_connector_payout_retries_enabled";
+
     fn db_key(dimensions: &impl dimension_state::DimensionsBase) -> Option<String> {
         dimensions
             .get_processor_merchant_id()
-            .and_then(|merchant_id| {
-                dimensions
-                    .get_payout_retry_type()
-                    .map(|retry_type| match retry_type {
-                        common_enums::PayoutRetryType::SingleConnector => format!(
-                            "max_auto_single_connector_payout_retries_enabled_{}",
-                            merchant_id.get_string_repr()
-                        ),
-                        common_enums::PayoutRetryType::MultiConnector => format!(
-                            "max_auto_multiple_connector_payout_retries_enabled_{}",
-                            merchant_id.get_string_repr()
-                        ),
-                    })
-            })
+            .map(|merchant_id| format!("{}_{}", Self::KEY, merchant_id.get_string_repr()))
+    }
+}
+
+config! {
+    superposition_key = MAX_AUTO_MULTIPLE_CONNECTOR_PAYOUT_RETRIES_ENABLED,
+    legacy_superposition_key = "max_auto_payout_retries",
+    output = u32,
+    default = 2u32,
+    requires = dimension_state::DimensionsWithProcessorAndProviderMerchantIdAndPayoutRetryType,
+    targeting_key = id_type::CustomerId
+}
+
+impl DatabaseBackedConfig for MaxAutoMultipleConnectorPayoutRetriesEnabled {
+    const KEY: &'static str = "max_auto_multiple_connector_payout_retries_enabled";
+
+    fn db_key(dimensions: &impl dimension_state::DimensionsBase) -> Option<String> {
+        dimensions
+            .get_processor_merchant_id()
+            .map(|merchant_id| format!("{}_{}", Self::KEY, merchant_id.get_string_repr()))
+    }
+}
+
+impl dimension_state::DimensionsWithProcessorAndProviderMerchantIdAndPayoutRetryType {
+    pub async fn get_max_auto_payout_retries(
+        &self,
+        storage: &dyn StorageInterface,
+        superposition_client: &superposition::SuperpositionClient,
+        targeting_key: Option<&id_type::CustomerId>,
+    ) -> u32 {
+        match self.get_payout_retry_type() {
+            Some(common_enums::PayoutRetryType::SingleConnector) => {
+                self.get_max_auto_single_connector_payout_retries_enabled(
+                    storage,
+                    superposition_client,
+                    targeting_key,
+                )
+                .await
+            }
+            Some(common_enums::PayoutRetryType::MultiConnector) | None => {
+                self.get_max_auto_multiple_connector_payout_retries_enabled(
+                    storage,
+                    superposition_client,
+                    targeting_key,
+                )
+                .await
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
fixed payouts superposition foldering options for max_retries

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

### Main changes

- Replaces the single `payouts.max_auto_payout_retries` configuration with two second-degree keys:

  - `payouts.max_auto_single_connector_payout_retries_enabled`, default `3`
  - `payouts.max_auto_multiple_connector_payout_retries_enabled`, default `2`

- Retains the existing `get_max_auto_payout_retries()` interface. It selects the appropriate configuration based on `PayoutRetryType`:

  - `SingleConnector` → single-connector configuration
  - `MultiConnector` or missing retry type → multiple-connector configuration

- Extends the `config!` macro with `legacy_superposition_key`, allowing a foldered key to explicitly fall back to a differently named first-degree key.

- Preserves backward compatibility with legacy Superposition keys:

  - Single connector → `max_auto_single_connector_payout_retries`
  - Multiple connector → `max_auto_payout_retries`

- Keeps the existing merchant-specific database configuration keys unchanged through two separate `DatabaseBackedConfig` implementations.

### Additional Superposition seed changes

The PR also adds or moves several unrelated second-degree defaults:

- Payment connector capabilities under `payments.*`
- Webhook configuration under `webhooks.webhooks`
- Refund/dispute settings under `refunds_and_disputes.*`
- Ephemeral-key settings under `session_misc.*`
- Moves `routing.threeds_routing_region_uas` to `system.threeds_routing_region_uas`

### Notable behavioral changes

These deserve attention because they extend beyond the stated payout-foldering fix:

- Payout retry defaults change from unified `0` to single `3` and multiple `2`.
- Refund-sync retry configuration changes from 17 retries over several days to 5 retries at 5-minute intervals.
- `vaulting.should_trigger_fingerprint_migration` changes from `false` to `true`.
- `vaulting.fingerprint_secret` is removed from the seed configuration.
- No unit tests were added.

Overall, the runtime payout API remains compatible, while the underlying Superposition configuration is split into two second-degree keys with legacy lookup support. The seed-file changes include several additional behavioral changes that may be worth separating or explicitly documenting.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
