### PR TITLE
refactor(ucs): convert connector errors to router data in the wrapper, not per-handler

### DIFF
--- a/crates/router/src/core/payments/gateway/access_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/access_token_gateway.rs
@@ -12,7 +12,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -176,25 +175,10 @@ where
                     .await
                 {
                     Ok(response) => response,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for access token (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to create access token"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -144,33 +144,10 @@ where
                     .await
                     {
                         Ok(resp) => resp,
+                        // Connector errors (4xx/5xx from the connector via UCS) are converted
+                        // back into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by
+                        // the wrapper, not here — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            // Check if this is a connector error (4xx/5xx from connector via UCS)
-                            if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                report.current_context()
-                            {
-                                let (code, message, status_code, connector) = (
-                                    &inner.code,
-                                    &inner.message,
-                                    inner.status_code,
-                                    &inner.connector,
-                                );
-                                logger::debug!(
-                                    "Connector error via UCS for recurring charge (connector {}, status {}): {} - {}",
-                                    connector,
-                                    status_code,
-                                    code,
-                                    message
-                                );
-                                router_data.response = Err(inner.as_ref().into());
-                                router_data.connector_http_status_code = Some(status_code);
-                                return Ok((
-                                    router_data,
-                                    (),
-                                    payments_grpc::RecurringPaymentServiceChargeResponse::default(),
-                                ));
-                            }
-                            // Propagate as Err for proper HTTP error handling
                             return Err(report.attach_printable("Failed to charge recurring payment"));
                         }
                     };
@@ -250,37 +227,10 @@ where
                     .await
                     {
                         Ok(resp) => resp,
+                        // Connector errors (4xx/5xx from the connector via UCS) are converted
+                        // back into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by
+                        // the wrapper, not here — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            // Check if this is a connector error (4xx/5xx from connector via UCS)
-                            // If so, set it as router_data.response = Err(ErrorResponse) and return Ok
-                            // This matches how direct connector errors are handled
-                            if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                report.current_context()
-                            {
-                                let (code, message, status_code, connector) = (
-                                    &inner.code,
-                                    &inner.message,
-                                    inner.status_code,
-                                    &inner.connector,
-                                );
-                                logger::debug!(
-                                    "Connector error via UCS (connector {}, status {}): {} - {}",
-                                    connector,
-                                    status_code,
-                                    code,
-                                    message
-                                );
-                                router_data.response = Err(inner.as_ref().into());
-                                // Return Ok with router_data containing the error response
-                                // This ensures the connector error flows through the normal
-                                // response handling path (same as direct connector errors)
-                                router_data.connector_http_status_code = Some(status_code);
-                                return Ok((
-                                    router_data,
-                                    (),
-                                    payments_grpc::PaymentServiceAuthorizeResponse::default(),
-                                ));
-                            }
                             return Err(report.attach_printable("Failed to authorize payment"));
                         }
                     };

--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -148,7 +148,9 @@ where
                         // back into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by
                         // the wrapper, not here — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            return Err(report.attach_printable("Failed to charge recurring payment"));
+                            return Err(
+                                report.attach_printable("Failed to charge recurring payment")
+                            );
                         }
                     };
 

