### PR TITLE
fix(routing): skip Decision Engine evaluation when the profile has no active routing algorithm

### DIFF
--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -1614,8 +1614,29 @@ pub async fn perform_hybrid_routing_if_enabled(
         utils::get_routing_result_source(state, dimensions).await,
         api_models::routing::RoutingResultSource::DecisionEngine
     );
+    let has_active_routing_algorithm = business_profile
+        .routing_algorithm
+        .clone()
+        .and_then(|ra| {
+            ra.parse_value::<api::routing::RoutingAlgorithmRef>("RoutingAlgorithmRef")
+                .ok()
+        })
+        .and_then(|algorithm_ref| algorithm_ref.algorithm_id)
+        .is_some();
 
-    if is_decision_engine_cutover_enabled {
+    if !has_active_routing_algorithm {
+        logger::debug!(
+            business_profile_id=?business_profile.get_id(),
+            "decision_engine_euclid: no active routing algorithm, skipping DE evaluation"
+        );
+        logger::info!(
+            business_profile_id=?business_profile.get_id(),
+            routing_source = "hyperswitch_static",
+            "decision_engine_euclid: selected routing source after hybrid stage"
+        );
+
+        (static_connectors.to_vec(), static_approach)
+    } else if is_decision_engine_cutover_enabled {
         let hybrid_stage_outcome = stage
             .route(input)
             .await


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

On the v1 payments path, the hybrid routing stage called the Decision Engine's `routing/evaluate` even when the profile has **no active routing algorithm**: `perform_static_routing_locally` falls back to the merchant default connectors and the flow proceeds into `perform_hybrid_routing_if_enabled`, whose only gates were the cutover source / global shadow flags.

Since rules are dual-written HS → DE, a rule-less profile has nothing for DE to evaluate — every payment produced a pointless DE call ("active rule not present" spam / fallback echoes) and polluted shadow-mode diff data (fallback-vs-fallback comparisons logging `is_equal=true` without exercising any rule, or noise mismatches).

`perform_hybrid_routing_if_enabled` now checks the profile's `routing_algorithm` ref and, when no active algorithm is present, skips DE evaluation entirely — both the inline cutover call and the shadow spawn — serving the Hyperswitch static/fallback result and logging `routing_source = hyperswitch_static` as usual (plus a debug line naming the skip reason).

This matches `perform_static_routing_v1` (v2 payments / payouts / decide flows), which already returns the fallback before any DE call when no algorithm is present.

Notes:
- A cutover profile with rules only on the DE side is not a reachable state via normal flows (rules are created on HS first and dual-written), so gating on the HS algorithm is safe.
- If the algorithm exists but fails to load/evaluate, behavior is unchanged (DE is still consulted) — the gate only covers "no active rule configured".

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes #13701.

Part of the shadow-mode rollout (#13564, #13695): with shadow enabled for all merchants, rule-less profiles would multiply DE load and Loki volume for zero signal, and their fallback-vs-fallback "matches" would corrupt per-profile cutover decisions.

## How did you test it?

- `cargo check -p router` — clean; `cargo +nightly fmt` applied.
- Traced both callers: v1 payments (`static_dynamic_routing_v1_for_payments`) now skips DE for rule-less profiles; `perform_static_routing_v1` already had the equivalent early fallback.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
