### PR TITLE
fix(routing): make shadow DE logs attributable, is_equal truthful, and DE timeout effective

### DIFF
--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -1614,8 +1614,29 @@ pub async fn perform_hybrid_routing_if_enabled(
         utils::get_routing_result_source(state, dimensions).await,
         api_models::routing::RoutingResultSource::DecisionEngine
     );
+    let has_active_routing_algorithm = business_profile
+        .routing_algorithm
+        .clone()
+        .and_then(|ra| {
+            ra.parse_value::<api::routing::RoutingAlgorithmRef>("RoutingAlgorithmRef")
+                .ok()
+        })
+        .and_then(|algorithm_ref| algorithm_ref.algorithm_id)
+        .is_some();
 
-    if is_decision_engine_cutover_enabled {
+    if !has_active_routing_algorithm {
+        logger::debug!(
+            business_profile_id=?business_profile.get_id(),
+            "decision_engine_euclid: no active routing algorithm, skipping DE evaluation"
+        );
+        logger::info!(
+            business_profile_id=?business_profile.get_id(),
+            routing_source = "hyperswitch_static",
+            "decision_engine_euclid: selected routing source after hybrid stage"
+        );
+
+        (static_connectors.to_vec(), static_approach)
+    } else if is_decision_engine_cutover_enabled {
         let hybrid_stage_outcome = stage
             .route(input)
             .await

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -1660,6 +1660,8 @@ pub async fn perform_hybrid_routing_if_enabled(
         if state.conf.open_router.static_routing_enabled
             && state.conf.open_router.shadow_routing_enabled
         {
+            use router_env::tracing::Instrument;
+
             let payment_id = payment_dsl_input
                 .payment_attempt
                 .payment_id
@@ -1671,18 +1673,30 @@ pub async fn perform_hybrid_routing_if_enabled(
             let shadow_fallback = fallback_config.to_vec();
             let shadow_static_connectors = static_connectors.to_vec();
 
-            tokio::spawn(async move {
-                utils::shadow_decision_engine_routing(
-                    shadow_state,
-                    shadow_profile,
-                    payment_id,
-                    shadow_backend_input,
-                    shadow_fallback,
-                    shadow_static_connectors,
-                    static_is_volume_split,
-                )
-                .await;
-            });
+            // The detached task loses the request span, so carry the identifiers explicitly —
+            // every log inside (comparison + DE errors) stays attributable per profile/payment.
+            let shadow_span = router_env::tracing::info_span!(
+                "shadow_decision_engine_routing",
+                de_shadow = true,
+                profile_id = %business_profile.get_id().get_string_repr(),
+                merchant_id = %business_profile.merchant_id.get_string_repr(),
+                payment_id = %payment_id,
+            );
+            tokio::spawn(
+                async move {
+                    utils::shadow_decision_engine_routing(
+                        shadow_state,
+                        shadow_profile,
+                        payment_id,
+                        shadow_backend_input,
+                        shadow_fallback,
+                        shadow_static_connectors,
+                        static_is_volume_split,
+                    )
+                    .await;
+                }
+                .instrument(shadow_span),
+            );
         }
 
         (static_connectors.to_vec(), static_approach)

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -1672,9 +1672,6 @@ pub async fn perform_hybrid_routing_if_enabled(
             let shadow_backend_input = backend_input.clone();
             let shadow_fallback = fallback_config.to_vec();
             let shadow_static_connectors = static_connectors.to_vec();
-
-            // The detached task loses the request span, so carry the identifiers explicitly —
-            // every log inside (comparison + DE errors) stays attributable per profile/payment.
             let shadow_span = router_env::tracing::info_span!(
                 "shadow_decision_engine_routing",
                 de_shadow = true,

--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -211,7 +211,6 @@ where
     }
 
     let http_request = request_builder.build();
-    logger::info!(?http_request, decision_engine_request_path = %path, "decision_engine: Constructed Decision Engine API request details ({})", context_message);
     let should_parse_response = events_wrapper
         .as_ref()
         .map(|wrapper| wrapper.parse_response)
@@ -252,11 +251,6 @@ where
 
         match response {
             Ok(resp) => {
-                logger::debug!(
-                    "decision_engine: Received response from Decision Engine API ({:?})",
-                    String::from_utf8_lossy(&resp.response) // For logging
-                );
-
                 let resp = should_parse_response
                     .then(|| {
                         if std::any::TypeId::of::<Res>() == std::any::TypeId::of::<String>()
@@ -358,15 +352,14 @@ impl DecisionEngineApiHandler for EuclidApiClient {
         )
         .await?;
 
-        let parsed_response =
-            event_response
-                .response
-                .as_ref()
-                .ok_or(errors::RoutingError::OpenRouterError(
-                    "Response from decision engine API is empty".to_string(),
-                ))?;
+        // Reject an empty DE response even though the parsed value itself is unused here.
+        event_response
+            .response
+            .as_ref()
+            .ok_or(errors::RoutingError::OpenRouterError(
+                "Response from decision engine API is empty".to_string(),
+            ))?;
 
-        logger::debug!(parsed_response = ?parsed_response, response_type = %std::any::type_name::<Res>(), euclid_request_path = %path, "decision_engine_euclid: Successfully parsed response from Euclid API");
         Ok(event_response)
     }
 }
@@ -679,7 +672,6 @@ pub async fn perform_decision_euclid_routing(
     routing_event.set_routable_connectors(euclid_response.evaluated_output.clone());
     state.event_handler.log_event(&routing_event);
 
-    logger::debug!(decision_engine_euclid_response=?euclid_response,"decision_engine_euclid");
     logger::debug!(decision_engine_euclid_selected_connector=?euclid_response.evaluated_output,"decision_engine_euclid");
     Ok(euclid_response)
 }

--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -176,7 +176,7 @@ pub async fn build_and_send_decision_engine_http_request<Req, Res, ErrRes>(
     http_method: services::Method,
     path: &str,
     request_body: Option<Req>,
-    _timeout: Option<u64>,
+    timeout: Option<u64>,
     context_message: &str,
     events_wrapper: Option<RoutingEventsWrapper<Req>>,
 ) -> RoutingResult<RoutingEventsResponse<Res>>
@@ -232,7 +232,7 @@ where
     let closure = || async {
         let request_start = std::time::Instant::now();
         let response =
-            services::call_connector_api(state, http_request, "Decision Engine API call", None)
+            services::call_connector_api(state, http_request, "Decision Engine API call", timeout)
                 .await
                 .change_context(errors::RoutingError::OpenRouterCallFailed)?;
 

--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -1071,14 +1071,14 @@ impl DeDiffReason {
 impl DeComparisonResult {
     /// Why this comparison counts toward the kill switch, if it does (empty DE result => `Unresponsive`).
     fn diff_reason(self) -> Option<DeDiffReason> {
-        if !self.is_equal {
-            Some(DeDiffReason::ResultMismatch)
-        } else if self.is_equal_length {
+        if self.is_equal {
             None
         } else if self.is_de_result_empty {
             Some(DeDiffReason::Unresponsive)
-        } else {
+        } else if !self.is_equal_length {
             Some(DeDiffReason::LengthMismatch)
+        } else {
+            Some(DeDiffReason::ResultMismatch)
         }
     }
 }
@@ -1090,22 +1090,21 @@ pub fn compare_and_log_result<T: RoutingEq<T> + Serialize>(
     is_volume: bool,
 ) -> DeComparisonResult {
     let is_de_result_empty = de_result.is_empty();
-    let is_equal = if is_de_result_empty && result.is_empty() {
-        true
-    } else {
-        de_result
+    let is_equal_in_length = de_result.len() == result.len();
+    // Equal means identical: same length AND same elements in order — an empty or
+    // prefix-only DE result is not equal (zip alone would be vacuously true).
+    let is_equal = is_equal_in_length
+        && de_result
             .iter()
             .zip(result.iter())
-            .all(|(a, b)| T::is_equal(a, b))
-    };
-
-    let is_equal_in_length = de_result.len() == result.len();
+            .all(|(a, b)| T::is_equal(a, b));
 
     router_env::logger::debug!(
         routing_flow=?flow,
         is_equal=?is_equal,
         is_equal_length=?is_equal_in_length,
         is_volume=?is_volume,
+        is_de_result_empty=?is_de_result_empty,
         de_response=?to_json_string(&de_result),
         hs_response=?to_json_string(&result),
         "decision_engine_euclid"


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Hotfix backport of #13695 onto `hotfix-2026.08.12.0` (the build currently running on sandbox, where shadow-mode validation is live).

Cherry-picks the three commits from #13695 (no code changes on top):
1. **Shadow DE logs attributable** — the detached shadow task is wrapped in a span carrying `profile_id`, `merchant_id`, `payment_id` and `de_shadow=true`; its logs were previously anonymous (observed on sandbox: `fn: "?"`, no identifiers), making per-profile diff validation impossible.
2. **`is_equal` truthful** — an empty or prefix-only DE result no longer logs a vacuous `is_equal=true` (observed on sandbox: `de_response: []` with `is_equal: true`); `is_de_result_empty` is logged explicitly. Kill-switch counting classification is preserved.
3. **DE timeout effective + duplicate payload logs dropped** — the declared-but-unused 5s `EUCLID_API_TIMEOUT` is now actually passed to the HTTP client (calls previously ran at the 30s global default, including inline cutover calls), and the DE request/response is logged once instead of up to five times per call.
4. **Skip DE evaluation for rule-less profiles** (backport of #13702, closes #13701) — a profile with no active routing algorithm no longer fires DE `routing/evaluate` (inline or shadow); the static/fallback result is served directly, eliminating pointless DE load and fallback-vs-fallback noise in shadow diffs.


## Motivation and Context

Closes #13697.

Sandbox is actively running shadow-mode validation on this release line; without these fixes the shadow diffs cannot be attributed to profiles/merchants and empty DE responses masquerade as matches, which would corrupt cutover decisions.

Backport of #13695.

## How did you test it?

- Cherry-picked cleanly onto `hotfix-2026.08.12.0`; `cargo check -p router` — clean.
- Both log defects were reproduced from live sandbox logs on this exact build (`2026.08.12.0`).

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- retrigger hotfix-pr-check: original #13695 merged -->