--- a/crates/router/src/core/payments/gateway/cancel_gateway.rs
+++ b/crates/router/src/core/payments/gateway/cancel_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -120,31 +119,10 @@ where
                     .await
                 {
                     Ok(resp) => resp,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            let (code, message, status_code, connector) = (
-                                &inner.code,
-                                &inner.message,
-                                inner.status_code,
-                                &inner.connector,
-                            );
-                            logger::debug!(
-                                "Connector error via UCS for void (connector {}, status {}): {} - {}",
-                                connector,
-                                status_code,
-                                code,
-                                message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceVoidResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to Void payment"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/capture_gateway.rs
+++ b/crates/router/src/core/payments/gateway/capture_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -122,31 +121,10 @@ where
                     .await
                 {
                     Ok(resp) => resp,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            let (code, message, status_code, connector) = (
-                                &inner.code,
-                                &inner.message,
-                                inner.status_code,
-                                &inner.connector,
-                            );
-                            logger::debug!(
-                                "Connector error via UCS for capture (connector {}, status {}): {} - {}",
-                                connector,
-                                status_code,
-                                code,
-                                message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceCaptureResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to capture payment"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use hyperswitch_masking::ExposeInterface as UcsMaskingExposeInterface;
 use unified_connector_service_client::payments as payments_grpc;
@@ -126,25 +125,10 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for complete authorize (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceAuthorizeResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to get payment"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/create_customer_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_customer_gateway.rs
@@ -12,7 +12,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -134,25 +133,10 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for create connector customer (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::CustomerServiceCreateResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to create connector customer"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/create_order_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_order_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -126,25 +125,10 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for create order (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceCreateOrderResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to create order"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/incremental_authorization_gateway.rs
+++ b/crates/router/src/core/payments/gateway/incremental_authorization_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -137,25 +136,10 @@ where
                     .await
                     {
                         Ok(response) => response,
+                        // Connector errors (4xx/5xx from the connector via UCS) are converted
+                        // back into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by
+                        // the wrapper, not here — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                report.current_context()
-                            {
-                                logger::debug!(
-                                    "Connector error via UCS for incremental authorization (connector {}, status {}): {} - {}",
-                                    inner.connector,
-                                    inner.status_code,
-                                    inner.code,
-                                    inner.message
-                                );
-                                router_data.response = Err(inner.as_ref().into());
-                                router_data.connector_http_status_code = Some(inner.status_code);
-                                return Ok((
-                                    router_data,
-                                    (),
-                                    payments_grpc::PaymentServiceIncrementalAuthorizationResponse::default(),
-                                ));
-                            }
                             return Err(report.attach_printable(
                                 "Failed to in incremental authorize payment",
                             ));

--- a/crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs
+++ b/crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -131,25 +130,10 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for payment method tokenization (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentMethodServiceTokenizeResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to Tokenize payment method"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/pre_authorize_void_gateway.rs
+++ b/crates/router/src/core/payments/gateway/pre_authorize_void_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -128,25 +127,10 @@ where
                     .await
                 {
                     Ok(response) => response,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for pre-authorize void (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceVoidResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to Cancel payment"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/psync_gateway.rs
+++ b/crates/router/src/core/payments/gateway/psync_gateway.rs
@@ -12,7 +12,6 @@ use hyperswitch_interfaces::{
     unified_connector_service::{
         get_payments_response_from_ucs_webhook_content,
         handle_unified_connector_service_response_for_payment_get,
-        transformers::UnifiedConnectorServiceError,
     },
 };
 use hyperswitch_masking::ExposeInterface as UcsMaskingExposeInterface;
@@ -205,31 +204,10 @@ where
                             .await
                         {
                             Ok(resp) => resp,
+                            // Connector errors (4xx/5xx from the connector via UCS) are converted
+                            // back into `Ok(RouterData)` carrying `response: Err(ErrorResponse)`
+                            // by the wrapper, not here — see `ucs_logging_wrapper_granular`.
                             Err(report) => {
-                                if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                    report.current_context()
-                                {
-                                    let (code, message, status_code, connector) = (
-                                        &inner.code,
-                                        &inner.message,
-                                        inner.status_code,
-                                        &inner.connector,
-                                    );
-                                    logger::debug!(
-                                        "Connector error via UCS for psync (connector {}, status {}): {} - {}",
-                                        connector,
-                                        status_code,
-                                        code,
-                                        message
-                                    );
-                                    router_data.response = Err(inner.as_ref().into());
-                                    router_data.connector_http_status_code = Some(status_code);
-                                    return Ok((
-                                        router_data,
-                                        (),
-                                        payments_grpc::PaymentServiceGetResponse::default(),
-                                    ));
-                                }
                                 return Err(report.attach_printable("Failed to get payment"));
                             }
                         };

--- a/crates/router/src/core/payments/gateway/psync_gateway.rs
+++ b/crates/router/src/core/payments/gateway/psync_gateway.rs
@@ -251,10 +251,10 @@ where
                                 Some(MinorUnit::new(captured_amount));
                         }
                         if return_raw_connector_response.unwrap_or(false) {
-                            router_data.raw_connector_response = payment_get_response
-                                .raw_connector_response
-                                .clone()
-                                .map(|raw_connector_response| raw_connector_response.expose().into());
+                            router_data.raw_connector_response =
+                                payment_get_response.raw_connector_response.clone().map(
+                                    |raw_connector_response| raw_connector_response.expose().into(),
+                                );
                         }
                         router_data.connector_http_status_code = Some(status_code);
                         router_data.sender_payment_instrument_id =

--- a/crates/router/src/core/payments/gateway/session_gateway.rs
+++ b/crates/router/src/core/payments/gateway/session_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -127,25 +126,10 @@ where
                     .await
                     {
                         Ok(response) => response,
+                        // Connector errors (4xx/5xx from the connector via UCS) are converted
+                        // back into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by
+                        // the wrapper, not here — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                report.current_context()
-                            {
-                                logger::debug!(
-                                    "Connector error via UCS for sdk session token (connector {}, status {}): {} - {}",
-                                    inner.connector,
-                                    inner.status_code,
-                                    inner.code,
-                                    inner.message
-                                );
-                                router_data.response = Err(inner.as_ref().into());
-                                router_data.connector_http_status_code = Some(inner.status_code);
-                                return Ok((
-                                    router_data,
-                                    (),
-                                    payments_grpc::MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse::default(),
-                                ));
-                            }
                             return Err(
                                 report.attach_printable("Failed to create SDK session token")
                             );

--- a/crates/router/src/core/payments/gateway/session_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/session_token_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -130,25 +129,10 @@ where
                     .await
                 {
                     Ok(response) => response,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for session token (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::MerchantAuthenticationServiceCreateServerSessionAuthenticationTokenResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to create session token"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/setup_mandate.rs
+++ b/crates/router/src/core/payments/gateway/setup_mandate.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -124,25 +123,10 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // Connector errors (4xx/5xx from the connector via UCS) are converted back
+                    // into `Ok(RouterData)` carrying `response: Err(ErrorResponse)` by the
+                    // wrapper, not here — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for setup mandate (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceSetupRecurringResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to setup recurring payment"));
                     }
                 };

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -3073,6 +3073,7 @@ where
     Resp: std::fmt::Debug + Clone + Send + Sync + 'static,
     GrpcReq: serde::Serialize,
     GrpcResp: serde::Serialize,
+    FlowOutput: Default,
     F: FnOnce(
             RouterData<T, Req, Resp>,
             GrpcReq,
@@ -3099,6 +3100,9 @@ where
     let payout_id = router_data.payout_id.clone();
     let payment_method = router_data.payment_method;
     let payment_method_type = router_data.payment_method_type;
+    // Kept so a `ConnectorError` can be turned back into an `Ok` router data here, in the one
+    // place that does this conversion, instead of every handler closure doing it themselves.
+    let router_data_for_connector_error = router_data.clone();
     let grpc_header = grpc_header_builder.build();
     // Log the actual gRPC request with masking
     let grpc_request_body = hyperswitch_masking::masked_serialize(&grpc_request)
@@ -3182,11 +3186,32 @@ where
                 "error": error.to_string(),
                 "error_type": "ucs_call_failed"
             });
-            (
-                error.current_context().http_status(),
-                Some(error_body),
-                Err(error),
-            )
+
+            // A `ConnectorError` is the connector answering with a 4xx/5xx through UCS, not UCS
+            // itself failing. Direct connector integrations surface that as `Ok(RouterData)`
+            // carrying `response: Err(ErrorResponse)`, not as a request-level `Err` — so this
+            // matches that shape here, in the one place that does this conversion, rather than
+            // in each handler closure. Handlers used to build this recovery value themselves,
+            // which meant the kill switch's `Err` arm above was unreachable for the one error
+            // variant it exists to catch, and the event this function logs carried a masked
+            // *empty* gRPC response instead of the connector's actual error.
+            if let UnifiedConnectorServiceError::ConnectorError(inner) = error.current_context() {
+                let mut recovered_router_data = router_data_for_connector_error;
+                recovered_router_data.response = Err(inner.as_ref().into());
+                recovered_router_data.connector_http_status_code = Some(inner.status_code);
+
+                (
+                    inner.status_code,
+                    Some(error_body),
+                    Ok((recovered_router_data, FlowOutput::default())),
+                )
+            } else {
+                (
+                    error.current_context().http_status(),
+                    Some(error_body),
+                    Err(error),
+                )
+            }
         }
     };
 

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -3102,7 +3102,7 @@ where
     let payment_method_type = router_data.payment_method_type;
     // Kept so a `ConnectorError` can be turned back into an `Ok` router data here, in the one
     // place that does this conversion, instead of every handler closure doing it themselves.
-    let router_data_for_connector_error = router_data.clone();
+    let recovery_router_data = router_data.clone();
     let grpc_header = grpc_header_builder.build();
     // Log the actual gRPC request with masking
     let grpc_request_body = hyperswitch_masking::masked_serialize(&grpc_request)
@@ -3196,14 +3196,14 @@ where
             // variant it exists to catch, and the event this function logs carried a masked
             // *empty* gRPC response instead of the connector's actual error.
             if let UnifiedConnectorServiceError::ConnectorError(inner) = error.current_context() {
-                let mut recovered_router_data = router_data_for_connector_error;
-                recovered_router_data.response = Err(inner.as_ref().into());
-                recovered_router_data.connector_http_status_code = Some(inner.status_code);
+                let mut recovery_router_data = recovery_router_data;
+                recovery_router_data.response = Err(inner.as_ref().into());
+                recovery_router_data.connector_http_status_code = Some(inner.status_code);
 
                 (
                     inner.status_code,
                     Some(error_body),
-                    Ok((recovered_router_data, FlowOutput::default())),
+                    Ok((recovery_router_data, FlowOutput::default())),
                 )
             } else {
                 (


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

`ucs_logging_wrapper_granular` classifies UCS failures for the [kill switch](https://github.com/juspay/hyperswitch/pull/13639) in its own `Err` arm, on the assumption — stated in a comment on that arm — that "every payment and payout gateway funnels through here with the UCS error still typed." That assumption is false for the one error variant the kill switch's `connector_outcome` reason exists to catch.

15 call sites across 14 payment gateway handlers (`authorize_gateway.rs` has two) each duplicate the same block: if the UCS call fails with `UnifiedConnectorServiceError::ConnectorError` — the connector answering with a 4xx/5xx through UCS — the handler builds an `ErrorResponse`, sets it on `router_data.response`, and returns `Ok(...)` instead of propagating `Err`. This mirrors how a direct (non-UCS) connector integration surfaces a decline, so it's the right *outcome* — but doing it inside each handler closure means the wrapper's `Err` arm, where `record_failure` (the kill switch) and the request/response event logging both live, never sees it.

Two consequences of the duplication, not just one:

1. **The kill switch cannot observe a connector 4xx/5xx.** Every other failure shape — UCS unreachable, an unsupported flow, a response HS can't decode — reaches the wrapper's `Err` arm and trips correctly. A connector declining through UCS does not, because the handler already turned it into `Ok` before the wrapper's classifier runs. Confirmed against a real Stripe 401 (`api_key_expired`) on a primary-scope UCS call: UCS returned it as a gRPC `Unauthenticated` error with `CONNECTOR_ERROR_RESPONSE`, and the kill switch's `GET /unified-connector-service/kill-switch/{scope}` endpoint reported `tripped: false` throughout.
2. **The UCS connector event logs a masked empty struct as the error.** The wrapper's `Ok` arm serializes the third tuple element (the gRPC response) into the connector event. Each handler's swallow path constructs that value as `SomeResponse::default()` — an empty message, not the connector's actual code/message/decline reason — so the audit event for a connector decline carries no diagnostic content in its `error` field, even though the status code is routed there correctly.

## What changed

Moved the `ConnectorError` → `Ok(RouterData)` conversion into `ucs_logging_wrapper_granular` itself, in its `Err(error)` arm — the one place that already has the typed `UnifiedConnectorServiceError` and already runs the kill switch and event logging. The wrapper takes one extra `router_data.clone()` before invoking `handler` (mirroring the clone every call site already takes to pass into the wrapper), so it retains a `RouterData` to attach the recovered response to on this path. `FlowOutput` gained a `Default` bound — satisfied everywhere already, since all 15 sites already use `()`.

Each of the 15 handler closures now does nothing but propagate `Err(report)` on any UCS failure. No handler special-cases `ConnectorError` any more.

Net effect:
- The kill switch's `Err` arm is now genuinely reachable for every failure shape, including connector 4xx/5xx — the comment's claim is now true instead of aspirational.
- The connector event's `error` field now carries the same informative `error.to_string()` content the wrapper already builds for non-`ConnectorError` failures (`Debug`-formatted `ConnectorErrorInner`: code, message, reason, connector, decline codes), instead of a masked empty gRPC struct.
- ~250 fewer lines: the conversion exists in one place instead of 15.

## Behaviour change worth flagging explicitly

This activates `record_failure` for connector declines across all 15 payment flows, where today it silently does not fire for 14 of them (refunds already had a hand-inserted `record_failure` call ahead of their own swallow, so they were already correct). Combined with the kill switch's `connector_outcome` reason (added in a follow-up to #13639), an ordinary connector decline on a primary scope will now count toward that scope's trip threshold, fleet-wide, starting from this PR merging. That's the intended behaviour of `connector_outcome` finally taking effect — but it's a live change in production behaviour for the kill switch, not just a refactor, and worth confirming with whoever owns the kill switch's rollout before merging.

Not in scope: `payouts/gateway/*.rs` and `webhooks/gateway.rs` never had this swallow pattern — they already propagate `Err` to the wrapper correctly, so nothing to change there.

## Verification

- `cargo check -p router --features v1 --lib` — clean, 0 errors
- `just clippy redis-rs` and `just clippy fred` (CI's exact invocations, `-D warnings`) — both clean. Checked `fred` specifically because the kill switch PR previously hit a `clippy::large_futures` failure on that backend from a much smaller change; the extra `.clone()` here does not regress it.
- `cargo test -p router -p hyperswitch_interfaces --features v1 --lib kill_switch` — kill switch unit tests, unaffected by this change (they test the classifier and key-building, not the wrapper wiring) but run as a sanity check.
- `cargo check -p router --features v2 --lib` fails identically on a clean `origin/main` (unrelated `common_utils`/`id_type` breakage, confirmed via `git stash`) — pre-existing, not touched by this PR.
