### PR TITLE
fix(checkout): populate auth code from connector-response

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -2141,6 +2141,7 @@ pub struct CheckoutWebhookData {
     pub currency: String,
     pub processed_on: Option<String>,
     pub approved: Option<bool>,
+    pub auth_code: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2351,7 +2352,7 @@ impl TryFrom<&webhooks::IncomingWebhookRequestDetails<'_>> for PaymentsResponse 
             }),
             scheme_id: None,
             processing: None,
-            auth_code: None,
+            auth_code: data.auth_code,
         };
 
         Ok(psync_struct)

--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -1309,6 +1309,7 @@ pub struct PaymentsResponse {
     approved: Option<bool>,
     processed_on: Option<String>,
     source: Option<Source>,
+    auth_code: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -1415,9 +1416,12 @@ impl TryFrom<PaymentsResponseRouterData<PaymentsResponse>> for PaymentsAuthorize
             None
         };
 
-        let additional_information =
-            convert_to_additional_payment_method_connector_response(item.response.source.as_ref())
-                .map(ConnectorResponseData::with_additional_payment_method_data);
+        let additional_information = convert_to_additional_payment_method_connector_response(
+            item.response.source.as_ref(),
+            item.response.auth_code.clone(),
+            item.data.request.payment_method_type,
+        )
+        .map(ConnectorResponseData::with_additional_payment_method_data);
 
         let payments_response_data = PaymentsResponseData::TransactionResponse {
             resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
@@ -1629,9 +1633,12 @@ impl TryFrom<PaymentsSyncResponseRouterData<PaymentsResponse>> for PaymentsSyncR
             None
         };
 
-        let additional_information =
-            convert_to_additional_payment_method_connector_response(item.response.source.as_ref())
-                .map(ConnectorResponseData::with_additional_payment_method_data);
+        let additional_information = convert_to_additional_payment_method_connector_response(
+            item.response.source.as_ref(),
+            item.response.auth_code.clone(),
+            item.data.request.payment_method_type,
+        )
+        .map(ConnectorResponseData::with_additional_payment_method_data);
 
         let payments_response_data = PaymentsResponseData::TransactionResponse {
             resource_id: ResponseId::ConnectorTransactionId(item.response.id.clone()),
@@ -2344,6 +2351,7 @@ impl TryFrom<&webhooks::IncomingWebhookRequestDetails<'_>> for PaymentsResponse 
             }),
             scheme_id: None,
             processing: None,
+            auth_code: None,
         };
 
         Ok(psync_struct)
