### PR TITLE
ci(deja): gate PRs on the deja-art label and the replay verdict

### DIFF
--- a/.github/workflows/deja-art-gate.yml
+++ b/.github/workflows/deja-art-gate.yml
@@ -1,0 +1,81 @@
+name: Deja ART Gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  checks: read
+
+concurrency:
+  group: deja-art-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deja-art-gate:
+    name: Deja ART verdict
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Require the deja-art label
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "${LABELS}" | jq -e 'index("deja-art")' > /dev/null; then
+            echo "deja-art label present."
+          else
+            echo "::error::Add the 'deja-art' label to run a Deja ART replay for this pull request."
+            exit 1
+          fi
+
+      - name: Wait for the Deja ART Replay verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "Waiting for the 'Deja ART Replay' check on ${HEAD_SHA}..."
+          ABSENT_POLLS=0
+          # 30s x 340 polls stays inside the 180-minute job timeout.
+          for _ in $(seq 1 340); do
+            RUN=$(
+              gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs?check_name=Deja%20ART%20Replay" \
+                --jq '.check_runs | sort_by(.started_at) | last'
+            )
+            STATUS=$(echo "${RUN}" | jq -r '.status // "absent"')
+            CONCLUSION=$(echo "${RUN}" | jq -r '.conclusion // empty')
+
+            if [ "${STATUS}" = "completed" ]; then
+              if [ "${CONCLUSION}" = "success" ]; then
+                echo "Deja ART replay verdict: PASS"
+                exit 0
+              fi
+              echo "::error::Deja ART replay concluded '${CONCLUSION:-unknown}'. Remove and re-add the 'deja-art' label to retry."
+              exit 1
+            fi
+
+            if [ "${STATUS}" = "absent" ]; then
+              ABSENT_POLLS=$((ABSENT_POLLS + 1))
+              # ~20 minutes with no check-run: the replay was likely never
+              # triggered for this commit (e.g. new commits were pushed after
+              # the label was added).
+              if [ "${ABSENT_POLLS}" -ge 40 ]; then
+                echo "::error::No Deja ART replay ran for this commit. Remove and re-add the 'deja-art' label to trigger one."
+                exit 1
+              fi
+              echo "No replay check for this commit yet..."
+            else
+              echo "Replay status: ${STATUS}"
+            fi
+
+            sleep 30
+          done
+
+          echo "::error::Timed out waiting for the Deja ART Replay verdict."
+          exit 1


### PR DESCRIPTION
The gate fails until the deja-art label is present, then polls the 'Deja ART Replay' check-run that Jenkins posts on the head commit and passes only when it concludes success. Uses only the built-in token (checks: read); no internal endpoints are touched.




## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
