### PR TITLE
fix(ucs): suppress X-Connector-Config header for Netcetera

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2033,44 +2033,49 @@ pub fn build_unified_connector_service_auth_metadata(
             merchant_id: Secret::new(merchant_id.to_string()),
             connector_config,
         }),
-        // Netcetera is UCS's one authentication-only, no-key connector: its mTLS cert is
-        // presented on the VGS outbound route, not via UCS auth headers, and connector-service
-        // explicitly opts it out of the CertificateAuth->ConnectorSpecificConfig conversion
-        // (see `ConnectorEnum::Netcetera => Err(...)` in connector-service's router_data.rs),
-        // routing it via the `x-auth: no-key` shortcut instead. Sending it as multi-auth-key
-        // makes UCS fail with "Failed to convert legacy auth for connector: netcetera".
-        ConnectorAuthType::CertificateAuth { .. } if connector_name == "netcetera" => {
-            Ok(ConnectorAuthMetadata {
-                connector_name,
-                auth_type: consts::UCS_AUTH_NO_KEY.to_string(),
-                api_key: None,
-                key1: None,
-                key2: None,
-                api_secret: None,
-                auth_key_map: None,
-                merchant_id: Secret::new(merchant_id.to_string()),
-                connector_config: None,
-            })
-        }
         ConnectorAuthType::CertificateAuth {
             certificate,
             private_key,
-        } => Ok(ConnectorAuthMetadata {
-            connector_name,
-            auth_type: consts::UCS_AUTH_MULTI_KEY.to_string(),
-            api_key: Some(certificate.clone()),
-            key1: Some(private_key.clone()),
-            // UCS's "multi-auth-key" header parsing unconditionally requires x-key2 and
-            // x-api-secret to be present. Connectors reaching this arm only supply
-            // certificate/private_key, so duplicate private_key here purely to satisfy
-            // UCS's presence check; the connector implementation itself never reads
-            // key2/api_secret.
-            key2: Some(private_key.clone()),
-            api_secret: Some(private_key.clone()),
-            auth_key_map: None,
-            merchant_id: Secret::new(merchant_id.to_string()),
-            connector_config,
-        }),
+        } => {
+            if connector_name == "netcetera" {
+                // Netcetera is UCS's one authentication-only, no-key connector: its mTLS cert
+                // is presented on the VGS outbound route, not via UCS auth headers, and
+                // connector-service explicitly opts it out of the
+                // CertificateAuth->ConnectorSpecificConfig conversion (see
+                // `ConnectorEnum::Netcetera => Err(...)` in connector-service's
+                // router_data.rs), routing it via the `x-auth: no-key` shortcut instead.
+                // Sending it as multi-auth-key makes UCS fail with "Failed to convert legacy
+                // auth for connector: netcetera".
+                Ok(ConnectorAuthMetadata {
+                    connector_name,
+                    auth_type: consts::UCS_AUTH_NO_KEY.to_string(),
+                    api_key: None,
+                    key1: None,
+                    key2: None,
+                    api_secret: None,
+                    auth_key_map: None,
+                    merchant_id: Secret::new(merchant_id.to_string()),
+                    connector_config: None,
+                })
+            } else {
+                Ok(ConnectorAuthMetadata {
+                    connector_name,
+                    auth_type: consts::UCS_AUTH_MULTI_KEY.to_string(),
+                    api_key: Some(certificate.clone()),
+                    key1: Some(private_key.clone()),
+                    // UCS's "multi-auth-key" header parsing unconditionally requires x-key2
+                    // and x-api-secret to be present. Connectors reaching this branch only
+                    // supply certificate/private_key, so duplicate private_key here purely
+                    // to satisfy UCS's presence check; the connector implementation itself
+                    // never reads key2/api_secret.
+                    key2: Some(private_key.clone()),
+                    api_secret: Some(private_key.clone()),
+                    auth_key_map: None,
+                    merchant_id: Secret::new(merchant_id.to_string()),
+                    connector_config,
+                })
+            }
+        }
         _ => Err(UnifiedConnectorServiceError::FailedToObtainAuthType)
             .attach_printable("Unsupported ConnectorAuthType for header injection"),
     }

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2033,6 +2033,44 @@ pub fn build_unified_connector_service_auth_metadata(
             merchant_id: Secret::new(merchant_id.to_string()),
             connector_config,
         }),
