### PR TITLE
feat(analytics): add payment method audit table for API events and tag internal service traffic

### DIFF
--- a/crates/analytics/docs/clickhouse/scripts/api_events.sql
+++ b/crates/analytics/docs/clickhouse/scripts/api_events.sql
@@ -360,3 +360,98 @@ FROM
     api_events_queue
 WHERE
     length(_error) = 0;
+
+CREATE TABLE api_events_payment_method_audit (
+    `merchant_id` LowCardinality(String),
+    `payment_method_id` String,
+    `payment_id` Nullable(String),
+    `payment_method` Nullable(String),
+    `payment_method_type` Nullable(String),
+    `customer_id` Nullable(String),
+    `user_id` Nullable(String),
+    `auth_user_id` Nullable(String),
+    `connector` Nullable(String),
+    `request_id` String,
+    `flow_type` LowCardinality(String),
+    `api_flow` LowCardinality(String),
+    `api_auth_type` LowCardinality(String),
+    `request` String,
+    `response` Nullable(String),
+    `error` Nullable(String),
+    `authentication_data` Nullable(String),
+    `status_code` UInt32,
+    `created_at` DateTime64(3),
+    `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
+    `latency` UInt128,
+    `user_agent` String,
+    `ip_addr` String,
+    `hs_latency` Nullable(UInt128),
+    `http_method` LowCardinality(Nullable(String)),
+    `url_path` Nullable(String),
+    `masked_response` Nullable(String)
+) ENGINE = MergeTree PARTITION BY merchant_id
+ORDER BY
+    (merchant_id, payment_method_id) TTL inserted_at + toIntervalMonth(18) SETTINGS index_granularity = 8192;
+
+CREATE MATERIALIZED VIEW api_events_payment_method_audit_mv TO api_events_payment_method_audit (
+    `merchant_id` String,
+    `payment_method_id` String,
+    `payment_id` Nullable(String),
+    `payment_method` Nullable(String),
+    `payment_method_type` Nullable(String),
+    `customer_id` Nullable(String),
+    `user_id` Nullable(String),
+    `auth_user_id` Nullable(String),
+    `connector` Nullable(String),
+    `request_id` String,
+    `flow_type` LowCardinality(String),
+    `api_flow` LowCardinality(String),
+    `api_auth_type` LowCardinality(String),
+    `request` String,
+    `response` Nullable(String),
+    `error` Nullable(String),
+    `authentication_data` Nullable(String),
+    `status_code` UInt32,
+    `created_at` DateTime64(3),
+    `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
+    `latency` UInt128,
+    `user_agent` String,
+    `ip_addr` String,
+    `hs_latency` Nullable(UInt128),
+    `http_method` LowCardinality(Nullable(String)),
+    `url_path` Nullable(String),
+    `masked_response` Nullable(String)
+) AS
+SELECT
+    merchant_id,
+    payment_method_id,
+    payment_id,
+    payment_method,
+    payment_method_type,
+    customer_id,
+    user_id,
+    auth_user_id,
+    connector,
+    request_id,
+    flow_type,
+    api_flow,
+    api_auth_type,
+    request,
+    response,
+    error,
+    authentication_data,
+    status_code,
+    created_at_timestamp AS created_at,
+    now() AS inserted_at,
+    latency,
+    user_agent,
+    ip_addr,
+    hs_latency,
+    http_method,
+    url_path,
+    response AS masked_response
+FROM
+    api_events_queue
+WHERE
+    (length(_error) = 0)
+    AND (payment_method_id IS NOT NULL);

--- a/crates/api_models/src/events.rs
+++ b/crates/api_models/src/events.rs
@@ -238,13 +238,37 @@ impl ApiEventMetric for PaymentMethodSessionResponse {
     }
 }
 #[cfg(feature = "tokenization_v2")]
-impl ApiEventMetric for tokenization::GenericTokenizationRequest {}
+impl ApiEventMetric for tokenization::GenericTokenizationRequest {
+    fn get_api_event_type(&self) -> Option<ApiEventsType> {
+        Some(ApiEventsType::Customer {
+            customer_id: Some(self.customer_id.clone()),
+        })
+    }
+}
 
 #[cfg(feature = "tokenization_v2")]
-impl ApiEventMetric for tokenization::GenericTokenizationResponse {}
+impl ApiEventMetric for tokenization::GenericTokenizationResponse {
+    fn get_api_event_type(&self) -> Option<ApiEventsType> {
+        Some(ApiEventsType::Token {
+            token_id: Some(self.id.clone()),
+        })
+    }
+}
 
 #[cfg(feature = "tokenization_v2")]
-impl ApiEventMetric for tokenization::DeleteTokenDataResponse {}
+impl ApiEventMetric for tokenization::DeleteTokenDataResponse {
+    fn get_api_event_type(&self) -> Option<ApiEventsType> {
+        Some(ApiEventsType::Token {
+            token_id: Some(self.id.clone()),
+        })
+    }
+}
 
 #[cfg(feature = "tokenization_v2")]
-impl ApiEventMetric for tokenization::DeleteTokenDataRequest {}
+impl ApiEventMetric for tokenization::DeleteTokenDataRequest {
+    fn get_api_event_type(&self) -> Option<ApiEventsType> {
+        Some(ApiEventsType::PaymentMethodSession {
+            payment_method_session_id: self.session_id.clone(),
+        })
+    }
+}

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -3281,7 +3281,15 @@ pub struct TokenDataResponse {
 }
 
 #[cfg(feature = "v2")]
-impl common_utils::events::ApiEventMetric for TokenDataResponse {}
+impl common_utils::events::ApiEventMetric for TokenDataResponse {
+    fn get_api_event_type(&self) -> Option<common_utils::events::ApiEventsType> {
+        Some(common_utils::events::ApiEventsType::PaymentMethod {
+            payment_method_id: self.payment_method_id.clone(),
+            payment_method_type: None,
+            payment_method_subtype: None,
+        })
+    }
+}
 
 #[cfg(feature = "v2")]
 #[derive(Debug, serde::Serialize, ToSchema)]
@@ -4713,7 +4721,21 @@ pub struct NetworkTokenStatusCheckSuccessResponse {
 }
 
 #[cfg(feature = "v2")]
-impl common_utils::events::ApiEventMetric for NetworkTokenStatusCheckResponse {}
+impl common_utils::events::ApiEventMetric for NetworkTokenStatusCheckResponse {
+    fn get_api_event_type(&self) -> Option<common_utils::events::ApiEventsType> {
+        match self {
+            Self::SuccessResponse(success) => {
+                Some(common_utils::events::ApiEventsType::PaymentMethod {
+                    payment_method_id: success.payment_method_id.clone(),
+                    payment_method_type: None,
+                    payment_method_subtype: None,
+                })
+            }
+            // No payment method id in the failure shape; fall back to the request-side event.
+            Self::FailureResponse(_) => None,
+        }
+    }
+}
 
 #[cfg(feature = "v2")]
 #[derive(Debug, serde::Serialize, ToSchema)]

