### PR TITLE
test(cypress): add CVC omit and risk message coverage for cybersource

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
@@ -701,6 +701,116 @@ export const connectorDetails = {
         },
       },
     },
+    CvcOmitAndRiskMessages: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          value: "connector_1",
+        },
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        mandate_data: singleUseMandateData,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    CvcOmitNoBilling: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          value: "connector_1",
+        },
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+        billing: {
+          address: {
+            first_name: "Test",
+            last_name: "User",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+          error_code: "MISSING_FIELD",
+        },
+      },
+    },
+    CvcOmitEmptyCvc: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          value: "connector_1",
+        },
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            ...successfulNo3DSCardDetails,
+            card_cvc: "",
+          },
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Invalid card_cvc length",
+            code: "IR_16",
+          },
+        },
+      },
+    },
+    CvcOmitOmittedCvc: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          value: "connector_1",
+        },
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            card_number: "4242424242424242",
+            card_exp_month: "01",
+            card_exp_year: "50",
+            card_holder_name: "joseph Doe",
+          },
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            error_type: "invalid_request",
+            message: "Json deserialize error: missing field `card_cvc`",
+            code: "IR_06",
+          },
+        },
+      },
+    },
     MandateMultiUseNo3DSAutoCapture: {
       Configs: {
         CONNECTOR_CREDENTIAL: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -811,6 +811,7 @@ export const CONNECTOR_LISTS = {
     CLIENT_SESSION_VALIDATION: ["stripe"],
     WEBHOOK_CONFIG: ["stripe"],
     REQUIRES_CVV: ["bankofamerica"],
+    CVC_OMIT: ["cybersource"],
     // Add more inclusion lists
   },
 };

--- a/cypress-tests/cypress/e2e/spec/Payment/57-CvcOmitAndRiskMessages.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/57-CvcOmitAndRiskMessages.cy.js
@@ -1,0 +1,201 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, * as utils from "../../configs/Payment/Utils";
+
+let globalState;
+let connector;
+
+describe("Card - CVC Omit and Risk Messages flow test", () => {
+  before("seed global state", function () {
+    let skip = false;
+
+    cy.task("getGlobalState")
+      .then((state) => {
+        globalState = new State(state);
+        connector = globalState.get("connectorId");
+
+        if (
+          utils.shouldIncludeConnector(
+            connector,
+            utils.CONNECTOR_LISTS.INCLUDE.CVC_OMIT
+          )
+        ) {
+          skip = true;
+        }
+      })
+      .then(() => {
+        if (skip) {
+          this.skip();
+        }
+      });
+  });
+
+  afterEach("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("CVC Omission via Mandate MIT Flow", () => {
+    let shouldContinue = true;
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("cit-mandate-setup-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["CvcOmitAndRiskMessages"];
+
+      cy.citForMandatesCallTest(
+        fixtures.citConfirmBody,
+        data,
+        100,
+        true,
+        "automatic",
+        "setup_mandate",
+        globalState
+      );
+
+      if (shouldContinue)
+        shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("mit-no-cvc-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["MITAutoCapture"];
+
+      cy.mitForMandatesCallTest(
+        fixtures.mitConfirmBody,
+        data,
+        200,
+        true,
+        "automatic",
+        globalState
+      );
+
+      if (shouldContinue)
+        shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("retrieve-mit-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["MITAutoCapture"];
+
+      cy.retrievePaymentCallTest({ globalState, data });
+    });
+  });
+
+  context("Baseline Payment with Valid CVC", () => {
+    let shouldContinue = true;
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("create-confirm-payment-with-cvc-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["No3DSAutoCapture"];
+
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+
+      if (shouldContinue)
+        shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("retrieve-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["No3DSAutoCapture"];
+
+      cy.retrievePaymentCallTest({ globalState, data });
+    });
+  });
+
+  context(
+    "Payment with missing billing fields (risk message verification)",
+    () => {
+      let shouldContinue = true;
+
+      beforeEach(function () {
+        if (!shouldContinue) {
+          this.skip();
+        }
+      });
+
+      it("payment-with-missing-billing-fields-test", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["CvcOmitNoBilling"];
+
+        cy.createConfirmPaymentTest(
+          fixtures.createConfirmPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+      });
+    }
+  );
+
+  context("Negative - Payment with empty CVC", () => {
+    let shouldContinue = true;
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("payment-with-empty-cvc-error-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["CvcOmitEmptyCvc"];
+
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+  });
+
+  context("Negative - Payment with omitted CVC field", () => {
+    let shouldContinue = true;
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("payment-with-omitted-cvc-error-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["CvcOmitOmittedCvc"];
+
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

> **Note:** This PR adds Cypress E2E test coverage — no production code changes.

## Description
<!-- Describe your changes in detail -->

Adds a new Cypress spec (`57-CvcOmitAndRiskMessages.cy.js`) covering CVC omission behaviour and risk/AVS error message construction for the **cybersource** connector. The spec includes 8 test cases spanning happy-path CIT/MIT mandate flows, baseline CVC payments, and negative cases for empty/omitted CVC and missing billing fields. Corresponding config keys were added to `Cybersource.js` and the connector was registered in `Utils.js` under `CONNECTOR_LISTS.INCLUDE.CVC_OMIT`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

No API, database, or configuration changes. Only `cypress-tests/` files were modified:

- `cypress-tests/cypress/e2e/spec/Payment/57-CvcOmitAndRiskMessages.cy.js` — new spec covering CVC omit & risk message happy path + negative cases
- `cypress-tests/cypress/e2e/configs/Payment/Cybersource.js` — added 4 config keys: `CvcOmitAndRiskMessages`, `CvcOmitNoBilling`, `CvcOmitEmptyCvc`, `CvcOmitOmittedCvc`
- `cypress-tests/cypress/e2e/configs/Payment/Utils.js` — added `CVC_OMIT: ["cybersource"]` to `CONNECTOR_LISTS.INCLUDE`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

PR [#13630](https://github.com/juspay/hyperswitch/pull/13630) omits `securityCode` from Cybersource card payloads when CVC is empty/whitespace and fixes risk/AVS error message construction to avoid empty fragments. This PR adds the E2E test coverage for that change to prevent regressions.

- Closes #13743
- Related to #13630

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Full regression suite was executed against the changed connector(s). All `RUNNER_RESULT` blocks from the QA pipeline are included verbatim below.

### Changed-spec verification — `cybersource`

```
RUNNER_RESULT:
  Connector: cybersource
  SpecFile: cypress/e2e/spec/Payment/57-CvcOmitAndRiskMessages.cy.js
  PrereqsUsed: spec/Payment/01-AccountCreate, 02-CustomerCreate, 03-ConnectorCreate
  TotalTests: 14
  Passed: 14
  Failed: 0
  Skipped: 0
  OverallStatus: PASS

  Failures:
    - none

  SkippedTests:
    - none

  FlakeyTests:
    - none

  BlockedReasons:
    - none
```

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| cybersource | 14 | 14 | 0 | 0 | PASS |

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

> Rust formatting/linting items are N/A — this PR only touches `cypress-tests/` (JavaScript/TypeScript Cypress specs and configs).