+        // Netcetera is UCS's one authentication-only, no-key connector: its mTLS cert is
+        // presented on the VGS outbound route, not via UCS auth headers, and connector-service
+        // explicitly opts it out of the CertificateAuth->ConnectorSpecificConfig conversion
+        // (see `ConnectorEnum::Netcetera => Err(...)` in connector-service's router_data.rs),
+        // routing it via the `x-auth: no-key` shortcut instead. Sending it as multi-auth-key
+        // makes UCS fail with "Failed to convert legacy auth for connector: netcetera".
+        ConnectorAuthType::CertificateAuth { .. } if connector_name == "netcetera" => {
+            Ok(ConnectorAuthMetadata {
+                connector_name,
+                auth_type: consts::UCS_AUTH_NO_KEY.to_string(),
+                api_key: None,
+                key1: None,
+                key2: None,
+                api_secret: None,
+                auth_key_map: None,
+                merchant_id: Secret::new(merchant_id.to_string()),
+                connector_config: None,
+            })
+        }
+        ConnectorAuthType::CertificateAuth {
+            certificate,
+            private_key,
+        } => Ok(ConnectorAuthMetadata {
+            connector_name,
+            auth_type: consts::UCS_AUTH_MULTI_KEY.to_string(),
+            api_key: Some(certificate.clone()),
+            key1: Some(private_key.clone()),
+            // UCS's "multi-auth-key" header parsing unconditionally requires x-key2 and
+            // x-api-secret to be present. Connectors reaching this arm only supply
+            // certificate/private_key, so duplicate private_key here purely to satisfy
+            // UCS's presence check; the connector implementation itself never reads
+            // key2/api_secret.
+            key2: Some(private_key.clone()),
+            api_secret: Some(private_key.clone()),
+            auth_key_map: None,
+            merchant_id: Secret::new(merchant_id.to_string()),
+            connector_config,
+        }),
         _ => Err(UnifiedConnectorServiceError::FailedToObtainAuthType)
             .attach_printable("Unsupported ConnectorAuthType for header injection"),
     }

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -1953,6 +1953,9 @@ pub fn build_unified_connector_service_auth_metadata(
         .change_context(UnifiedConnectorServiceError::FailedToObtainAuthType)
         .attach_printable("Failed to obtain ConnectorAuthType")?;
     let merchant_id = processor_merchant_id.get_string_repr();
+    let connector = Connector::from_str(&connector_name)
+        .change_context(UnifiedConnectorServiceError::FailedToObtainAuthType)
+        .attach_printable_lazy(|| format!("Invalid connector name: {connector_name}"))?;
     // Extract connector metadata from MCA for connector-specific config
     let merchant_account_metadata = merchant_connector_account.get_metadata();
     let merchant_account_metadata_value = merchant_account_metadata
@@ -1960,7 +1963,7 @@ pub fn build_unified_connector_service_auth_metadata(
         .and_then(|m| serde_json::to_value(m.clone().expose()).ok());
     // Build connector-specific config for supported connectors
     let connector_config = connector_config::build_connector_config_header(
-        &connector_name,
+        connector,
         &auth_type,
         merchant_account_metadata_value.as_ref(),
     )
@@ -2037,7 +2040,7 @@ pub fn build_unified_connector_service_auth_metadata(
             certificate,
             private_key,
         } => {
-            if connector_name == "netcetera" {
+            if matches!(connector, Connector::Netcetera) {
                 // Netcetera is UCS's one authentication-only, no-key connector: its mTLS cert
                 // is presented on the VGS outbound route, not via UCS auth headers, and
                 // connector-service explicitly opts it out of the

--- a/crates/router/src/core/unified_connector_service/connector_config.rs
+++ b/crates/router/src/core/unified_connector_service/connector_config.rs
@@ -1613,6 +1613,14 @@ pub fn build_connector_config_header(
         merchant_account_metadata,
     ))?;
 
+    // Netcetera has no connector-specific config on the wire (connector-service's
+    // `ConnectorSpecificConfig` oneof has no `netcetera` case), so sending this header makes
+    // UCS hard-error on deserialization instead of falling back to the legacy auth header.
+    // Suppress it here so UCS takes the legacy-header path, which does work for Netcetera.
+    if matches!(config, ConnectorSpecificConfig::Netcetera) {
+        return Ok(None);
+    }
+
     let config_json = serde_json::to_value(&config)
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to serialize connector config to JSON value")?;

--- a/crates/router/src/core/unified_connector_service/connector_config.rs
+++ b/crates/router/src/core/unified_connector_service/connector_config.rs
@@ -3,7 +3,7 @@
 //! This module provides functionality to transform connector authentication data
 //! into connector-specific configuration structures expected by the Unified Connector Service (UCS).
 
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 use common_enums::{connector_enums::Connector, enums::Currency};
 use common_utils::ext_traits::ValueExt;
@@ -1599,14 +1599,10 @@ impl ForeignTryFrom<(Connector, &ConnectorAuthType, Option<&serde_json::Value>)>
 
 /// Build the X_CONNECTOR_CONFIG header value for any connector
 pub fn build_connector_config_header(
-    connector_name: &str,
+    connector: Connector,
     auth_type: &ConnectorAuthType,
     merchant_account_metadata: Option<&serde_json::Value>,
 ) -> RouterResult<Option<String>> {
-    let connector = Connector::from_str(connector_name)
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable_lazy(|| format!("Invalid connector name: {}", connector_name))?;
-
     let config = ConnectorSpecificConfig::foreign_try_from((
         connector,
         auth_type,


### PR DESCRIPTION
## Summary
Hotfix-branch cherry-pick of https://github.com/juspay/hyperswitch/pull/13673 (main).

- `connector-service`'s `ConnectorSpecificConfig` proto oneof has no `netcetera` case, so router unconditionally sending the typed `x-connector-config` header for `Connector::Netcetera` (`ConnectorAuthType::CertificateAuth`) makes UCS hard-fail deserialization (`unknown variant \`Netcetera\``) instead of falling back to the legacy `x-connector-auth` header.
- `Connector::Netcetera`'s own doc comment says "no connector-specific config needed" — `build_connector_config_header` now returns `Ok(None)` for it, restoring the legacy-header fallback path.

## Test plan
- [ ] `cargo check -p router` / `just clippy` (v1 + v2)
- [ ] Manual: run a Netcetera external-3ds-over-VGS payment and confirm PreAuthenticate/Authenticate no longer error with `unknown variant \`Netcetera\`` and instead log `Typed connector config headers not found, falling back to legacy headers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)