@@ -2405,18 +2413,31 @@ impl From<String> for utils::ErrorCodeAndMessage {
 
 fn convert_to_additional_payment_method_connector_response(
     source: Option<&Source>,
+    auth_code: Option<String>,
+    payment_method_type: Option<enums::PaymentMethodType>,
 ) -> Option<AdditionalPaymentMethodConnectorResponse> {
-    source.map(|code| {
-        let payment_checks = serde_json::json!({
-            "avs_result": code.avs_check,
-            "card_validation_result": code.cvv_check,
-        });
-        AdditionalPaymentMethodConnectorResponse::Card {
-            authentication_data: None,
-            payment_checks: Some(payment_checks),
-            card_network: None,
-            domestic_network: None,
-            auth_code: None,
+    match payment_method_type {
+        Some(enums::PaymentMethodType::GooglePay) => {
+            Some(AdditionalPaymentMethodConnectorResponse::GooglePay { auth_code })
         }
-    })
+        Some(enums::PaymentMethodType::ApplePay) => {
+            Some(AdditionalPaymentMethodConnectorResponse::ApplePay { auth_code })
+        }
+        _ => {
+            let payment_checks = source.map(|code| {
+                serde_json::json!({
+                    "avs_result": code.avs_check,
+                    "card_validation_result": code.cvv_check,
+                })
+            });
+
+            Some(AdditionalPaymentMethodConnectorResponse::Card {
+                authentication_data: None,
+                payment_checks,
+                card_network: None,
+                domestic_network: None,
+                auth_code,
+            })
+        }
+    }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Populated the auth_code field returned by Checkout in the payment response, so it is now stored and surfaced correctly for card, Google Pay, and Apple Pay payments.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
### Request
```
{
    
    "amount": 1000,
    "currency": "ZAR",
    "confirm": true,
    "capture_method": "automatic",
    "authentication_type": "three_ds",
    "profile_id":"pro_NBhWV43R9FfjV1G1hyLv",
    "customer": {
        "id": "cust_757925533435ree33444354134",
        "name": "John"
    },
    "three_ds_data": {
    "authentication_cryptogram": {
      "cavv": {
        "authentication_cryptogram": "3q2+78r+ur7erb7vyv66vv////8="
      }
    },
    "ds_trans_id": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
    "version": "2.1.0",
    "eci": "05",
    "transaction_status": "Y",
    "exemption_indicator": "low_value"
  },
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
      "card": {
        "card_number": "4111111111111111",
        "card_exp_month": "12",
        "card_exp_year": "2031",
        "card_holder_name": "John Doe",
        "card_cvc":"123"
      }
    },
   
    "billing": {
      "address": {
        "first_name": "John",
        "last_name": "Doe",
        "country": "IT"
        
      },
      "email": "customer@example.com"
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "125.0.0.1"
    }
    
}
```

### Response 
```
{
    "payment_id": "pay_kvKlobX0vvW5SEuKB2eI",
    "merchant_id": "merchant_1781624290",
    "status": "succeeded",
    "amount": 1000,
    "net_amount": 1000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 1000,
    "processor_merchant_id": "merchant_1781624290",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fTkJoV1Y0M1I5RmZqVjFHMWh5THYscHVibGlzaGFibGVfa2V5PXBrX2Rldl85YjE2NDg0Y2RjNzQ0OGUwOWVmN2Y4MGJkMDBkMTFjNixjbGllbnRfc2VjcmV0PXBheV9rdktsb2JYMHZ2VzVTRXVLQjJlSV9zZWNyZXRfc0hhNHpCejVhTmtvQmNKR29xTXMsY3VzdG9tZXJfaWQ9Y3VzdF83NTc5MjU1MzM0MzVyZWUzMzQ0NDM1NDEzNCxjbGllbnRfc2Vzc2lvbl9pZD1jbGllbnRfc2Vzc196WndhYWpRQjFvZTQ5T3ZQYUJ6MixwYXltZW50X2lkPXBheV9rdktsb2JYMHZ2VzVTRXVLQjJlSQ==",
    "connector": "checkout",
    "state_metadata": null,
    "client_secret": "pay_kvKlobX0vvW5SEuKB2eI_secret_sHa4zBz5aNkoBcJGoqMs",
    "created": "2026-08-12T12:55:43.818Z",
    "modified_at": "2026-08-12T12:55:45.325Z",
    "connector_customer_id": null,
    "currency": "ZAR",
    "customer_id": "cust_757925533435ree33444354134",
    "customer": {
        "id": "cust_757925533435ree33444354134",
        "name": "John",
        "email": null,
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": "DEBIT",
            "card_network": "Visa",
            "card_issuer": "CONOTOXIA SP Z O.O.",
            "card_issuing_country": "POLAND",
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "2031",
            "card_holder_name": "John Doe",
            "payment_checks": {
                "avs_result": "G",
                "card_validation_result": "Y"
            },
            "authentication_data": null,
            "auth_code": "978679"
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": null,
            "country": "IT",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": null,
            "state": null,
            "first_name": "John",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": null,
        "email": "customer@example.com"
    },
    "order_details": null,
    "email": null,
    "name": "John",
    "phone": null,
    "return_url": null,
    "authentication_type": "three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "pay_4mas6pybqofy3p2cr75hxuytju",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "pay_kvKlobX0vvW5SEuKB2eI_1",
    "payment_link": null,
    "profile_id": "pro_NBhWV43R9FfjV1G1hyLv",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_bwzBXjINQlGwH51uClgD",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-08-12T13:10:43.818Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "125.0.0.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": "198100840135766",
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-08-12T12:55:45.325Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
