### PR TITLE
fix(router): scope incoming webhook lookups by merchant_connector_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,12 +3104,14 @@ version = "0.1.0"
 dependencies = [
  "async-bb8-diesel",
  "base64 0.22.1",
+ "bb8",
  "common_enums",
  "common_types",
  "common_utils",
  "deja",
  "diesel",
  "error-stack 0.4.1",
+ "futures 0.3.31",
  "hyperswitch_masking",
  "router_derive",
  "router_env",
@@ -3118,6 +3120,7 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 1.0.69",
  "time 0.3.41",
+ "tokio 1.48.0",
 ]
 
 [[package]]

--- a/crates/diesel_models/Cargo.toml
+++ b/crates/diesel_models/Cargo.toml
@@ -35,5 +35,14 @@ router_derive = { version = "0.1.0", path = "../router_derive" }
 router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"] }
 deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false, features = ["error-stack"] }
 
+[dev-dependencies]
+bb8 = "0.8.6"
+tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
+futures = "0.3"
+
+[[test]]
+name = "webhook_lookup_scoping"
+required-features = ["v1"]
+
 [lints]
 workspace = true

--- a/crates/diesel_models/src/query/payment_attempt.rs
+++ b/crates/diesel_models/src/query/payment_attempt.rs
@@ -201,6 +201,7 @@ impl PaymentAttempt {
         conn: &PgPooledConn,
         processor_merchant_id: &common_utils::id_type::MerchantId,
         connector_txn_id: &str,
+        merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
     ) -> StorageResult<Self> {
         let (txn_id, txn_data) = common_utils::types::ConnectorTransactionId::form_id_and_data(
             connector_txn_id.to_string(),
@@ -211,13 +212,31 @@ impl PaymentAttempt {
             .attach_printable_lazy(|| {
                 format!("Failed to retrieve txn_id for ({txn_id:?}, {txn_data:?})")
             })?;
-        generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
-            conn,
-            dsl::processor_merchant_id
-                .eq(processor_merchant_id.to_owned())
-                .and(dsl::connector_transaction_id.eq(connector_transaction_id.to_owned())),
-        )
-        .await
+        match merchant_connector_id {
+            Some(merchant_connector_id) => {
+                generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
+                    conn,
+                    dsl::processor_merchant_id
+                        .eq(processor_merchant_id.to_owned())
+                        .and(dsl::connector_transaction_id.eq(connector_transaction_id.to_owned()))
+                        .and(
+                            dsl::merchant_connector_id
+                                .eq(merchant_connector_id.to_owned())
+                                .or(dsl::merchant_connector_id.is_null()),
+                        ),
+                )
+                .await
+            }
+            None => {
+                generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
+                    conn,
+                    dsl::processor_merchant_id
+                        .eq(processor_merchant_id.to_owned())
+                        .and(dsl::connector_transaction_id.eq(connector_transaction_id.to_owned())),
+                )
+                .await
+            }
+        }
     }
 
     #[cfg(feature = "v2")]

--- a/crates/diesel_models/src/query/refund.rs
+++ b/crates/diesel_models/src/query/refund.rs
@@ -123,15 +123,35 @@ impl Refund {
         processor_merchant_id: &common_utils::id_type::MerchantId,
         connector_refund_id: &str,
         connector: &str,
+        merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
     ) -> StorageResult<Self> {
-        generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
-            conn,
-            dsl::processor_merchant_id
-                .eq(processor_merchant_id.to_owned())
-                .and(dsl::connector_refund_id.eq(connector_refund_id.to_owned()))
-                .and(dsl::connector.eq(connector.to_owned())),
-        )
-        .await
+        match merchant_connector_id {
+            Some(merchant_connector_id) => {
+                generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
+                    conn,
+                    dsl::processor_merchant_id
+                        .eq(processor_merchant_id.to_owned())
+                        .and(dsl::connector_refund_id.eq(connector_refund_id.to_owned()))
+                        .and(dsl::connector.eq(connector.to_owned()))
+                        .and(
+                            dsl::merchant_connector_id
+                                .eq(merchant_connector_id.to_owned())
+                                .or(dsl::merchant_connector_id.is_null()),
+                        ),
+                )
+                .await
+            }
+            None => {
+                generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
+                    conn,
+                    dsl::processor_merchant_id
+                        .eq(processor_merchant_id.to_owned())
+                        .and(dsl::connector_refund_id.eq(connector_refund_id.to_owned()))
+                        .and(dsl::connector.eq(connector.to_owned())),
+                )
+                .await
+            }
+        }
     }
 
     // Fallback function for stagger release - queries by merchant_id when processor_merchant_id is NULL
