### PR TITLE
feat(blocklist): add profile_id column to blocklist tables

### DIFF
--- a/crates/diesel_models/src/batch_blocklist_job.rs
+++ b/crates/diesel_models/src/batch_blocklist_job.rs
@@ -6,6 +6,8 @@ use time::PrimitiveDateTime;
 
 use crate::schema::batch_blocklist_jobs;
 
+// `profile_id` is read-only for now: the column exists and is selected, but
+// nothing writes or filters on it until the profile-scoping change lands.
 #[derive(Clone, Debug, Identifiable, Queryable, Selectable, Deserialize, Serialize)]
 #[diesel(table_name = batch_blocklist_jobs, primary_key(id), check_for_backend(diesel::pg::Pg))]
 pub struct BatchBlocklistJob {
@@ -17,6 +19,7 @@ pub struct BatchBlocklistJob {
     pub failed_rows: i32,
     pub created_at: PrimitiveDateTime,
     pub updated_at: PrimitiveDateTime,
+    pub profile_id: Option<id_type::ProfileId>,
 }
 
 #[derive(Clone, Debug, Insertable, Deserialize, Serialize)]

--- a/crates/diesel_models/src/blocklist.rs
+++ b/crates/diesel_models/src/blocklist.rs
@@ -15,6 +15,8 @@ pub struct BlocklistNew {
     pub created_by: Option<String>,
 }
 
+// `profile_id` is read-only for now: the column exists and is selected, but
+// nothing writes or filters on it until the profile-scoping change lands.
 #[derive(
     Clone, Debug, Eq, PartialEq, Identifiable, Queryable, Selectable, Deserialize, Serialize,
 )]
@@ -27,4 +29,5 @@ pub struct Blocklist {
     pub created_at: time::PrimitiveDateTime,
     pub processor_merchant_id: Option<common_utils::id_type::MerchantId>,
     pub created_by: Option<String>,
+    pub profile_id: Option<common_utils::id_type::ProfileId>,
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -202,6 +202,8 @@ diesel::table! {
         failed_rows -> Int4,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        #[max_length = 64]
+        profile_id -> Nullable<Varchar>,
     }
 }
 
@@ -221,6 +223,8 @@ diesel::table! {
         processor_merchant_id -> Nullable<Varchar>,
         #[max_length = 255]
         created_by -> Nullable<Varchar>,
+        #[max_length = 64]
+        profile_id -> Nullable<Varchar>,
     }
 }
 

--- a/crates/diesel_models/src/schema_v2.rs
+++ b/crates/diesel_models/src/schema_v2.rs
@@ -202,6 +202,8 @@ diesel::table! {
         failed_rows -> Int4,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        #[max_length = 64]
+        profile_id -> Nullable<Varchar>,
     }
 }
 
@@ -221,6 +223,8 @@ diesel::table! {
         processor_merchant_id -> Nullable<Varchar>,
         #[max_length = 255]
         created_by -> Nullable<Varchar>,
+        #[max_length = 64]
+        profile_id -> Nullable<Varchar>,
     }
 }
 

--- a/crates/router/src/db/batch_blocklist_job.rs
+++ b/crates/router/src/db/batch_blocklist_job.rs
@@ -126,6 +126,7 @@ impl BatchBlocklistJobInterface for MockDb {
             failed_rows: new.failed_rows,
             created_at: new.created_at,
             updated_at: new.updated_at,
+            profile_id: None,
         };
         jobs.push(job.clone());
         Ok(job)

--- a/crates/router/src/db/blocklist.rs
+++ b/crates/router/src/db/blocklist.rs
@@ -279,6 +279,7 @@ impl BlocklistInterface for MockDb {
                     created_at: entry.created_at,
                     processor_merchant_id: entry.processor_merchant_id,
                     created_by: entry.created_by,
+                    profile_id: None,
                 });
                 inserted += 1;
             }

--- a/migrations/2026-08-10-090000_add_profile_id_to_blocklist_tables/down.sql
+++ b/migrations/2026-08-10-090000_add_profile_id_to_blocklist_tables/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE blocklist DROP COLUMN IF EXISTS profile_id;
+
+ALTER TABLE batch_blocklist_jobs DROP COLUMN IF EXISTS profile_id;

--- a/migrations/2026-08-10-090000_add_profile_id_to_blocklist_tables/up.sql
+++ b/migrations/2026-08-10-090000_add_profile_id_to_blocklist_tables/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+
+ALTER TABLE blocklist ADD COLUMN IF NOT EXISTS profile_id VARCHAR(64);
+
+ALTER TABLE batch_blocklist_jobs ADD COLUMN IF NOT EXISTS profile_id VARCHAR(64);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

First of two PRs scoping the blocklist to the business profile. This one is schema preparation only:
it adds the `profile_id` column and wires it into the schema and the `Queryable` structs. Nothing
reads, writes or filters on it, and no constraint changes, so behaviour is unchanged.



### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

The blocklist is scoped to the merchant. Entries, the lookups on the payment hot path, and the guard
toggle are all keyed on merchant id, so a merchant running several business profiles cannot block a
card BIN on one profile while leaving it allowed on another — blocking one profile blocks all of
them. The `blocklist` primary key `(merchant_id, fingerprint_id)` and the unique index
`(processor_merchant_id, fingerprint_id)` both reject a second profile's insert of the same BIN as a
duplicate.

## Linked Issues

- Issue: https://github.com/juspay/hyperswitch-cloud/issues/22597

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
-->

Compile gate, both feature sets, run against exactly this commit:

- `cargo +nightly fmt --all -- --check` — clean
- `just check` — clean (4m37s)
- `just check_v2` — clean (3m44s)

`just clippy` / `just clippy_v2` are still running at the time of opening; I will confirm in a
comment and tick the checklist box once they land.

No behavioural test accompanies this PR, because there is no behaviour to test: the column is never
written, read or filtered on. The migration's up/down round-trip is covered by the existing
`migration-check` workflow, which runs `just migrate run --locked-schema` and
`just migrate redo --locked-schema --all` against both `diesel.toml` and `diesel_v2.toml` — that is
also what verifies the two schema files match the migration.

Existing blocklist coverage (`cypress-tests/.../41-CardPaymentBlocking.cy.js` and
`35-PaymentsEligibilityAPI.cy.js`) should be unaffected, since no request or response shape changes.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
