### PR TITLE
fix(ucs): populate calida shop name from MCA metadata in ConnectorSpecificConfig

### DIFF
--- a/crates/router/src/core/unified_connector_service/connector_config.rs
+++ b/crates/router/src/core/unified_connector_service/connector_config.rs
@@ -111,6 +111,11 @@ pub struct PaysafeMetadata {
     pub account_id: PaysafePaymentMethodDetails,
 }
 
+#[derive(Debug, serde::Deserialize)]
+pub struct CalidaMetadata {
+    shop_name: Secret<String>,
+}
+
 /// Paysafe payment method details for account_id configuration.
 /// Contains per-currency account IDs for card, ACH, Apple Pay, Interac,
 /// Skrill and paysafecard.
@@ -593,7 +598,10 @@ pub enum ConnectorSpecificConfig {
     /// Nexixpay connector configuration
     Nexixpay { api_key: Secret<String> },
     /// Calida connector configuration
-    Calida { api_key: Secret<String> },
+    Calida {
+        api_key: Secret<String>,
+        shop_name: Option<Secret<String>>,
+    },
     /// Celero connector configuration
     Celero { api_key: Secret<String> },
     /// Stax connector configuration
@@ -880,9 +888,19 @@ impl ForeignTryFrom<(Connector, &ConnectorAuthType, Option<&serde_json::Value>)>
                 _ => Err(err("Fiservcommercehub requires MultiAuthKey auth type")),
             },
             Connector::Calida => match auth {
-                ConnectorAuthType::HeaderKey { api_key } => Ok(Self::Calida {
-                    api_key: api_key.clone(),
-                }),
+                ConnectorAuthType::HeaderKey { api_key } => {
+                    let calida_meta = metadata
+                        .map(|m| {
+                            serde_json::from_value::<CalidaMetadata>(m.clone())
+                                .map_err(|_| err("Invalid Calida metadata format"))
+                        })
+                        .transpose()?;
+
+                    Ok(Self::Calida {
+                        api_key: api_key.clone(),
+                        shop_name: calida_meta.as_ref().map(|m| m.shop_name.clone()),
+                    })
+                }
                 _ => Err(err("Calida requires HeaderKey auth type")),
             },
             Connector::Celero => match auth {


### PR DESCRIPTION
## Description

Companion to [hyperswitch-prism PR #2106](https://github.com/juspay/hyperswitch-prism/pull/2106). Calida (bluecode wallet) authorize requires `shop_name` in the payment request. It is a **required** MCA metadata field during connector setup (`[calida.metadata.shop_name]` required=true). Today HS sends only `api_key` in `ConnectorSpecificConfig::Calida` over gRPC, so UCS shadow authorizes for bluecode payments fail with `Missing required field: connector_feature_data` before reaching the connector.

This PR parses the MCA metadata JSON into `CalidaMetadata { shop_name }` and forwards it via `ConnectorSpecificConfig::Calida.shop_name`, mirroring the existing `MifinityMetadata` mechanism (juspay/hyperswitch #13596).

## Motivation and Context

- UCS shadow-mode VS_48 diffs for calida/bluecode: HS returns charged, UCS returns error (55 key differences, hs 56 keys vs ucs 1).
- Without this change the UCS-side fix in PR #2106 is inert in production.
- No behavior change when MCA metadata is absent (`shop_name: None`), which preserves current semantics for existing setups that relied on `connector_feature_data`.

## Additional Changes

- [x] API contract change: `ConnectorSpecificConfig::Calida` gains optional `shop_name` (backward compatible — option field)

## How did you test it

- `cargo check -p router --lib` passes (0 errors).

---

Fixes #13714