--- a/crates/router/src/events/api_logs.rs
+++ b/crates/router/src/events/api_logs.rs
@@ -69,10 +69,23 @@ impl ApiEvent {
         http_method: &http::Method,
         infra_components: Option<serde_json::Value>,
     ) -> Self {
+        // Internal-api-key auth means this call came from another Hyperswitch service (e.g.
+        // the pay server calling the modular payment methods service), not from a merchant.
+        // Suffix the flow tag so service-to-service traffic is distinguishable in analytics
+        // from direct API traffic on the same routes.
+        let mut api_flow = api_flow.to_string();
+        if matches!(
+            auth_type,
+            AuthenticationType::InternalApiKey
+                | AuthenticationType::InternalMerchantIdProfileId { .. }
+        ) {
+            api_flow.push_str("_microservice");
+        }
+
         Self {
             tenant_id,
             merchant_id,
-            api_flow: api_flow.to_string(),
+            api_flow,
             created_at_timestamp: OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000,
             request_id: request_id.to_string(),
             latency,

--- a/crates/router/src/events/api_logs.rs
+++ b/crates/router/src/events/api_logs.rs
@@ -69,23 +69,10 @@ impl ApiEvent {
         http_method: &http::Method,
         infra_components: Option<serde_json::Value>,
     ) -> Self {
-        // Internal-api-key auth means this call came from another Hyperswitch service (e.g.
-        // the pay server calling the modular payment methods service), not from a merchant.
-        // Suffix the flow tag so service-to-service traffic is distinguishable in analytics
-        // from direct API traffic on the same routes.
-        let mut api_flow = api_flow.to_string();
-        if matches!(
-            auth_type,
-            AuthenticationType::InternalApiKey
-                | AuthenticationType::InternalMerchantIdProfileId { .. }
-        ) {
-            api_flow.push_str("_microservice");
-        }
-
         Self {
             tenant_id,
             merchant_id,
-            api_flow,
+            api_flow: api_flow.to_string(),
             created_at_timestamp: OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000,
             request_id: request_id.to_string(),
             latency,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

The modular payment methods service publishes its API events to a separate Kafka topic today. Once it publishes to the shared `api_logs_topic`, its events land in `api_events` alongside router traffic, which needs two things to be usable:

- A payment method scoped audit table, in the same shape as the existing payment (`api_events_audit`) and payout (`api_events_payout_audit`) audit tables: `api_events_payment_method_audit` keyed on a mandatory `payment_method_id`, plus the materialized view that populates it
- A way to tell service-to-service calls apart from direct merchant traffic on the same routes: `api_flow` is now suffixed with `_microservice` when the request authenticated with the internal API key

Also implements `ApiEventMetric` for the v2 token data, network token status check and tokenization request/response types, which previously emitted untyped `Miscellaneous` events and so carried no payment method identifier for the audit table to key on.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

create customer
```
curl -s -X POST http://localhost:8080/v2/customers \
  -H 'Content-Type: application/json' -H "Authorization: api-key=$KEY" -H "X-Profile-Id: $PID" \
  -d '{"name":"PM Audit Proof Customer","email":"pmaudit-proof@example.com"}'
```
customer id - 0a_cus_01a0193cbc257c919042b5ef7aa91472

Payment method — merchant auth
```
curl -s -X POST http://localhost:8080/v2/payment-methods \
  -H 'Content-Type: application/json' -H "Authorization: api-key=$KEY" -H "X-Profile-Id: $PID" \
  -d '{"payment_method_type":"card","payment_method_subtype":"credit",
       "customer_id":"0a_cus_01a0193cbc257c919042b5ef7aa91472",
       "payment_method_data":{"card":{"card_number":"4111111145551142",
         "card_exp_month":"10","card_exp_year":"30","card_holder_name":"John Doe"}},
       "storage_type":"persistent"}'
{ "id": "0a_pm_01a01943a12170638b056a9b22a34cd0",
  "payment_method_type": "card", "payment_method_subtype": "credit",
  "payment_method_data": { "card": { "last4_digits": "1142", "saved_to_locker": true } } }
```

Payment method — internal service auth
```
curl -s -X POST http://localhost:8080/v2/payment-methods \
  -H 'Content-Type: application/json' \
  -H 'X-Internal-Api-Key: test_internal_api_key' \
  -H "X-Merchant-Id: $MID" -H "X-Profile-Id: $PID" \
  -d '{...same body...}'
```
pm id-  0a_pm_01a01945f59f7cd19923c9e0ea467668


Proof 1 — payment_methods table (Postgres)
<img width="1715" height="912" alt="Screenshot 2026-08-19 at 2 46 02 PM" src="https://github.com/user-attachments/assets/36325302-d4c6-4731-953c-4bef1c54b37a" />

                   id                   | pm_type | subtype | status | in_locker
----------------------------------------+---------+---------+--------+-----------
 0a_pm_01a01945f59f7cd19923c9e0ea467668 | card    | credit  | new    | t
 0a_pm_01a01945f51e72b3acbfdee46c62f548 | card    | credit  | new    | t
 0a_pm_01a01943a12170638b056a9b22a34cd0 | card    | credit  | new    | t

Proof 2 — api_events_payment_method_audit (ClickHouse)

SELECT payment_method_id, api_flow, api_auth_type, status_code, url_path, created_at
FROM api_events_payment_method_audit ORDER BY created_at;
payment_method_id: 0a_pm_01a01943a12170638b056a9b22a34cd0
api_flow:          PaymentMethodsCreate
api_auth_type:     api_key
status_code:       200      url_path: /v2/payment-methods

payment_method_id: 0a_pm_01a01945f51e72b3acbfdee46c62f548
api_auth_type:     api_key

payment_method_id: 0a_pm_01a01945f59f7cd19923c9e0ea467668
api_auth_type:     internal_merchant_id_profile_id     ← internal service traffic

Every payment_method_id matches a real row in the Postgres table above.

Proof 3 — internal-traffic tagging works

┌─api_auth_type───────────────────┬─events─┐
│ internal_merchant_id_profile_id │      1 │
│ api_key                         │      2 │
└─────────────────────────────────┴────────┘

Proof 4 — MV filter and shared topic

┌─api_events_total─┬─pm_audit_rows─┐
│               17 │             3 │
└──────────────────┴───────────────┘
17 events reached api_events; only the 3 carrying a payment_method_id landed in the audit table — the MV's WHERE payment_method_id IS NOT NULL behaving correctly.

<img width="1470" height="457" alt="Screenshot 2026-08-19 at 2 47 10 PM" src="https://github.com/user-attachments/assets/0583b28c-c5c6-4a19-b58f-708470d1d028" />


Topics — the requirement that PM service topics match router v1:
$ kafka-topics --list
hyperswitch-api-log-events
Exactly one topic. The payment-method service events went to hyperswitch-api-log-events — the same api_logs_topic router v1 uses — not a separate topic. That's the PR's core premise confirmed.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
