### PR TITLE
fix(ucs): add missing CertificateAuth arm for header injection, no-key for Netcetera

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2033,6 +2033,44 @@ pub fn build_unified_connector_service_auth_metadata(
             merchant_id: Secret::new(merchant_id.to_string()),
             connector_config,
         }),
+        // Netcetera is UCS's one authentication-only, no-key connector: its mTLS cert is
+        // presented on the VGS outbound route, not via UCS auth headers, and connector-service
+        // explicitly opts it out of the CertificateAuth->ConnectorSpecificConfig conversion
+        // (see `ConnectorEnum::Netcetera => Err(...)` in connector-service's router_data.rs),
+        // routing it via the `x-auth: no-key` shortcut instead. Sending it as multi-auth-key
+        // makes UCS fail with "Failed to convert legacy auth for connector: netcetera".
+        ConnectorAuthType::CertificateAuth { .. } if connector_name == "netcetera" => {
+            Ok(ConnectorAuthMetadata {
+                connector_name,
+                auth_type: consts::UCS_AUTH_NO_KEY.to_string(),
+                api_key: None,
+                key1: None,
+                key2: None,
+                api_secret: None,
+                auth_key_map: None,
+                merchant_id: Secret::new(merchant_id.to_string()),
+                connector_config: None,
+            })
+        }
+        ConnectorAuthType::CertificateAuth {
+            certificate,
+            private_key,
+        } => Ok(ConnectorAuthMetadata {
+            connector_name,
+            auth_type: consts::UCS_AUTH_MULTI_KEY.to_string(),
+            api_key: Some(certificate.clone()),
+            key1: Some(private_key.clone()),
+            // UCS's "multi-auth-key" header parsing unconditionally requires x-key2 and
+            // x-api-secret to be present. Connectors reaching this arm only supply
+            // certificate/private_key, so duplicate private_key here purely to satisfy
+            // UCS's presence check; the connector implementation itself never reads
+            // key2/api_secret.
+            key2: Some(private_key.clone()),
+            api_secret: Some(private_key.clone()),
+            auth_key_map: None,
+            merchant_id: Secret::new(merchant_id.to_string()),
+            connector_config,
+        }),
         _ => Err(UnifiedConnectorServiceError::FailedToObtainAuthType)
             .attach_printable("Unsupported ConnectorAuthType for header injection"),
     }


### PR DESCRIPTION
## Summary
- This hotfix branch was cut from a point that predates `CertificateAuth` support in `build_unified_connector_service_auth_metadata` (added to `main` later via a separate PR), so Netcetera's `CertificateAuth` MCA always fell into the catch-all `_ => Err(FailedToObtainAuthType)`, failing pre-authenticate before ever reaching UCS ("Unsupported ConnectorAuthType for header injection").
- Netcetera is UCS's one authentication-only, no-key connector: its mTLS cert is presented on the VGS outbound route, not via UCS auth headers, and connector-service explicitly opts it out of the `CertificateAuth`->`ConnectorSpecificConfig` conversion (`ConnectorEnum::Netcetera => Err(...)` in connector-service). Routed it via the `x-auth: no-key` shortcut instead, matching connector-service's documented design.
- The generic `multi-auth-key` path is kept for any other `CertificateAuth` connector, with `key2`/`api_secret` duplicated from `private_key` to satisfy UCS's presence check on those headers.

This builds on top of `aa957b1c05` (X-Connector-Config suppression for Netcetera) already on this branch — both are needed together for Netcetera's pre-authenticate call to succeed.

## Test plan
- [x] `cargo check -p router --features v1`
- [x] Local end-to-end payment through Netcetera external 3DS + VGS external vault + Checkout succeeded