@@ -140,15 +160,35 @@ impl Refund {
         processor_merchant_id: &common_utils::id_type::MerchantId,
         connector_refund_id: &str,
         connector: &str,
+        merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
     ) -> StorageResult<Self> {
-        generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
-            conn,
-            dsl::merchant_id
-                .eq(processor_merchant_id.to_owned())
-                .and(dsl::connector_refund_id.eq(connector_refund_id.to_owned()))
-                .and(dsl::connector.eq(connector.to_owned())),
-        )
-        .await
+        match merchant_connector_id {
+            Some(merchant_connector_id) => {
+                generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
+                    conn,
+                    dsl::merchant_id
+                        .eq(processor_merchant_id.to_owned())
+                        .and(dsl::connector_refund_id.eq(connector_refund_id.to_owned()))
+                        .and(dsl::connector.eq(connector.to_owned()))
+                        .and(
+                            dsl::merchant_connector_id
+                                .eq(merchant_connector_id.to_owned())
+                                .or(dsl::merchant_connector_id.is_null()),
+                        ),
+                )
+                .await
+            }
+            None => {
+                generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
+                    conn,
+                    dsl::merchant_id
+                        .eq(processor_merchant_id.to_owned())
+                        .and(dsl::connector_refund_id.eq(connector_refund_id.to_owned()))
+                        .and(dsl::connector.eq(connector.to_owned())),
+                )
+                .await
+            }
+        }
     }
 
     pub async fn find_by_internal_reference_id_processor_merchant_id(

--- a/crates/diesel_models/tests/webhook_lookup_scoping.rs
+++ b/crates/diesel_models/tests/webhook_lookup_scoping.rs
@@ -1,0 +1,374 @@
+#![cfg(feature = "v1")]
+#![allow(clippy::panic_in_result_fn)]
+
+use std::{borrow::Cow, error::Error};
+
+use async_bb8_diesel::AsyncRunQueryDsl;
+use common_utils::{
+    date_time,
+    id_type::{MerchantConnectorAccountId, MerchantId, OrganizationId, PaymentId, ProfileId},
+    types::{ConnectorTransactionId, MinorUnit},
+};
+use diesel::{delete, pg::PgConnection, prelude::*, update};
+use diesel_models::{
+    enums::{AttemptStatus, Currency, RefundStatus, RefundType},
+    schema::{payment_attempt::dsl as pa_dsl, refund::dsl as refund_dsl},
+    PaymentAttempt, PaymentAttemptNew, PgPooledConn, Refund, RefundNew,
+};
+
+const CONNECTOR: &str = "stripe";
+
+async fn build_pool(
+    database_url: String,
+) -> Result<
+    bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>,
+    Box<dyn Error + Send + Sync>,
+> {
+    let manager = async_bb8_diesel::ConnectionManager::<PgConnection>::new(database_url);
+    let pool = bb8::Pool::builder()
+        .max_size(5)
+        .connection_timeout(std::time::Duration::from_secs(30))
+        .build(manager)
+        .await?;
+    Ok(pool)
+}
+
+fn merchant_id(suffix: &str) -> Result<MerchantId, Box<dyn Error + Send + Sync>> {
+    Ok(MerchantId::try_from(Cow::from(format!("mer_wb_{suffix}")))?)
+}
+
+fn merchant_connector_account_id(
+    suffix: &str,
+) -> Result<MerchantConnectorAccountId, Box<dyn Error + Send + Sync>> {
+    Ok(MerchantConnectorAccountId::try_from(Cow::from(
+        suffix.to_owned(),
+    ))?)
+}
+
+fn payment_attempt_new(
+    merchant_id: &MerchantId,
+    payment_id: &PaymentId,
+    profile_id: &ProfileId,
+    organization_id: &OrganizationId,
+    attempt_id: String,
+    merchant_connector_id: Option<MerchantConnectorAccountId>,
+) -> PaymentAttemptNew {
+    PaymentAttemptNew {
+        payment_id: payment_id.clone(),
+        merchant_id: merchant_id.clone(),
+        attempt_id,
+        status: AttemptStatus::Charged,
+        amount: MinorUnit::new(100),
+        currency: Some(Currency::USD),
+        save_to_locker: None,
+        connector: Some(CONNECTOR.to_string()),
+        error_message: None,
+        offer_amount: None,
+        surcharge_amount: None,
+        tax_amount: None,
+        payment_method_id: None,
+        payment_method: None,
+        capture_method: None,
+        capture_on: None,
+        confirm: true,
+        authentication_type: None,
+        created_at: date_time::now(),
+        modified_at: date_time::now(),
+        last_synced: None,
+        cancellation_reason: None,
+        amount_to_capture: None,
+        mandate_id: None,
+        browser_info: None,
+        payment_token: None,
+        error_code: None,
+        connector_metadata: None,
+        payment_experience: None,
+        payment_method_type: None,
+        payment_method_data: None,
+        business_sub_label: None,
+        straight_through_algorithm: None,
+        preprocessing_step_id: None,
+        mandate_details: None,
+        error_reason: None,
+        connector_response_reference_id: None,
+        multiple_capture_count: None,
+        amount_capturable: MinorUnit::new(0),
+        updated_by: "webhook_lookup_scoping_test".to_string(),
+        merchant_connector_id,
+        authentication_data: None,
+        encoded_data: None,
+        unified_code: None,
+        unified_message: None,
+        net_amount: None,
+        external_three_ds_authentication_attempted: None,
+        authentication_connector: None,
+        authentication_id: None,
+        mandate_data: None,
+        fingerprint_id: None,
+        payment_method_billing_address_id: None,
+        client_source: None,
+        client_version: None,
+        customer_acceptance: None,
+        profile_id: profile_id.clone(),
+        organization_id: organization_id.clone(),
+        card_network: None,
+        shipping_cost: None,
+        order_tax_amount: None,
+        connector_mandate_detail: None,
+        request_extended_authorization: None,
+        extended_authorization_applied: None,
+        capture_before: None,
+        card_discovery: None,
+        processor_merchant_id: Some(merchant_id.clone()),
+        created_by: None,
+        setup_future_usage_applied: None,
+        routing_approach: None,
+        connector_request_reference_id: None,
+        network_transaction_id: None,
+        network_details: None,
+        is_stored_credential: None,
+        authorized_amount: None,
+        extended_authorization_last_applied_at: None,
+        tokenization: None,
+        encrypted_payment_method_data: None,
+        error_details: None,
+        retry_type: None,
+        installment_data: None,
+        external_surcharge_details: None,
+        network_transaction_link_id: None,
+        sender_payment_instrument_id: None,
+        external_threeds_authentication_type: None,
+        applied_offer_details: None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn refund_new(
+    merchant_id: &MerchantId,
+    payment_id: &PaymentId,
+    organization_id: &OrganizationId,
+    refund_id: String,
+    internal_reference_id: String,
+    attempt_id: String,
+    connector_transaction_id: String,
+    connector_refund_id: String,
+    merchant_connector_id: Option<MerchantConnectorAccountId>,
+) -> RefundNew {
+    RefundNew {
+        refund_id,
+        payment_id: payment_id.clone(),
+        merchant_id: merchant_id.clone(),
+        internal_reference_id,
+        external_reference_id: None,
+        connector_transaction_id: ConnectorTransactionId::from(connector_transaction_id),
+        connector: CONNECTOR.to_string(),
+        connector_refund_id: Some(ConnectorTransactionId::from(connector_refund_id)),
+        refund_type: RefundType::InstantRefund,
+        total_amount: MinorUnit::new(100),
+        currency: Currency::USD,
+        refund_amount: MinorUnit::new(100),
+        refund_status: RefundStatus::Success,
+        sent_to_gateway: true,
+        metadata: None,
+        refund_arn: None,
+        created_at: date_time::now(),
+        modified_at: date_time::now(),
+        description: None,
+        attempt_id,
+        refund_reason: None,
+        profile_id: None,
+        updated_by: "webhook_lookup_scoping_test".to_string(),
+        merchant_connector_id,
+        charges: None,
+        organization_id: organization_id.clone(),
+        split_refunds: None,
+        processor_refund_data: None,
+        processor_transaction_data: None,
+        processor_merchant_id: Some(merchant_id.clone()),
+        created_by: None,
+    }
+}
+
+#[tokio::test]
+async fn payment_lookup_is_scoped_by_merchant_connector_id(
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipped: DATABASE_URL not set");
+        return Ok(());
+    };
+    let pool = build_pool(database_url).await?;
+    let pooled = pool.get().await?;
+    let conn: &PgPooledConn = &pooled;
+
+    let suffix = std::process::id().to_string();
+    let merchant_id = merchant_id(&suffix)?;
+    let profile_id = ProfileId::try_from(Cow::from("prof_wb"))?;
+    let organization_id = OrganizationId::try_from(Cow::from("org_wb"))?;
+    let mca1 = merchant_connector_account_id(&format!("mca_wb_{suffix}_1"))?;
+    let mca2 = merchant_connector_account_id(&format!("mca_wb_{suffix}_2"))?;
+    let connector_transaction_id = format!("conn_txn_wb_{suffix}");
+
+    let payment_id_1 = PaymentId::try_from(Cow::from(format!("pay_wb_{suffix}_1")))?;
+    let payment_id_2 = PaymentId::try_from(Cow::from(format!("pay_wb_{suffix}_2")))?;
+    let attempt_id_1 = format!("pa_wb_1_{suffix}");
+    let attempt_id_2 = format!("pa_wb_2_{suffix}");
+
+    let _attempt_1 = payment_attempt_new(
+        &merchant_id,
+        &payment_id_1,
+        &profile_id,
+        &organization_id,
+        attempt_id_1.clone(),
+        Some(mca1.clone()),
+    )
+    .insert(conn)
+    .await?;
+
+    let _attempt_2 = payment_attempt_new(
+        &merchant_id,
+        &payment_id_2,
+        &profile_id,
+        &organization_id,
+        attempt_id_2.clone(),
+        Some(mca2.clone()),
+    )
+    .insert(conn)
+    .await?;
+
+    for attempt_id in [attempt_id_1, attempt_id_2] {
+        update(
+            pa_dsl::payment_attempt.filter(
+                pa_dsl::attempt_id
+                    .eq(attempt_id)
+                    .and(pa_dsl::merchant_id.eq(merchant_id.clone())),
+            ),
+        )
+        .set(pa_dsl::connector_transaction_id.eq(Some(connector_transaction_id.clone())))
+        .execute_async(conn)
+        .await?;
+    }
+
+    let result_mca1 = PaymentAttempt::find_by_processor_merchant_id_connector_txn_id(
+        conn,
+        &merchant_id,
+        &connector_transaction_id,
+        Some(&mca1),
+    )
+    .await?;
+    assert_eq!(result_mca1.merchant_connector_id, Some(mca1.clone()));
+
+    let result_mca2 = PaymentAttempt::find_by_processor_merchant_id_connector_txn_id(
+        conn,
+        &merchant_id,
+        &connector_transaction_id,
+        Some(&mca2),
+    )
+    .await?;
+    assert_eq!(result_mca2.merchant_connector_id, Some(mca2.clone()));
+
+    let result_any = PaymentAttempt::find_by_processor_merchant_id_connector_txn_id(
+        conn,
+        &merchant_id,
+        &connector_transaction_id,
+        None,
+    )
+    .await?;
+    assert!(result_any.merchant_connector_id.is_some());
+
+    delete(pa_dsl::payment_attempt.filter(pa_dsl::merchant_id.eq(merchant_id)))
+        .execute_async(conn)
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn refund_lookup_is_scoped_by_merchant_connector_id(
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipped: DATABASE_URL not set");
+        return Ok(());
+    };
+    let pool = build_pool(database_url).await?;
+    let pooled = pool.get().await?;
+    let conn: &PgPooledConn = &pooled;
+
+    let suffix = std::process::id().to_string();
+    let merchant_id = merchant_id(&format!("ref_{suffix}"))?;
+    let organization_id = OrganizationId::try_from(Cow::from("org_wb_ref"))?;
+    let mca1 = merchant_connector_account_id(&format!("mca_wb_ref_{suffix}_1"))?;
+    let mca2 = merchant_connector_account_id(&format!("mca_wb_ref_{suffix}_2"))?;
+    let connector_refund_id = format!("connector_refund_id_wb_{suffix}");
+
+    let payment_id_1 = PaymentId::try_from(Cow::from(format!("pay_wb_ref_{suffix}_1")))?;
+    let payment_id_2 = PaymentId::try_from(Cow::from(format!("pay_wb_ref_{suffix}_2")))?;
+    let refund_id_1 = format!("refund_wb_1_{suffix}");
+    let refund_id_2 = format!("refund_wb_2_{suffix}");
+    let attempt_id_1 = format!("pa_wb_ref_1_{suffix}");
+    let attempt_id_2 = format!("pa_wb_ref_2_{suffix}");
+    let connector_transaction_id = format!("conn_txn_wb_ref_{suffix}");
+
+    let _refund_1 = refund_new(
+        &merchant_id,
+        &payment_id_1,
+        &organization_id,
+        refund_id_1,
+        format!("internal_ref_1_{suffix}"),
+        attempt_id_1,
+        connector_transaction_id.clone(),
+        connector_refund_id.clone(),
+        Some(mca1.clone()),
+    )
+    .insert(conn)
+    .await?;
+
+    let _refund_2 = refund_new(
+        &merchant_id,
+        &payment_id_2,
+        &organization_id,
+        refund_id_2,
+        format!("internal_ref_2_{suffix}"),
+        attempt_id_2,
+        connector_transaction_id.clone(),
+        connector_refund_id.clone(),
+        Some(mca2.clone()),
+    )
+    .insert(conn)
+    .await?;
+
+    let result_mca1 = Refund::find_by_processor_merchant_id_connector_refund_id_connector(
+        conn,
+        &merchant_id,
+        &connector_refund_id,
+        CONNECTOR,
+        Some(&mca1),
+    )
+    .await?;
+    assert_eq!(result_mca1.merchant_connector_id, Some(mca1.clone()));
+
+    let result_mca2 = Refund::find_by_processor_merchant_id_connector_refund_id_connector(
+        conn,
+        &merchant_id,
+        &connector_refund_id,
+        CONNECTOR,
+        Some(&mca2),
+    )
+    .await?;
+    assert_eq!(result_mca2.merchant_connector_id, Some(mca2.clone()));
+
+    let result_any = Refund::find_by_processor_merchant_id_connector_refund_id_connector(
+        conn,
+        &merchant_id,
+        &connector_refund_id,
+        CONNECTOR,
+        None,
+    )
+    .await?;
+    assert!(result_any.merchant_connector_id.is_some());
+
+    delete(refund_dsl::refund.filter(refund_dsl::merchant_id.eq(merchant_id)))
+        .execute_async(conn)
+        .await?;
+
+    Ok(())
+}

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -140,6 +140,7 @@ pub trait PaymentAttemptInterface {
         &self,
         processor_merchant_id: &id_type::MerchantId,
         connector_txn_id: &str,
+        merchant_connector_id: Option<&id_type::MerchantConnectorAccountId>,
         storage_scheme: storage_enums::MerchantStorageScheme,
         merchant_key_store: &MerchantKeyStore,
     ) -> error_stack::Result<PaymentAttempt, Self::Error>;

--- a/crates/router/src/core/disputes.rs
+++ b/crates/router/src/core/disputes.rs
@@ -879,6 +879,7 @@ pub async fn fetch_disputes_from_connector(
             &state,
             dispute.object_reference_id.clone(),
             platform.get_processor(),
+            None,
         )
         .await;
 

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -661,6 +661,7 @@ pub async fn get_payment_intent_payment_attempt(
                     .find_payment_attempt_by_processor_merchant_id_connector_txn_id(
                         processor_merchant_id,
                         id,
+                        None,
                         storage_scheme,
                         key_store,
                     )

--- a/crates/router/src/core/webhooks/gateway.rs
+++ b/crates/router/src/core/webhooks/gateway.rs
@@ -749,6 +749,7 @@ async fn build_webhook_resource_data(
                 state,
                 reference.clone(),
                 platform.get_processor(),
+                None,
             )
             .await?;
             Ok(Some(WebhookResourceData::Payment { payment_attempt }))
@@ -984,6 +985,7 @@ async fn build_event_context(
                 &ctx.state,
                 reference.clone(),
                 ctx.platform.get_processor(),
+                None,
             )
             .await
             .ok()?

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -527,6 +527,7 @@ async fn process_webhook_business_logic(
     };
 
     let profile_id = &merchant_connector_account.profile_id;
+    let merchant_connector_id = merchant_connector_account.merchant_connector_id.clone();
 
     let business_profile = state
         .store
@@ -586,6 +587,7 @@ async fn process_webhook_business_logic(
                 event_type,
                 &content,
                 webhook_resource_data,
+                Some(&merchant_connector_id),
             ))
             .await
             .attach_printable("Incoming webhook flow for payments failed"),
@@ -599,6 +601,7 @@ async fn process_webhook_business_logic(
                 source_verified,
                 event_type,
                 webhook_resource_data,
+                Some(&merchant_connector_id),
             ))
             .await
             .attach_printable("Incoming webhook flow for refunds failed"),
@@ -613,6 +616,7 @@ async fn process_webhook_business_logic(
                 request_details,
                 event_type,
                 webhook_resource_data,
+                Some(&merchant_connector_id),
             ))
             .await
             .attach_printable("Incoming webhook flow for disputes failed"),
