### PR TITLE
fix(connector): [airwallex] treat SUCCEEDED intent as idempotent success in CompleteAuthorize

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/airwallex.rs
+++ b/crates/hyperswitch_connectors/src/connectors/airwallex.rs
@@ -148,12 +148,24 @@ impl ConnectorCommon for Airwallex {
                     .provider_original_response_code
                     .clone()
                     .and_then(airwallex::map_error_code_to_message);
+                // When Airwallex rejects a confirm_continue operation on a PaymentIntent that has
+                // already reached the SUCCEEDED status, the payment is genuinely completed. Mark it
+                // as charged so the core does not finalize it as failed. The message is the only
+                // carrier of the intent status because `AirwallexErrorResponse` has no status field.
+                let attempt_status = match (response.code.as_str(), response.message.as_str()) {
+                    ("invalid_status_for_operation", message)
+                        if message.contains("status SUCCEEDED") =>
+                    {
+                        Some(enums::AttemptStatus::Charged)
+                    }
+                    _ => None,
+                };
                 Ok(ErrorResponse {
                     status_code,
                     code: response.code,
                     message: response.message,
                     reason: response.source,
-                    attempt_status: None,
+                    attempt_status,
                     connector_transaction_id: None,
                     connector_response_reference_id: None,
                     network_advice_code: None,
@@ -1450,5 +1462,78 @@ impl ConnectorSpecifications for Airwallex {
         } else {
             api::ConnectorCustomerAction::NoAction
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperswitch_domain_models::router_data::ErrorResponse;
+    use hyperswitch_interfaces::types::Response;
+
+    use super::*;
+
+    fn build_error_response(body: &str) -> ErrorResponse {
+        // Arrange
+        let response = Response {
+            headers: None,
+            response: bytes::Bytes::from(body.to_string()),
+            status_code: http::StatusCode::BAD_REQUEST.as_u16(),
+        };
+
+        // Act
+        Airwallex::new()
+            .build_error_response(response, None)
+            .unwrap()
+    }
+
+    #[test]
+    fn should_treat_invalid_status_for_operation_on_succeeded_intent_as_charged() {
+        // Arrange
+        let body = r#"{"code":"invalid_status_for_operation","message":"The PaymentIntent status SUCCEEDED is invalid for operation confirm_continue.","source":"payment_intent"}"#;
+
+        // Act
+        let error_response = build_error_response(body);
+
+        // Assert
+        assert_eq!(
+            error_response.attempt_status,
+            Some(enums::AttemptStatus::Charged)
+        );
+    }
+
+    #[test]
+    fn should_not_treat_genuine_decline_as_charged() {
+        // Arrange
+        let body = r#"{"code":"card_declined","message":"Your card was declined."}"#;
+
+        // Act
+        let error_response = build_error_response(body);
+
+        // Assert
+        assert_eq!(error_response.attempt_status, None);
+    }
+
+    #[test]
+    fn should_not_treat_failed_intent_error_as_charged() {
+        // Arrange
+        let body = r#"{"code":"invalid_status_for_operation","message":"The PaymentIntent status FAILED is invalid for operation confirm_continue."}"#;
+
+        // Act
+        let error_response = build_error_response(body);
+
+        // Assert
+        assert_eq!(error_response.attempt_status, None);
+    }
+
+    #[test]
+    fn should_not_treat_succeeded_message_with_other_error_code_as_charged() {
+        // Arrange
+        let body = r#"{"code":"payment_intent_expired","message":"The PaymentIntent status SUCCEEDED is invalid for operation confirm_continue."}"#;
+
+        // Act
+        let error_response = build_error_response(body);
+
+        // Assert
+        assert_eq!(error_response.attempt_status, None);
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Airwallex's `CompleteAuthorize` implementation calls `POST /api/v1/pa/payment_intents/{id}/confirm_continue` unconditionally. With 3DS, by the time the shopper is redirected back from the challenge page the Airwallex PaymentIntent is already `SUCCEEDED`, so `confirm_continue` is rejected with a 400 `invalid_status_for_operation` error ("The PaymentIntent status SUCCEEDED is invalid for operation confirm_continue."). The connector's error response left `attempt_status` unset, and the core's generic 4xx fallback finalized the genuinely charged payment as `failed` — a funds-divergence bug (Airwallex charged the customer, hyperswitch shows failed).

This change treats that error as an idempotent completion: when Airwallex reports the intent is already `SUCCEEDED`, the connector now returns `AttemptStatus::Charged`, which the core resolves to `succeeded`. The mapping is precise — it requires both the error code `invalid_status_for_operation` and a message naming the `SUCCEEDED` status — so genuine declines and errors on non-succeeded intents keep their previous behavior.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Fixes #13681

This covers the legacy/direct connector path. The UCS-side Airwallex 3DS flow reimplements this flow separately and will need the same idempotent-success handling.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Added unit tests with mocked Airwallex error responses in `crates/hyperswitch_connectors/src/connectors/airwallex.rs`:
- `invalid_status_for_operation` with a `SUCCEEDED` intent message → `attempt_status` is `Charged` (this test failed before the change and passes after)
- genuine decline (`card_declined`) → unchanged (`attempt_status` unset)
- `invalid_status_for_operation` with a `FAILED` intent message → unchanged
- `SUCCEEDED` message under a different error code → unchanged

Ran `cargo test -p hyperswitch_connectors --no-default-features --features "v1,payouts,frm" --lib connectors::airwallex` — 4 tests pass. `cargo +nightly fmt --all --check` and `cargo clippy -p hyperswitch_connectors` are clean.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible