### PR TITLE
feat(payment_link): add dedicated dashboard endpoint for Payment Link creation

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1819,6 +1819,33 @@ impl PaymentsRequest {
         }
         Ok(())
     }
+
+    
+    pub fn for_payment_link(self) -> Self {
+        Self {
+            amount: self.amount,
+            currency: self.currency,
+            return_url: self.return_url,
+            payment_id: self.payment_id,
+            authentication_type: self.authentication_type,
+            billing: self.billing,
+            customer: self.customer,
+            description: self.description,
+            setup_future_usage: self.setup_future_usage,
+            order_details: self.order_details,
+            metadata: self.metadata,
+            payment_link_config_id: self.payment_link_config_id,
+            profile_id: self.profile_id,
+            routing: self.routing,
+            session_expiry: self.session_expiry,
+            merchant_order_reference_id: self.merchant_order_reference_id,
+            allowed_payment_method_types: self.allowed_payment_method_types,
+            capture_method: self.capture_method,
+            payment_link: Some(true),
+            confirm: Some(false),
+            ..Default::default()
+        }
+    }
 }
 
 #[cfg(feature = "v1")]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1820,7 +1820,6 @@ impl PaymentsRequest {
         Ok(())
     }
 
-    
     pub fn for_payment_link(self) -> Self {
         Self {
             amount: self.amount,

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1019,6 +1019,7 @@ impl Payments {
         {
             route = route
                 .service(web::resource("").route(web::post().to(payments::payments_create)))
+                .service(web::resource("/payment_link").route(web::post().to(payments::payment_link_create)))
                 .service(
                     web::resource("/session_tokens")
                         .route(web::post().to(payments::payments_connector_session)),

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -195,6 +195,8 @@ impl From<Flow> for ApiIdentifier {
             | Flow::RecoveryPaymentsCreate
             | Flow::PaymentsSubmitCheckEligibility
             | Flow::PaymentsSubmitEligibility
+            // PaymentLinkCreate creates a payment intent, so it uses the Payments lock namespace
+            | Flow::PaymentLinkCreate
             | Flow::PaymentsCancelPostCaptureSync => Self::Payments,
             Flow::PayoutsCreate
             | Flow::PayoutsRetrieve

--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -160,7 +160,7 @@ pub async fn payment_link_create(
     {
         return api::log_and_return_error_response(err.into());
     };
-    
+
     if let Some(api_enums::CaptureMethod::Scheduled) = payload.capture_method {
         return http_not_implemented();
     };

--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -144,6 +144,80 @@ pub async fn payments_create(
     .await
 }
 
+#[cfg(feature = "v1")]
+#[instrument(skip_all, fields(flow = ?Flow::PaymentLinkCreate, payment_id))]
+pub async fn payment_link_create(
+    state: web::Data<app::AppState>,
+    req: actix_web::HttpRequest,
+    json_payload: web::Json<payment_types::PaymentsRequest>,
+) -> impl Responder {
+    let flow = Flow::PaymentLinkCreate;
+    let mut payload = json_payload.into_inner().for_payment_link();
+
+    if let Err(err) = payload
+        .validate()
+        .map_err(|message| errors::ApiErrorResponse::InvalidRequestData { message })
+    {
+        return api::log_and_return_error_response(err.into());
+    };
+    
+    if let Some(api_enums::CaptureMethod::Scheduled) = payload.capture_method {
+        return http_not_implemented();
+    };
+
+    if let Err(err) = get_or_generate_payment_id(&mut payload) {
+        return api::log_and_return_error_response(err);
+    }
+
+    let header_payload = match HeaderPayload::foreign_try_from(req.headers()) {
+        Ok(headers) => headers,
+        Err(err) => {
+            return api::log_and_return_error_response(err);
+        }
+    };
+
+    tracing::Span::current().record(
+        "payment_id",
+        payload
+            .payment_id
+            .as_ref()
+            .map(|payment_id_type| payment_id_type.get_payment_intent_id())
+            .transpose()
+            .unwrap_or_default()
+            .as_ref()
+            .map(|id| id.get_string_repr())
+            .unwrap_or_default(),
+    );
+
+    let locking_action = payload.get_locking_input(flow.clone());
+
+    Box::pin(api::server_wrap(
+        flow,
+        state,
+        &req,
+        payload,
+        |state, auth: auth::AuthenticationData, req, req_state| {
+            authorize_verify_select::<_>(
+                payments::PaymentCreate,
+                state,
+                req_state,
+                auth.platform,
+                auth.profile.map(|profile| profile.get_id().clone()),
+                header_payload.clone(),
+                req,
+                api::AuthFlow::Client,
+            )
+        },
+        &auth::InternalMerchantIdProfileIdAuth(auth::JWTAuth {
+            permission: Permission::ProfilePaymentWrite,
+            allow_connected: true,
+            allow_platform: false,
+        }),
+        locking_action,
+    ))
+    .await
+}
+
 #[cfg(feature = "v2")]
 pub async fn recovery_payments_create(
     state: web::Data<app::AppState>,

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -395,6 +395,8 @@ pub enum Flow {
     PaymentLinkList,
     /// Payment Link Status
     PaymentLinkStatus,
+    /// Payment Link Create flow
+    PaymentLinkCreate,
     /// Create a profile
     ProfileCreate,
     /// Update a profile


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
There was no dedicated endpoint for creating payment links via dashboard. Merchants were required to use the full POST /payments endpoint and manually set payment_link: true, which exposed the entire payments request surface — including fields that are irrelevant in a payment link context.

Added a new POST /payments/payment_link endpoint specifically for payment link creation via the dashboard. Dashboard users authenticated via JWT (Permission::ProfilePaymentWrite) can create payment links without touching the full /payments surface. API key auth is intentionally excluded since this is a dashboard-only flow.

Internally reuses the PaymentCreate core flow but restricts the accepted fields to only those relevant for payment link creation via a for_payment_link() projection on PaymentsRequest. Fields not in the allowlist are silently dropped. payment_link: true and confirm: false are enforced internally.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested via Api-key - use JWT token 
### Request 
```
curl --location 'http://localhost:8080/payments/payment_link' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_Q4xyddk2evrrIxC6W2tvh2AYN7s6Cw0gPY86xqeYBRAIMEmvpBJVmlr9io3bXM2A' \
--data-raw '{
    "amount": 200,
    "currency": "AUD",
    "confirm": true,
    "capture_method": "automatic",
    
    "customer":{
        "name": "Aniket"
    },
    "description": "null",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "off_session": true,
    "billing": {
        "email": "test@example.com",
        "address": {
            "first_name": "PiX",
            "last_name": "ss"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "125.0.0.1"
    },
    "recurring_details": {
        "type": "payment_method_id",
        "data": "pm_C7VJ98kgl801wadfnYcD"
    },

    "profile_id": "pro_NBhWV43R9FfjV1G1hyLv",
    
    "customer_acceptance": {
        "acceptance_type": "online",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "125.0.0.1",
            "user_agent": "amet irure esse"
        }
    }
}'
```

### Response
```
{
    "payment_id": "pay_uD0JOVELcbTizyzfZLTu",
    "merchant_id": "merchant_1781624290",
    "status": "requires_payment_method",
    "amount": 200,
    "net_amount": 200,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "processor_merchant_id": "merchant_1781624290",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fTkJoV1Y0M1I5RmZqVjFHMWh5THYscHVibGlzaGFibGVfa2V5PXBrX2Rldl85YjE2NDg0Y2RjNzQ0OGUwOWVmN2Y4MGJkMDBkMTFjNixjbGllbnRfc2VjcmV0PXBheV91RDBKT1ZFTGNiVGl6eXpmWkxUdV9zZWNyZXRfSTd2cVJYcjduWm9iQk9nME44cngsY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfRTdJZUFZRkRiR09EUlFSUGVGUGUscGF5bWVudF9pZD1wYXlfdUQwSk9WRUxjYlRpenl6ZlpMVHU=",
    "connector": null,
    "state_metadata": null,
    "client_secret": "pay_uD0JOVELcbTizyzfZLTu_secret_I7vqRXr7nZobBOg0N8rx",
    "created": "2026-08-12T21:02:47.597Z",
    "modified_at": "2026-08-12T21:02:47.619Z",
    "connector_customer_id": null,
    "currency": "AUD",
    "customer_id": null,
    "customer": {
        "id": null,
        "name": "Aniket",
        "email": null,
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": "null",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": null,
    "payment_method_data": null,
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": null,
            "country": null,
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": null,
            "state": null,
            "first_name": "PiX",
            "last_name": "ss",
            "origin_zip": null
        },
        "phone": null,
        "email": "test@example.com"
    },
    "order_details": null,
    "email": null,
    "name": "Aniket",
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": {
        "link": "http://localhost:8080/payment_link/merchant_1781624290/pay_uD0JOVELcbTizyzfZLTu?locale=en",
        "secure_link": null,
        "payment_link_id": "plink_tD7smaj8yiMGdur4DssV"
    },
    "profile_id": "pro_NBhWV43R9FfjV1G1hyLv",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": null,
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-08-12T21:17:47.592Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-08-12T21:02:47.619Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```


Only the permitted fields are processed; all remaining fields are discarded to ensure that irrelevant fields are not exposed.

<img width="1728" height="244" alt="image" src="https://github.com/user-attachments/assets/2410fac1-9349-4d35-8937-fb05f1ee2cce" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
