### PR TITLE
fix(ucs): suppress X-Connector-Config header for Netcetera

### DIFF
--- a/crates/router/src/core/unified_connector_service/connector_config.rs
+++ b/crates/router/src/core/unified_connector_service/connector_config.rs
@@ -1762,6 +1762,14 @@ pub fn build_connector_config_header(
         merchant_account_metadata,
     ))?;
 
+    // Netcetera has no connector-specific config on the wire (connector-service's
+    // `ConnectorSpecificConfig` oneof has no `netcetera` case), so sending this header makes
+    // UCS hard-error on deserialization instead of falling back to the legacy auth header.
+    // Suppress it here so UCS takes the legacy-header path, which does work for Netcetera.
+    if matches!(config, ConnectorSpecificConfig::Netcetera) {
+        return Ok(None);
+    }
+
     let config_json = serde_json::to_value(&config)
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to serialize connector config to JSON value")?;


### PR DESCRIPTION
## Summary
- `connector-service`'s `ConnectorSpecificConfig` proto oneof has never had a `netcetera` case (confirmed across `main` and every relevant feature/fix branch).
- Since #13557, router unconditionally builds and sends the typed `x-connector-config` header for `Connector::Netcetera` (`ConnectorAuthType::CertificateAuth`), which UCS now hard-fails to deserialize (`unknown variant \`Netcetera\`, expected one of \`Adyen\`, ...`) instead of falling back to the legacy `x-connector-auth` header.
- Confirmed via integ logs (build `2026.08.12.0-dirty-eefdfe9b7`) and reproduced by diffing against sandbox's custom branch (`sbx-custom-cug-hyperswitch-server`, commit `3ae23cd`), which never picked up the #13557 change and therefore still suppresses the header for Netcetera, hitting UCS's legacy-header fallback path successfully.
- `Connector::Netcetera`'s own doc comment already says "no connector-specific config needed" — so the correct fix is for `build_connector_config_header` to return `Ok(None)` for Netcetera, restoring the legacy-header path that sandbox proves works, rather than touching connector-service's proto.

## Test plan
- [ ] `cargo check -p router` / `just clippy` (v1 + v2)
- [ ] Manual: run a Netcetera external-3ds-over-VGS payment against integ-matching UCS build and confirm PreAuthenticate/Authenticate no longer error with `unknown variant \`Netcetera\`` and instead log `Typed connector config headers not found, falling back to legacy headers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)