### PR TITLE
fix(revenue_recovery): return actionable webhook errors

### DIFF
--- a/crates/api_models/src/process_tracker/revenue_recovery.rs
+++ b/crates/api_models/src/process_tracker/revenue_recovery.rs
@@ -32,8 +32,13 @@ pub struct RevenueRecoveryRetriggerRequest {
     #[schema(example = "2022-09-10T10:11:12Z")]
     #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
     pub schedule_time: Option<PrimitiveDateTime>,
-    /// Status of The Process Tracker Task
-    pub status: enums::ProcessTrackerStatus,
-    /// Business Status of The Process Tracker Task
-    pub business_status: String,
+    /// Status of The Process Tracker Task. If not provided, the existing
+    /// status is retained as is.
+    pub status: Option<enums::ProcessTrackerStatus>,
+    /// Business Status of The Process Tracker Task. If not provided, the
+    /// existing business status is retained as is.
+    pub business_status: Option<String>,
+    /// Retry count to set on the process tracker task. If not provided, the
+    /// existing retry count is retained as is.
+    pub retry_count: Option<i32>,
 }

--- a/crates/hyperswitch_connectors/src/connectors/chargebee.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee.rs
@@ -836,7 +836,14 @@ impl webhooks::IncomingWebhook for Chargebee {
     ) -> CustomResult<revenue_recovery::RevenueRecoveryAttemptData, errors::ConnectorError> {
         let webhook =
             transformers::ChargebeeWebhookBody::get_webhook_object_from_body(request.body)?;
-        revenue_recovery::RevenueRecoveryAttemptData::try_from(webhook)
+        let attempt_data = revenue_recovery::RevenueRecoveryAttemptData::try_from(webhook)?;
+        // Log the Chargebee gateway ID to verify that it is configured on the billing connector.
+        router_env::logger::info!(
+            connector_account_reference_id = %attempt_data.connector_account_reference_id,
+            invoice_id = ?attempt_data.merchant_reference_id,
+            "chargebee revenue recovery attempt data"
+        );
+        Ok(attempt_data)
     }
     #[cfg(all(feature = "revenue_recovery", feature = "v2"))]
     fn get_revenue_recovery_invoice_details(

--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -479,17 +479,137 @@ pub struct ChargebeeTransactionData {
     #[serde(default, with = "common_utils::custom_serde::timestamp::option")]
     date: Option<PrimitiveDateTime>,
     payment_method: ChargebeeTransactionPaymentMethod,
-    payment_method_details: String,
+    payment_method_details: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ChargebeeTransactionPaymentMethod {
     Card,
+    #[serde(rename = "unionpay")]
+    UnionPay,
+    SouthKoreanCards,
+    PaypalExpressCheckout,
+    AmazonPayments,
+    ApplePay,
+    GooglePay,
+    #[serde(rename = "wechat_pay")]
+    WeChatPay,
+    #[serde(rename = "alipay")]
+    AliPay,
+    #[serde(rename = "alipay_hk")]
+    AliPayHk,
+    Venmo,
+    KakaoPay,
+    RevolutPay,
+    CashAppPay,
+    Twint,
+    GoPay,
+    Gcash,
+    Dana,
+    TouchNGo,
+    Swish,
+    Ideal,
+    Sofort,
+    Bancontact,
+    PayconiqByBancontact,
+    Giropay,
+    Dotpay,
+    OnlineBankingPoland,
+    Trustly,
+    Bizum,
+    NetbankingEmandates,
+    PayByBank,
+    Upi,
+    DirectDebit,
+    PayTo,
+    FasterPayments,
+    SepaInstantTransfer,
+    AutomatedBankTransfer,
+    Pix,
+    Promptpay,
+    Klarna,
+    KlarnaPayNow,
+    AfterPay,
+    Stablecoin,
+    #[serde(other)]
+    Other,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ChargebeePaymentMethodDetails {
+#[cfg(all(feature = "revenue_recovery", feature = "v2"))]
+impl ChargebeeTransactionPaymentMethod {
+    fn payment_method_sub_type(self) -> Option<enums::PaymentMethodType> {
+        match self {
+            Self::PaypalExpressCheckout => Some(enums::PaymentMethodType::Paypal),
+            Self::AmazonPayments => Some(enums::PaymentMethodType::AmazonPay),
+            Self::ApplePay => Some(enums::PaymentMethodType::ApplePay),
+            Self::GooglePay => Some(enums::PaymentMethodType::GooglePay),
+            Self::WeChatPay => Some(enums::PaymentMethodType::WeChatPay),
+            Self::AliPay => Some(enums::PaymentMethodType::AliPay),
+            Self::AliPayHk => Some(enums::PaymentMethodType::AliPayHk),
+            Self::Venmo => Some(enums::PaymentMethodType::Venmo),
+            Self::KakaoPay => Some(enums::PaymentMethodType::KakaoPay),
+            Self::RevolutPay => Some(enums::PaymentMethodType::RevolutPay),
+            Self::CashAppPay => Some(enums::PaymentMethodType::Cashapp),
+            Self::Twint => Some(enums::PaymentMethodType::Twint),
+            Self::GoPay => Some(enums::PaymentMethodType::GoPay),
+            Self::Gcash => Some(enums::PaymentMethodType::Gcash),
+            Self::Dana => Some(enums::PaymentMethodType::Dana),
+            Self::TouchNGo => Some(enums::PaymentMethodType::TouchNGo),
+            Self::Swish => Some(enums::PaymentMethodType::Swish),
+            Self::Ideal => Some(enums::PaymentMethodType::Ideal),
+            Self::Sofort => Some(enums::PaymentMethodType::Sofort),
+            Self::Bancontact | Self::PayconiqByBancontact => {
+                Some(enums::PaymentMethodType::BancontactCard)
+            }
+            Self::Giropay => Some(enums::PaymentMethodType::Giropay),
+            Self::Dotpay | Self::OnlineBankingPoland => {
+                Some(enums::PaymentMethodType::OnlineBankingPoland)
+            }
+            Self::Trustly => Some(enums::PaymentMethodType::Trustly),
+            Self::Bizum => Some(enums::PaymentMethodType::Bizum),
+            Self::NetbankingEmandates => Some(enums::PaymentMethodType::LocalBankRedirect),
+            Self::PayByBank => Some(enums::PaymentMethodType::OpenBanking),
+            Self::Upi => Some(enums::PaymentMethodType::UpiCollect),
+            Self::DirectDebit => Some(enums::PaymentMethodType::Sepa),
+            Self::PayTo => Some(enums::PaymentMethodType::Becs),
+            Self::FasterPayments => Some(enums::PaymentMethodType::Bacs),
+            Self::SepaInstantTransfer => Some(enums::PaymentMethodType::InstantBankTransfer),
+            Self::AutomatedBankTransfer => Some(enums::PaymentMethodType::LocalBankTransfer),
+            Self::Pix => Some(enums::PaymentMethodType::Pix),
+            Self::Promptpay => Some(enums::PaymentMethodType::PromptPay),
+            Self::Klarna | Self::KlarnaPayNow => Some(enums::PaymentMethodType::Klarna),
+            Self::AfterPay => Some(enums::PaymentMethodType::AfterpayClearpay),
+            Self::Stablecoin => Some(enums::PaymentMethodType::CryptoCurrency),
+            Self::Card | Self::UnionPay | Self::SouthKoreanCards => None,
+            Self::Other => None,
+        }
+    }
+
+    fn parse_payment_method_details(
+        self,
+        raw_details: &str,
+    ) -> Result<ChargebeePaymentMethodDetails, error_stack::Report<errors::ConnectorError>> {
+        match self {
+            Self::Card | Self::UnionPay | Self::SouthKoreanCards => {
+                let details: ChargebeeCardPaymentMethodDetails = serde_json::from_str(raw_details)
+                    .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
+                Ok(ChargebeePaymentMethodDetails::Card(details.card))
+            }
+            _ => Ok(ChargebeePaymentMethodDetails::NonCard),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ChargebeePaymentMethodDetails {
+    Card(ChargebeeCardDetails),
+    NonCard,
+}
+
+#[cfg(all(feature = "revenue_recovery", feature = "v2"))]
+#[derive(Deserialize, Debug)]
+struct ChargebeeCardPaymentMethodDetails {
     card: ChargebeeCardDetails,
 }
 
@@ -523,27 +643,31 @@ pub enum ChargebeeCardBrand {
     Pulse,
     Accel,
     Nyce,
+    #[serde(other)]
+    Other,
 }
 
-impl From<ChargebeeCardBrand> for common_enums::CardNetwork {
+impl From<ChargebeeCardBrand> for Option<common_enums::CardNetwork> {
     fn from(brand: ChargebeeCardBrand) -> Self {
-        match brand {
-            ChargebeeCardBrand::Visa => Self::Visa,
-            ChargebeeCardBrand::Mastercard => Self::Mastercard,
-            ChargebeeCardBrand::AmericanExpress => Self::AmericanExpress,
-            ChargebeeCardBrand::Jcb => Self::JCB,
-            ChargebeeCardBrand::DinersClub => Self::DinersClub,
-            ChargebeeCardBrand::Discover => Self::Discover,
-            ChargebeeCardBrand::CartesBancaires => Self::CartesBancaires,
-            ChargebeeCardBrand::UnionPay => Self::UnionPay,
-            ChargebeeCardBrand::Interac => Self::Interac,
-            ChargebeeCardBrand::RuPay => Self::RuPay,
-            ChargebeeCardBrand::Maestro => Self::Maestro,
-            ChargebeeCardBrand::Star => Self::Star,
-            ChargebeeCardBrand::Pulse => Self::Pulse,
-            ChargebeeCardBrand::Accel => Self::Accel,
-            ChargebeeCardBrand::Nyce => Self::Nyce,
-        }
+        use common_enums::CardNetwork;
+        Some(match brand {
+            ChargebeeCardBrand::Visa => CardNetwork::Visa,
+            ChargebeeCardBrand::Mastercard => CardNetwork::Mastercard,
+            ChargebeeCardBrand::AmericanExpress => CardNetwork::AmericanExpress,
+            ChargebeeCardBrand::Jcb => CardNetwork::JCB,
+            ChargebeeCardBrand::DinersClub => CardNetwork::DinersClub,
+            ChargebeeCardBrand::Discover => CardNetwork::Discover,
+            ChargebeeCardBrand::CartesBancaires => CardNetwork::CartesBancaires,
+            ChargebeeCardBrand::UnionPay => CardNetwork::UnionPay,
+            ChargebeeCardBrand::Interac => CardNetwork::Interac,
+            ChargebeeCardBrand::RuPay => CardNetwork::RuPay,
+            ChargebeeCardBrand::Maestro => CardNetwork::Maestro,
+            ChargebeeCardBrand::Star => CardNetwork::Star,
+            ChargebeeCardBrand::Pulse => CardNetwork::Pulse,
+            ChargebeeCardBrand::Accel => CardNetwork::Accel,
+            ChargebeeCardBrand::Nyce => CardNetwork::Nyce,
+            ChargebeeCardBrand::Other => return None,
+        })
     }
 }
 
@@ -552,6 +676,11 @@ impl From<ChargebeeCardBrand> for common_enums::CardNetwork {
 pub enum ChargebeeFundingType {
     Credit,
     Debit,
+    Prepaid,
+    NotKnown,
+    NotApplicable,
+    #[serde(other)]
+    Other,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -597,8 +726,39 @@ pub struct ChargebeePaymentMethod {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ChargebeeGateway {
+    Adyen,
     Stripe,
     Braintree,
+    AuthorizeNet,
+    Paypal,
+    PaypalPro,
+    PaypalExpressCheckout,
+    PaypalPayflowPro,
+    AmazonPayments,
+    Worldpay,
+    Vantiv,
+    Beanstream,
+    Elavon,
+    Nmi,
+    Gocardless,
+    Moneris,
+    MonerisUs,
+    Bluesnap,
+    Cybersource,
+    CheckoutCom,
+    IngenicoDirect,
+    Mollie,
+    Razorpay,
+    GlobalPayments,
+    BankOfAmerica,
+    Ebanx,
+    Dlocal,
+    Nuvei,
+    Paystack,
+    JpMorgan,
+    DeutscheBank,
+    #[serde(other)]
+    Other,
 }
 
 impl ChargebeeWebhookBody {
@@ -655,25 +815,15 @@ pub struct ChargebeeMandateDetails {
 }
 
 impl ChargebeeCustomer {
-    // the logic to find connector customer id & mandate id is different for different gateways, reference : https://apidocs.chargebee.com/docs/api/customers?prod_cat_ver=2#customer_payment_method_reference_id .
     pub fn find_connector_ids(&self) -> Result<ChargebeeMandateDetails, errors::ConnectorError> {
-        match self.payment_method.gateway {
-            ChargebeeGateway::Stripe | ChargebeeGateway::Braintree => {
-                let mut parts = self.payment_method.reference_id.split('/');
-                let customer_id = parts
-                    .next()
-                    .ok_or(errors::ConnectorError::WebhookBodyDecodingFailed)?
-                    .to_string();
-                let mandate_id = parts
-                    .next_back()
-                    .ok_or(errors::ConnectorError::WebhookBodyDecodingFailed)?
-                    .to_string();
-                Ok(ChargebeeMandateDetails {
-                    customer_id,
-                    mandate_id,
-                })
-            }
-        }
+        let reference_id = self.payment_method.reference_id.as_str();
+        let mut parts = reference_id.split('/');
+        let customer_id = parts.next().unwrap_or(reference_id);
+        let mandate_id = parts.next_back().unwrap_or(customer_id);
+        Ok(ChargebeeMandateDetails {
+            customer_id: customer_id.to_string(),
+            mandate_id: mandate_id.to_string(),
+        })
     }
 }
 
@@ -706,13 +856,34 @@ impl TryFrom<ChargebeeWebhookBody> for revenue_recovery::RevenueRecoveryAttemptD
         let connector_account_reference_id = item.content.transaction.gateway_account_id.clone();
         let transaction_created_at = item.content.transaction.date;
         let status = enums::AttemptStatus::from(item.content.transaction.status);
-        let payment_method_type =
-            enums::PaymentMethod::from(item.content.transaction.payment_method);
-        let payment_method_details: ChargebeePaymentMethodDetails =
-            serde_json::from_str(&item.content.transaction.payment_method_details)
-                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
-        let payment_method_sub_type =
-            enums::PaymentMethodType::from(payment_method_details.card.funding_type);
+        let chargebee_payment_method = item.content.transaction.payment_method;
+        let payment_method_type = enums::PaymentMethod::try_from(chargebee_payment_method)?;
+        let payment_method_details = item
+            .content
+            .transaction
+            .payment_method_details
+            .as_deref()
+            .map(|raw_details| chargebee_payment_method.parse_payment_method_details(raw_details))
+            .transpose()?;
+        let (payment_method_sub_type, card_info) = match payment_method_details {
+            Some(ChargebeePaymentMethodDetails::Card(card)) => (
+                enums::PaymentMethodType::from(card.funding_type),
+                api_models::payments::AdditionalCardInfo {
+                    card_network: card.brand.into(),
+                    card_isin: Some(card.iin),
+                    ..Default::default()
+                },
+            ),
+            Some(ChargebeePaymentMethodDetails::NonCard) | None => (
+                chargebee_payment_method.payment_method_sub_type().ok_or(
+                    errors::ConnectorError::NotSupported {
+                        message: "payment method in revenue recovery webhook".to_string(),
+                        connector: "chargebee",
+                    },
+                )?,
+                api_models::payments::AdditionalCardInfo::default(),
+            ),
+        };
         // Chargebee retry count will always be less than u16 always. Chargebee can have maximum 12 retry attempts
         #[allow(clippy::as_conversions)]
         let retry_count = item
@@ -752,26 +923,7 @@ impl TryFrom<ChargebeeWebhookBody> for revenue_recovery::RevenueRecoveryAttemptD
             invoice_billing_started_at_time,
             // This field is none because it is specific to stripebilling.
             charge_id: None,
-            // Need to populate these card info field
-            card_info: api_models::payments::AdditionalCardInfo {
-                card_network: Some(payment_method_details.card.brand.into()),
-                card_isin: Some(payment_method_details.card.iin),
-                card_issuer: None,
-                card_type: None,
-                card_issuing_country: None,
-                card_issuing_country_code: None,
-                bank_code: None,
-                last4: None,
-                card_extended_bin: None,
-                card_exp_month: None,
-                card_exp_year: None,
-                card_holder_name: None,
-                payment_checks: None,
-                authentication_data: None,
-                is_regulated: None,
-                signature_network: None,
-                auth_code: None,
-            },
+            card_info,
         })
     }
 }
@@ -789,10 +941,58 @@ impl From<ChargebeeTranasactionStatus> for enums::AttemptStatus {
     }
 }
 
-impl From<ChargebeeTransactionPaymentMethod> for enums::PaymentMethod {
-    fn from(payment_method: ChargebeeTransactionPaymentMethod) -> Self {
+impl TryFrom<ChargebeeTransactionPaymentMethod> for enums::PaymentMethod {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(payment_method: ChargebeeTransactionPaymentMethod) -> Result<Self, Self::Error> {
         match payment_method {
-            ChargebeeTransactionPaymentMethod::Card => Self::Card,
+            ChargebeeTransactionPaymentMethod::Card
+            | ChargebeeTransactionPaymentMethod::UnionPay
+            | ChargebeeTransactionPaymentMethod::SouthKoreanCards => Ok(Self::Card),
+            ChargebeeTransactionPaymentMethod::PaypalExpressCheckout
+            | ChargebeeTransactionPaymentMethod::AmazonPayments
+            | ChargebeeTransactionPaymentMethod::ApplePay
+            | ChargebeeTransactionPaymentMethod::GooglePay
+            | ChargebeeTransactionPaymentMethod::WeChatPay
+            | ChargebeeTransactionPaymentMethod::AliPay
+            | ChargebeeTransactionPaymentMethod::AliPayHk
+            | ChargebeeTransactionPaymentMethod::Venmo
+            | ChargebeeTransactionPaymentMethod::KakaoPay
+            | ChargebeeTransactionPaymentMethod::RevolutPay
+            | ChargebeeTransactionPaymentMethod::CashAppPay
+            | ChargebeeTransactionPaymentMethod::Twint
+            | ChargebeeTransactionPaymentMethod::GoPay
+            | ChargebeeTransactionPaymentMethod::Gcash
+            | ChargebeeTransactionPaymentMethod::Dana
+            | ChargebeeTransactionPaymentMethod::TouchNGo
+            | ChargebeeTransactionPaymentMethod::Swish => Ok(Self::Wallet),
+            ChargebeeTransactionPaymentMethod::DirectDebit
+            | ChargebeeTransactionPaymentMethod::PayTo => Ok(Self::BankDebit),
+            ChargebeeTransactionPaymentMethod::SepaInstantTransfer
+            | ChargebeeTransactionPaymentMethod::AutomatedBankTransfer
+            | ChargebeeTransactionPaymentMethod::FasterPayments
+            | ChargebeeTransactionPaymentMethod::Pix => Ok(Self::BankTransfer),
+            ChargebeeTransactionPaymentMethod::Ideal
+            | ChargebeeTransactionPaymentMethod::Sofort
+            | ChargebeeTransactionPaymentMethod::Bancontact
+            | ChargebeeTransactionPaymentMethod::PayconiqByBancontact
+            | ChargebeeTransactionPaymentMethod::Giropay
+            | ChargebeeTransactionPaymentMethod::Dotpay
+            | ChargebeeTransactionPaymentMethod::OnlineBankingPoland
+            | ChargebeeTransactionPaymentMethod::Trustly
+            | ChargebeeTransactionPaymentMethod::Bizum
+            | ChargebeeTransactionPaymentMethod::NetbankingEmandates => Ok(Self::BankRedirect),
+            ChargebeeTransactionPaymentMethod::PayByBank => Ok(Self::OpenBanking),
+            ChargebeeTransactionPaymentMethod::Upi => Ok(Self::Upi),
+            ChargebeeTransactionPaymentMethod::Promptpay => Ok(Self::RealTimePayment),
+            ChargebeeTransactionPaymentMethod::Stablecoin => Ok(Self::Crypto),
+            ChargebeeTransactionPaymentMethod::Klarna
+            | ChargebeeTransactionPaymentMethod::KlarnaPayNow
+            | ChargebeeTransactionPaymentMethod::AfterPay => Ok(Self::PayLater),
+            ChargebeeTransactionPaymentMethod::Other => Err(errors::ConnectorError::NotSupported {
+                message: "payment method in revenue recovery webhook".to_string(),
+                connector: "chargebee",
+            }
+            .into()),
         }
     }
 }
@@ -802,6 +1002,19 @@ impl From<ChargebeeFundingType> for enums::PaymentMethodType {
         match funding_type {
             ChargebeeFundingType::Credit => Self::Credit,
             ChargebeeFundingType::Debit => Self::Debit,
+            ChargebeeFundingType::Prepaid
+            | ChargebeeFundingType::NotKnown
+            | ChargebeeFundingType::NotApplicable
+            | ChargebeeFundingType::Other => {
+                #[cfg(feature = "v2")]
+                {
+                    Self::Card
+                }
+                #[cfg(feature = "v1")]
+                {
+                    Self::Credit
+                }
+            }
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -469,6 +469,7 @@ pub struct ChargebeeInvoicePayments {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ChargebeeTransactionData {
+    id: Option<String>,
     id_at_gateway: Option<String>,
     status: ChargebeeTranasactionStatus,
     error_code: Option<String>,
@@ -841,6 +842,7 @@ impl TryFrom<ChargebeeWebhookBody> for revenue_recovery::RevenueRecoveryAttemptD
             .content
             .transaction
             .id_at_gateway
+            .or(item.content.transaction.id)
             .map(common_utils::types::ConnectorTransactionId::TxnId);
         let error_code = item.content.transaction.error_code.clone();
         let error_message = item.content.transaction.error_text.clone();

--- a/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
@@ -474,6 +474,26 @@ pub struct CustomerRequestData {
     merchant_customer_id: Option<common_utils::id_type::CustomerId>,
 }
 
+/// PayPal keeps legacy Billing Agreements in a different namespace from Vault v3 tokens, and
+/// accepts them on their own field rather than as a `vault_id`. Billing connectors such as
+/// Chargebee hand us the agreement id for stored PayPal payment methods, so a mandate payment
+/// has to be able to charge either kind of credential.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BillingAgreementStruct {
+    billing_agreement_id: Secret<String>,
+}
+
+impl BillingAgreementStruct {
+    /// PayPal billing agreement ids are consistently `B-` prefixed, which is the only signal
+    /// available here - the mandate id reaches the connector as an opaque string with no
+    /// accompanying metadata describing which namespace it belongs to.
+    const ID_PREFIX: &'static str = "B-";
+
+    fn is_billing_agreement_id(mandate_id: &str) -> bool {
+        mandate_id.starts_with(Self::ID_PREFIX)
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum CardRequest {
@@ -537,6 +557,7 @@ pub enum ShippingPreference {
 pub enum PaypalRedirectionRequest {
     PaypalRedirectionStruct(PaypalRedirectionStruct),
     PaypalVaultStruct(VaultStruct),
+    BillingAgreementStruct(BillingAgreementStruct),
 }
 
 #[derive(Debug, Serialize)]
@@ -1274,16 +1295,26 @@ impl TryFrom<&PaypalRouterData<&PaymentsAuthorizeRouterData>> for PaypalPayments
                         }),
                     ))),
                     enums::PaymentMethodType::Paypal => Ok(Some(PaymentSourceItem::Paypal(
-                        PaypalRedirectionRequest::PaypalVaultStruct(VaultStruct {
-                            vault_id: connector_mandate_id.into(),
-                            attributes: item.router_data.get_optional_customer_id().as_ref().map(
-                                |customer_id| VaultRequestAttributes {
-                                    customer: Some(CustomerRequestData {
-                                        merchant_customer_id: Some(customer_id.clone()),
-                                    }),
+                        if BillingAgreementStruct::is_billing_agreement_id(&connector_mandate_id) {
+                            PaypalRedirectionRequest::BillingAgreementStruct(
+                                BillingAgreementStruct {
+                                    billing_agreement_id: connector_mandate_id.into(),
                                 },
-                            ),
-                        }),
+                            )
+                        } else {
+                            PaypalRedirectionRequest::PaypalVaultStruct(VaultStruct {
+                                vault_id: connector_mandate_id.into(),
+                                attributes: item
+                                    .router_data
+                                    .get_optional_customer_id()
+                                    .as_ref()
+                                    .map(|customer_id| VaultRequestAttributes {
+                                        customer: Some(CustomerRequestData {
+                                            merchant_customer_id: Some(customer_id.clone()),
+                                        }),
+                                    }),
+                            })
+                        },
                     ))),
                     enums::PaymentMethodType::Ach
                     | enums::PaymentMethodType::Affirm

--- a/crates/hyperswitch_connectors/src/connectors/stripe.rs
+++ b/crates/hyperswitch_connectors/src/connectors/stripe.rs
@@ -870,6 +870,12 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Str
                 "v1/setup_intents",
                 x,
             )),
+            Ok(x) if x.starts_with("ch_") => Ok(format!(
+                "{}{}/{}",
+                self.base_url(connectors),
+                "v1/charges",
+                x,
+            )),
             Ok(x) => Ok(format!(
                 "{}{}/{}{}",
                 self.base_url(connectors),
@@ -911,6 +917,21 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Str
                 let response: stripe::SetupIntentResponse = res
                     .response
                     .parse_struct("SetupIntentSyncResponse")
+                    .change_context(ConnectorError::ResponseDeserializationFailed)?;
+
+                event_builder.map(|i| i.set_response_body(&response));
+                router_env::logger::info!(connector_response=?response);
+
+                RouterData::try_from(ResponseRouterData {
+                    response,
+                    data: data.clone(),
+                    http_code: res.status_code,
+                })
+            }
+            Ok(x) if x.starts_with("ch_") => {
+                let response: stripe::ChargeSyncResponse = res
+                    .response
+                    .parse_struct("ChargeSyncResponse")
                     .change_context(ConnectorError::ResponseDeserializationFailed)?;
 
                 event_builder.map(|i| i.set_response_body(&response));

--- a/crates/hyperswitch_connectors/src/connectors/stripe/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/stripe/transformers.rs
@@ -3221,6 +3221,9 @@ impl StripeChargeEnum {
 pub struct StripeCharge {
     pub id: String,
     pub payment_method_details: Option<StripePaymentMethodDetailsResponse>,
+    /// The `outcome` object from the Stripe charge, describing whether the payment was accepted
+    /// and the risk/network assessment behind that decision.
+    pub outcome: Option<StripeChargeOutcome>,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq, Serialize)]
@@ -4783,6 +4786,113 @@ impl<F, T> TryFrom<ResponseRouterData<F, ChargesResponse, T, PaymentsResponseDat
         Ok(Self {
             status,
             response,
+            ..item.data
+        })
+    }
+}
+
+/// Full representation of the Stripe charge `outcome` object, shared by the
+/// charge sync response and the payment intent's `latest_charge`.
+/// See <https://docs.stripe.com/api/charges/object#charge_object-outcome>
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub struct StripeChargeOutcome {
+    /// Possible values: authorized, manual_review, issuer_declined, blocked, invalid
+    #[serde(rename = "type")]
+    pub outcome_type: Option<String>,
+    /// Possible values: approved_by_network, declined_by_network, not_sent_to_network,
+    /// reversed_after_approval
+    pub network_status: Option<String>,
+    /// Enumerated reason for the outcome type (e.g. highest_risk_level, rule)
+    pub reason: Option<String>,
+    /// Stripe Radar's evaluation of the riskiness (normal, elevated, highest, not_assessed, unknown)
+    pub risk_level: Option<String>,
+    /// Stripe Radar's numeric risk score (0-100), only available with Radar for Fraud Teams
+    pub risk_score: Option<i32>,
+    /// Human-readable description of the outcome, meant for the recipient of the payment
+    pub seller_message: Option<String>,
+    /// Advice on how to proceed with an error (confirm_card_data, do_not_try_again, try_again_later)
+    pub advice_code: Option<String>,
+    /// Network advice code for network-declined charges
+    pub network_advice_code: Option<String>,
+    /// Network decline code for network-declined charges
+    pub network_decline_code: Option<String>,
+    /// The ID of the Radar rule that matched the payment, if applicable
+    pub rule: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ChargeSyncResponse {
+    pub id: String,
+    pub status: StripePaymentStatus,
+    pub payment_intent: Option<String>,
+    pub amount_captured: Option<MinorUnit>,
+    pub failure_code: Option<String>,
+    pub failure_message: Option<String>,
+    pub outcome: Option<StripeChargeOutcome>,
+}
+
+impl<F, T> TryFrom<ResponseRouterData<F, ChargeSyncResponse, T, PaymentsResponseData>>
+    for RouterData<F, T, PaymentsResponseData>
+{
+    type Error = error_stack::Report<ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<F, ChargeSyncResponse, T, PaymentsResponseData>,
+    ) -> Result<Self, Self::Error> {
+        let status = get_stripe_payment_status(item.response.status, item.data.status);
+
+        let resource_id = item
+            .response
+            .payment_intent
+            .clone()
+            .unwrap_or_else(|| item.response.id.clone());
+        let outcome = item.response.outcome.clone();
+        let response = if is_payment_failure(status) {
+            Err(hyperswitch_domain_models::router_data::ErrorResponse {
+                code: item
+                    .response
+                    .failure_code
+                    .clone()
+                    .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
+                message: item
+                    .response
+                    .failure_message
+                    .clone()
+                    .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
+                reason: item.response.failure_message.clone(),
+                status_code: item.http_code,
+                attempt_status: Some(status),
+                connector_transaction_id: Some(resource_id.clone()),
+                connector_response_reference_id: Some(resource_id.clone()),
+                network_advice_code: outcome.as_ref().and_then(|o| o.network_advice_code.clone()),
+                network_decline_code: outcome
+                    .as_ref()
+                    .and_then(|o| o.network_decline_code.clone()),
+                network_error_message: outcome.as_ref().and_then(|o| o.seller_message.clone()),
+                connector_metadata: None,
+            })
+        } else {
+            Ok(PaymentsResponseData::TransactionResponse {
+                resource_id: ResponseId::ConnectorTransactionId(resource_id.clone()),
+                redirection_data: Box::new(None),
+                mandate_reference: Box::new(None),
+                connector_metadata: None,
+                network_txn_id: None,
+                network_txn_link_id: None,
+                connector_response_reference_id: Some(resource_id.clone()),
+                incremental_authorization_allowed: None,
+                authentication_data: None,
+                charges: None,
+            })
+        };
+
+        Ok(Self {
+            status,
+            response,
+            amount_captured: item
+                .response
+                .amount_captured
+                .map(|amount| amount.get_amount_as_i64()),
+            minor_amount_captured: item.response.amount_captured,
             ..item.data
         })
     }

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -458,8 +458,10 @@ pub enum RevenueRecoveryError {
     PaymentIntentCreateFailed,
     #[error("Source verification failed for billing connector")]
     WebhookAuthenticationFailed,
-    #[error("Payment merchant connector account not found using account reference id")]
-    PaymentMerchantConnectorAccountNotFound,
+    #[error("Payment merchant connector account {id} not found using account reference id")]
+    PaymentMerchantConnectorAccountNotFound { id: String },
+    #[error("Payment attempt cannot be recorded while the invoice is in {status} state")]
+    PaymentAttemptRecordNotAllowed { status: String },
     #[error("Failed to fetch primitive date_time")]
     ScheduleTimeFetchFailed,
     #[error("Failed to create process tracker")]
@@ -484,4 +486,50 @@ pub enum RevenueRecoveryError {
     RevenueRecoveryAttemptDataCreateFailed,
     #[error("Failed to insert the revenue recovery payment method data in redis")]
     RevenueRecoveryRedisInsertFailed,
+}
+
+#[cfg(all(feature = "revenue_recovery", feature = "v2"))]
+impl common_utils::errors::ErrorSwitch<ApiErrorResponse> for RevenueRecoveryError {
+    fn switch(&self) -> ApiErrorResponse {
+        match self {
+            Self::WebhookAuthenticationFailed => ApiErrorResponse::WebhookAuthenticationFailed,
+            Self::InvoiceWebhookProcessingFailed
+            | Self::TransactionWebhookProcessingFailed
+            | Self::RevenueRecoveryAttemptDataCreateFailed
+            | Self::CustomerIdNotFound => ApiErrorResponse::WebhookUnprocessableEntity,
+
+            Self::PaymentMerchantConnectorAccountNotFound { id } => {
+                ApiErrorResponse::MerchantConnectorAccountNotFound { id: id.clone() }
+            }
+            Self::PaymentAttemptRecordNotAllowed { status } => {
+                ApiErrorResponse::PreconditionFailed {
+                    message: format!(
+                        "payment attempt cannot be recorded because the invoice is already in \
+                         {status} state"
+                    ),
+                }
+            }
+
+            Self::BillingThresholdRetryCountFetchFailed => {
+                ApiErrorResponse::InvalidConnectorConfiguration {
+                    config: "revenue_recovery.billing_connector_retry_threshold".to_string(),
+                }
+            }
+
+            Self::PaymentAttemptIdNotFound | Self::RetryAlgorithmTypeNotFound => {
+                ApiErrorResponse::WebhookResourceNotFound
+            }
+            Self::PaymentIntentFetchFailed
+            | Self::PaymentAttemptFetchFailed
+            | Self::PaymentIntentCreateFailed
+            | Self::ScheduleTimeFetchFailed
+            | Self::ProcessTrackerCreationError
+            | Self::ProcessTrackerResponseError
+            | Self::BillingConnectorPaymentsSyncFailed
+            | Self::BillingConnectorInvoiceSyncFailed
+            | Self::RetryCountFetchFailed
+            | Self::RetryAlgorithmUpdationFailed
+            | Self::RevenueRecoveryRedisInsertFailed => ApiErrorResponse::WebhookProcessingFailure,
+        }
+    }
 }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -429,6 +429,14 @@ pub async fn construct_payment_router_data_for_authorize<'a>(
             .and_then(|noon| noon.order_category.clone())
     });
 
+    // Check if this is a MIT payment (MIT with mandate_id or MandatePayment)
+    let is_mit_payment = payment_data.payment_method_data.as_ref().map(|data| {
+        matches!(
+            data,
+            hyperswitch_domain_models::payment_method_data::PaymentMethodData::MandatePayment
+        )
+    });
+
     // TODO: few fields are repeated in both routerdata and request
     let request = types::PaymentsAuthorizeData {
         payment_method_data: payment_data
@@ -436,7 +444,7 @@ pub async fn construct_payment_router_data_for_authorize<'a>(
             .get_required_value("payment_method_data")?,
         setup_future_usage: Some(payment_data.payment_intent.setup_future_usage),
         mandate_id: payment_data.mandate_data.clone(),
-        off_session: None,
+        off_session: is_mit_payment,
         setup_mandate_details: None,
         confirm: true,
         capture_method: Some(payment_data.payment_intent.capture_method),
@@ -556,7 +564,17 @@ pub async fn construct_payment_router_data_for_authorize<'a>(
         payment_method_status: None,
         payment_method_token: None,
         connector_customer: connector_customer_id,
-        recurring_mandate_payment_data: None,
+        // Connectors read this on the `MandatePayment` branch to decide which stored credential
+        // to charge - PayPal, for instance, picks between a card vault and a PayPal vault based
+        // on the sub type - so it is only populated for MIT payments.
+        recurring_mandate_payment_data: is_mit_payment.unwrap_or(false).then(|| {
+            hyperswitch_domain_models::router_data::RecurringMandatePaymentData {
+                payment_method_type: payment_data.payment_attempt.payment_method_subtype,
+                original_payment_authorized_amount: None,
+                original_payment_authorized_currency: None,
+                mandate_metadata: None,
+            }
+        }),
         // TODO: This has to be generated as the reference id based on the connector configuration
         // Some connectros might not accept accept the global id. This has to be done when generating the reference id
         connector_request_reference_id,

--- a/crates/router/src/core/revenue_recovery.rs
+++ b/crates/router/src/core/revenue_recovery.rs
@@ -1160,13 +1160,22 @@ pub async fn resume_revenue_recovery_process_tracker(
             let pt_update = storage::ProcessTrackerUpdate::Update {
                 name: process_tracker.name.clone(),
                 tracking_data: Some(process_tracker.tracking_data.clone()),
-                business_status: Some(request_retrigger.business_status.clone()),
-                status: Some(request_retrigger.status),
+                // For business_status and status, use the values from the request
+                // if provided, otherwise retain the existing values on the task
+                // (None leaves the column unchanged).
+                business_status: request_retrigger.business_status.clone(),
+                status: request_retrigger.status,
                 updated_at: Some(common_utils::date_time::now()),
-                retry_count: Some(process_tracker.retry_count + 1),
-                schedule_time: Some(request_retrigger.schedule_time.unwrap_or(
-                    common_utils::date_time::now().saturating_add(time::Duration::seconds(600)),
-                )),
+                // Use the retry count from the request if provided, otherwise
+                // retain the existing retry count on the task.
+                retry_count: Some(
+                    request_retrigger
+                        .retry_count
+                        .unwrap_or(process_tracker.retry_count),
+                ),
+                // Use the schedule time from the request if provided, otherwise
+                // retain the existing schedule time on the task.
+                schedule_time: request_retrigger.schedule_time,
             };
             let updated_pt = db
                 .update_process(process_tracker, pt_update)
@@ -1184,8 +1193,91 @@ pub async fn resume_revenue_recovery_process_tracker(
             };
             Ok(ApplicationResponse::Json(response))
         }
-        IntentStatus::Succeeded
-        | IntentStatus::Cancelled
+        // Payment already charged, but the record-back to the billing connector may have failed
+        // (e.g. `site_not_found`). PSYNC only *syncs* the existing attempt (no re-charge) and, on
+        // `SuccessfulPayment`, re-runs `record_back_to_billing_connector`. So (re)enqueue a PSYNC
+        // task for the executed attempt to retry the record-back.
+        IntentStatus::Succeeded => {
+            // Sync the intent's *active* (charged) attempt, NOT tracking_data's attempt — the latter
+            // is the original failed attempt; the successful retry lives on `active_attempt_id`.
+            let payment_intent = db
+                .find_payment_intent_by_id(
+                    &id,
+                    &revenue_recovery_payment_data.key_store,
+                    revenue_recovery_payment_data
+                        .merchant_account
+                        .storage_scheme,
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::PaymentNotFound)
+                .attach_printable("failed to fetch payment intent to resolve the active attempt")?;
+            let active_attempt_id = payment_intent.active_attempt_id.clone().ok_or(report!(
+                errors::ApiErrorResponse::GenericNotFoundError {
+                    message: "Succeeded recovery intent has no active attempt to sync".to_owned(),
+                }
+            ))?;
+
+            let psync_task = PSYNC_WORKFLOW;
+            let psync_process_tracker_id =
+                active_attempt_id.get_psync_revenue_recovery_id(psync_task, runner);
+
+            let psync_pt = match db
+                .find_process_by_id(&psync_process_tracker_id)
+                .await
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("error retrieving the psync process tracker id")?
+            {
+                // PSYNC task already present -> reset it so the consumer re-runs it.
+                Some(existing_psync) => {
+                    let pt_update = storage::ProcessTrackerUpdate::Update {
+                        name: existing_psync.name.clone(),
+                        tracking_data: Some(existing_psync.tracking_data.clone()),
+                        // For business_status and status, use the values from the
+                        // request if provided, otherwise retain the existing values
+                        // on the task. Note: to re-run a finished PSYNC task the
+                        // caller must pass a runnable status explicitly.
+                        business_status: request_retrigger.business_status.clone(),
+                        status: request_retrigger.status,
+                        updated_at: Some(common_utils::date_time::now()),
+                        retry_count: Some(existing_psync.retry_count + 1),
+                        // Use the schedule time from the request if provided,
+                        // otherwise retain the existing schedule time on the task.
+                        schedule_time: request_retrigger.schedule_time,
+                    };
+                    db.update_process(existing_psync, pt_update)
+                        .await
+                        .change_context(errors::ApiErrorResponse::GenericNotFoundError {
+                            message: "Failed to update the psync process tracker".to_owned(),
+                        })?
+                }
+                // No PSYNC task (record-back originally failed inside EXECUTE) -> insert one.
+                None => {
+                    insert_psync_pcr_task_to_pt(
+                        tracking_data.billing_mca_id.clone(),
+                        db,
+                        tracking_data.merchant_id.clone(),
+                        tracking_data.global_payment_id.clone(),
+                        tracking_data.profile_id.clone(),
+                        active_attempt_id.clone(),
+                        runner,
+                        tracking_data.revenue_recovery_retry,
+                        state.conf.application_source,
+                    )
+                    .await?
+                }
+            };
+
+            let response = revenue_recovery::RevenueRecoveryResponse {
+                id: psync_pt.id,
+                name: psync_pt.name,
+                schedule_time_for_payment: None,
+                schedule_time_for_psync: psync_pt.schedule_time,
+                status: psync_pt.status,
+                business_status: psync_pt.business_status,
+            };
+            Ok(ApplicationResponse::Json(response))
+        }
+        IntentStatus::Cancelled
         | IntentStatus::CancelledPostCapture
         | IntentStatus::Processing
         | IntentStatus::RequiresCustomerAction
@@ -1199,7 +1291,6 @@ pub async fn resume_revenue_recovery_process_tracker(
         | IntentStatus::PartiallyCapturedAndProcessing
         | IntentStatus::Conflicted
         | IntentStatus::Expired
-        | IntentStatus::PartiallyCapturedAndProcessing
         | IntentStatus::Review => Err(report!(errors::ApiErrorResponse::NotSupported {
             message: "Invalid Payment Status ".to_owned(),
         })),

--- a/crates/router/src/core/revenue_recovery/types.rs
+++ b/crates/router/src/core/revenue_recovery/types.rs
@@ -1538,7 +1538,7 @@ pub fn construct_invoice_record_back_router_data(
         flow: PhantomData::<router_flow_types::InvoiceRecordBack>,
         tenant_id: state.tenant.tenant_id.clone(),
         resource_common_data: flow_common_types::InvoiceRecordBackData {
-            connector_meta_data: None,
+            connector_meta_data: billing_mca.metadata.clone(),
         },
         connector_auth_type: auth_type,
         request: revenue_recovery_request::InvoiceRecordBackRequest {

--- a/crates/router/src/core/webhooks/incoming_v2.rs
+++ b/crates/router/src/core/webhooks/incoming_v2.rs
@@ -363,7 +363,7 @@ async fn incoming_webhooks_core<W: types::OutgoingWebhookType>(
                             &object_ref_id,
                         ))
                         .await
-                        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+                        .switch()
                         .attach_printable("Failed to process recovery incoming webhook")?
                     }
                 }

--- a/crates/router/src/core/webhooks/recovery_incoming.rs
+++ b/crates/router/src/core/webhooks/recovery_incoming.rs
@@ -179,17 +179,26 @@ pub async fn recovery_incoming_webhook_flow(
         action: RecoveryAction::get_action(event_type, attempt_triggered_by),
     };
 
+    if matches!(
+        recovery_action.action,
+        common_types::payments::RecoveryAction::InvalidAction
+    ) {
+        logger::info!("No recovery action needed for this event type");
+        return Ok(webhooks::WebhookResponseTracker::NoEffect);
+    }
+
     let mca_retry_threshold = billing_connector_account
         .get_retry_threshold()
         .ok_or(report!(
             errors::RevenueRecoveryError::BillingThresholdRetryCountFetchFailed
         ))?;
 
+    // Default to 0 for newly created payment intents that have no feature_metadata yet
     let intent_retry_count = recovery_intent_from_payment_attempt
         .feature_metadata
         .as_ref()
         .and_then(|metadata| metadata.get_retry_count())
-        .ok_or(report!(errors::RevenueRecoveryError::RetryCountFetchFailed))?;
+        .unwrap_or(0);
 
     logger::info!("Intent retry count: {:?}", intent_retry_count);
     recovery_action
@@ -257,11 +266,12 @@ async fn handle_schedule_failed_payment(
     let (recovery_attempt_from_payment_attempt, recovery_intent_from_payment_attempt) =
         payment_attempt_with_recovery_intent;
 
-    // When intent_retry_count is less than or equal to threshold
-    (intent_retry_count <= mca_retry_threshold)
+    // When intent_retry_count is strictly less than threshold, billing connector
+    // hasn't retried enough times yet — let it handle retries and wait.
+    (intent_retry_count < mca_retry_threshold)
         .then(|| {
-            logger::error!(
-                "Payment retry count {} is less than threshold {}",
+            logger::info!(
+                "Payment retry count {} is less than threshold {}, waiting for billing connector",
                 intent_retry_count,
                 mca_retry_threshold
             );

--- a/crates/router/src/core/webhooks/recovery_incoming.rs
+++ b/crates/router/src/core/webhooks/recovery_incoming.rs
@@ -733,9 +733,18 @@ impl RevenueRecoveryAttempt {
             }
             Ok(_) => Err(errors::RevenueRecoveryError::PaymentAttemptFetchFailed)
                 .attach_printable("Unexpected response from record attempt core"),
-            error @ Err(_) => {
+            Err(error) => {
                 logger::error!(?error);
-                Err(errors::RevenueRecoveryError::PaymentAttemptFetchFailed)
+                // Retrying cannot record another attempt after the invoice reaches a final state.
+                let recovery_error = match error.current_context() {
+                    errors::ApiErrorResponse::PaymentUnexpectedState { current_value, .. } => {
+                        errors::RevenueRecoveryError::PaymentAttemptRecordNotAllowed {
+                            status: current_value.clone(),
+                        }
+                    }
+                    _ => errors::RevenueRecoveryError::PaymentAttemptFetchFailed,
+                };
+                Err(recovery_error)
                     .attach_printable("failed to record attempt in recovery webhook flow")
             }
         }?;
@@ -847,7 +856,9 @@ impl RevenueRecoveryAttempt {
                 connector_account_reference_id.clone(),
             )
             .ok_or(report!(
-                errors::RevenueRecoveryError::PaymentMerchantConnectorAccountNotFound
+                errors::RevenueRecoveryError::PaymentMerchantConnectorAccountNotFound {
+                    id: connector_account_reference_id.clone()
+                }
             ))
             .attach_printable_lazy(|| {
                 format!(
@@ -861,7 +872,13 @@ impl RevenueRecoveryAttempt {
         let db = &*state.store;
         db.find_merchant_connector_account_by_id(&payment_merchant_connector_account_id, key_store)
             .await
-            .change_context(errors::RevenueRecoveryError::PaymentMerchantConnectorAccountNotFound)
+            .change_context(
+                errors::RevenueRecoveryError::PaymentMerchantConnectorAccountNotFound {
+                    id: payment_merchant_connector_account_id
+                        .get_string_repr()
+                        .to_string(),
+                },
+            )
             .attach_printable_lazy(|| {
                 format!(
                     "failed to fetch payment merchant connector account {} mapped to account \
@@ -1237,7 +1254,7 @@ impl BillingConnectorInvoiceSyncResponseData {
             Ok(response) => Ok(response),
             error @ Err(_) => {
                 logger::error!(?error);
-                Err(errors::RevenueRecoveryError::BillingConnectorPaymentsSyncFailed)
+                Err(errors::RevenueRecoveryError::BillingConnectorInvoiceSyncFailed)
                     .attach_printable("Failed while fetching billing connector Invoice details")
             }
         }?;

--- a/crates/router/src/core/webhooks/recovery_incoming.rs
+++ b/crates/router/src/core/webhooks/recovery_incoming.rs
@@ -123,6 +123,34 @@ pub async fn recovery_incoming_webhook_flow(
         billing_connector_invoice_details.as_ref(),
     )?;
 
+    let is_event_recovery_transaction_event = event_type.is_recovery_transaction_event();
+
+    // Resolve the gateway before persistence to avoid creating records for an unmapped account.
+    let resolved_transaction_details = if is_event_recovery_transaction_event {
+        let invoice_transaction_details =
+            RevenueRecoveryAttempt::get_recovery_invoice_transaction_details(
+                connector_enum,
+                request_details,
+                billing_connector_payment_details.as_ref(),
+                &invoice_details.0,
+            )?;
+
+        let payment_merchant_connector_account = invoice_transaction_details
+            .find_payment_merchant_connector_account(
+                &state,
+                platform.get_processor().get_key_store(),
+                &billing_connector_account,
+            )
+            .await?;
+
+        Some((
+            invoice_transaction_details,
+            payment_merchant_connector_account,
+        ))
+    } else {
+        None
+    };
+
     // Fetch the intent using merchant reference id, if not found create new intent.
     let payment_intent = invoice_details
         .get_payment_intent(&state, &req_state, &platform, &business_profile)
@@ -135,20 +163,15 @@ pub async fn recovery_incoming_webhook_flow(
         })
         .await?;
 
-    let is_event_recovery_transaction_event = event_type.is_recovery_transaction_event();
     let (recovery_attempt_from_payment_attempt, recovery_intent_from_payment_attempt) =
         RevenueRecoveryAttempt::get_recovery_payment_attempt(
-            is_event_recovery_transaction_event,
+            resolved_transaction_details,
             &billing_connector_account,
             &state,
-            connector_enum,
             &req_state,
-            billing_connector_payment_details.as_ref(),
-            request_details,
             &platform,
             &business_profile,
             &payment_intent,
-            &invoice_details.0,
         )
         .await?;
 
@@ -816,42 +839,46 @@ impl RevenueRecoveryAttempt {
         state: &SessionState,
         key_store: &domain::MerchantKeyStore,
         billing_connector_account: &domain::MerchantConnectorAccount,
-    ) -> CustomResult<Option<domain::MerchantConnectorAccount>, errors::RevenueRecoveryError> {
+    ) -> CustomResult<domain::MerchantConnectorAccount, errors::RevenueRecoveryError> {
+        let connector_account_reference_id = &self.0.connector_account_reference_id;
+
         let payment_merchant_connector_account_id = billing_connector_account
             .get_payment_merchant_connector_account_id_using_account_reference_id(
-                self.0.connector_account_reference_id.clone(),
-            );
+                connector_account_reference_id.clone(),
+            )
+            .ok_or(report!(
+                errors::RevenueRecoveryError::PaymentMerchantConnectorAccountNotFound
+            ))
+            .attach_printable_lazy(|| {
+                format!(
+                    "no payment merchant connector account is mapped to account reference id \
+                     {connector_account_reference_id} in the feature metadata of billing connector \
+                     account {}",
+                    billing_connector_account.get_id().get_string_repr()
+                )
+            })?;
+
         let db = &*state.store;
-        let payment_merchant_connector_account = payment_merchant_connector_account_id
-            .as_ref()
-            .async_map(|mca_id| async move {
-                db.find_merchant_connector_account_by_id(mca_id, key_store)
-                    .await
-            })
+        db.find_merchant_connector_account_by_id(&payment_merchant_connector_account_id, key_store)
             .await
-            .transpose()
             .change_context(errors::RevenueRecoveryError::PaymentMerchantConnectorAccountNotFound)
-            .attach_printable(
-                "failed to fetch payment merchant connector id using account reference id",
-            )?;
-        Ok(payment_merchant_connector_account)
+            .attach_printable_lazy(|| {
+                format!(
+                    "failed to fetch payment merchant connector account {} mapped to account \
+                     reference id {connector_account_reference_id}",
+                    payment_merchant_connector_account_id.get_string_repr()
+                )
+            })
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn get_recovery_payment_attempt(
-        is_recovery_transaction_event: bool,
+        resolved_transaction_details: Option<(Self, domain::MerchantConnectorAccount)>,
         billing_connector_account: &domain::MerchantConnectorAccount,
         state: &SessionState,
-        connector_enum: &connector_integration_interface::ConnectorEnum,
         req_state: &ReqState,
-        billing_connector_payment_details: Option<
-            &revenue_recovery_response::BillingConnectorPaymentsSyncResponse,
-        >,
-        request_details: &hyperswitch_interfaces::webhooks::IncomingWebhookRequestDetails<'_>,
         platform: &domain::Platform,
         business_profile: &domain::Profile,
         payment_intent: &revenue_recovery::RecoveryPaymentIntent,
-        invoice_details: &revenue_recovery::RevenueRecoveryInvoiceData,
     ) -> CustomResult<
         (
             Option<revenue_recovery::RecoveryPaymentAttempt>,
@@ -859,24 +886,8 @@ impl RevenueRecoveryAttempt {
         ),
         errors::RevenueRecoveryError,
     > {
-        let payment_attempt_with_recovery_intent = match is_recovery_transaction_event {
-            true => {
-                let invoice_transaction_details = Self::get_recovery_invoice_transaction_details(
-                    connector_enum,
-                    request_details,
-                    billing_connector_payment_details,
-                    invoice_details,
-                )?;
-
-                // Find the payment merchant connector ID at the top level to avoid multiple DB calls.
-                let payment_merchant_connector_account = invoice_transaction_details
-                    .find_payment_merchant_connector_account(
-                        state,
-                        platform.get_processor().get_key_store(),
-                        billing_connector_account,
-                    )
-                    .await?;
-
+        let payment_attempt_with_recovery_intent = match resolved_transaction_details {
+            Some((invoice_transaction_details, payment_merchant_connector_account)) => {
                 let (payment_attempt, updated_payment_intent) = invoice_transaction_details
                     .get_payment_attempt(
                         state,
@@ -896,7 +907,7 @@ impl RevenueRecoveryAttempt {
                                 business_profile,
                                 payment_intent,
                                 &billing_connector_account.get_id(),
-                                payment_merchant_connector_account,
+                                Some(payment_merchant_connector_account),
                             )
                             .await
                     })
@@ -904,7 +915,7 @@ impl RevenueRecoveryAttempt {
                 (Some(payment_attempt), updated_payment_intent)
             }
 
-            false => (None, payment_intent.clone()),
+            None => (None, payment_intent.clone()),
         };
 
         Ok(payment_attempt_with_recovery_intent)

--- a/crates/router/src/workflows/revenue_recovery.rs
+++ b/crates/router/src/workflows/revenue_recovery.rs
@@ -1116,11 +1116,6 @@ pub async fn check_hard_decline(
     state: &SessionState,
     payment_attempt: &payment_attempt::PaymentAttempt,
 ) -> Result<bool, error_stack::Report<storage_impl::errors::RecoveryError>> {
-    let error_message = payment_attempt
-        .error
-        .as_ref()
-        .map(|details| details.message.clone());
-
     let error_code = payment_attempt
         .error
         .as_ref()
@@ -1131,6 +1126,21 @@ pub async fn check_hard_decline(
         .clone()
         .ok_or(storage_impl::errors::RecoveryError::ValueNotFound)
         .attach_printable("unable to derive payment connector from payment attempt")?;
+
+    // Stripe returns the same generic `message` for every card decline and carries the issuer's
+    // decline code only in `reason` (`message - <message>, decline_code - <decline_code>`), so the
+    // gsm lookup uses `reason` for stripe to tell a lost card apart from a retryable decline.
+    let matches_gsm_on_error_reason = connector_name
+        .parse::<common_enums::connector_enums::Connector>()
+        .map(|connector| connector == common_enums::connector_enums::Connector::Stripe)
+        .unwrap_or(false);
+
+    let error_message = payment_attempt.error.as_ref().map(|details| {
+        matches_gsm_on_error_reason
+            .then(|| details.reason.clone())
+            .flatten()
+            .unwrap_or_else(|| details.message.clone())
+    });
 
     let gsm_record = payments::helpers::get_gsm_record(
         state,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Returns actionable responses for revenue recovery webhook failures that cannot succeed on retry.

- Converts revenue recovery domain errors into specific webhook API errors.
- Returns an authentication error for failed source verification.
- Returns an unprocessable response for invalid invoice or transaction data.
- Identifies missing payment MCA mappings and billing retry-threshold configuration.
- Returns a failed precondition when the invoice no longer permits recording an attempt.
- Preserves processing failures for transient internal and downstream errors.
- Uses the invoice-sync error context when the billing invoice sync response fails.

### Stack Dependency

Depends on [#13718](https://github.com/juspay/hyperswitch/pull/13718).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

The incoming webhook handler previously converted every revenue recovery error into a generic 5xx response. Chargebee would therefore retry malformed payloads, missing merchant configuration, and terminal invoice-state failures even though replaying the same event could not resolve them.

Mapping non-retryable failures to specific 4xx responses stops futile webhook retries and exposes the configuration or state that must be corrected. Transient failures remain retryable.

## How did you test it?

- `cargo +nightly fmt --all -- --check`
- `cargo check --package router --no-default-features --features release,v2,redis-rs`
- `git diff --check origin/main..HEAD`

Validation was run on the complete stacked branch.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

## Related Issue

Closes #13717