@@ -858,6 +862,7 @@ async fn payments_incoming_webhook_flow(
     event_type: webhooks::IncomingWebhookEvent,
     content: &super::gateway::WebhookContent,
     webhook_resource_data: Option<WebhookResourceData>,
+    merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
 ) -> CustomResult<WebhookResponseTracker, errors::ApiErrorResponse> {
     let consume_or_trigger_flow = if source_verified {
         let resource_object = webhook_details.resource_object.clone();
@@ -879,17 +884,34 @@ async fn payments_incoming_webhook_flow(
     let shadow_ucs_call_connector_action: Option<payments::CallConnectorAction> = None;
 
     // Reuse the pre-fetched payment attempt when available; otherwise fetch now.
-    let payment_attempt =
-        if let Some(WebhookResourceData::Payment { payment_attempt }) = webhook_resource_data {
-            payment_attempt
-        } else {
+    // When the object reference is a connector-transaction-id, re-fetch scoped by
+    // merchant_connector_id so that the returned attempt belongs to this MCA.
+    let payment_attempt = if let Some(WebhookResourceData::Payment { payment_attempt }) =
+        webhook_resource_data
+    {
+        if matches!(
+            &webhook_details.object_reference_id,
+            webhooks::ObjectReferenceId::PaymentId(api::PaymentIdType::ConnectorTransactionId(_))
+        ) {
             get_payment_attempt_from_object_reference_id(
                 &state,
                 webhook_details.object_reference_id.clone(),
                 platform.get_processor(),
+                merchant_connector_id,
             )
             .await?
-        };
+        } else {
+            payment_attempt
+        }
+    } else {
+        get_payment_attempt_from_object_reference_id(
+            &state,
+            webhook_details.object_reference_id.clone(),
+            platform.get_processor(),
+            merchant_connector_id,
+        )
+        .await?
+    };
 
     let payments_response = match webhook_details.object_reference_id {
         webhooks::ObjectReferenceId::PaymentId(ref id) => {
@@ -911,6 +933,13 @@ async fn payments_incoming_webhook_flow(
                 )
                 .await?;
 
+            let resource_id = match id {
+                api::PaymentIdType::ConnectorTransactionId(_) => {
+                    api::PaymentIdType::PaymentAttemptId(payment_attempt.attempt_id.clone())
+                }
+                _ => id.clone(),
+            };
+
             let response = Box::pin(payments::payments_core::<
                 api::PSync,
                 api::PaymentsResponse,
@@ -925,7 +954,7 @@ async fn payments_incoming_webhook_flow(
                 None,
                 payments::operations::PaymentStatus,
                 api::PaymentsRetrieveRequest {
-                    resource_id: id.clone(),
+                    resource_id,
                     merchant_id: Some(platform.get_processor().get_account().get_id().clone()),
                     force_sync: true,
                     connector: None,
@@ -1548,6 +1577,7 @@ async fn refunds_incoming_webhook_flow(
     source_verified: bool,
     event_type: webhooks::IncomingWebhookEvent,
     webhook_resource_data: Option<WebhookResourceData>,
+    merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
 ) -> CustomResult<WebhookResponseTracker, errors::ApiErrorResponse> {
     let db = &*state.store;
     //find refund by connector refund id
@@ -1567,6 +1597,7 @@ async fn refunds_incoming_webhook_flow(
                     platform.get_processor().get_account().get_id(),
                     &id,
                     connector_name,
+                    merchant_connector_id,
                     platform.get_processor().get_account().storage_scheme,
                 )
                 .await
@@ -1730,6 +1761,7 @@ pub async fn get_payment_attempt_from_object_reference_id(
     state: &SessionState,
     object_reference_id: webhooks::ObjectReferenceId,
     processor: &domain::Processor,
+    merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
 ) -> CustomResult<PaymentAttempt, errors::ApiErrorResponse> {
     let db = &*state.store;
     match object_reference_id {
@@ -1737,6 +1769,7 @@ pub async fn get_payment_attempt_from_object_reference_id(
             .find_payment_attempt_by_processor_merchant_id_connector_txn_id(
                 processor.get_account().get_id(),
                 id,
+                merchant_connector_id,
                 processor.get_account().storage_scheme,
                 processor.get_key_store(),
             )
@@ -2316,6 +2349,7 @@ async fn frm_incoming_webhook_flow(
             &state,
             object_ref_id,
             platform.get_processor(),
+            None,
         )
         .await?;
         let payment_response = match event_type {
@@ -2435,19 +2469,38 @@ async fn disputes_incoming_webhook_flow(
     request_details: &IncomingWebhookRequestDetails<'_>,
     event_type: webhooks::IncomingWebhookEvent,
     webhook_resource_data: Option<WebhookResourceData>,
+    merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
 ) -> CustomResult<WebhookResponseTracker, errors::ApiErrorResponse> {
     metrics::INCOMING_DISPUTE_WEBHOOK_METRIC.add(1, &[]);
     if source_verified {
         let db = &*state.store;
         // Reuse the pre-fetched payment attempt when available; otherwise fetch now.
+        // When the object reference is a connector-transaction-id, re-fetch scoped by
+        // merchant_connector_id so that the returned attempt belongs to this MCA.
         let payment_attempt =
             if let Some(WebhookResourceData::Payment { payment_attempt }) = webhook_resource_data {
-                payment_attempt
+                if matches!(
+                    &webhook_details.object_reference_id,
+                    webhooks::ObjectReferenceId::PaymentId(
+                        api::PaymentIdType::ConnectorTransactionId(_)
+                    )
+                ) {
+                    get_payment_attempt_from_object_reference_id(
+                        &state,
+                        webhook_details.object_reference_id.clone(),
+                        platform.get_processor(),
+                        merchant_connector_id,
+                    )
+                    .await?
+                } else {
+                    payment_attempt
+                }
             } else {
                 get_payment_attempt_from_object_reference_id(
                     &state,
                     webhook_details.object_reference_id.clone(),
                     platform.get_processor(),
+                    merchant_connector_id,
                 )
                 .await?
             };
@@ -2575,6 +2628,7 @@ async fn bank_transfer_webhook_flow(
             &state,
             webhook_details.object_reference_id,
             platform.get_processor(),
+            None,
         )
         .await?;
         let payment_id = payment_attempt.payment_id.clone();
@@ -2842,6 +2896,7 @@ async fn update_connector_mandate_details(
             state,
             object_ref_id,
             platform.get_processor(),
+            None,
         )
         .await?;
         if let Some(ref payment_method_id) = payment_attempt.payment_method_id {

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1819,6 +1819,7 @@ impl PaymentAttemptInterface for KafkaStore {
         &self,
         processor_merchant_id: &id_type::MerchantId,
         connector_txn_id: &str,
+        merchant_connector_id: Option<&id_type::MerchantConnectorAccountId>,
         storage_scheme: MerchantStorageScheme,
         key_store: &domain::MerchantKeyStore,
     ) -> CustomResult<storage::PaymentAttempt, errors::StorageError> {
@@ -1826,6 +1827,7 @@ impl PaymentAttemptInterface for KafkaStore {
             .find_payment_attempt_by_processor_merchant_id_connector_txn_id(
                 processor_merchant_id,
                 connector_txn_id,
+                merchant_connector_id,
                 storage_scheme,
                 key_store,
             )
@@ -3079,6 +3081,7 @@ impl RefundInterface for KafkaStore {
         processor_merchant_id: &id_type::MerchantId,
         connector_refund_id: &str,
         connector: &str,
+        merchant_connector_id: Option<&id_type::MerchantConnectorAccountId>,
         storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<diesel_refund::Refund, errors::StorageError> {
         self.diesel_store
@@ -3086,6 +3089,7 @@ impl RefundInterface for KafkaStore {
                 processor_merchant_id,
                 connector_refund_id,
                 connector,
+                merchant_connector_id,
                 storage_scheme,
             )
             .await

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -47,6 +47,7 @@ pub trait RefundInterface {
         processor_merchant_id: &common_utils::id_type::MerchantId,
         connector_refund_id: &str,
         connector: &str,
+        merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
         storage_scheme: enums::MerchantStorageScheme,
     ) -> CustomResult<diesel_refund::Refund, errors::StorageError>;
 
@@ -318,6 +319,7 @@ mod storage {
             processor_merchant_id: &common_utils::id_type::MerchantId,
             connector_refund_id: &str,
             connector: &str,
+            merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<diesel_refund::Refund, errors::StorageError> {
             let conn = connection::pg_connection_read(self).await?;
@@ -329,6 +331,7 @@ mod storage {
                     processor_merchant_id,
                     connector_refund_id,
                     connector,
+                    merchant_connector_id,
                 )
                 .await;
 
@@ -344,6 +347,7 @@ mod storage {
                             processor_merchant_id,
                             connector_refund_id,
                             connector,
+                            merchant_connector_id,
                         )
                         .await
                         .map_err(|error| report!(errors::StorageError::from(error)))
@@ -1059,6 +1063,7 @@ mod storage {
             processor_merchant_id: &common_utils::id_type::MerchantId,
             connector_refund_id: &str,
             connector: &str,
+            merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
             storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<diesel_refund::Refund, errors::StorageError> {
             // Stagger release fallback: first try processor_merchant_id, if not found fallback to merchant_id
@@ -1071,6 +1076,7 @@ mod storage {
                         processor_merchant_id,
                         connector_refund_id,
                         connector,
+                        merchant_connector_id,
                     )
                     .await;
 
@@ -1086,6 +1092,7 @@ mod storage {
                                 processor_merchant_id,
                                 connector_refund_id,
                                 connector,
+                                merchant_connector_id,
                             )
                             .await
                             .map_err(|error| report!(errors::StorageError::from(error)))
@@ -1120,13 +1127,25 @@ mod storage {
                     };
                     Box::pin(db_utils::try_redis_get_else_try_database_get(
                         async {
-                            Box::pin(kv_wrapper(
+                            let refund = Box::pin(kv_wrapper::<diesel_refund::Refund, _, _>(
                                 self,
                                 KvOperation::<diesel_refund::Refund>::HGet(&lookup.sk_id),
                                 key,
                             ))
                             .await?
-                            .try_into_hget()
+                            .try_into_hget()?;
+                            if let Some(merchant_connector_id) = merchant_connector_id {
+                                if let Some(merchant_connector_id_in_kv) =
+                                    refund.merchant_connector_id.as_ref()
+                                {
+                                    if merchant_connector_id_in_kv != merchant_connector_id {
+                                        return Err(
+                                            redis_interface::errors::RedisError::NotFound.into()
+                                        );
+                                    }
+                                }
+                            }
+                            Ok(refund)
                         },
                         database_call,
                     ))
@@ -1560,6 +1579,7 @@ impl RefundInterface for MockDb {
         processor_merchant_id: &common_utils::id_type::MerchantId,
         connector_refund_id: &str,
         connector: &str,
+        _merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
         _storage_scheme: enums::MerchantStorageScheme,
     ) -> CustomResult<diesel_refund::Refund, errors::StorageError> {
         let refunds = self.refunds.lock().await;

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -199,6 +199,7 @@ pub async fn find_payment_intent_from_payment_id_type(
                 .find_payment_attempt_by_processor_merchant_id_connector_txn_id(
                     platform.get_processor().get_account().get_id(),
                     &connector_transaction_id,
+                    None,
                     platform.get_processor().get_account().storage_scheme,
                     platform.get_processor().get_key_store(),
                 )
@@ -260,6 +261,7 @@ pub async fn find_payment_intent_from_refund_id_type(
                 platform.get_processor().get_account().get_id(),
                 &id,
                 connector_name,
+                None,
                 platform.get_processor().get_account().storage_scheme,
             )
             .await

--- a/crates/router/src/workflows/process_dispute.rs
+++ b/crates/router/src/workflows/process_dispute.rs
@@ -78,6 +78,7 @@ impl ProcessTrackerWorkflow<SessionState> for ProcessDisputeWorkflow {
             state,
             tracking_data.dispute_payload.object_reference_id.clone(),
             platform.get_processor(),
+            None,
         )
         .await?;
 

--- a/crates/storage_impl/src/mock_db/payment_attempt.rs
+++ b/crates/storage_impl/src/mock_db/payment_attempt.rs
@@ -126,6 +126,7 @@ impl PaymentAttemptInterface for MockDb {
         &self,
         _processor_merchant_id: &common_utils::id_type::MerchantId,
         _connector_txn_id: &str,
+        _merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
         _storage_scheme: storage_enums::MerchantStorageScheme,
         _merchant_key_store: &MerchantKeyStore,
     ) -> CustomResult<PaymentAttempt, StorageError> {

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -287,6 +287,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         &self,
         processor_merchant_id: &common_utils::id_type::MerchantId,
         connector_txn_id: &str,
+        merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
         _storage_scheme: MerchantStorageScheme,
         merchant_key_store: &MerchantKeyStore,
     ) -> CustomResult<PaymentAttempt, errors::StorageError> {
@@ -298,6 +299,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
             &conn,
             processor_merchant_id,
             connector_txn_id,
+            merchant_connector_id,
         )
         .await
         .map_err(|er| {
@@ -1431,6 +1433,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
         &self,
         processor_merchant_id: &common_utils::id_type::MerchantId,
         connector_txn_id: &str,
+        merchant_connector_id: Option<&common_utils::id_type::MerchantConnectorAccountId>,
         storage_scheme: MerchantStorageScheme,
         merchant_key_store: &MerchantKeyStore,
     ) -> error_stack::Result<PaymentAttempt, errors::StorageError> {
@@ -1446,6 +1449,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .find_payment_attempt_by_processor_merchant_id_connector_txn_id(
                         processor_merchant_id,
                         connector_txn_id,
+                        merchant_connector_id,
                         storage_scheme,
                         merchant_key_store,
                     )
@@ -1463,6 +1467,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                         .find_payment_attempt_by_processor_merchant_id_connector_txn_id(
                             processor_merchant_id,
                             connector_txn_id,
+                            merchant_connector_id,
                             storage_scheme,
                             merchant_key_store,
                         )
@@ -1477,13 +1482,25 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .attach_printable("Missing KeyManagerState")?;
                 Box::pin(try_redis_get_else_try_database_get(
                     async {
-                        let diesel_payment_attempt = Box::pin(kv_wrapper(
-                            self,
-                            KvOperation::<DieselPaymentAttempt>::HGet(&lookup.sk_id),
-                            key,
-                        ))
-                        .await?
-                        .try_into_hget()?;
+                        let diesel_payment_attempt =
+                            Box::pin(kv_wrapper::<DieselPaymentAttempt, _, _>(
+                                self,
+                                KvOperation::<DieselPaymentAttempt>::HGet(&lookup.sk_id),
+                                key,
+                            ))
+                            .await?
+                            .try_into_hget()?;
+                        if let Some(merchant_connector_id) = merchant_connector_id {
+                            if let Some(merchant_connector_id_in_kv) =
+                                diesel_payment_attempt.merchant_connector_id.as_ref()
+                            {
+                                if merchant_connector_id_in_kv != merchant_connector_id {
+                                    return Err(
+                                        redis_interface::errors::RedisError::NotFound.into()
+                                    );
+                                }
+                            }
+                        }
                         PaymentAttempt::convert_back(
                             key_manager_state,
                             diesel_payment_attempt,
@@ -1499,6 +1516,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                             .find_payment_attempt_by_processor_merchant_id_connector_txn_id(
                                 processor_merchant_id,
                                 connector_txn_id,
+                                merchant_connector_id,
                                 storage_scheme,
                                 merchant_key_store,
                             )


### PR DESCRIPTION
## Type of Change

- [X] Bugfix

## Description

Incoming webhook object resolution ignored which merchant connector account (MCA) the webhook was verified against. Payments, refunds and disputes were looked up only by merchant + connector-side id, so with two MCAs on the same connector a connector-side id collision could return an arbitrary row and update the wrong account.

The signature-verified `merchant_connector_id` is now threaded through the incoming payment/refund/dispute webhook flows and used to scope the object lookups. Callers that do not resolve an MCA (public payment status sync, MCA resolution for webhook source verification, webhook resource pre-fetch) keep the existing unscoped behavior.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Fixes #13679

Webhook source verification is per-MCA (each MCA carries its own `connector_webhook_details`), but the lookups that run after verification were never scoped by the verified MCA. Multiple MCAs per merchant+connector are supported, and connector-side transaction/refund ids are connector-scoped rather than globally unique, so two accounts on the same connector can collide on `connector_transaction_id` / `connector_refund_id` and an arbitrary row would be updated.

## How did you test it?

Added a DB-backed regression test in `crates/diesel_models` that seeds two payment attempts (and two refunds) sharing the same connector-side id but different `merchant_connector_id`, and asserts that the scoped lookup returns the row for the requested MCA. `cargo test -p diesel_models --features v1 --test webhook_lookup_scoping` passes. `cargo +nightly fmt --all` and `cargo clippy` are clean on the changed crates; `cargo check -p router --features v1` compiles.

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible