### PR TITLE
feat(router): add UCS kill switch circuit breaker

### DIFF
--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -365,6 +365,21 @@ pub const UCS_ROLLOUT_CONFIG_NOT_CONFIGURED: &str = "not_configured";
 // UCS feature enabled config
 pub const UCS_ENABLED: &str = "ucs_enabled";
 
+/// Redis key prefix for UCS kill switch error counts.
+/// Full key: `ucs_kill_switch_{rollout_config_key}`
+pub const UCS_KILL_SWITCH_REDIS_PREFIX: &str = "ucs_kill_switch";
+
+/// DB config key for the global UCS kill switch error threshold.
+/// Value is parsed as u64; default is 0 (a single error triggers the kill switch).
+pub const UCS_KILL_SWITCH_THRESHOLD: &str = "ucs_kill_switch_threshold";
+
+/// DB config key prefix to disable the kill switch for a specific rollout scope.
+/// Full key: `ucs_kill_switch_disabled_{rollout_config_key}`
+pub const UCS_KILL_SWITCH_DISABLED_PREFIX: &str = "ucs_kill_switch_disabled";
+
+/// TTL for the UCS kill switch error count Redis key, in seconds (1 day).
+pub const UCS_KILL_SWITCH_TTL_IN_SECS: u64 = 86400;
+
 /// Header value indicating that signature-key-based authentication is used.
 pub const UCS_AUTH_SIGNATURE_KEY: &str = "signature-key";
 

--- a/crates/router/src/core/authentication.rs
+++ b/crates/router/src/core/authentication.rs
@@ -399,7 +399,7 @@ async fn resolve_proxy_ucs_gateway_and_vault_mca<PayF: Clone, RdF: Clone, T, R>(
 where
     R: Send + Sync + Clone,
 {
-    let (execution_path, updated_state) =
+    let (execution_path, updated_state, _matched_rollout_config_key) =
         unified_connector_service::should_call_unified_connector_service(
             state,
             processor,
@@ -513,6 +513,7 @@ async fn call_ucs_pre_authenticate_proxy(
             processor,
             connector_enum,
             execution_mode,
+            None,
         ),
     )
     .await;
@@ -970,6 +971,7 @@ async fn call_ucs_post_authenticate_proxy<F: Clone>(
             external_vault_merchant_connector_account,
             processor,
             execution_mode,
+            None,
         ),
     )
     .await;
@@ -1379,7 +1381,7 @@ async fn call_ucs_authenticate_proxy(
             )
         });
 
-    let (execution_path, updated_state) =
+    let (execution_path, updated_state, _matched_rollout_config_key) =
         unified_connector_service::should_call_unified_connector_service(
             state,
             processor,
@@ -1462,6 +1464,7 @@ async fn call_ucs_authenticate_proxy(
             external_vault_merchant_connector_account,
             processor,
             execution_mode,
+            None,
             Some(
                 payment_intent
                     .force_3ds_challenge

--- a/crates/router/src/core/metrics.rs
+++ b/crates/router/src/core/metrics.rs
@@ -112,3 +112,6 @@ counter_metric!(SDK_AUTH_SESSION_VALIDATED_TOTAL, GLOBAL_METER); // No. of SDK a
 counter_metric!(SDK_AUTH_INVALID_SESSION_TOTAL, GLOBAL_METER); // No. of SDK auth requests with invalid session_id - tracked per merchant_id
 
 counter_metric!(FINGERPRINT_SECRET_SUPERPOSITION_FETCH_COUNT, GLOBAL_METER); // No. of fingerprint secret fetches from Superposition during migration fallback
+
+counter_metric!(UCS_KILL_SWITCH_ERROR_RECORDED, GLOBAL_METER); // No. of UCS errors recorded for kill switch evaluation
+counter_metric!(UCS_KILL_SWITCH_ACTIVATED, GLOBAL_METER); // No. of times UCS kill switch forced traffic to Direct path

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -3470,7 +3470,7 @@ where
 {
     let previous_gateway = extract_gateway_system_from_payment_intent(payment_data);
 
-    let (execution_path, updated_state) = should_call_unified_connector_service(
+    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
         state,
         platform.get_processor(),
         &router_data,
@@ -3527,6 +3527,7 @@ where
                     &external_vault_merchant_connector_account,
                     platform.get_processor(),
                     execution_mode,
+                    matched_rollout_config_key.clone(),
                 )
                 .await?;
             router_data
@@ -3549,6 +3550,7 @@ where
                         merchant_connector_account: merchant_connector_account.clone(),
                         execution_path,
                         execution_mode,
+                        matched_rollout_config_key: matched_rollout_config_key.clone(),
                     },
                 )
                 .await?;
@@ -3567,6 +3569,7 @@ where
                 merchant_connector_account: merchant_connector_account.clone(),
                 execution_path,
                 execution_mode,
+                matched_rollout_config_key,
             };
 
             let (connector_request, should_continue) = if should_continue_further {
@@ -6295,7 +6298,7 @@ where
     // Extract previous gateway from payment data
     let previous_gateway = extract_gateway_system_from_payment_intent(payment_data);
 
-    let (execution_path, updated_state) = should_call_unified_connector_service(
+    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
         state,
         processor,
         &router_data,
@@ -6326,6 +6329,7 @@ where
         merchant_connector_account: merchant_connector_account.clone(),
         execution_path,
         execution_mode,
+        matched_rollout_config_key,
     };
 
     if core_utils::get_flow_name::<F>().unwrap_or_default() != "PSync" {
@@ -6885,7 +6889,7 @@ where
     let previous_gateway = extract_gateway_system_from_payment_intent(payment_data);
 
     // do order creation
-    let (execution_path, updated_state) = should_call_unified_connector_service(
+    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
         state,
         platform.get_processor(),
         &router_data,
@@ -6916,6 +6920,7 @@ where
         merchant_connector_account: merchant_connector_account_type_details.clone(),
         execution_path,
         execution_mode,
+        matched_rollout_config_key,
     };
 
     let should_continue = match router_data
@@ -7017,7 +7022,7 @@ where
         // Extract previous gateway from payment data
         let previous_gateway = extract_gateway_system_from_payment_intent(payment_data);
 
-        let (execution_path, updated_state) = should_call_unified_connector_service(
+        let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
             state,
             processor,
             &router_data,
@@ -7047,6 +7052,7 @@ where
             merchant_connector_account: merchant_connector_account_type_details.clone(),
             execution_path,
             execution_mode,
+            matched_rollout_config_key,
         };
         let call_connector_service_response = call_connector_service(
             &updated_state,
@@ -7131,6 +7137,7 @@ where
                 external_vault_merchant_connector_account_type_details.clone(),
                 processor,
                 ExecutionMode::Primary, //UCS is called in primary mode
+                None,
             )
             .await?;
 
@@ -7212,7 +7219,7 @@ where
         )
         .await?;
 
-    let (execution_path, updated_state) = should_call_unified_connector_service(
+    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
         state,
         platform.get_processor(),
         &router_data,
@@ -7243,6 +7250,7 @@ where
         merchant_connector_account: merchant_connector_account.clone(),
         execution_path,
         execution_mode,
+        matched_rollout_config_key,
     };
 
     // Update feature metadata to track Direct routing usage for stickiness
@@ -8271,7 +8279,7 @@ where
     dyn api::Connector:
         services::api::ConnectorIntegration<F, RouterDReq, router_types::PaymentsResponseData>,
 {
-    let (execution_path, updated_state) = should_call_unified_connector_service(
+    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
         state,
         processor,
         &router_data,
@@ -8302,6 +8310,7 @@ where
         merchant_connector_account: merchant_connector_account.clone(),
         execution_path,
         execution_mode,
+        matched_rollout_config_key,
     };
 
     router_data

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -3470,16 +3470,17 @@ where
 {
     let previous_gateway = extract_gateway_system_from_payment_intent(payment_data);
 
-    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
-        state,
-        platform.get_processor(),
-        &router_data,
-        previous_gateway,
-        call_connector_action.clone(),
-        None,
-        common_enums::TransactionType::Payment,
-    )
-    .await?;
+    let (execution_path, updated_state, matched_rollout_config_key) =
+        should_call_unified_connector_service(
+            state,
+            platform.get_processor(),
+            &router_data,
+            previous_gateway,
+            call_connector_action.clone(),
+            None,
+            common_enums::TransactionType::Payment,
+        )
+        .await?;
 
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
@@ -6298,16 +6299,17 @@ where
     // Extract previous gateway from payment data
     let previous_gateway = extract_gateway_system_from_payment_intent(payment_data);
 
-    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
-        state,
-        processor,
-        &router_data,
-        previous_gateway,
-        call_connector_action.clone(),
-        shadow_ucs_call_connector_action.clone(),
-        common_enums::TransactionType::Payment,
-    )
-    .await?;
+    let (execution_path, updated_state, matched_rollout_config_key) =
+        should_call_unified_connector_service(
+            state,
+            processor,
+            &router_data,
+            previous_gateway,
+            call_connector_action.clone(),
+            shadow_ucs_call_connector_action.clone(),
+            common_enums::TransactionType::Payment,
+        )
+        .await?;
 
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
@@ -6889,16 +6891,17 @@ where
     let previous_gateway = extract_gateway_system_from_payment_intent(payment_data);
 
     // do order creation
-    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
-        state,
-        platform.get_processor(),
-        &router_data,
-        previous_gateway,
-        call_connector_action.clone(),
-        None,
-        common_enums::TransactionType::Payment,
-    )
-    .await?;
+    let (execution_path, updated_state, matched_rollout_config_key) =
+        should_call_unified_connector_service(
+            state,
+            platform.get_processor(),
+            &router_data,
+            previous_gateway,
+            call_connector_action.clone(),
+            None,
+            common_enums::TransactionType::Payment,
+        )
+        .await?;
 
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
@@ -7022,16 +7025,17 @@ where
         // Extract previous gateway from payment data
         let previous_gateway = extract_gateway_system_from_payment_intent(payment_data);
 
-        let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
-            state,
-            processor,
-            &router_data,
-            previous_gateway,
-            call_connector_action.clone(),
-            None,
-            common_enums::TransactionType::Payment,
-        )
-        .await?;
+        let (execution_path, updated_state, matched_rollout_config_key) =
+            should_call_unified_connector_service(
+                state,
+                processor,
+                &router_data,
+                previous_gateway,
+                call_connector_action.clone(),
+                None,
+                common_enums::TransactionType::Payment,
+            )
+            .await?;
         let lineage_ids = grpc_client::LineageIds::new(
             business_profile.merchant_id.clone(),
             business_profile.get_id().clone(),
@@ -7219,16 +7223,17 @@ where
         )
         .await?;
 
-    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
-        state,
-        platform.get_processor(),
-        &router_data,
-        None,
-        call_connector_action.clone(),
-        None,
-        common_enums::TransactionType::Payment,
-    )
-    .await?;
+    let (execution_path, updated_state, matched_rollout_config_key) =
+        should_call_unified_connector_service(
+            state,
+            platform.get_processor(),
+            &router_data,
+            None,
+            call_connector_action.clone(),
+            None,
+            common_enums::TransactionType::Payment,
+        )
+        .await?;
 
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),
@@ -8279,16 +8284,17 @@ where
     dyn api::Connector:
         services::api::ConnectorIntegration<F, RouterDReq, router_types::PaymentsResponseData>,
 {
-    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
-        state,
-        processor,
-        &router_data,
-        None, // No previous gateway information required for session flow
-        call_connector_action.clone(),
-        None,
-        common_enums::TransactionType::Payment,
-    )
-    .await?;
+    let (execution_path, updated_state, matched_rollout_config_key) =
+        should_call_unified_connector_service(
+            state,
+            processor,
+            &router_data,
+            None, // No previous gateway information required for session flow
+            call_connector_action.clone(),
+            None,
+            common_enums::TransactionType::Payment,
+        )
+        .await?;
 
     let lineage_ids = grpc_client::LineageIds::new(
         business_profile.merchant_id.clone(),

--- a/crates/router/src/core/payments/flows.rs
+++ b/crates/router/src/core/payments/flows.rs
@@ -323,6 +323,7 @@ pub trait Feature<F, T> {
         _external_vault_merchant_connector_account: domain::MerchantConnectorAccountTypeDetails,
         _processor: &domain::Processor,
         _unified_connector_service_execution_mode: common_enums::ExecutionMode,
+        _matched_rollout_config_key: Option<String>,
     ) -> RouterResult<()>
     where
         F: Clone,
@@ -342,6 +343,7 @@ pub trait Feature<F, T> {
         _external_vault_merchant_connector_account: &'a helpers::MerchantConnectorAccountType,
         _processor: &domain::Processor,
         _unified_connector_service_execution_mode: common_enums::ExecutionMode,
+        _matched_rollout_config_key: Option<String>,
     ) -> RouterResult<()>
     where
         F: Clone,

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -1589,6 +1589,7 @@ pub async fn call_unified_connector_service_pre_authenticate(
     processor: &domain::Processor,
     connector: enums::connector_enums::Connector,
     unified_connector_service_execution_mode: enums::ExecutionMode,
+    matched_rollout_config_key: Option<String>,
 ) -> errors::CustomResult<
     (
         types::RouterData<
@@ -1647,6 +1648,7 @@ pub async fn call_unified_connector_service_pre_authenticate(
         payment_pre_authenticate_request,
         headers_builder,
         unified_connector_service_execution_mode,
+        matched_rollout_config_key,
         |mut router_data, payment_pre_authenticate_request, grpc_headers| async move {
             let response = client
                 .payment_pre_authenticate(
@@ -1717,6 +1719,7 @@ pub async fn call_unified_connector_service_pre_authenticate_proxy(
     processor: &domain::Processor,
     connector: enums::connector_enums::Connector,
     unified_connector_service_execution_mode: enums::ExecutionMode,
+    matched_rollout_config_key: Option<String>,
 ) -> errors::CustomResult<
     types::RouterData<
         api::PreAuthenticate,
@@ -1793,6 +1796,7 @@ pub async fn call_unified_connector_service_pre_authenticate_proxy(
             payment_pre_authenticate_request,
             headers_builder,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, payment_pre_authenticate_request, grpc_headers| async move {
                 let response = Box::pin(client.payment_pre_authenticate(
                     payment_pre_authenticate_request,

--- a/crates/router/src/core/payments/flows/complete_authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/complete_authorize_flow.rs
@@ -762,6 +762,7 @@ pub async fn call_unified_connector_service_authenticate(
     processor: &domain::Processor,
     connector: connector_enums::Connector,
     unified_connector_service_execution_mode: common_enums::ExecutionMode,
+    matched_rollout_config_key: Option<String>,
 ) -> errors::CustomResult<
     types::RouterData<
         api::Authenticate,
@@ -816,6 +817,7 @@ pub async fn call_unified_connector_service_authenticate(
         payment_authenticate_request,
         headers_builder,
         unified_connector_service_execution_mode,
+        matched_rollout_config_key,
         |mut router_data, payment_authenticate_request, grpc_headers| async move {
             let response = Box::pin(client.payment_authenticate(
                 payment_authenticate_request,
@@ -889,6 +891,7 @@ pub async fn call_unified_connector_service_authenticate_proxy(
     external_vault_merchant_connector_account: helpers::MerchantConnectorAccountType,
     processor: &domain::Processor,
     unified_connector_service_execution_mode: common_enums::ExecutionMode,
+    matched_rollout_config_key: Option<String>,
     force_3ds_challenge: Option<bool>,
     notification_url: Option<common_utils::types::Url>,
     acquirer_metadata: Option<serde_json::Value>,
@@ -975,6 +978,7 @@ pub async fn call_unified_connector_service_authenticate_proxy(
         payment_authenticate_request,
         headers_builder,
         unified_connector_service_execution_mode,
+        matched_rollout_config_key,
         |mut router_data, payment_authenticate_request, grpc_headers| async move {
             let response = Box::pin(client.payment_authenticate(
                 payment_authenticate_request,
@@ -1027,6 +1031,7 @@ pub async fn call_unified_connector_service_post_authenticate(
     #[cfg(feature = "v2")] merchant_connector_account: domain::MerchantConnectorAccountTypeDetails,
     processor: &domain::Processor,
     unified_connector_service_execution_mode: common_enums::ExecutionMode,
+    matched_rollout_config_key: Option<String>,
 ) -> errors::CustomResult<
     types::RouterData<
         api::PostAuthenticate,
@@ -1081,6 +1086,7 @@ pub async fn call_unified_connector_service_post_authenticate(
         payment_post_authenticate_request,
         headers_builder,
         unified_connector_service_execution_mode,
+        matched_rollout_config_key,
         |mut router_data, payment_post_authenticate_request, grpc_headers| async move {
             let response = Box::pin(client.payment_post_authenticate(
                 payment_post_authenticate_request,
@@ -1150,6 +1156,7 @@ pub async fn call_unified_connector_service_post_authenticate_proxy(
     external_vault_merchant_connector_account: helpers::MerchantConnectorAccountType,
     processor: &domain::Processor,
     unified_connector_service_execution_mode: common_enums::ExecutionMode,
+    matched_rollout_config_key: Option<String>,
 ) -> errors::CustomResult<
     types::RouterData<
         api::PostAuthenticate,
@@ -1224,6 +1231,7 @@ pub async fn call_unified_connector_service_post_authenticate_proxy(
         payment_post_authenticate_request,
         headers_builder,
         unified_connector_service_execution_mode,
+        matched_rollout_config_key,
         |mut router_data, payment_post_authenticate_request, grpc_headers| async move {
             let response = Box::pin(client.payment_post_authenticate(
                 payment_post_authenticate_request,

--- a/crates/router/src/core/payments/flows/external_proxy_flow.rs
+++ b/crates/router/src/core/payments/flows/external_proxy_flow.rs
@@ -407,6 +407,7 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
         external_vault_merchant_connector_account: domain::MerchantConnectorAccountTypeDetails,
         processor: &domain::Processor,
         unified_connector_service_execution_mode: enums::ExecutionMode,
+        matched_rollout_config_key: Option<String>,
     ) -> RouterResult<()> {
         let client = state
             .grpc_client
@@ -462,6 +463,7 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
             payment_authorize_request.clone(),
             headers_builder,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key.clone(),
             |mut router_data, payment_authorize_request, grpc_headers| async move {
                 let response = Box::pin(client
                     .payment_authorize(
@@ -521,6 +523,7 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
         external_vault_merchant_connector_account: &'a helpers::MerchantConnectorAccountType,
         processor: &domain::Processor,
         unified_connector_service_execution_mode: enums::ExecutionMode,
+        matched_rollout_config_key: Option<String>,
     ) -> RouterResult<()> {
         let client = state
             .grpc_client
@@ -578,6 +581,7 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
             payment_authorize_request.clone(),
             headers_builder,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key.clone(),
             |mut router_data, payment_authorize_request, grpc_headers| async move {
                 let response = Box::pin(client
                     .payment_authorize(

--- a/crates/router/src/core/payments/gateway/access_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/access_token_gateway.rs
@@ -80,6 +80,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
 
         let client = state
             .grpc_client
@@ -165,6 +166,7 @@ where
             create_access_token_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, create_access_token_request, grpc_headers| async move {
                 let response = match client
                     .create_access_token(

--- a/crates/router/src/core/payments/gateway/authenticate_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authenticate_gateway.rs
@@ -67,6 +67,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let connector_enum =
             common_enums::connector_enums::Connector::from_str(&router_data.connector)
                 .change_context(ConnectorError::InvalidConnectorName)
@@ -80,6 +81,7 @@ where
             processor,
             connector_enum,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
         )
         .await
     }

--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -75,6 +75,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -135,6 +136,7 @@ where
                 recurring_payment_charge_request,
                 grpc_headers,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key.clone(),
                 |mut router_data, recurring_payment_charge_request, grpc_headers| async move {
                     let response = match Box::pin(client.recurring_payment_charge(
                         recurring_payment_charge_request,
@@ -241,6 +243,7 @@ where
                 granular_authorize_request,
                 grpc_headers,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, granular_authorize_request, grpc_headers| async move {
                     let response = match Box::pin(client.payment_authorize(
                         granular_authorize_request,

--- a/crates/router/src/core/payments/gateway/cancel_gateway.rs
+++ b/crates/router/src/core/payments/gateway/cancel_gateway.rs
@@ -65,6 +65,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -114,6 +115,7 @@ where
             payment_void_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, payment_void_request, grpc_headers| async move {
                 let response = match client
                     .payment_void(payment_void_request, connector_auth_metadata, grpc_headers)

--- a/crates/router/src/core/payments/gateway/capture_gateway.rs
+++ b/crates/router/src/core/payments/gateway/capture_gateway.rs
@@ -65,6 +65,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -112,6 +113,7 @@ where
             payment_capture_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, payment_capture_request, grpc_headers| async move {
                 let response = match client
                     .payment_capture(

--- a/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
@@ -69,6 +69,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -117,6 +118,7 @@ where
             granular_authorize_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, granular_authorize_request, grpc_headers| async move {
                 let response = match Box::pin(client.payment_authorize(
                     granular_authorize_request,

--- a/crates/router/src/core/payments/gateway/context.rs
+++ b/crates/router/src/core/payments/gateway/context.rs
@@ -42,6 +42,10 @@ pub struct RouterGatewayContext {
 
     /// Execution path (Direct, UCS, or Shadow)
     pub execution_path: ExecutionPath,
+
+    /// The rollout config key matched during UCS execution path resolution.
+    /// Used by the UCS kill switch to scope error counting.
+    pub matched_rollout_config_key: Option<String>,
 }
 
 impl RouterGatewayContext {
@@ -73,6 +77,7 @@ impl RouterGatewayContext {
             execution_mode,
             execution_path,
             creds_identifier,
+            matched_rollout_config_key: None,
         }
     }
     pub fn direct(
@@ -93,6 +98,7 @@ impl RouterGatewayContext {
             execution_mode: ExecutionMode::NotApplicable,
             execution_path: ExecutionPath::Direct,
             creds_identifier,
+            matched_rollout_config_key: None,
         }
     }
 }

--- a/crates/router/src/core/payments/gateway/create_customer_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_customer_gateway.rs
@@ -74,6 +74,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
 
         let client = state
             .grpc_client
@@ -125,6 +126,7 @@ where
             create_connector_customer_request,
             grpc_headers,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, create_connector_customer_request, grpc_headers| async move {
                 let response = match Box::pin(client.create_connector_customer(
                     create_connector_customer_request,

--- a/crates/router/src/core/payments/gateway/create_order_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_order_gateway.rs
@@ -70,6 +70,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -117,6 +118,7 @@ where
             create_order_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, create_order_request, grpc_headers| async move {
                 let response = match Box::pin(client.payment_create_order(
                     create_order_request,

--- a/crates/router/src/core/payments/gateway/incremental_authorization_gateway.rs
+++ b/crates/router/src/core/payments/gateway/incremental_authorization_gateway.rs
@@ -78,6 +78,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -128,6 +129,7 @@ where
                 incremental_authorization_request,
                 header_payload,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, incremental_authorization_request, grpc_headers| async move {
                     let response = match Box::pin(client.payment_incremental_authorization(
                         incremental_authorization_request,

--- a/crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs
+++ b/crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs
@@ -76,6 +76,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -122,6 +123,7 @@ where
             payment_method_tokenize_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, payment_method_tokenize_request, grpc_headers| async move {
                 let response = match Box::pin(client.payment_method_tokenize(
                     payment_method_tokenize_request,

--- a/crates/router/src/core/payments/gateway/post_authenticate_gateway.rs
+++ b/crates/router/src/core/payments/gateway/post_authenticate_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         complete_authorize_flow::call_unified_connector_service_post_authenticate(
             router_data,
             state,
@@ -71,6 +72,7 @@ where
             merchant_connector_account,
             processor,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
         )
         .await
     }

--- a/crates/router/src/core/payments/gateway/pre_authenticate_gateway.rs
+++ b/crates/router/src/core/payments/gateway/pre_authenticate_gateway.rs
@@ -66,6 +66,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let connector_enum =
             common_enums::connector_enums::Connector::from_str(&router_data.connector)
                 .change_context(ConnectorError::InvalidConnectorName)
@@ -79,6 +80,7 @@ where
             processor,
             connector_enum,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
         )
         .await
         .map(|(router_data, _)| router_data)

--- a/crates/router/src/core/payments/gateway/pre_authorize_void_gateway.rs
+++ b/crates/router/src/core/payments/gateway/pre_authorize_void_gateway.rs
@@ -73,6 +73,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -122,6 +123,7 @@ where
             payment_void_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, payment_void_request, grpc_headers| async move {
                 let response = match client
                     .payment_void(payment_void_request, connector_auth_metadata, grpc_headers)

--- a/crates/router/src/core/payments/gateway/psync_gateway.rs
+++ b/crates/router/src/core/payments/gateway/psync_gateway.rs
@@ -133,6 +133,7 @@ where
                 let lineage_ids = context.lineage_ids;
                 let header_payload = context.header_payload;
                 let unified_connector_service_execution_mode = context.execution_mode;
+                let matched_rollout_config_key = context.matched_rollout_config_key;
                 let is_ucs_psync_disabled = state
                     .conf
                     .grpc_client
@@ -199,6 +200,7 @@ where
                     payment_get_request,
                     header_payload,
                     unified_connector_service_execution_mode,
+                    matched_rollout_config_key,
                     |mut router_data, payment_get_request, grpc_headers| async move {
                         let response = match client
                             .payment_get(payment_get_request, connector_auth_metadata, grpc_headers)

--- a/crates/router/src/core/payments/gateway/session_gateway.rs
+++ b/crates/router/src/core/payments/gateway/session_gateway.rs
@@ -70,6 +70,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -118,6 +119,7 @@ where
                 create_sdk_session_token_request,
                 header_payload,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, create_sdk_session_token_request, grpc_headers| async move {
                     let response = match Box::pin(client.create_sdk_session_token(
                         create_sdk_session_token_request,

--- a/crates/router/src/core/payments/gateway/session_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/session_token_gateway.rs
@@ -72,6 +72,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
 
         let client = state
             .grpc_client
@@ -120,6 +121,7 @@ where
             create_session_token_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, create_session_token_request, grpc_headers| async move {
                 let response = match client
                     .create_session_token(

--- a/crates/router/src/core/payments/gateway/setup_mandate.rs
+++ b/crates/router/src/core/payments/gateway/setup_mandate.rs
@@ -68,6 +68,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -115,6 +116,7 @@ where
             payment_setup_recurring_request,
             header_payload,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, payment_setup_recurring_request, grpc_headers| async move {
                 let response = match Box::pin(client.payment_setup_recurring(
                     payment_setup_recurring_request,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2561,6 +2561,9 @@ pub struct RolloutExecutionResult {
     pub should_execute: bool,
     pub proxy_override: Option<ProxyOverride>,
     pub execution_mode: ExecutionMode,
+    /// The DB config key that was matched during rollout precedence resolution.
+    /// Used by the UCS kill switch to scope error counting and threshold checks.
+    pub matched_config_key: Option<String>,
 }
 
 impl Default for RolloutExecutionResult {
@@ -2569,6 +2572,7 @@ impl Default for RolloutExecutionResult {
             should_execute: false,
             proxy_override: None,
             execution_mode: ExecutionMode::NotApplicable,
+            matched_config_key: None,
         }
     }
 }
@@ -2656,6 +2660,7 @@ impl From<RolloutConfig> for RolloutExecutionResult {
                             should_execute: true,
                             proxy_override,
                             execution_mode: config.execution_mode,
+                            matched_config_key: None,
                         }
                     }
                     false => {
@@ -2764,7 +2769,7 @@ pub async fn should_execute_based_on_rollout_with_precedence(
             }
             Some(config) => {
                 logger::info!(config_key = %key, "Rollout config found, using this key");
-                return Ok(serde_json::from_str::<RolloutConfig>(&config.config)
+                let mut result = serde_json::from_str::<RolloutConfig>(&config.config)
                     .map(RolloutExecutionResult::from)
                     .map_err(|err| {
                         logger::error!(
@@ -2774,7 +2779,9 @@ pub async fn should_execute_based_on_rollout_with_precedence(
                         );
                         RolloutExecutionResult::default()
                     })
-                    .unwrap_or_default());
+                    .unwrap_or_default();
+                result.matched_config_key = Some(key.clone());
+                return Ok(result);
             }
             None => {
                 // Unexpected DB error — skip and try next key

--- a/crates/router/src/core/payouts.rs
+++ b/crates/router/src/core/payouts.rs
@@ -4082,7 +4082,7 @@ pub async fn decide_unified_connector_service_payout<F: Clone>(
     // Extract previous gateway from payment data
     let previous_gateway = extract_gateway_system_from_payouts(payout_data);
 
-    let (execution_path, updated_state) = should_call_unified_connector_service(
+    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
         state,
         platform.get_processor(),
         router_data,
@@ -4138,6 +4138,7 @@ pub async fn decide_unified_connector_service_payout<F: Clone>(
         merchant_connector_account,
         execution_path,
         execution_mode,
+        matched_rollout_config_key,
     };
     // Update feature metadata to track Direct routing usage for stickiness
     update_gateway_system_in_payout_metadata(payout_data, gateway_context.get_gateway_system())?;

--- a/crates/router/src/core/payouts.rs
+++ b/crates/router/src/core/payouts.rs
@@ -4082,16 +4082,17 @@ pub async fn decide_unified_connector_service_payout<F: Clone>(
     // Extract previous gateway from payment data
     let previous_gateway = extract_gateway_system_from_payouts(payout_data);
 
-    let (execution_path, updated_state, matched_rollout_config_key) = should_call_unified_connector_service(
-        state,
-        platform.get_processor(),
-        router_data,
-        previous_gateway,
-        common_enums::enums::CallConnectorAction::Trigger,
-        None,
-        common_enums::TransactionType::Payout,
-    )
-    .await?;
+    let (execution_path, updated_state, matched_rollout_config_key) =
+        should_call_unified_connector_service(
+            state,
+            platform.get_processor(),
+            router_data,
+            previous_gateway,
+            common_enums::enums::CallConnectorAction::Trigger,
+            None,
+            common_enums::TransactionType::Payout,
+        )
+        .await?;
 
     let lineage_ids = grpc_client::LineageIds::new(
         payout_data.payouts.merchant_id.clone(),

--- a/crates/router/src/core/payouts/gateway/cancel_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/cancel_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -111,6 +112,7 @@ where
                 granular_payout_void_request,
                 grpc_headers,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, granular_payout_void_request, grpc_headers| async move {
                     let response = Box::pin(client.payout_void(
                         granular_payout_void_request,

--- a/crates/router/src/core/payouts/gateway/context.rs
+++ b/crates/router/src/core/payouts/gateway/context.rs
@@ -26,6 +26,9 @@ pub struct RouterGatewayContext {
     pub execution_path: ExecutionPath,
     /// Execution mode (Primary or Shadow)
     pub execution_mode: ExecutionMode,
+    /// The rollout config key matched during UCS execution path resolution.
+    /// Used by the UCS kill switch to scope error counting.
+    pub matched_rollout_config_key: Option<String>,
 }
 impl RouterGatewayContext {
     /// Get the gateway system (Direct, UnifiedConnectorService, etc.)

--- a/crates/router/src/core/payouts/gateway/create_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/create_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -116,6 +117,7 @@ where
                 granular_payout_create_request,
                 grpc_headers,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, granular_payout_create_request, grpc_headers| async move {
                     let response = Box::pin(client.payout_create(
                         granular_payout_create_request,

--- a/crates/router/src/core/payouts/gateway/eligibility_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/eligibility_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -111,6 +112,7 @@ where
                 granular_payout_eligibility_request,
                 grpc_headers,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, granular_payout_eligibility_request, grpc_headers| async move {
                     let response = Box::pin(client.payout_eligibility(
                         granular_payout_eligibility_request,

--- a/crates/router/src/core/payouts/gateway/fulfill_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/fulfill_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -111,6 +112,7 @@ where
                 granular_payout_transfer_request,
                 grpc_headers,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, granular_payout_transfer_request, grpc_headers| async move {
                     let response = Box::pin(client.payout_transfer(
                         granular_payout_transfer_request,

--- a/crates/router/src/core/payouts/gateway/quote_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/quote_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -111,6 +112,7 @@ where
                 granular_payout_stage_request,
                 grpc_headers,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, granular_payout_stage_request, grpc_headers| async move {
                     let response = Box::pin(client.payout_stage(
                         granular_payout_stage_request,

--- a/crates/router/src/core/payouts/gateway/recipient_account_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/recipient_account_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -110,6 +111,7 @@ where
             granular_payout_enroll_disburse_account_request,
             grpc_headers,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, granular_payout_enroll_disburse_account_request, grpc_headers| async move {
                 let response = Box::pin(client.payout_enroll_disburse_account(
                     granular_payout_enroll_disburse_account_request,

--- a/crates/router/src/core/payouts/gateway/recipient_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/recipient_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -110,6 +111,7 @@ where
             granular_payout_create_recipient_request,
             grpc_headers,
             unified_connector_service_execution_mode,
+            matched_rollout_config_key,
             |mut router_data, granular_payout_create_recipient_request, grpc_headers| async move {
                 let response = Box::pin(client.payout_create_recipient(
                     granular_payout_create_recipient_request,

--- a/crates/router/src/core/payouts/gateway/sync_gateway.rs
+++ b/crates/router/src/core/payouts/gateway/sync_gateway.rs
@@ -63,6 +63,7 @@ where
         let lineage_ids = context.lineage_ids;
         let header_payload = context.header_payload;
         let unified_connector_service_execution_mode = context.execution_mode;
+        let matched_rollout_config_key = context.matched_rollout_config_key;
         let client = state
             .grpc_client
             .unified_connector_service_client
@@ -111,6 +112,7 @@ where
                 granular_payout_get_request,
                 grpc_headers,
                 unified_connector_service_execution_mode,
+                matched_rollout_config_key,
                 |mut router_data, granular_payout_get_request, grpc_headers| async move {
                     let response = Box::pin(client.payout_get(
                         granular_payout_get_request,

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -221,7 +221,7 @@ pub async fn trigger_refund_to_gateway(
     )
     .await?;
 
-    let (execution_path, updated_state) =
+    let (execution_path, updated_state, matched_rollout_config_key) =
         unified_connector_service::should_call_unified_connector_service(
             state,
             platform.get_processor(),
@@ -256,6 +256,7 @@ pub async fn trigger_refund_to_gateway(
         merchant_connector_account: merchant_connector_account.clone(),
         execution_path,
         execution_mode,
+        matched_rollout_config_key,
     };
 
     // Add access token for both UCS and direct connector paths
@@ -887,7 +888,7 @@ pub async fn sync_refund_with_gateway(
     // Access token available or not needed - proceed with execution
 
     // Check which gateway system to use for refund sync
-    let (execution_path, updated_state) =
+    let (execution_path, updated_state, matched_rollout_config_key) =
         unified_connector_service::should_call_unified_connector_service(
             state,
             platform.get_processor(),
@@ -922,6 +923,7 @@ pub async fn sync_refund_with_gateway(
         merchant_connector_account: merchant_connector_account.clone(),
         execution_path,
         execution_mode,
+        matched_rollout_config_key,
     };
 
     // Add access token for both UCS and direct connector paths

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -408,13 +408,12 @@ where
 
     // Check UCS kill switch: if error count exceeds threshold, force Direct path.
     // Only applies when execution path is UCS Primary and connector has a direct fallback.
-    let is_kill_switch_applicable = matches!(
-        execution_path,
-        ExecutionPath::UnifiedConnectorService
-    ) && matches!(
-        connector_integration_type,
-        ConnectorIntegrationType::DirectandUCSConnector
-    );
+    let is_kill_switch_applicable =
+        matches!(execution_path, ExecutionPath::UnifiedConnectorService)
+            && matches!(
+                connector_integration_type,
+                ConnectorIntegrationType::DirectandUCSConnector
+            );
 
     if is_kill_switch_applicable {
         let force_direct = kill_switch::should_force_direct_path(
@@ -470,7 +469,11 @@ where
         flow_name
     );
 
-    Ok((execution_path, session_state, rollout_result.matched_config_key))
+    Ok((
+        execution_path,
+        session_state,
+        rollout_result.matched_config_key,
+    ))
 }
 
 /// Creates a new SessionState with proxy configuration updated from the override
@@ -2993,11 +2996,7 @@ where
             );
 
             // Record error for UCS kill switch evaluation
-            kill_switch::record_ucs_error(
-                state,
-                matched_rollout_config_key.as_deref(),
-            )
-            .await;
+            kill_switch::record_ucs_error(state, matched_rollout_config_key.as_deref()).await;
 
             let error_body = serde_json::json!({
                 "error": error.to_string(),
@@ -3132,11 +3131,7 @@ where
             );
 
             // Record error for UCS kill switch evaluation
-            kill_switch::record_ucs_error(
-                state,
-                matched_rollout_config_key.as_deref(),
-            )
-            .await;
+            kill_switch::record_ucs_error(state, matched_rollout_config_key.as_deref()).await;
 
             let error_body = serde_json::json!({
                 "error": error.to_string(),

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -68,6 +68,7 @@ use crate::{
 };
 
 pub mod connector_config;
+pub mod kill_switch;
 pub mod transformers;
 
 /// Returns Apple Pay data from payment method token when it has decrypt data,
@@ -303,7 +304,7 @@ pub async fn should_call_unified_connector_service<F: Clone, T, R>(
     call_connector_action: CallConnectorAction,
     shadow_ucs_call_connector_action: Option<CallConnectorAction>,
     transaction_type: common_enums::TransactionType,
-) -> RouterResult<(ExecutionPath, SessionState)>
+) -> RouterResult<(ExecutionPath, SessionState, Option<String>)>
 where
     R: Send + Sync + Clone,
 {
@@ -405,6 +406,34 @@ where
         }
     };
 
+    // Check UCS kill switch: if error count exceeds threshold, force Direct path.
+    // Only applies when execution path is UCS Primary and connector has a direct fallback.
+    let is_kill_switch_applicable = matches!(
+        execution_path,
+        ExecutionPath::UnifiedConnectorService
+    ) && matches!(
+        connector_integration_type,
+        ConnectorIntegrationType::DirectandUCSConnector
+    );
+
+    if is_kill_switch_applicable {
+        let force_direct = kill_switch::should_force_direct_path(
+            state,
+            rollout_result.matched_config_key.as_deref(),
+        )
+        .await;
+        if force_direct {
+            router_env::logger::warn!(
+                merchant_id = %merchant_id,
+                connector = %connector_name,
+                flow = %flow_name,
+                matched_config_key = ?rollout_result.matched_config_key,
+                "UCS kill switch activated, forcing Direct path"
+            );
+            execution_path = ExecutionPath::Direct;
+        }
+    }
+
     // Handle proxy configuration for Shadow UCS flows
     let session_state = match execution_path {
         ExecutionPath::ShadowUnifiedConnectorService => {
@@ -441,7 +470,7 @@ where
         flow_name
     );
 
-    Ok((execution_path, session_state))
+    Ok((execution_path, session_state, rollout_result.matched_config_key))
 }
 
 /// Creates a new SessionState with proxy configuration updated from the override
@@ -2883,6 +2912,7 @@ pub async fn ucs_logging_wrapper<T, F, Fut, Req, Resp, GrpcReq, GrpcResp, FlowOu
     grpc_request: GrpcReq,
     grpc_header_builder: external_services::grpc_client::GrpcHeadersUcsBuilderFinal,
     execution_mode: ExecutionMode,
+    matched_rollout_config_key: Option<String>,
     handler: F,
 ) -> RouterResult<(RouterData<T, Req, Resp>, FlowOutput)>
 where
@@ -2962,6 +2992,13 @@ where
                 router_env::metric_attributes!(("connector", connector_name.clone(),)),
             );
 
+            // Record error for UCS kill switch evaluation
+            kill_switch::record_ucs_error(
+                state,
+                matched_rollout_config_key.as_deref(),
+            )
+            .await;
+
             let error_body = serde_json::json!({
                 "error": error.to_string(),
                 "error_type": "ucs_call_failed"
@@ -3010,6 +3047,7 @@ pub async fn ucs_logging_wrapper_granular<T, F, Fut, Req, Resp, GrpcReq, FlowOut
     grpc_request: GrpcReq,
     grpc_header_builder: external_services::grpc_client::GrpcHeadersUcsBuilderFinal,
     execution_mode: ExecutionMode,
+    matched_rollout_config_key: Option<String>,
     handler: F,
 ) -> CustomResult<(RouterData<T, Req, Resp>, FlowOutput), UnifiedConnectorServiceError>
 where
@@ -3092,6 +3130,13 @@ where
                 1,
                 router_env::metric_attributes!(("connector", connector_name.clone(),)),
             );
+
+            // Record error for UCS kill switch evaluation
+            kill_switch::record_ucs_error(
+                state,
+                matched_rollout_config_key.as_deref(),
+            )
+            .await;
 
             let error_body = serde_json::json!({
                 "error": error.to_string(),
@@ -3274,6 +3319,7 @@ pub async fn call_unified_connector_service_for_refund_execute(
         ucs_refund_request,
         grpc_header_builder,
         execution_mode,
+        None,
         |mut router_data, grpc_request, grpc_headers| async move {
             // Call UCS payment_refund method
             let response = match ucs_client
@@ -3410,6 +3456,7 @@ pub async fn call_unified_connector_service_for_refund_sync(
         ucs_refund_sync_request,
         grpc_header_builder,
         execution_mode,
+        None,
         |mut router_data, grpc_request, grpc_headers| async move {
             // Call UCS refund_sync method
             let response = match ucs_client

--- a/crates/router/src/core/unified_connector_service/kill_switch.rs
+++ b/crates/router/src/core/unified_connector_service/kill_switch.rs
@@ -10,10 +10,7 @@ async fn get_kill_switch_threshold(state: &SessionState) -> u64 {
     let db = state.store.as_ref();
 
     let config_result = db
-        .find_config_by_key_unwrap_or(
-            consts::UCS_KILL_SWITCH_THRESHOLD,
-            Some("0".to_string()),
-        )
+        .find_config_by_key_unwrap_or(consts::UCS_KILL_SWITCH_THRESHOLD, Some("0".to_string()))
         .await;
 
     let config = match config_result {
@@ -93,10 +90,7 @@ async fn get_error_count(state: &SessionState, redis_key: &str) -> u64 {
     };
 
     let count_result = redis_conn
-        .increment_fields_in_hash(
-            &redis_key.into(),
-            &[("count".to_string(), 0i64)],
-        )
+        .increment_fields_in_hash(&redis_key.into(), &[("count".to_string(), 0i64)])
         .await;
 
     let count = match count_result {
@@ -133,10 +127,7 @@ async fn increment_error_count(state: &SessionState, redis_key: &str) -> u64 {
     };
 
     let increment_result = redis_conn
-        .increment_fields_in_hash(
-            &redis_key.into(),
-            &[("count".to_string(), 1i64)],
-        )
+        .increment_fields_in_hash(&redis_key.into(), &[("count".to_string(), 1i64)])
         .await;
 
     let new_count = match increment_result {
@@ -176,10 +167,7 @@ async fn increment_error_count(state: &SessionState, redis_key: &str) -> u64 {
 ///
 /// Uses the matched rollout config key as scope, derives the Redis key, increments the count,
 /// and emits a metric.
-pub async fn record_ucs_error(
-    state: &SessionState,
-    matched_config_key: Option<&str>,
-) {
+pub async fn record_ucs_error(state: &SessionState, matched_config_key: Option<&str>) {
     let config_key = match matched_config_key {
         Some(key) => key,
         None => {
@@ -198,9 +186,7 @@ pub async fn record_ucs_error(
 
     metrics::UCS_KILL_SWITCH_ERROR_RECORDED.add(
         1,
-        router_env::metric_attributes!(
-            ("matched_config_key", config_key.to_string()),
-        ),
+        router_env::metric_attributes!(("matched_config_key", config_key.to_string()),),
     );
 }
 
@@ -251,9 +237,7 @@ pub async fn should_force_direct_path(
     if is_active {
         metrics::UCS_KILL_SWITCH_ACTIVATED.add(
             1,
-            router_env::metric_attributes!(
-                ("matched_config_key", config_key.to_string()),
-            ),
+            router_env::metric_attributes!(("matched_config_key", config_key.to_string()),),
         );
     }
 

--- a/crates/router/src/core/unified_connector_service/kill_switch.rs
+++ b/crates/router/src/core/unified_connector_service/kill_switch.rs
@@ -1,0 +1,261 @@
+use router_env::logger;
+
+use crate::{consts, core::metrics, routes::SessionState};
+
+/// Fetches the global UCS kill switch error threshold from the DB config.
+///
+/// Returns 0 if the config key is absent or unparseable, meaning a single error
+/// will trigger the kill switch.
+async fn get_kill_switch_threshold(state: &SessionState) -> u64 {
+    let db = state.store.as_ref();
+
+    let config_result = db
+        .find_config_by_key_unwrap_or(
+            consts::UCS_KILL_SWITCH_THRESHOLD,
+            Some("0".to_string()),
+        )
+        .await;
+
+    let config = match config_result {
+        Ok(config) => config,
+        Err(error) => {
+            logger::error!(
+                ?error,
+                "Failed to fetch UCS kill switch threshold config from DB"
+            );
+            return 0;
+        }
+    };
+
+    let threshold = config.config.parse::<u64>().unwrap_or_else(|error| {
+        logger::error!(
+            ?error,
+            config_value = %config.config,
+            "Failed to parse UCS kill switch threshold config, defaulting to 0"
+        );
+        0
+    });
+
+    threshold
+}
+
+/// Checks whether the kill switch is disabled for a specific config key
+/// by looking up `ucs_kill_switch_disabled_{config_key}` in the DB config.
+///
+/// Returns true (disabled) only when the config value is explicitly "true".
+/// Returns false (enabled) when the key is absent, unparseable, or "false".
+async fn is_kill_switch_disabled(state: &SessionState, config_key: &str) -> bool {
+    let db = state.store.as_ref();
+    let disabled_key = format!("{}_{}", consts::UCS_KILL_SWITCH_DISABLED_PREFIX, config_key);
+
+    let config_result = db
+        .find_config_by_key_unwrap_or(&disabled_key, Some("false".to_string()))
+        .await;
+
+    let config = match config_result {
+        Ok(config) => config,
+        Err(error) => {
+            logger::error!(
+                ?error,
+                disabled_key = %disabled_key,
+                "Failed to fetch UCS kill switch disabled config from DB"
+            );
+            return false;
+        }
+    };
+
+    let is_disabled = config.config.parse::<bool>().unwrap_or_else(|error| {
+        logger::error!(
+            ?error,
+            disabled_key = %disabled_key,
+            config_value = %config.config,
+            "Failed to parse UCS kill switch disabled config, defaulting to false"
+        );
+        false
+    });
+
+    is_disabled
+}
+
+/// Fetches the current UCS error count from Redis for the given scope.
+///
+/// Returns 0 if the key does not exist or if the Redis call fails.
+async fn get_error_count(state: &SessionState, redis_key: &str) -> u64 {
+    let redis_conn = match state.store.get_redis_conn() {
+        Ok(conn) => conn,
+        Err(error) => {
+            logger::error!(
+                ?error,
+                "Failed to get redis connection for UCS kill switch error count lookup"
+            );
+            return 0;
+        }
+    };
+
+    let count_result = redis_conn
+        .increment_fields_in_hash(
+            &redis_key.into(),
+            &[("count".to_string(), 0i64)],
+        )
+        .await;
+
+    let count = match count_result {
+        Ok(counts) => counts.into_iter().next().unwrap_or(0) as u64,
+        Err(error) => {
+            logger::error!(
+                ?error,
+                redis_key = %redis_key,
+                "Failed to get UCS kill switch error count from Redis"
+            );
+            0
+        }
+    };
+
+    count
+}
+
+/// Increments the UCS error count in Redis for the given scope.
+///
+/// Uses HINCRBY to atomically increment. On the first error (count becomes 1),
+/// sets a TTL of 1 day so the key auto-expires and UCS is retried.
+///
+/// Returns the count after increment.
+async fn increment_error_count(state: &SessionState, redis_key: &str) -> u64 {
+    let redis_conn = match state.store.get_redis_conn() {
+        Ok(conn) => conn,
+        Err(error) => {
+            logger::error!(
+                ?error,
+                "Failed to get redis connection for UCS kill switch error recording"
+            );
+            return 0;
+        }
+    };
+
+    let increment_result = redis_conn
+        .increment_fields_in_hash(
+            &redis_key.into(),
+            &[("count".to_string(), 1i64)],
+        )
+        .await;
+
+    let new_count = match increment_result {
+        Ok(counts) => counts.into_iter().next().unwrap_or(0) as u64,
+        Err(error) => {
+            logger::error!(
+                ?error,
+                redis_key = %redis_key,
+                "Failed to increment UCS kill switch error count in Redis"
+            );
+            return 0;
+        }
+    };
+
+    // Set TTL on first error so the key auto-expires after 1 day
+    if new_count == 1 {
+        let ttl_result = redis_conn
+            .set_expiry(
+                &redis_key.into(),
+                consts::UCS_KILL_SWITCH_TTL_IN_SECS as i64,
+            )
+            .await;
+
+        if let Err(error) = ttl_result {
+            logger::error!(
+                ?error,
+                redis_key = %redis_key,
+                "Failed to set TTL on UCS kill switch error count key"
+            );
+        }
+    }
+
+    new_count
+}
+
+/// Records a UCS error for kill switch evaluation.
+///
+/// Uses the matched rollout config key as scope, derives the Redis key, increments the count,
+/// and emits a metric.
+pub async fn record_ucs_error(
+    state: &SessionState,
+    matched_config_key: Option<&str>,
+) {
+    let config_key = match matched_config_key {
+        Some(key) => key,
+        None => {
+            logger::debug!("No matched config key, skipping kill switch error recording");
+            return;
+        }
+    };
+    let redis_key = format!("{}_{}", consts::UCS_KILL_SWITCH_REDIS_PREFIX, config_key);
+    let new_count = increment_error_count(state, &redis_key).await;
+
+    logger::info!(
+        matched_config_key = %config_key,
+        new_count = new_count,
+        "Recorded UCS error for kill switch"
+    );
+
+    metrics::UCS_KILL_SWITCH_ERROR_RECORDED.add(
+        1,
+        router_env::metric_attributes!(
+            ("matched_config_key", config_key.to_string()),
+        ),
+    );
+}
+
+/// Determines whether the UCS kill switch should block UCS calls for a given scope.
+///
+/// Uses the matched rollout config key as scope for both the disabled check and the error
+/// count check.
+///
+/// The kill switch is active when ALL of the following are true:
+/// 1. The kill switch is not disabled for this scope via DB config
+/// 2. The error count in Redis exceeds the configured threshold
+///
+/// Returns true if UCS should be bypassed in favor of the Direct path.
+pub async fn should_force_direct_path(
+    state: &SessionState,
+    matched_config_key: Option<&str>,
+) -> bool {
+    let config_key = match matched_config_key {
+        Some(key) => key,
+        None => {
+            logger::debug!("No matched config key, kill switch not applicable");
+            return false;
+        }
+    };
+
+    let is_disabled = is_kill_switch_disabled(state, config_key).await;
+    if is_disabled {
+        logger::info!(
+            matched_config_key = %config_key,
+            "UCS kill switch is disabled for this scope, allowing UCS"
+        );
+        return false;
+    }
+
+    let threshold = get_kill_switch_threshold(state).await;
+    let redis_key = format!("{}_{}", consts::UCS_KILL_SWITCH_REDIS_PREFIX, config_key);
+    let error_count = get_error_count(state, &redis_key).await;
+    let is_active = error_count > threshold;
+
+    logger::info!(
+        matched_config_key = %config_key,
+        error_count = error_count,
+        threshold = threshold,
+        is_active = is_active,
+        "UCS kill switch evaluation"
+    );
+
+    if is_active {
+        metrics::UCS_KILL_SWITCH_ACTIVATED.add(
+            1,
+            router_env::metric_attributes!(
+                ("matched_config_key", config_key.to_string()),
+            ),
+        );
+    }
+
+    is_active
+}


### PR DESCRIPTION
## Summary
- Adds a threshold-based circuit breaker for UCS that automatically routes traffic to the Direct path when error counts exceed a configurable threshold
- Error counts are tracked in Redis (HINCRBY) with a 1-day TTL for automatic recovery
- Kill switch can be disabled per-scope via DB config (`ucs_kill_switch_disabled_{rollout_config_key}`)
- Uses the matched rollout config key from precedence resolution as the scope — no redundant key construction
- Only applies to `DirectandUCSConnector` types (UCS-only connectors are unaffected since they have no fallback)

## Config keys
| Key | Purpose | Default |
|---|---|---|
| `ucs_kill_switch_threshold` | Global error threshold (DB config) | `0` (single error triggers) |
| `ucs_kill_switch_disabled_{config_key}` | Disable kill switch per scope (DB config) | `false` |
| `ucs_kill_switch_{config_key}` | Error count (Redis, 1-day TTL) | auto |

## Test plan
- [ ] Verify UCS errors increment the Redis hash counter
- [ ] Verify kill switch activates when error count > threshold
- [ ] Verify `ucs_kill_switch_disabled` config bypasses the kill switch
- [ ] Verify UCS-only connectors are unaffected
- [ ] Verify Redis key auto-expires after 1 day (TTL set on first error)