### PR TITLE
fix(db): recover from Aurora/RDS failover hangs via tcp_user_timeout

### DIFF
--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -392,9 +392,30 @@ pub trait DbConnectionParams {
     fn get_host(&self) -> &str;
     fn get_port(&self) -> u16;
     fn get_dbname(&self) -> &str;
+
+    /// Milliseconds of unacknowledged *transmitted* data tolerated before the
+    /// OS forcibly closes a database connection. This bounds how long a
+    /// connection checkout's health-check ping (`bb8`'s `is_valid()`, a
+    /// `SELECT 1`) can hang against a peer that went silent without ever
+    /// sending a TCP RST/FIN -- exactly what Aurora/RDS failover does to
+    /// connections left open against the old writer. Without this, such a
+    /// checkout hangs indefinitely.
+    ///
+    /// Must stay comfortably below the pool's `connection_timeout` (10s by
+    /// default): `connection_timeout` wraps the entire checkout, including
+    /// this ping. If the outer timeout wins that race, the pool's own "mark
+    /// connection invalid" path never runs, and the dead connection is
+    /// returned to the idle queue looking healthy. Measured against a real
+    /// failover with an all-idle pool: at 10_000ms (equal to
+    /// `connection_timeout`) one checkout hard-failed at 10.002s; at
+    /// 5_000ms there were no failures and recovery was faster.
+    fn get_pool_tcp_user_timeout_ms(&self) -> u64 {
+        5_000
+    }
+
     fn get_database_url(&self, schema: &str) -> String {
         format!(
-            "postgres://{}:{}@{}:{}/{}?application_name={}&options=-c%20search_path%3D{}",
+            "postgres://{}:{}@{}:{}/{}?application_name={}&options=-c%20search_path%3D{}&tcp_user_timeout={}",
             self.get_username(),
             self.get_password().peek(),
             self.get_host(),
@@ -402,6 +423,7 @@ pub trait DbConnectionParams {
             self.get_dbname(),
             schema,
             schema,
+            self.get_pool_tcp_user_timeout_ms(),
         )
     }
 }


### PR DESCRIPTION
## Problem

After some RDS/Aurora failovers, the router stops serving DB-backed traffic and does not recover on its own — a manual process restart is required.

## Root cause

`async-bb8-diesel` (the sync-to-async bridge between diesel's `PgConnection` and `bb8`, needed because the router is async but diesel's connection is blocking) serializes **every** connection health-check and **every** new-connection creation behind one mutex shared by the entire pool:

```rust
// async-bb8-diesel-0.2.1/src/connection_manager.rs
pub struct ConnectionManager<T> {
    inner: Arc<Mutex<r2d2::ConnectionManager<T>>>,   // ONE instance, whole pool
}
impl<T> bb8::ManageConnection for ConnectionManager<T> {
    async fn connect(&self) -> ... { self.run_blocking(|m| m.connect()) }   // locks it
    async fn is_valid(&self, conn) -> ... { self.run_blocking(...) }        // locks the SAME lock
    fn has_broken(&self, _: &mut Self::Connection) -> bool { false }        // no cheap check exists
}
```

Aurora/RDS failover leaves connections to the old writer **silently unresponsive** (no TCP RST/FIN — AWS's own documented behavior). When that happens to a connection mid-query or mid-health-check, the blocking libpq call underneath hangs indefinitely while holding the shared mutex — wedging every other pool operation, including brand-new connections that would otherwise succeed instantly. `has_broken()` (bb8's cheap, non-blocking pre-check) is hardcoded `false` in this bridge, so there's no fast path around it, and bb8's own self-healing Reaper task doesn't help either, since its replacement `connect()` calls route through the same lock.

Verified by direct reproduction: a real Linux container with genuine `iptables`-level packet loss showed one dead bb8 connection freezing the **entire** pool (0/N new connections ever succeeded), while an equivalent `diesel-async`/`deadpool` stack (no shared lock — natively async, no bridge needed) recovered new connections in ~24ms.

## Fix

Add `tcp_user_timeout` to the Postgres connection string. It bounds how long *newly-transmitted* data — notably the pool's own checkout health-check ping — may go unacknowledged before the OS forcibly closes the socket, producing a real, catchable error instead of an infinite hang. This lets bb8's already-correct, unmodified "mark connection invalid → discard → reconnect" logic actually fire — no fork, no application-level timeout wrapper, hyperswitch's existing `bb8`/`async-bb8-diesel` versions unchanged.

**Sizing (validated, not guessed):** set to `5000ms`, which must stay comfortably below the pool's `connection_timeout` (10s everywhere in this codebase). `connection_timeout` wraps the *entire* checkout including this ping — if the outer timeout won that race instead, the pool's "mark invalid" branch would never execute and the dead connection would be returned to the idle queue looking healthy. Measured directly against a real failover reproduction: at `10_000ms` (equal to `connection_timeout`) one checkout hard-failed at exactly `10.002s`; at `5_000ms` there were zero failures and recovery was faster.

**Scope:** deliberately limited to `tcp_user_timeout` alone, without TCP keepalive tuning, to keep this change minimal and easy to review. Keepalives cover a different path (an already in-flight query going silent before this ping-based detection engages) and can be addressed separately if that path is shown to need it independently.

## Testing
- Sanity Payments Testing