### PR TITLE
fix(hyperswitch_domain_models): include order_tax_amount in v2 net amount

### DIFF
--- a/crates/hyperswitch_domain_models/src/payments.rs
+++ b/crates/hyperswitch_domain_models/src/payments.rs
@@ -721,20 +721,56 @@ impl AmountDetails {
         self.skip_external_tax_calculation.as_bool()
     }
 
-    /// Calculate the net amount for the order
-    pub fn calculate_net_amount(&self) -> MinorUnit {
+    /// Get the order tax amount that applies to this order.
+    ///
+    /// The tax is resolved only when it has already been determined. Under
+    /// `TaxCalculationOverride::Calculate` the external tax provider has not been called yet, so
+    /// there is no tax to report or to charge.
+    ///
+    /// `payment_method_subtype` is supplied once a payment method has been chosen, so that a tax
+    /// calculated for that specific payment method is preferred over the payment method agnostic
+    /// default tax. `None` resolves to the default tax amount.
+    fn get_order_tax_amount(
+        &self,
+        payment_method_subtype: Option<common_enums::PaymentMethodType>,
+    ) -> Option<MinorUnit> {
+        match self.skip_external_tax_calculation {
+            common_enums::TaxCalculationOverride::Skip => self
+                .tax_details
+                .as_ref()
+                .and_then(|tax_details| tax_details.get_tax_amount(payment_method_subtype)),
+            common_enums::TaxCalculationOverride::Calculate => None,
+        }
+    }
+
+    /// Sum the order amount and every additional charge into the net amount, using the order tax
+    /// amount that the caller reports alongside it.
+    ///
+    /// The net amount and the order tax amount are surfaced together on both payment intents and
+    /// payment attempts, so they have to be derived from the same value to stay consistent.
+    fn calculate_net_amount_with_order_tax(
+        &self,
+        order_tax_amount: Option<MinorUnit>,
+    ) -> MinorUnit {
         self.order_amount
             + self.shipping_cost.unwrap_or(MinorUnit::zero())
+            + order_tax_amount.unwrap_or(MinorUnit::zero())
             + self.surcharge_amount.unwrap_or(MinorUnit::zero())
             + self.tax_on_surcharge.unwrap_or(MinorUnit::zero())
+    }
+
+    /// Calculate the net amount for the order
+    ///
+    /// No payment method has been chosen at this point, so the payment method agnostic default tax
+    /// is used, matching the order tax amount reported on intent only responses.
+    pub fn calculate_net_amount(&self) -> MinorUnit {
+        self.calculate_net_amount_with_order_tax(self.get_order_tax_amount(None))
     }
 
     pub fn create_attempt_amount_details(
         &self,
         confirm_intent_request: &api_models::payments::PaymentsConfirmIntentRequest,
     ) -> payment_attempt::AttemptAmountDetails {
-        let net_amount = self.calculate_net_amount();
-
         let surcharge_amount = match self.skip_surcharge_calculation {
             common_enums::SurchargeCalculationOverride::Skip => self.surcharge_amount,
             common_enums::SurchargeCalculationOverride::Calculate => None,
@@ -745,14 +781,10 @@ impl AmountDetails {
             common_enums::SurchargeCalculationOverride::Calculate => None,
         };
 
-        let order_tax_amount = match self.skip_external_tax_calculation {
-            common_enums::TaxCalculationOverride::Skip => {
-                self.tax_details.as_ref().and_then(|tax_details| {
-                    tax_details.get_tax_amount(confirm_intent_request.payment_method_subtype)
-                })
-            }
-            common_enums::TaxCalculationOverride::Calculate => None,
-        };
+        let order_tax_amount =
+            self.get_order_tax_amount(confirm_intent_request.payment_method_subtype);
+
+        let net_amount = self.calculate_net_amount_with_order_tax(order_tax_amount);
 
         payment_attempt::AttemptAmountDetails::from(payment_attempt::AttemptAmountDetailsSetter {
             net_amount,
@@ -799,14 +831,8 @@ impl AmountDetails {
             common_enums::SurchargeCalculationOverride::Calculate => None,
         };
 
-        let order_tax_amount = match self.skip_external_tax_calculation {
-            common_enums::TaxCalculationOverride::Skip => {
-                self.tax_details.as_ref().and_then(|tax_details| {
-                    tax_details.get_tax_amount(confirm_intent_request.payment_method_subtype)
-                })
-            }
-            common_enums::TaxCalculationOverride::Calculate => None,
-        };
+        let order_tax_amount =
+            self.get_order_tax_amount(confirm_intent_request.payment_method_subtype);
 
         payment_attempt::AttemptAmountDetails::from(payment_attempt::AttemptAmountDetailsSetter {
             net_amount,
@@ -825,8 +851,6 @@ impl AmountDetails {
         &self,
         _confirm_intent_request: &api_models::payments::ProxyPaymentsRequest,
     ) -> payment_attempt::AttemptAmountDetails {
-        let net_amount = self.calculate_net_amount();
-
         let surcharge_amount = match self.skip_surcharge_calculation {
             common_enums::SurchargeCalculationOverride::Skip => self.surcharge_amount,
             common_enums::SurchargeCalculationOverride::Calculate => None,
@@ -837,13 +861,9 @@ impl AmountDetails {
             common_enums::SurchargeCalculationOverride::Calculate => None,
         };
 
-        let order_tax_amount = match self.skip_external_tax_calculation {
-            common_enums::TaxCalculationOverride::Skip => self
-                .tax_details
-                .as_ref()
-                .and_then(|tax_details| tax_details.get_tax_amount(None)),
-            common_enums::TaxCalculationOverride::Calculate => None,
-        };
+        let order_tax_amount = self.get_order_tax_amount(None);
+
+        let net_amount = self.calculate_net_amount_with_order_tax(order_tax_amount);
 
         payment_attempt::AttemptAmountDetails::from(payment_attempt::AttemptAmountDetailsSetter {
             net_amount,
@@ -1796,4 +1816,162 @@ impl VaultData {
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub struct GuestCustomer {
     pub customer_id: String,
+}
+
+#[cfg(all(test, feature = "v2"))]
+mod amount_details_tests {
+    use diesel_models::{DefaultTax, PaymentMethodTypeTax};
+
+    use super::*;
+
+    const ORDER_AMOUNT: i64 = 10_000;
+    const ORDER_TAX_AMOUNT: i64 = 800;
+
+    fn amount_details(tax_details: Option<TaxDetails>) -> AmountDetails {
+        AmountDetails {
+            order_amount: MinorUnit::new(ORDER_AMOUNT),
+            currency: common_enums::Currency::USD,
+            shipping_cost: None,
+            tax_details,
+            skip_external_tax_calculation: common_enums::TaxCalculationOverride::Skip,
+            skip_surcharge_calculation: common_enums::SurchargeCalculationOverride::Skip,
+            surcharge_amount: None,
+            tax_on_surcharge: None,
+            amount_captured: None,
+        }
+    }
+
+    fn default_tax(order_tax_amount: i64) -> TaxDetails {
+        TaxDetails {
+            default: Some(DefaultTax {
+                order_tax_amount: MinorUnit::new(order_tax_amount),
+            }),
+            payment_method_type: None,
+        }
+    }
+
+    fn payment_method_tax(
+        order_tax_amount: i64,
+        pmt: common_enums::PaymentMethodType,
+    ) -> TaxDetails {
+        TaxDetails {
+            default: None,
+            payment_method_type: Some(PaymentMethodTypeTax {
+                order_tax_amount: MinorUnit::new(order_tax_amount),
+                pmt,
+            }),
+        }
+    }
+
+    fn confirm_intent_request(
+        payment_method_subtype: Option<common_enums::PaymentMethodType>,
+    ) -> api_models::payments::PaymentsConfirmIntentRequest {
+        api_models::payments::PaymentsConfirmIntentRequest {
+            return_url: None,
+            payment_method_data: api_models::payments::PaymentMethodDataRequest {
+                payment_method_data: None,
+                billing: None,
+            },
+            split_payment_method_data: None,
+            payment_method_type: common_enums::PaymentMethod::Card,
+            payment_method_subtype,
+            shipping: None,
+            customer_acceptance: None,
+            browser_info: None,
+            payment_method_id: None,
+            payment_token: None,
+            merchant_connector_details: None,
+            return_raw_connector_response: None,
+            webhook_url: None,
+        }
+    }
+
+    #[test]
+    fn net_amount_includes_the_order_tax() {
+        let amount_details = amount_details(Some(default_tax(ORDER_TAX_AMOUNT)));
+
+        assert_eq!(
+            amount_details.calculate_net_amount(),
+            MinorUnit::new(ORDER_AMOUNT + ORDER_TAX_AMOUNT)
+        );
+    }
+
+    #[test]
+    fn net_amount_without_tax_details_is_the_order_amount() {
+        let amount_details = amount_details(None);
+
+        assert_eq!(
+            amount_details.calculate_net_amount(),
+            MinorUnit::new(ORDER_AMOUNT)
+        );
+    }
+
+    #[test]
+    fn net_amount_sums_every_component() {
+        let mut amount_details = amount_details(Some(default_tax(ORDER_TAX_AMOUNT)));
+        amount_details.shipping_cost = Some(MinorUnit::new(500));
+        amount_details.surcharge_amount = Some(MinorUnit::new(200));
+        amount_details.tax_on_surcharge = Some(MinorUnit::new(20));
+
+        assert_eq!(
+            amount_details.calculate_net_amount(),
+            MinorUnit::new(ORDER_AMOUNT + 500 + ORDER_TAX_AMOUNT + 200 + 20)
+        );
+    }
+
+    /// Intent level callers have not chosen a payment method yet, so a tax calculated for one
+    /// specific payment method must not be charged before that payment method is known.
+    #[test]
+    fn net_amount_ignores_payment_method_specific_tax() {
+        let amount_details = amount_details(Some(payment_method_tax(
+            ORDER_TAX_AMOUNT,
+            common_enums::PaymentMethodType::Credit,
+        )));
+
+        assert_eq!(
+            amount_details.calculate_net_amount(),
+            MinorUnit::new(ORDER_AMOUNT)
+        );
+    }
+
+    /// The attempt persists the payment method aware tax, so its net amount has to use the same
+    /// value rather than the default one.
+    #[test]
+    fn attempt_net_amount_matches_the_reported_order_tax_amount() {
+        let amount_details = amount_details(Some(payment_method_tax(
+            ORDER_TAX_AMOUNT,
+            common_enums::PaymentMethodType::Credit,
+        )));
+
+        let attempt = amount_details.create_attempt_amount_details(&confirm_intent_request(Some(
+            common_enums::PaymentMethodType::Credit,
+        )));
+
+        assert_eq!(
+            attempt.get_order_tax_amount(),
+            Some(MinorUnit::new(ORDER_TAX_AMOUNT))
+        );
+        assert_eq!(
+            attempt.get_net_amount(),
+            MinorUnit::new(ORDER_AMOUNT + ORDER_TAX_AMOUNT)
+        );
+    }
+
+    /// Tax that the external provider has not calculated yet is reported nowhere, so it must not
+    /// be charged through the net amount either, at the intent level or on the attempt.
+    #[test]
+    fn tax_that_is_yet_to_be_calculated_is_charged_nowhere() {
+        let mut amount_details = amount_details(Some(default_tax(ORDER_TAX_AMOUNT)));
+        amount_details.skip_external_tax_calculation =
+            common_enums::TaxCalculationOverride::Calculate;
+
+        let attempt = amount_details.create_attempt_amount_details(&confirm_intent_request(None));
+
+        assert_eq!(attempt.get_order_tax_amount(), None);
+        assert_eq!(attempt.get_net_amount(), MinorUnit::new(ORDER_AMOUNT));
+        assert_eq!(
+            amount_details.calculate_net_amount(),
+            attempt.get_net_amount()
+        );
+    }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

`AmountDetails::calculate_net_amount()` summed the order amount, shipping cost, surcharge and tax on surcharge, but never added the order tax. The V1 equivalent, `NetAmount::get_total_amount()`, includes it, and `AttemptAmountDetails::net_amount` documents itself as "The total amount for this payment attempt. This includes all the surcharge and tax amounts".

The order tax is now resolved in one place and the net amount is derived from the same value the caller reports alongside it.

- `get_order_tax_amount(payment_method_subtype)` resolves the tax that applies. It returns `None` under `TaxCalculationOverride::Calculate`, because the external tax provider has not been called yet and there is no tax to report or to charge. Otherwise it prefers a tax calculated for the chosen payment method and falls back to the payment method agnostic default, which is what `TaxDetails::get_tax_amount` already does. Passing `None` resolves to the default tax.
- `calculate_net_amount_with_order_tax(order_tax_amount)` performs the summation once, from a tax amount the caller supplies.
- `calculate_net_amount()` keeps its signature and passes the default tax, which is the value intent level callers report next to it.
- `create_attempt_amount_details` and `proxy_create_attempt_amount_details` derive the net amount from the same `order_tax_amount` they persist, instead of computing it separately.

The invariant this restores is that `net_amount` includes exactly the `order_tax_amount` reported beside it, at every call site.

Resolving the override inside `get_order_tax_amount` also removes three copies of the same `match` from the attempt paths, so intent level and attempt level can no longer drift apart.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

The shape of `PaymentAmountDetailsResponse` is unchanged. The `net_amount` value it carries becomes correct.

## Motivation and Context

Fixes #13712.

`calculate_net_amount()` has eight call sites, and the omission reaches all of them rather than only the response field:

| Call site | Effect of dropping the order tax |
| --- | --- |
| `AmountDetails::create_attempt_amount_details` | the attempt is created, and the payment authorized, for less than the order is worth |
| `AmountDetails::proxy_create_attempt_amount_details` | the same, on the proxy confirm path |
| `core/split_payments.rs` | gift card allocation does not cover the order, because `remaining_to_allocate` starts below the real total |
| `core/payments/routing.rs` | session routing rules are evaluated against an amount lower than what will be charged |
| `core/payments/payment_methods.rs` `filter_amount_based` | a payment method whose `maximum_amount` cannot cover the order can survive filtering |
| `core/payments/payment_methods.rs` zero amount check | an intent carrying only tax is mistaken for a zero amount mandate intent |
| `core/payments/transformers.rs` intent response | `net_amount` contradicts the `order_tax_amount` reported next to it |
| `core/payments/transformers.rs` confirm response | the same, and the value is also reused as `amount_captured` for split payments |

## How did you test it?

Unit tests were added to `crates/hyperswitch_domain_models/src/payments.rs` and run with:

```text
cargo test -p hyperswitch_domain_models --no-default-features --features v2,revenue_recovery --lib -- amount_details_tests
```

- `net_amount_includes_the_order_tax` — the case from the issue: order amount 10000 with an order tax of 800 gives 10800 rather than 10000.
- `net_amount_without_tax_details_is_the_order_amount` — intents carrying no tax are unaffected.
- `net_amount_sums_every_component` — order amount, shipping cost, tax, surcharge and tax on surcharge together.
- `net_amount_ignores_payment_method_specific_tax` — a tax calculated for one specific payment method is not charged before a payment method has been chosen.
- `attempt_net_amount_matches_the_reported_order_tax_amount` — the attempt's net amount uses the payment method aware tax it persists, not the default one.
- `tax_that_is_yet_to_be_calculated_is_charged_nowhere` — with `skip_external_tax_calculation` set to `Calculate`, the intent level helper and the attempt agree that no tax is reported and none is charged.

6 passed, 0 failed.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
