### PR TITLE
fix(core): restore refund sync for terminal statuses when force_sync is set

### DIFF
--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -820,14 +820,16 @@ fn should_call_refund(
     force_sync: bool,
     all_keys_required: bool,
 ) -> bool {
-    // This allows refund sync at connector level if all_keys_required or force_sync is enabled for non terminal refund statuses (i.e. not success or failure)
+    // This allows refund sync at connector level if all_keys_required or force_sync is enabled,
+    // or if the refund is not in a terminal status (i.e. not success, failure or transaction failure)
     all_keys_required
-        || (force_sync
-            && !matches!(
-                refund.refund_status,
-                diesel_models::enums::RefundStatus::Failure
-                    | diesel_models::enums::RefundStatus::Success
-            ))
+        || force_sync
+        || !matches!(
+            refund.refund_status,
+            diesel_models::enums::RefundStatus::Failure
+                | diesel_models::enums::RefundStatus::Success
+                | diesel_models::enums::RefundStatus::TransactionFailure
+        )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2376,4 +2378,90 @@ pub async fn get_refund_sync_process_schedule_time(
     let time_delta = process_tracker_utils::get_schedule_time(mapping, retry_count);
 
     Ok(process_tracker_utils::get_time_from_delta(time_delta))
+}
+
+#[cfg(test)]
+mod tests {
+    use common_utils::date_time;
+    use diesel_models::{
+        enums::{Currency, RefundStatus, RefundType},
+        refund::Refund,
+    };
+    use super::*;
+
+    fn make_refund(status: RefundStatus) -> Refund {
+        Refund {
+            internal_reference_id: String::new(),
+            refund_id: String::new(),
+            payment_id: common_utils::id_type::PaymentId::default(),
+            merchant_id: common_utils::id_type::MerchantId::default(),
+            connector_transaction_id: ConnectorTransactionId::from("test_txn_id".to_string()),
+            connector: String::new(),
+            connector_refund_id: None,
+            external_reference_id: None,
+            refund_type: RefundType::RegularRefund,
+            total_amount: MinorUnit::new(0),
+            currency: Currency::USD,
+            refund_amount: MinorUnit::new(0),
+            refund_status: status,
+            sent_to_gateway: false,
+            refund_error_message: None,
+            metadata: None,
+            refund_arn: None,
+            created_at: date_time::now(),
+            modified_at: date_time::now(),
+            description: None,
+            attempt_id: String::new(),
+            refund_reason: None,
+            refund_error_code: None,
+            profile_id: None,
+            updated_by: String::new(),
+            merchant_connector_id: None,
+            charges: None,
+            organization_id: common_utils::id_type::OrganizationId::default(),
+            connector_refund_data: None,
+            connector_transaction_data: None,
+            split_refunds: None,
+            unified_code: None,
+            unified_message: None,
+            processor_refund_data: None,
+            processor_transaction_data: None,
+            issuer_error_code: None,
+            issuer_error_message: None,
+            processor_merchant_id: None,
+            created_by: None,
+        }
+    }
+
+    fn expected(status: RefundStatus, force_sync: bool, all_keys_required: bool) -> bool {
+        all_keys_required
+            || force_sync
+            || !matches!(
+                status,
+                RefundStatus::Failure | RefundStatus::Success | RefundStatus::TransactionFailure
+            )
+    }
+
+    #[test]
+    fn should_call_refund_predicate_directions() {
+        let statuses = [
+            RefundStatus::Failure,
+            RefundStatus::Success,
+            RefundStatus::TransactionFailure,
+            RefundStatus::Pending,
+            RefundStatus::ManualReview,
+        ];
+        for &status in &statuses {
+            for force_sync in [false, true] {
+                for all_keys_required in [false, true] {
+                    let refund = make_refund(status);
+                    assert_eq!(
+                        should_call_refund(&refund, force_sync, all_keys_required),
+                        expected(status, force_sync, all_keys_required),
+                        "status={status:?} force_sync={force_sync} all_keys_required={all_keys_required}"
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

`GET /refunds/{id}?force_sync=true` silently no-ops when the refund is already in a terminal status (`Success`/`Failure`): `should_call_refund` gates `force_sync` behind a non-terminal-status check, so the request returns the stale database row without consulting the connector.

This restores the pre-#11725 behavior and v2 parity: `force_sync` is again an unconditional override that consults the connector even for terminal refunds, and `TransactionFailure` is now treated as a terminal failure state like `Failure`. When the connector is called, `sync_refund_with_gateway` already materializes the returned status (including a connector-side reversal) and fires the outgoing webhook — only the predicate was blocking it.

Note: with this change, non-terminal refunds (`Pending`, `ManualReview`) are again synced with the connector when retrieved without `force_sync`, matching v2 and the behavior before #11725.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Fixes #13680

Since #11725 (released 2026.04.10.0), an explicit `force_sync=true` on a refund in `Success`/`Failure` returns the stale row — no connector call, no error, no indication the sync was skipped. If the connector later reverses a succeeded refund and the reversal webhook is lost, the refund stays stuck at `success` with no supported way to pull the connector's truth back in. v2 still has the unconditional `force_sync` disjunct, so the same API behaves oppositely between v1 and v2.

#11725's own description says terminal refunds should skip sync when "all_keys_required or force_sync" is set, but the merged code only gates `force_sync` — leaving the `all_keys_required` bypass and contradicting its stated intent. The terminal set also omits `TransactionFailure`, which the rest of the refund flow already treats as terminal.

Note: v1 no longer has the `connector_refund_id` guard that v2 still has (removed in #12755), so v1 may consult the connector for a refund without a connector refund id; that v1/v2 divergence is tracked separately and deliberately left out of this change.

## How did you test it?

- Added a table-driven unit test for `should_call_refund` covering all five `RefundStatus` variants × `force_sync` × `all_keys_required` (20 cases), including the regression direction terminal + `force_sync=true`.
- The test fails on the base commit (terminal + `force_sync=true` returns false) and passes with the fix: `cargo test -p router --lib --features v1 core::refunds::tests::should_call_refund_predicate_directions` → ok, 1 passed.

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible