### PR TITLE
fix(ucs): fire kill switch on connector errors in Ok(RouterData)

### DIFF
--- a/crates/hyperswitch_interfaces/src/api/gateway.rs
+++ b/crates/hyperswitch_interfaces/src/api/gateway.rs
@@ -410,6 +410,9 @@ where
             let return_raw_connector_response_clone = return_raw_connector_response;
             let context_clone = context;
             let connector_name = router_data.connector.clone();
+            let merchant_id = router_data.merchant_id.clone();
+            let payment_method = router_data.payment_method;
+            let payment_method_type = router_data.payment_method_type;
             tokio::spawn(
                 async move {
                     let gateway: Box<
@@ -442,6 +445,9 @@ where
                         connector_name,
                         direct_for_compare,
                         ucs_for_compare,
+                        Some(&merchant_id),
+                        Some(payment_method),
+                        payment_method_type,
                     )
                     .await;
                 }
@@ -544,6 +550,9 @@ where
             let return_raw_connector_response_clone = return_raw_connector_response;
             let context_clone = context;
             let connector_name = router_data.connector.clone();
+            let merchant_id = router_data.merchant_id.clone();
+            let payment_method = router_data.payment_method;
+            let payment_method_type = router_data.payment_method_type;
             tokio::spawn(
                 async move {
                     let gateway: Box<
@@ -576,6 +585,9 @@ where
                         connector_name,
                         direct_for_compare,
                         ucs_for_compare,
+                        Some(&merchant_id),
+                        Some(payment_method),
+                        payment_method_type,
                     )
                     .await;
                 }

--- a/crates/hyperswitch_interfaces/src/helpers.rs
+++ b/crates/hyperswitch_interfaces/src/helpers.rs
@@ -1,8 +1,8 @@
 use common_utils::{
-    consts::{X_CONNECTOR_NAME, X_SUB_FLOW_NAME},
+    consts::{X_CONNECTOR_NAME, X_PAYMENT_METHOD, X_PAYMENT_METHOD_TYPE, X_SUB_FLOW_NAME},
     errors as common_utils_errors,
     ext_traits::Encode,
-    request,
+    id_type, request,
 };
 use error_stack::ResultExt;
 use hyperswitch_domain_models::router_data;
@@ -52,6 +52,9 @@ pub async fn serialize_comparison_results_and_send<S, F, RouterDReq, RouterDResp
         router_data::RouterData<F, RouterDReq, RouterDResp>,
         String,
     >,
+    merchant_id: Option<&id_type::MerchantId>,
+    payment_method: Option<common_enums::enums::PaymentMethod>,
+    payment_method_type: Option<common_enums::enums::PaymentMethodType>,
 ) where
     S: api_client::ApiClientWrapper + GetComparisonServiceConfig,
     F: Send + Clone + Sync + 'static,
@@ -94,6 +97,9 @@ pub async fn serialize_comparison_results_and_send<S, F, RouterDReq, RouterDResp
         connector_name,
         sub_flow_name,
         request_id,
+        merchant_id,
+        payment_method,
+        payment_method_type,
     )
     .await
     .inspect_err(|e| logger::warn!("Failed to send comparison data: {:?}", e));
@@ -107,6 +113,7 @@ pub async fn serialize_webhook_outcome_and_send_to_comparison_service<P, S>(
     comparison_service_config: types::ComparisonServiceConfig,
     connector_name: String,
     request_id: Option<String>,
+    merchant_id: Option<&id_type::MerchantId>,
 ) where
     P: serde::Serialize + std::fmt::Debug,
     S: serde::Serialize + std::fmt::Debug,
@@ -132,6 +139,9 @@ pub async fn serialize_webhook_outcome_and_send_to_comparison_service<P, S>(
         connector_name,
         Some("webhook".to_string()),
         request_id,
+        merchant_id,
+        None,
+        None,
     )
     .await
     {
@@ -140,6 +150,7 @@ pub async fn serialize_webhook_outcome_and_send_to_comparison_service<P, S>(
 }
 
 /// Sends router data comparison to external service
+#[allow(clippy::too_many_arguments)]
 pub async fn send_comparison_data(
     state: &dyn api_client::ApiClientWrapper,
     comparison_data: ComparisonData,
@@ -147,6 +158,9 @@ pub async fn send_comparison_data(
     connector_name: String,
     sub_flow_name: Option<String>,
     request_id: Option<String>,
+    merchant_id: Option<&id_type::MerchantId>,
+    payment_method: Option<common_enums::enums::PaymentMethod>,
+    payment_method_type: Option<common_enums::enums::PaymentMethodType>,
 ) -> common_utils_errors::CustomResult<(), errors::HttpClientError> {
     let mut request = request::RequestBuilder::new()
         .method(request::Method::Post)
@@ -172,6 +186,27 @@ pub async fn send_comparison_data(
         request.add_header(
             consts::X_REQUEST_ID,
             hyperswitch_masking::Maskable::Normal(req_id),
+        );
+    }
+
+    if let Some(merchant_id) = merchant_id {
+        request.add_header(
+            common_utils::consts::X_MERCHANT_ID,
+            hyperswitch_masking::Maskable::Normal(merchant_id.get_string_repr().to_string()),
+        );
+    }
+
+    if let Some(pm) = payment_method {
+        request.add_header(
+            X_PAYMENT_METHOD,
+            hyperswitch_masking::Maskable::Normal(pm.to_string()),
+        );
+    }
+
+    if let Some(pmt) = payment_method_type {
+        request.add_header(
+            X_PAYMENT_METHOD_TYPE,
+            hyperswitch_masking::Maskable::Normal(pmt.to_string()),
         );
     }
 

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -1398,3 +1398,207 @@ impl ErrorSwitch<ConnectorError> for UnifiedConnectorServiceError {
         }
     }
 }
+
+/// Why a UCS failure should return a rollout scope to the direct connector integration.
+///
+/// Named by where the failure originated, because that decides who fixes it: a `Hyperswitch`
+/// reason is a bug in this repo's request or response mapping, a `Ucs` reason is not.
+///
+/// Doubles as the metric label, so it is a small fixed set rather than the error itself — the
+/// error carries free-form strings and would be unbounded label cardinality.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum UcsKillSwitchReason {
+    /// Hyperswitch could not build a valid request. UCS was never reached.
+    HyperswitchRequestInvalid,
+    /// Hyperswitch could not decode what UCS returned. The two models disagree.
+    HyperswitchResponseUndecodable,
+    /// UCS rejected the request Hyperswitch sent it.
+    UcsRejectedRequest,
+    /// UCS does not implement this flow for this connector.
+    UcsFlowUnsupported,
+    /// UCS failed internally, or failed the flow without saying more.
+    UcsInternalError,
+    /// UCS could not be reached, or was too unwell to answer.
+    UcsUnreachable,
+    /// The connector rejected the request. May be a legitimate decline or a request UCS built
+    /// wrongly — indistinguishable at this layer, so we trip conservatively because falling back
+    /// to the battle-tested direct path is always safe.
+    ConnectorOutcome,
+}
+
+impl UnifiedConnectorServiceError {
+    /// Whether this failure should return the rollout scope to the direct connector integration.
+    ///
+    /// Every error qualifies, including [`Self::ConnectorError`]. A connector rejection may be a
+    /// legitimate decline or a request UCS built wrongly — since the two are indistinguishable,
+    /// we trip conservatively: falling back to the battle-tested direct path is always safe.
+    ///
+    /// Exhaustive: a new variant must be classified here rather than defaulting.
+    pub fn ucs_kill_switch_reason(&self) -> Option<UcsKillSwitchReason> {
+        match self {
+            // Hyperswitch could not read UCS's answer.
+            Self::ResponseDeserializationFailed | Self::ParsingFailed => {
+                Some(UcsKillSwitchReason::HyperswitchResponseUndecodable)
+            }
+
+            // Hyperswitch could not build the request. UCS was never reached.
+            Self::RequestEncodingFailed
+            | Self::RequestEncodingFailedWithReason(_)
+            | Self::MissingRequiredField { .. }
+            | Self::MissingRequiredFields { .. }
+            | Self::MissingConnectorName
+            | Self::InvalidConnectorName
+            | Self::InvalidDataFormat { .. }
+            | Self::FailedToObtainAuthType
+            | Self::HeaderInjectionFailed(_) => {
+                Some(UcsKillSwitchReason::HyperswitchRequestInvalid)
+            }
+
+            // Raised by Hyperswitch, but it reports a flow UCS cannot serve.
+            Self::NotImplemented(_) => Some(UcsKillSwitchReason::UcsFlowUnsupported),
+
+            // UCS-side by construction: `from_grpc_error` extracts connector errors first.
+            Self::TonicStatus { code, .. } => match code {
+                // UCS-wide rather than scope-specific. Still worth falling back for: while UCS
+                // is unwell the payment has nowhere else to go and fails outright.
+                tonic::Code::Unavailable
+                | tonic::Code::DeadlineExceeded
+                | tonic::Code::ResourceExhausted
+                | tonic::Code::Aborted
+                | tonic::Code::Cancelled => Some(UcsKillSwitchReason::UcsUnreachable),
+
+                // UCS rejected what Hyperswitch sent it.
+                tonic::Code::InvalidArgument
+                | tonic::Code::FailedPrecondition
+                | tonic::Code::OutOfRange
+                | tonic::Code::NotFound
+                | tonic::Code::AlreadyExists
+                | tonic::Code::Unauthenticated
+                | tonic::Code::PermissionDenied => Some(UcsKillSwitchReason::UcsRejectedRequest),
+
+                tonic::Code::Unimplemented => Some(UcsKillSwitchReason::UcsFlowUnsupported),
+
+                // UCS itself failed. `Unknown` is included because a rolling deploy surfaces as
+                // `Unavailable`, not `Unknown`, so `Unknown` is more often a server-side panic.
+                tonic::Code::Internal
+                | tonic::Code::DataLoss
+                | tonic::Code::Unknown
+                | tonic::Code::Ok => Some(UcsKillSwitchReason::UcsInternalError),
+            },
+
+            // Could not reach UCS at all. Same treatment as `Unavailable` above.
+            Self::ConnectionError(_) => Some(UcsKillSwitchReason::UcsUnreachable),
+
+            // No usable status never reaches here: `from_grpc_error` falls through to
+            // `TonicStatus`. A zero means UCS supplied one, which is UCS-side.
+            Self::ConnectorError(inner) if inner.status_code == 0 => {
+                Some(UcsKillSwitchReason::UcsInternalError)
+            }
+
+            // The connector answered. This may be a legitimate decline or a request UCS built
+            // wrongly — indistinguishable here. We trip conservatively: a false bypass to the
+            // direct path is safe (it served merchants for years), while a missed trip leaves
+            // merchants on a potentially broken UCS path.
+            Self::ConnectorError(_) => Some(UcsKillSwitchReason::ConnectorOutcome),
+
+            // Per-flow failure markers carrying no further detail.
+            Self::WebhookProcessingFailure
+            | Self::PaymentCreateOrderFailure
+            | Self::PaymentAuthorizeGranularFailure
+            | Self::CreateSessionTokenFailure
+            | Self::CreateAccessTokenFailure
+            | Self::PaymentMethodTokenizeFailure
+            | Self::CreateConnectorCustomerFailure
+            | Self::PaymentAuthorizeFailure
+            | Self::PaymentPreAuthenticateFailure
+            | Self::PaymentAuthenticateFailure
+            | Self::PaymentPostAuthenticateFailure
+            | Self::PaymentGetFailure
+            | Self::PaymentCaptureFailure
+            | Self::PaymentSetupRecurringFailure
+            | Self::RecurringPaymentChargeFailure
+            | Self::PaymentRefundFailure
+            | Self::RefundSyncFailure
+            | Self::IncomingWebhookHandleEventFailure
+            | Self::IncomingWebhookParseEventFailure
+            | Self::PaymentVoidFailure
+            | Self::CreateSdkSessionTokenFailure
+            | Self::PaymentIncrementalAuthorizationFailure
+            | Self::PayoutCreateFailure
+            | Self::PayoutTransferFailure
+            | Self::PayoutGetFailure
+            | Self::PayoutVoidFailure
+            | Self::PayoutStageFailure
+            | Self::PayoutCreateRecipientFailure
+            | Self::PayoutEnrollDisburseAccountFailure
+            | Self::SurchargeCalculateFailure
+            | Self::NotifyConnectorFailure => Some(UcsKillSwitchReason::UcsInternalError),
+        }
+    }
+}
+
+#[cfg(test)]
+mod ucs_kill_switch_reason_tests {
+    use super::*;
+
+    fn tonic_status(code: tonic::Code) -> UnifiedConnectorServiceError {
+        UnifiedConnectorServiceError::TonicStatus {
+            code,
+            message: "from ucs".to_string(),
+        }
+    }
+
+    #[test]
+    fn ucs_wide_grpc_codes_still_qualify() {
+        // While UCS is unwell the payment has no fallback and fails outright, so these qualify
+        // like any other. They share a label so a run of them reads as one UCS-wide event.
+        for code in [
+            tonic::Code::Unavailable,
+            tonic::Code::DeadlineExceeded,
+            tonic::Code::ResourceExhausted,
+            tonic::Code::Aborted,
+            tonic::Code::Cancelled,
+        ] {
+            assert_eq!(
+                tonic_status(code).ucs_kill_switch_reason(),
+                Some(UcsKillSwitchReason::UcsUnreachable),
+                "{code:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ucs_side_grpc_codes_are_kill_switch_worthy() {
+        // `from_grpc_error` extracts connector errors and timeouts before producing TonicStatus,
+        // so what reaches here is UCS-side and repeats identically for this scope.
+        let cases = [
+            (
+                tonic::Code::InvalidArgument,
+                UcsKillSwitchReason::UcsRejectedRequest,
+            ),
+            (
+                tonic::Code::FailedPrecondition,
+                UcsKillSwitchReason::UcsRejectedRequest,
+            ),
+            (
+                tonic::Code::Unauthenticated,
+                UcsKillSwitchReason::UcsRejectedRequest,
+            ),
+            (
+                tonic::Code::Unimplemented,
+                UcsKillSwitchReason::UcsFlowUnsupported,
+            ),
+            (tonic::Code::Internal, UcsKillSwitchReason::UcsInternalError),
+            (tonic::Code::Unknown, UcsKillSwitchReason::UcsInternalError),
+        ];
+
+        for (code, expected) in cases {
+            assert_eq!(
+                tonic_status(code).ucs_kill_switch_reason(),
+                Some(expected),
+                "{code:?}"
+            );
+        }
+    }
+}

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -365,6 +365,19 @@ pub const UCS_ROLLOUT_CONFIG_NOT_CONFIGURED: &str = "not_configured";
 // UCS feature enabled config
 pub const UCS_ENABLED: &str = "ucs_enabled";
 
+// Config key gating the UCS kill switch. Read through the same cached config lookup as
+// `UCS_ENABLED`, so the switch can be turned on or off without a redeploy.
+pub const UCS_KILL_SWITCH_ENABLED: &str = "ucs_kill_switch_enabled";
+
+// Prefix of the redis key holding a kill switch trip. Absent until a scope trips.
+pub const UCS_KILL_SWITCH_REDIS_PREFIX: &str = "ucs_kill_switch";
+
+// Lifetime of a trip, in seconds. A trip is meant to be cleared by an operator, but
+// `redis_interface` has no setter that writes a key without an expiry, so it is spelled as a
+// bound rather than left open. A week outlives a long weekend; a still-broken scope trips again
+// on its next request.
+pub const UCS_KILL_SWITCH_TTL_IN_SECONDS: i64 = 7 * 24 * 60 * 60;
+
 /// Header value indicating that signature-key-based authentication is used.
 pub const UCS_AUTH_SIGNATURE_KEY: &str = "signature-key";
 

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -365,10 +365,6 @@ pub const UCS_ROLLOUT_CONFIG_NOT_CONFIGURED: &str = "not_configured";
 // UCS feature enabled config
 pub const UCS_ENABLED: &str = "ucs_enabled";
 
-// Config key gating the UCS kill switch. Read through the same cached config lookup as
-// `UCS_ENABLED`, so the switch can be turned on or off without a redeploy.
-pub const UCS_KILL_SWITCH_ENABLED: &str = "ucs_kill_switch_enabled";
-
 // Prefix of the redis key holding a kill switch trip. Absent until a scope trips.
 pub const UCS_KILL_SWITCH_REDIS_PREFIX: &str = "ucs_kill_switch";
 

--- a/crates/router/src/core/metrics.rs
+++ b/crates/router/src/core/metrics.rs
@@ -94,6 +94,12 @@ counter_metric!(DECISION_ENGINE_REQUESTS, GLOBAL_METER);
 counter_metric!(DECISION_ENGINE_ROUTING_DIFF, GLOBAL_METER);
 counter_metric!(DECISION_ENGINE_KILL_SWITCH_TRIGGERED, GLOBAL_METER);
 
+// Qualifying UCS failures seen by the kill switch, emitted whether or not it is turned on so the
+// classifier can be validated against real traffic before the switch is turned on.
+counter_metric!(UCS_KILL_SWITCH_FAILURE, GLOBAL_METER);
+// Scopes tripped back to the direct integration.
+counter_metric!(UCS_KILL_SWITCH_TRIPPED, GLOBAL_METER);
+
 #[cfg(feature = "partial-auth")]
 counter_metric!(PARTIAL_AUTH_FAILURE, GLOBAL_METER);
 

--- a/crates/router/src/core/payments/flows/external_proxy_flow.rs
+++ b/crates/router/src/core/payments/flows/external_proxy_flow.rs
@@ -463,6 +463,7 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
             headers_builder,
             unified_connector_service_execution_mode,
             |mut router_data, payment_authorize_request, grpc_headers| async move {
+                // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper`.
                 let response = Box::pin(client
                     .payment_authorize(
                         payment_authorize_request,
@@ -470,7 +471,6 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
                         grpc_headers,
                     ))
                     .await
-                    .change_context(ApiErrorResponse::InternalServerError)
                     .attach_printable("Failed to authorize payment")?;
 
                 let payment_authorize_response = response.into_inner();
@@ -480,7 +480,6 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
                         payment_authorize_response.clone(),
                         router_data.status,
                     )
-                    .change_context(ApiErrorResponse::InternalServerError)
                     .attach_printable("Failed to deserialize UCS response")?;
 
                 let router_data_response = match ucs_data.router_data_response {
@@ -579,6 +578,7 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
             headers_builder,
             unified_connector_service_execution_mode,
             |mut router_data, payment_authorize_request, grpc_headers| async move {
+                // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper`.
                 let response = Box::pin(client
                     .payment_authorize(
                         payment_authorize_request,
@@ -586,7 +586,6 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
                         grpc_headers,
                     ))
                     .await
-                    .change_context(ApiErrorResponse::InternalServerError)
                     .attach_printable("Failed to authorize payment")?;
 
                 let payment_authorize_response = response.into_inner();
@@ -596,7 +595,6 @@ impl Feature<api::ExternalVaultProxy, types::ExternalVaultProxyPaymentsData>
                         payment_authorize_response.clone(),
                         router_data.status,
                     )
-                    .change_context(ApiErrorResponse::InternalServerError)
                     .attach_printable("Failed to deserialize UCS response")?;
 
                 let router_data_response = match ucs_data.router_data_response {

--- a/crates/router/src/core/payments/gateway/access_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/access_token_gateway.rs
@@ -12,7 +12,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -176,25 +175,8 @@ where
                     .await
                 {
                     Ok(response) => response,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for access token (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::MerchantAuthenticationServiceCreateServerAuthenticationTokenResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to create access token"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -144,34 +144,11 @@ where
                     .await
                     {
                         Ok(resp) => resp,
+                        // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            // Check if this is a connector error (4xx/5xx from connector via UCS)
-                            if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                report.current_context()
-                            {
-                                let (code, message, status_code, connector) = (
-                                    &inner.code,
-                                    &inner.message,
-                                    inner.status_code,
-                                    &inner.connector,
-                                );
-                                logger::debug!(
-                                    "Connector error via UCS for recurring charge (connector {}, status {}): {} - {}",
-                                    connector,
-                                    status_code,
-                                    code,
-                                    message
-                                );
-                                router_data.response = Err(inner.as_ref().into());
-                                router_data.connector_http_status_code = Some(status_code);
-                                return Ok((
-                                    router_data,
-                                    (),
-                                    payments_grpc::RecurringPaymentServiceChargeResponse::default(),
-                                ));
-                            }
-                            // Propagate as Err for proper HTTP error handling
-                            return Err(report.attach_printable("Failed to charge recurring payment"));
+                            return Err(
+                                report.attach_printable("Failed to charge recurring payment")
+                            );
                         }
                     };
 
@@ -250,37 +227,8 @@ where
                     .await
                     {
                         Ok(resp) => resp,
+                        // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            // Check if this is a connector error (4xx/5xx from connector via UCS)
-                            // If so, set it as router_data.response = Err(ErrorResponse) and return Ok
-                            // This matches how direct connector errors are handled
-                            if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                report.current_context()
-                            {
-                                let (code, message, status_code, connector) = (
-                                    &inner.code,
-                                    &inner.message,
-                                    inner.status_code,
-                                    &inner.connector,
-                                );
-                                logger::debug!(
-                                    "Connector error via UCS (connector {}, status {}): {} - {}",
-                                    connector,
-                                    status_code,
-                                    code,
-                                    message
-                                );
-                                router_data.response = Err(inner.as_ref().into());
-                                // Return Ok with router_data containing the error response
-                                // This ensures the connector error flows through the normal
-                                // response handling path (same as direct connector errors)
-                                router_data.connector_http_status_code = Some(status_code);
-                                return Ok((
-                                    router_data,
-                                    (),
-                                    payments_grpc::PaymentServiceAuthorizeResponse::default(),
-                                ));
-                            }
                             return Err(report.attach_printable("Failed to authorize payment"));
                         }
                     };

--- a/crates/router/src/core/payments/gateway/cancel_gateway.rs
+++ b/crates/router/src/core/payments/gateway/cancel_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -120,31 +119,8 @@ where
                     .await
                 {
                     Ok(resp) => resp,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            let (code, message, status_code, connector) = (
-                                &inner.code,
-                                &inner.message,
-                                inner.status_code,
-                                &inner.connector,
-                            );
-                            logger::debug!(
-                                "Connector error via UCS for void (connector {}, status {}): {} - {}",
-                                connector,
-                                status_code,
-                                code,
-                                message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceVoidResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to Void payment"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/capture_gateway.rs
+++ b/crates/router/src/core/payments/gateway/capture_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -122,31 +121,8 @@ where
                     .await
                 {
                     Ok(resp) => resp,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            let (code, message, status_code, connector) = (
-                                &inner.code,
-                                &inner.message,
-                                inner.status_code,
-                                &inner.connector,
-                            );
-                            logger::debug!(
-                                "Connector error via UCS for capture (connector {}, status {}): {} - {}",
-                                connector,
-                                status_code,
-                                code,
-                                message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceCaptureResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to capture payment"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use hyperswitch_masking::ExposeInterface as UcsMaskingExposeInterface;
 use unified_connector_service_client::payments as payments_grpc;
@@ -126,25 +125,8 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for complete authorize (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceAuthorizeResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to get payment"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/create_customer_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_customer_gateway.rs
@@ -12,7 +12,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -134,25 +133,8 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for create connector customer (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::CustomerServiceCreateResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to create connector customer"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/create_order_gateway.rs
+++ b/crates/router/src/core/payments/gateway/create_order_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -126,25 +125,8 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for create order (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceCreateOrderResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to create order"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/incremental_authorization_gateway.rs
+++ b/crates/router/src/core/payments/gateway/incremental_authorization_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -137,25 +136,8 @@ where
                     .await
                     {
                         Ok(response) => response,
+                        // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                report.current_context()
-                            {
-                                logger::debug!(
-                                    "Connector error via UCS for incremental authorization (connector {}, status {}): {} - {}",
-                                    inner.connector,
-                                    inner.status_code,
-                                    inner.code,
-                                    inner.message
-                                );
-                                router_data.response = Err(inner.as_ref().into());
-                                router_data.connector_http_status_code = Some(inner.status_code);
-                                return Ok((
-                                    router_data,
-                                    (),
-                                    payments_grpc::PaymentServiceIncrementalAuthorizationResponse::default(),
-                                ));
-                            }
                             return Err(report.attach_printable(
                                 "Failed to in incremental authorize payment",
                             ));

--- a/crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs
+++ b/crates/router/src/core/payments/gateway/payment_method_token_create_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -131,25 +130,8 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for payment method tokenization (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentMethodServiceTokenizeResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to Tokenize payment method"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/pre_authorize_void_gateway.rs
+++ b/crates/router/src/core/payments/gateway/pre_authorize_void_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -128,25 +127,8 @@ where
                     .await
                 {
                     Ok(response) => response,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for pre-authorize void (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceVoidResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to Cancel payment"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/psync_gateway.rs
+++ b/crates/router/src/core/payments/gateway/psync_gateway.rs
@@ -12,7 +12,6 @@ use hyperswitch_interfaces::{
     unified_connector_service::{
         get_payments_response_from_ucs_webhook_content,
         handle_unified_connector_service_response_for_payment_get,
-        transformers::UnifiedConnectorServiceError,
     },
 };
 use hyperswitch_masking::ExposeInterface as UcsMaskingExposeInterface;
@@ -205,31 +204,8 @@ where
                             .await
                         {
                             Ok(resp) => resp,
+                            // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                             Err(report) => {
-                                if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                    report.current_context()
-                                {
-                                    let (code, message, status_code, connector) = (
-                                        &inner.code,
-                                        &inner.message,
-                                        inner.status_code,
-                                        &inner.connector,
-                                    );
-                                    logger::debug!(
-                                        "Connector error via UCS for psync (connector {}, status {}): {} - {}",
-                                        connector,
-                                        status_code,
-                                        code,
-                                        message
-                                    );
-                                    router_data.response = Err(inner.as_ref().into());
-                                    router_data.connector_http_status_code = Some(status_code);
-                                    return Ok((
-                                        router_data,
-                                        (),
-                                        payments_grpc::PaymentServiceGetResponse::default(),
-                                    ));
-                                }
                                 return Err(report.attach_printable("Failed to get payment"));
                             }
                         };
@@ -273,10 +249,10 @@ where
                                 Some(MinorUnit::new(captured_amount));
                         }
                         if return_raw_connector_response.unwrap_or(false) {
-                            router_data.raw_connector_response = payment_get_response
-                                .raw_connector_response
-                                .clone()
-                                .map(|raw_connector_response| raw_connector_response.expose().into());
+                            router_data.raw_connector_response =
+                                payment_get_response.raw_connector_response.clone().map(
+                                    |raw_connector_response| raw_connector_response.expose().into(),
+                                );
                         }
                         router_data.connector_http_status_code = Some(status_code);
                         router_data.sender_payment_instrument_id =

--- a/crates/router/src/core/payments/gateway/session_gateway.rs
+++ b/crates/router/src/core/payments/gateway/session_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -127,25 +126,8 @@ where
                     .await
                     {
                         Ok(response) => response,
+                        // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                         Err(report) => {
-                            if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                                report.current_context()
-                            {
-                                logger::debug!(
-                                    "Connector error via UCS for sdk session token (connector {}, status {}): {} - {}",
-                                    inner.connector,
-                                    inner.status_code,
-                                    inner.code,
-                                    inner.message
-                                );
-                                router_data.response = Err(inner.as_ref().into());
-                                router_data.connector_http_status_code = Some(inner.status_code);
-                                return Ok((
-                                    router_data,
-                                    (),
-                                    payments_grpc::MerchantAuthenticationServiceCreateClientAuthenticationTokenResponse::default(),
-                                ));
-                            }
                             return Err(
                                 report.attach_printable("Failed to create SDK session token")
                             );

--- a/crates/router/src/core/payments/gateway/session_token_gateway.rs
+++ b/crates/router/src/core/payments/gateway/session_token_gateway.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -130,25 +129,8 @@ where
                     .await
                 {
                     Ok(response) => response,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for session token (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::MerchantAuthenticationServiceCreateServerSessionAuthenticationTokenResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to create session token"));
                     }
                 };

--- a/crates/router/src/core/payments/gateway/setup_mandate.rs
+++ b/crates/router/src/core/payments/gateway/setup_mandate.rs
@@ -9,7 +9,6 @@ use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
     errors::ConnectorError,
-    unified_connector_service::transformers::UnifiedConnectorServiceError,
 };
 use unified_connector_service_client::payments as payments_grpc;
 
@@ -124,25 +123,8 @@ where
                 .await
                 {
                     Ok(response) => response,
+                    // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper_granular`.
                     Err(report) => {
-                        if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                            report.current_context()
-                        {
-                            logger::debug!(
-                                "Connector error via UCS for setup mandate (connector {}, status {}): {} - {}",
-                                inner.connector,
-                                inner.status_code,
-                                inner.code,
-                                inner.message
-                            );
-                            router_data.response = Err(inner.as_ref().into());
-                            router_data.connector_http_status_code = Some(inner.status_code);
-                            return Ok((
-                                router_data,
-                                (),
-                                payments_grpc::PaymentServiceSetupRecurringResponse::default(),
-                            ));
-                        }
                         return Err(report.attach_printable("Failed to setup recurring payment"));
                     }
                 };

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2527,6 +2527,18 @@ pub struct RolloutConfig {
     pub http_url: Option<String>,
     pub https_url: Option<String>,
     pub execution_mode: ExecutionMode,
+    #[serde(default = "default_kill_switch_enabled")]
+    pub kill_switch_enabled: bool,
+    #[serde(default = "default_kill_switch_threshold")]
+    pub kill_switch_threshold: u64,
+}
+
+fn default_kill_switch_enabled() -> bool {
+    false
+}
+
+fn default_kill_switch_threshold() -> u64 {
+    1
 }
 
 #[serde_as]
@@ -2546,6 +2558,8 @@ impl Default for RolloutConfig {
             http_url: None,
             https_url: None,
             execution_mode: ExecutionMode::NotApplicable,
+            kill_switch_enabled: false,
+            kill_switch_threshold: 1,
         }
     }
 }
@@ -2558,6 +2572,8 @@ pub struct RolloutExecutionResult {
     pub should_execute: bool,
     pub proxy_override: Option<ProxyOverride>,
     pub execution_mode: ExecutionMode,
+    pub kill_switch_enabled: bool,
+    pub kill_switch_threshold: u64,
 }
 
 impl Default for RolloutExecutionResult {
@@ -2566,6 +2582,8 @@ impl Default for RolloutExecutionResult {
             should_execute: false,
             proxy_override: None,
             execution_mode: ExecutionMode::NotApplicable,
+            kill_switch_enabled: false,
+            kill_switch_threshold: 1,
         }
     }
 }
@@ -2653,6 +2671,8 @@ impl From<RolloutConfig> for RolloutExecutionResult {
                             should_execute: true,
                             proxy_override,
                             execution_mode: config.execution_mode,
+                            kill_switch_enabled: config.kill_switch_enabled,
+                            kill_switch_threshold: config.kill_switch_threshold,
                         }
                     }
                     false => {

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2501,15 +2501,12 @@ pub fn decide_payment_method_retrieval_action(
     }
 }
 
-pub async fn is_ucs_enabled(state: &SessionState, config_key: &str) -> bool {
+pub async fn is_config_flag_enabled(state: &SessionState, config_key: &str) -> bool {
     let db = state.store.as_ref();
     db.find_config_by_key_unwrap_or(config_key, Some("false".to_string()))
         .await
         .inspect_err(|error| {
-            logger::error!(
-                ?error,
-                "Failed to fetch `{config_key}` UCS enabled config from DB"
-            );
+            logger::error!(?error, "Failed to fetch `{config_key}` config from DB");
         })
         .ok()
         .and_then(|config| {
@@ -2517,7 +2514,7 @@ pub async fn is_ucs_enabled(state: &SessionState, config_key: &str) -> bool {
                 .config
                 .parse::<bool>()
                 .inspect_err(|error| {
-                    logger::error!(?error, "Failed to parse `{config_key}` UCS enabled config");
+                    logger::error!(?error, "Failed to parse `{config_key}` config");
                 })
                 .ok()
         })

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -637,6 +637,9 @@ async fn execute_refund_execute_via_direct_with_ucs_shadow(
         Err(e) => Err(format!("{:?}", e)),
     };
     let connector_name = router_data.connector.clone();
+    let merchant_id = router_data.merchant_id.clone();
+    let payment_method = router_data.payment_method;
+    let payment_method_type = router_data.payment_method_type;
 
     tokio::spawn(
         (async move {
@@ -661,6 +664,9 @@ async fn execute_refund_execute_via_direct_with_ucs_shadow(
                     connector_name,
                     direct_for_compare,
                     ucs_for_compare,
+                    Some(&merchant_id),
+                    Some(payment_method),
+                    payment_method_type,
                 ),
             )
             .await;
@@ -1183,6 +1189,9 @@ async fn execute_refund_sync_via_direct_with_ucs_shadow(
         Err(e) => Err(format!("{:?}", e)),
     };
     let connector_name = router_data.connector.clone();
+    let merchant_id = router_data.merchant_id.clone();
+    let payment_method = router_data.payment_method;
+    let payment_method_type = router_data.payment_method_type;
 
     tokio::spawn(
         (async move {
@@ -1207,6 +1216,9 @@ async fn execute_refund_sync_via_direct_with_ucs_shadow(
                     connector_name,
                     direct_for_compare,
                     ucs_for_compare,
+                    Some(&merchant_id),
+                    Some(payment_method),
+                    payment_method_type,
                 ),
             )
             .await;

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -46,7 +46,7 @@ use crate::{
         errors::{self, RouterResult},
         payments::{
             helpers::{
-                is_googlepay_predecrypted_flow_supported, is_ucs_enabled,
+                is_config_flag_enabled, is_googlepay_predecrypted_flow_supported,
                 should_execute_based_on_rollout, should_execute_based_on_rollout_with_precedence,
                 MerchantConnectorAccountType, ProxyOverride, WebhookRolloutConfig,
                 WebhookRolloutExecutionResult,
@@ -68,6 +68,7 @@ use crate::{
 };
 
 pub mod connector_config;
+pub mod kill_switch;
 pub mod transformers;
 
 /// Returns Apple Pay data from payment method token when it has decrypt data,
@@ -239,7 +240,7 @@ type UnifiedConnectorServiceCreateOrderResult = CustomResult<
 async fn check_ucs_availability(state: &SessionState) -> UcsAvailability {
     let is_client_available = state.grpc_client.unified_connector_service_client.is_some();
 
-    let is_enabled = is_ucs_enabled(state, consts::UCS_ENABLED).await;
+    let is_enabled = is_config_flag_enabled(state, consts::UCS_ENABLED).await;
 
     match (is_client_available, is_enabled) {
         (true, true) => {
@@ -325,7 +326,7 @@ where
     // Payments use org-level hierarchy; payouts use a single merchant-level key for now.
     let rollout_keys = match transaction_type {
         common_enums::TransactionType::Payment
-        | common_enums::TransactionType::ThreeDsAuthentication => build_rollout_keys(
+        | common_enums::TransactionType::ThreeDsAuthentication => build_rollout_keys_by_precedence(
             org_id,
             merchant_id,
             connector_name,
@@ -350,7 +351,8 @@ where
         should_execute_based_on_rollout_with_precedence(state, &rollout_keys).await?;
 
     // Single decision point using pattern matching
-    let (gateway_system, mut execution_path) = if ucs_availability == UcsAvailability::Disabled {
+    let (mut gateway_system, mut execution_path) = if ucs_availability == UcsAvailability::Disabled
+    {
         match call_connector_action {
             CallConnectorAction::UCSConsumeResponse(_) => {
                 Err(errors::ApiErrorResponse::InternalServerError)
@@ -404,6 +406,36 @@ where
             }
         }
     };
+
+    // Kill switch: a scope that already failed deterministically serves from the direct
+    // integration regardless of what its rollout config says.
+    //
+    // Only the primary path is diverted, and it is diverted to shadow rather than to direct — the
+    // merchant is served by the direct integration either way, but shadow keeps mirroring, so a
+    // tripped scope still produces the comparison signal needed to confirm a fix before it is
+    // reset. Shadow itself falls back to direct below when no proxy override is configured.
+    if matches!(execution_path, ExecutionPath::UnifiedConnectorService)
+        && is_kill_switch_applicable(connector_integration_type, &call_connector_action)
+    {
+        let rollout_scope = build_merchant_rollout_scope(
+            merchant_id,
+            connector_name,
+            &flow_name,
+            router_data.payment_method,
+            router_data.payment_method_type,
+        );
+
+        if Box::pin(kill_switch::is_tripped(state, &rollout_scope)).await {
+            router_env::logger::warn!(
+                merchant_id = %merchant_id,
+                connector = %connector_name,
+                flow = %flow_name,
+                "UCS kill switch is tripped for this scope, serving from the direct integration"
+            );
+            gateway_system = GatewaySystem::Direct;
+            execution_path = ExecutionPath::ShadowUnifiedConnectorService;
+        }
+    }
 
     // Handle proxy configuration for Shadow UCS flows
     let session_state = match execution_path {
@@ -465,6 +497,29 @@ fn create_updated_session_state_with_proxy(
     updated_state.conf = std::sync::Arc::new(updated_conf);
 
     updated_state
+}
+
+/// Whether the kill switch may divert this call away from UCS.
+///
+/// Two cases have nothing to fall back to, so diverting them would not protect the merchant — it
+/// would be the outage:
+///
+/// - [`ConnectorIntegrationType::UcsConnector`] connectors are served only by UCS. There are live
+///   merchants on these today, and the direct implementations behind them have never taken
+///   production traffic.
+/// - [`CallConnectorAction::UCSConsumeResponse`] carries a response UCS has already produced;
+///   handing it to any other gateway errors out, as the `UcsAvailability::Disabled` arm shows.
+fn is_kill_switch_applicable(
+    connector_integration_type: ConnectorIntegrationType,
+    call_connector_action: &CallConnectorAction,
+) -> bool {
+    !matches!(
+        connector_integration_type,
+        ConnectorIntegrationType::UcsConnector
+    ) && !matches!(
+        call_connector_action,
+        CallConnectorAction::UCSConsumeResponse(_)
+    )
 }
 
 fn decide_execution_path(
@@ -536,49 +591,35 @@ fn decide_execution_path(
     }
 }
 
-/// Builds rollout config keys in ascending precedence order:
-/// 1. `ucs_rollout_config_<org_id>`                               — org level (lowest)
-/// 2. `ucs_rollout_config_<org_id>_<merchant_id>`                 — org + merchant
-/// 3. `ucs_rollout_config_<org_id>_<merchant_id>_<connector>_...` — org + merchant + connector (highest)
+/// The merchant level of a rollout key: merchant, connector, payment method and flow.
 ///
-/// The caller tries keys highest → lowest and uses the first match found.
-/// Builds rollout config keys in ascending precedence order (lowest → highest):
-/// 1. `ucs_rollout_config_<org_id>`                                         — org level
-/// 2. `ucs_rollout_config_<org_id>_<merchant_id>`                           — org + merchant
-/// 3. `ucs_rollout_config_<org_id>_<merchant_id>_<connector>_...`           — org + merchant + connector
-/// 4. `ucs_rollout_config_<merchant_id>_<connector>_...`                    — merchant + connector (highest)
-///
-/// The caller iterates highest → lowest and uses the first match found.
-fn build_rollout_keys(
-    org_id: &str,
+/// The finest of the four precedence levels, and the only one that varies by connector or
+/// payment method. Shared with the kill switch so a trip targets exactly the key that enabled
+/// the traffic.
+pub fn build_merchant_rollout_scope(
     merchant_id: &str,
     connector_name: &str,
     flow_name: &str,
     payment_method: common_enums::PaymentMethod,
     payment_method_type: Option<PaymentMethodType>,
-) -> Vec<String> {
-    let prefix = consts::UCS_ROLLOUT_PERCENT_CONFIG_PREFIX;
-    let is_refund_flow = matches!(flow_name, "Execute" | "RSync");
+) -> String {
+    let payment_method_str = payment_method.to_string();
 
-    let (merchant_connector_key, org_merchant_connector_key) = if is_refund_flow {
-        // Refund flows: ucs_rollout_config_<merchant_id>_<connector>_<flow>
-        (
-            format!("{prefix}_{merchant_id}_{connector_name}_{flow_name}"),
-            format!("{prefix}_{org_id}_{merchant_id}_{connector_name}_{flow_name}"),
-        )
-    } else {
-        match payment_method {
+    match flow_name {
+        // Refund keys carry no payment method.
+        "Execute" | "RSync" => format!("{merchant_id}_{connector_name}_{flow_name}"),
+
+        _ => match payment_method {
+            // These payment methods are discriminated further by payment method type.
             common_enums::PaymentMethod::Wallet
             | common_enums::PaymentMethod::BankRedirect
             | common_enums::PaymentMethod::Voucher
             | common_enums::PaymentMethod::PayLater => {
-                let payment_method_str = payment_method.to_string();
                 let payment_method_type_str = payment_method_type
                     .map(|pmt| pmt.to_string())
                     .unwrap_or_else(|| "unknown".to_string());
-                (
-                    format!("{prefix}_{merchant_id}_{connector_name}_{payment_method_str}_{payment_method_type_str}_{flow_name}"),
-                    format!("{prefix}_{org_id}_{merchant_id}_{connector_name}_{payment_method_str}_{payment_method_type_str}_{flow_name}"),
+                format!(
+                    "{merchant_id}_{connector_name}_{payment_method_str}_{payment_method_type_str}_{flow_name}"
                 )
             }
             common_enums::PaymentMethod::Card
@@ -593,22 +634,36 @@ fn build_rollout_keys(
             | common_enums::PaymentMethod::MobilePayment
             | common_enums::PaymentMethod::NetworkToken
             | common_enums::PaymentMethod::OpenBanking => {
-                // For other payment methods, use a generic format without specific payment method type details
-                let payment_method_str = payment_method.to_string();
-                (
-                    format!("{prefix}_{merchant_id}_{connector_name}_{payment_method_str}_{flow_name}"),
-                    format!("{prefix}_{org_id}_{merchant_id}_{connector_name}_{payment_method_str}_{flow_name}"),
-                )
+                format!("{merchant_id}_{connector_name}_{payment_method_str}_{flow_name}")
             }
-        }
-    };
+        },
+    }
+}
 
-    // Ascending precedence order (lowest first, highest last)
+/// Rollout config keys, **lowest precedence first**. The caller reverses this and takes the
+/// first key that exists, so the order is load-bearing.
+fn build_rollout_keys_by_precedence(
+    org_id: &str,
+    merchant_id: &str,
+    connector_name: &str,
+    flow_name: &str,
+    payment_method: common_enums::PaymentMethod,
+    payment_method_type: Option<PaymentMethodType>,
+) -> Vec<String> {
+    let prefix = consts::UCS_ROLLOUT_PERCENT_CONFIG_PREFIX;
+    let scope = build_merchant_rollout_scope(
+        merchant_id,
+        connector_name,
+        flow_name,
+        payment_method,
+        payment_method_type,
+    );
+
     vec![
         format!("{prefix}_{org_id}"),
         format!("{prefix}_{org_id}_{merchant_id}"),
-        org_merchant_connector_key,
-        merchant_connector_key,
+        format!("{prefix}_{org_id}_{scope}"),
+        format!("{prefix}_{scope}"),
     ]
 }
 
@@ -3042,6 +3097,8 @@ where
     let refund_id = router_data.refund_id.clone();
     let dispute_id = router_data.dispute_id.clone();
     let payout_id = router_data.payout_id.clone();
+    let payment_method = router_data.payment_method;
+    let payment_method_type = router_data.payment_method_type;
     let grpc_header = grpc_header_builder.build();
     // Log the actual gRPC request with masking
     let grpc_request_body = hyperswitch_masking::masked_serialize(&grpc_request)
@@ -3092,6 +3149,34 @@ where
                 1,
                 router_env::metric_attributes!(("connector", connector_name.clone(),)),
             );
+
+            // Every payment and payout gateway funnels through here with the UCS error still
+            // typed, so this is the one place the kill switch has to observe.
+            match get_flow_name::<T>() {
+                Ok(flow_name) => {
+                    kill_switch::record_failure(
+                        state,
+                        kill_switch::UcsFailureContext {
+                            merchant_id: merchant_id.get_string_repr(),
+                            connector_name: &connector_name,
+                            flow_name: &flow_name,
+                            payment_id: &payment_id,
+                            payment_method,
+                            payment_method_type,
+                        },
+                        execution_mode,
+                        error.current_context(),
+                    )
+                    .await;
+                }
+                // Never expected, but skipping here would disable the kill switch for this flow
+                // without saying so.
+                Err(flow_name_error) => logger::error!(
+                    ?flow_name_error,
+                    connector = %connector_name,
+                    "ucs_kill_switch: could not resolve the flow name, failure not classified"
+                ),
+            }
 
             let error_body = serde_json::json!({
                 "error": error.to_string(),
@@ -3267,6 +3352,14 @@ pub async fn call_unified_connector_service_for_refund_execute(
 
     let prev_refund_status = router_data.request.refund_status;
 
+    // Captured before `router_data` moves into the wrapper, so the kill switch can build the same
+    // scope the gateway decision built.
+    let merchant_id_for_kill_switch = processor.get_account().get_id().clone();
+    let connector_name_for_kill_switch = router_data.connector.clone();
+    let payment_method_for_kill_switch = router_data.payment_method;
+    let payment_method_type_for_kill_switch = router_data.payment_method_type;
+    let payment_id_for_kill_switch = router_data.payment_id.clone();
+
     // Make UCS refund call with logging wrapper
     Box::pin(ucs_logging_wrapper(
         router_data,
@@ -3282,6 +3375,23 @@ pub async fn call_unified_connector_service_for_refund_execute(
             {
                 Ok(resp) => resp,
                 Err(report) => {
+                    // Recorded before the connector-error branch below returns `Ok`, so a refund
+                    // decline is classified on the same footing as a payment one.
+                    kill_switch::record_failure(
+                        state,
+                        kill_switch::UcsFailureContext {
+                            merchant_id: merchant_id_for_kill_switch.get_string_repr(),
+                            connector_name: &connector_name_for_kill_switch,
+                            flow_name: "Execute",
+                            payment_id: &payment_id_for_kill_switch,
+                            payment_method: payment_method_for_kill_switch,
+                            payment_method_type: payment_method_type_for_kill_switch,
+                        },
+                        execution_mode,
+                        report.current_context(),
+                    )
+                    .await;
+
                     if let UnifiedConnectorServiceError::ConnectorError(inner) =
                         report.current_context()
                     {
@@ -3403,6 +3513,14 @@ pub async fn call_unified_connector_service_for_refund_sync(
 
     let prev_refund_status = router_data.request.refund_status;
 
+    // Captured before `router_data` moves into the wrapper, so the kill switch can build the same
+    // scope the gateway decision built.
+    let merchant_id_for_kill_switch = processor.get_account().get_id().clone();
+    let connector_name_for_kill_switch = router_data.connector.clone();
+    let payment_method_for_kill_switch = router_data.payment_method;
+    let payment_method_type_for_kill_switch = router_data.payment_method_type;
+    let payment_id_for_kill_switch = router_data.payment_id.clone();
+
     // Make UCS refund sync call with logging wrapper
     Box::pin(ucs_logging_wrapper(
         router_data,
@@ -3418,6 +3536,23 @@ pub async fn call_unified_connector_service_for_refund_sync(
             {
                 Ok(resp) => resp,
                 Err(report) => {
+                    // Recorded before the connector-error branch below returns `Ok`, so a refund
+                    // decline is classified on the same footing as a payment one.
+                    kill_switch::record_failure(
+                        state,
+                        kill_switch::UcsFailureContext {
+                            merchant_id: merchant_id_for_kill_switch.get_string_repr(),
+                            connector_name: &connector_name_for_kill_switch,
+                            flow_name: "RSync",
+                            payment_id: &payment_id_for_kill_switch,
+                            payment_method: payment_method_for_kill_switch,
+                            payment_method_type: payment_method_type_for_kill_switch,
+                        },
+                        execution_mode,
+                        report.current_context(),
+                    )
+                    .await;
+
                     if let UnifiedConnectorServiceError::ConnectorError(inner) =
                         report.current_context()
                     {

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -3029,23 +3029,21 @@ where
         }
     };
 
-    if let ExecutionMode::Primary = execution_mode {
-        emit_ucs_connector_event(
-            state,
-            std::any::type_name::<T>(),
-            connector_name,
-            payment_id,
-            merchant_id,
-            refund_id,
-            dispute_id,
-            payout_id,
-            grpc_request_body,
-            status_code,
-            response_body,
-            external_latency,
-            execution_mode,
-        );
-    }
+    emit_ucs_connector_event(
+        state,
+        std::any::type_name::<T>(),
+        connector_name,
+        payment_id,
+        merchant_id,
+        refund_id,
+        dispute_id,
+        payout_id,
+        grpc_request_body,
+        status_code,
+        response_body,
+        external_latency,
+        execution_mode,
+    );
 
     // Set external latency on router data
     router_result.map(|mut router_data| {
@@ -3190,23 +3188,21 @@ where
         }
     };
 
-    if let ExecutionMode::Primary = execution_mode {
-        emit_ucs_connector_event(
-            state,
-            std::any::type_name::<T>(),
-            connector_name,
-            payment_id,
-            merchant_id,
-            refund_id,
-            dispute_id,
-            payout_id,
-            grpc_request_body,
-            status_code,
-            response_body,
-            external_latency,
-            execution_mode,
-        );
-    }
+    emit_ucs_connector_event(
+        state,
+        std::any::type_name::<T>(),
+        connector_name,
+        payment_id,
+        merchant_id,
+        refund_id,
+        dispute_id,
+        payout_id,
+        grpc_request_body,
+        status_code,
+        response_body,
+        external_latency,
+        execution_mode,
+    );
 
     // Set external latency on router data
     router_result.map(|mut router_data| {

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -407,8 +407,8 @@ where
         }
     };
 
-    // Kill switch: a scope that already failed deterministically serves from the direct
-    // integration regardless of what its rollout config says.
+    // Kill switch: a scope whose failure counter exceeds the configured threshold serves from
+    // the direct integration regardless of what its rollout config says.
     //
     // Only the primary path is diverted, and it is diverted to shadow rather than to direct — the
     // merchant is served by the direct integration either way, but shadow keeps mirroring, so a
@@ -425,12 +425,19 @@ where
             router_data.payment_method_type,
         );
 
-        if Box::pin(kill_switch::is_tripped(state, &rollout_scope)).await {
+        if Box::pin(kill_switch::is_kill_switched(
+            state,
+            &rollout_scope,
+            rollout_result.kill_switch_enabled,
+            rollout_result.kill_switch_threshold,
+        ))
+        .await
+        {
             router_env::logger::warn!(
                 merchant_id = %merchant_id,
                 connector = %connector_name,
                 flow = %flow_name,
-                "UCS kill switch is tripped for this scope, serving from the direct integration"
+                "UCS kill switch counter exceeds threshold for this scope, routing to shadow"
             );
             gateway_system = GatewaySystem::Direct;
             execution_path = ExecutionPath::ShadowUnifiedConnectorService;
@@ -2946,14 +2953,19 @@ where
     Resp: std::fmt::Debug + Clone + Send + Sync + 'static,
     GrpcReq: serde::Serialize,
     GrpcResp: serde::Serialize,
+    FlowOutput: Default,
     F: FnOnce(
             RouterData<T, Req, Resp>,
             GrpcReq,
             external_services::grpc_client::GrpcHeadersUcs,
         ) -> Fut
         + Send,
-    Fut: std::future::Future<Output = RouterResult<(RouterData<T, Req, Resp>, FlowOutput, GrpcResp)>>
-        + Send,
+    Fut: std::future::Future<
+            Output = CustomResult<
+                (RouterData<T, Req, Resp>, FlowOutput, GrpcResp),
+                UnifiedConnectorServiceError,
+            >,
+        > + Send,
 {
     tracing::Span::current().record("connector_name", &router_data.connector);
     tracing::Span::current().record("flow_type", std::any::type_name::<T>());
@@ -2966,6 +2978,11 @@ where
     let refund_id = router_data.refund_id.clone();
     let dispute_id = router_data.dispute_id.clone();
     let payout_id = router_data.payout_id.clone();
+    let payment_method = router_data.payment_method;
+    let payment_method_type = router_data.payment_method_type;
+    // Clone router_data before handler consumes it, so we can use it if the handler
+    // returns a ConnectorError (which we convert to Ok(router_data) with Err(ErrorResponse))
+    let router_data_clone = router_data.clone();
     let grpc_header = grpc_header_builder.build();
     // Log the actual gRPC request with masking
     let grpc_request_body = hyperswitch_masking::masked_serialize(&grpc_request)
@@ -2987,8 +3004,9 @@ where
     );
 
     // Execute UCS function and measure timing
+    // Box::pin the handler to reduce the monomorphized future size and prevent stack overflow
     let start_time = Instant::now();
-    let result = handler(router_data, grpc_request, grpc_header).await;
+    let result = Box::pin(handler(router_data, grpc_request, grpc_header)).await;
     let external_latency = start_time.elapsed().as_millis();
 
     // Create and emit connector event after UCS call
@@ -3011,21 +3029,86 @@ where
             )
         }
         Err(error) => {
-            // Update error metrics for UCS calls
-            crate::routes::metrics::CONNECTOR_ERROR_RESPONSE_COUNT.add(
-                1,
-                router_env::metric_attributes!(("connector", connector_name.clone(),)),
-            );
+            // Check if this is a connector error (4xx/5xx from connector via UCS).
+            // Convert it to Ok(router_data) with response = Err(ErrorResponse) so the
+            // caller sees a proper error response instead of a raw UCS error.
+            if let UnifiedConnectorServiceError::ConnectorError(inner) = error.current_context() {
+                // Fire kill switch for connector errors
+                if let Ok(flow_name) = get_flow_name::<T>() {
+                    kill_switch::record_failure(
+                        state,
+                        kill_switch::UcsFailureContext {
+                            merchant_id: merchant_id.get_string_repr(),
+                            connector_name: &connector_name,
+                            flow_name: &flow_name,
+                            payment_id: &payment_id,
+                            payment_method,
+                            payment_method_type,
+                        },
+                        execution_mode,
+                        error.current_context(),
+                    )
+                    .await;
+                }
 
-            let error_body = serde_json::json!({
-                "error": error.to_string(),
-                "error_type": "ucs_call_failed"
-            });
-            (
-                error.current_context().status_code().as_u16(),
-                Some(error_body),
-                Err(error),
-            )
+                let status_code = inner.status_code;
+                let mut router_data = router_data_clone;
+                router_data.response = Err(inner.as_ref().into());
+                router_data.connector_http_status_code = Some(status_code);
+
+                let error_body = serde_json::json!({
+                    "error": error.to_string(),
+                    "error_type": "connector_error"
+                });
+
+                (
+                    status_code,
+                    Some(error_body),
+                    Ok((router_data, FlowOutput::default())),
+                )
+            } else {
+                // Update error metrics for UCS calls
+                crate::routes::metrics::CONNECTOR_ERROR_RESPONSE_COUNT.add(
+                    1,
+                    router_env::metric_attributes!(("connector", connector_name.clone(),)),
+                );
+
+                // Fire kill switch for non-connector UCS errors
+                match get_flow_name::<T>() {
+                    Ok(flow_name) => {
+                        kill_switch::record_failure(
+                            state,
+                            kill_switch::UcsFailureContext {
+                                merchant_id: merchant_id.get_string_repr(),
+                                connector_name: &connector_name,
+                                flow_name: &flow_name,
+                                payment_id: &payment_id,
+                                payment_method,
+                                payment_method_type,
+                            },
+                            execution_mode,
+                            error.current_context(),
+                        )
+                        .await;
+                    }
+                    Err(flow_name_error) => logger::error!(
+                        ?flow_name_error,
+                        connector = %connector_name,
+                        "ucs_kill_switch: could not resolve the flow name, failure not classified"
+                    ),
+                }
+
+                let error_body = serde_json::json!({
+                    "error": error.to_string(),
+                    "error_type": "ucs_call_failed"
+                });
+                let api_error: errors::ApiErrorResponse = error.current_context().switch();
+                (
+                    api_error.status_code().as_u16(),
+                    Some(error_body),
+                    Err(error.change_context(api_error)),
+                )
+            }
         }
     };
 
@@ -3077,6 +3160,7 @@ where
             external_services::grpc_client::GrpcHeadersUcs,
         ) -> Fut
         + Send,
+    FlowOutput: Default,
     Fut: std::future::Future<
             Output = CustomResult<
                 (RouterData<T, Req, Resp>, FlowOutput, GrpcResp),
@@ -3117,9 +3201,14 @@ where
         ),
     );
 
+    // Clone router_data before handler consumes it, so we can use it if the handler
+    // returns a ConnectorError (which we convert to Ok(router_data) with Err(ErrorResponse))
+    let router_data_clone = router_data.clone();
+
     // Execute UCS function and measure timing
+    // Box::pin the handler to reduce the monomorphized future size and prevent stack overflow
     let start_time = Instant::now();
-    let result = handler(router_data, grpc_request, grpc_header).await;
+    let result = Box::pin(handler(router_data, grpc_request, grpc_header)).await;
     let external_latency = start_time.elapsed().as_millis();
 
     // Create and emit connector event after UCS call
@@ -3142,16 +3231,12 @@ where
             )
         }
         Err(error) => {
-            // Update error metrics for UCS calls
-            crate::routes::metrics::CONNECTOR_ERROR_RESPONSE_COUNT.add(
-                1,
-                router_env::metric_attributes!(("connector", connector_name.clone(),)),
-            );
-
-            // Every payment and payout gateway funnels through here with the UCS error still
-            // typed, so this is the one place the kill switch has to observe.
-            match get_flow_name::<T>() {
-                Ok(flow_name) => {
+            // Check if this is a connector error (4xx/5xx from connector via UCS).
+            // Convert it to Ok(router_data) with response = Err(ErrorResponse) so the
+            // caller sees a proper error response instead of a raw UCS error.
+            if let UnifiedConnectorServiceError::ConnectorError(inner) = error.current_context() {
+                // Fire kill switch for connector errors
+                if let Ok(flow_name) = get_flow_name::<T>() {
                     kill_switch::record_failure(
                         state,
                         kill_switch::UcsFailureContext {
@@ -3167,24 +3252,67 @@ where
                     )
                     .await;
                 }
-                // Never expected, but skipping here would disable the kill switch for this flow
-                // without saying so.
-                Err(flow_name_error) => logger::error!(
-                    ?flow_name_error,
-                    connector = %connector_name,
-                    "ucs_kill_switch: could not resolve the flow name, failure not classified"
-                ),
-            }
 
-            let error_body = serde_json::json!({
-                "error": error.to_string(),
-                "error_type": "ucs_call_failed"
-            });
-            (
-                error.current_context().http_status(),
-                Some(error_body),
-                Err(error),
-            )
+                let status_code = inner.status_code;
+                let mut router_data = router_data_clone;
+                router_data.response = Err(inner.as_ref().into());
+                router_data.connector_http_status_code = Some(status_code);
+
+                let error_body = serde_json::json!({
+                    "error": error.to_string(),
+                    "error_type": "connector_error"
+                });
+
+                (
+                    status_code,
+                    Some(error_body),
+                    Ok((router_data, FlowOutput::default())),
+                )
+            } else {
+                // Update error metrics for UCS calls
+                crate::routes::metrics::CONNECTOR_ERROR_RESPONSE_COUNT.add(
+                    1,
+                    router_env::metric_attributes!(("connector", connector_name.clone(),)),
+                );
+
+                // Every payment and payout gateway funnels through here with the UCS error still
+                // typed, so this is the one place the kill switch has to observe.
+                match get_flow_name::<T>() {
+                    Ok(flow_name) => {
+                        kill_switch::record_failure(
+                            state,
+                            kill_switch::UcsFailureContext {
+                                merchant_id: merchant_id.get_string_repr(),
+                                connector_name: &connector_name,
+                                flow_name: &flow_name,
+                                payment_id: &payment_id,
+                                payment_method,
+                                payment_method_type,
+                            },
+                            execution_mode,
+                            error.current_context(),
+                        )
+                        .await;
+                    }
+                    // Never expected, but skipping here would disable the kill switch for this flow
+                    // without saying so.
+                    Err(flow_name_error) => logger::error!(
+                        ?flow_name_error,
+                        connector = %connector_name,
+                        "ucs_kill_switch: could not resolve the flow name, failure not classified"
+                    ),
+                }
+
+                let error_body = serde_json::json!({
+                    "error": error.to_string(),
+                    "error_type": "ucs_call_failed"
+                });
+                (
+                    error.current_context().http_status(),
+                    Some(error_body),
+                    Err(error),
+                )
+            }
         }
     };
 
@@ -3348,14 +3476,6 @@ pub async fn call_unified_connector_service_for_refund_execute(
 
     let prev_refund_status = router_data.request.refund_status;
 
-    // Captured before `router_data` moves into the wrapper, so the kill switch can build the same
-    // scope the gateway decision built.
-    let merchant_id_for_kill_switch = processor.get_account().get_id().clone();
-    let connector_name_for_kill_switch = router_data.connector.clone();
-    let payment_method_for_kill_switch = router_data.payment_method;
-    let payment_method_type_for_kill_switch = router_data.payment_method_type;
-    let payment_id_for_kill_switch = router_data.payment_id.clone();
-
     // Make UCS refund call with logging wrapper
     Box::pin(ucs_logging_wrapper(
         router_data,
@@ -3365,67 +3485,11 @@ pub async fn call_unified_connector_service_for_refund_execute(
         execution_mode,
         |mut router_data, grpc_request, grpc_headers| async move {
             // Call UCS payment_refund method
-            let response = match ucs_client
+            // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper`.
+            let response = ucs_client
                 .payment_refund(grpc_request, connector_auth_metadata, grpc_headers)
                 .await
-            {
-                Ok(resp) => resp,
-                Err(report) => {
-                    // Recorded before the connector-error branch below returns `Ok`, so a refund
-                    // decline is classified on the same footing as a payment one.
-                    kill_switch::record_failure(
-                        state,
-                        kill_switch::UcsFailureContext {
-                            merchant_id: merchant_id_for_kill_switch.get_string_repr(),
-                            connector_name: &connector_name_for_kill_switch,
-                            flow_name: "Execute",
-                            payment_id: &payment_id_for_kill_switch,
-                            payment_method: payment_method_for_kill_switch,
-                            payment_method_type: payment_method_type_for_kill_switch,
-                        },
-                        execution_mode,
-                        report.current_context(),
-                    )
-                    .await;
-
-                    if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                        report.current_context()
-                    {
-                        let (code, message, status_code, reason, connector,
-                             network_decline_code, network_advice_code, network_error_message) = (
-                            &inner.code, &inner.message, inner.status_code, &inner.reason,
-                            &inner.connector, &inner.network_decline_code,
-                            &inner.network_advice_code, &inner.network_error_message,
-                        );
-                        logger::info!(
-                            "Connector error via UCS for refund execute (connector {}, status {}): {} - {}",
-                            connector,
-                            status_code,
-                            code,
-                            message
-                        );
-                        router_data.response = Err(ErrorResponse {
-                            code: code.clone(),
-                            message: message.clone(),
-                            reason: reason.clone(),
-                            status_code,
-                            attempt_status: None,
-                            connector_transaction_id: inner.connector_transaction_id.clone(),
-                            connector_response_reference_id: None,
-                            network_decline_code: network_decline_code.clone(),
-                            network_advice_code: network_advice_code.clone(),
-                            network_error_message: network_error_message.clone(),
-                            connector_metadata: None,
-                        });
-                        router_data.connector_http_status_code = Some(status_code);
-                        return Ok((router_data, (), payments_grpc::RefundResponse::default()));
-                    }
-                    let api_error = report.current_context().switch();
-                    return Err(report
-                        .change_context(api_error)
-                        .attach_printable("UCS refund execution failed"));
-                }
-            };
+                .attach_printable("UCS refund execution failed")?;
 
             let grpc_response = response.into_inner();
 
@@ -3435,7 +3499,6 @@ pub async fn call_unified_connector_service_for_refund_execute(
                     grpc_response.clone(),
                     prev_refund_status,
                 )
-                .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Failed to transform UCS refund response")?;
 
             router_data.response = refund_response_data;
@@ -3509,14 +3572,6 @@ pub async fn call_unified_connector_service_for_refund_sync(
 
     let prev_refund_status = router_data.request.refund_status;
 
-    // Captured before `router_data` moves into the wrapper, so the kill switch can build the same
-    // scope the gateway decision built.
-    let merchant_id_for_kill_switch = processor.get_account().get_id().clone();
-    let connector_name_for_kill_switch = router_data.connector.clone();
-    let payment_method_for_kill_switch = router_data.payment_method;
-    let payment_method_type_for_kill_switch = router_data.payment_method_type;
-    let payment_id_for_kill_switch = router_data.payment_id.clone();
-
     // Make UCS refund sync call with logging wrapper
     Box::pin(ucs_logging_wrapper(
         router_data,
@@ -3526,67 +3581,11 @@ pub async fn call_unified_connector_service_for_refund_sync(
         execution_mode,
         |mut router_data, grpc_request, grpc_headers| async move {
             // Call UCS refund_sync method
-            let response = match ucs_client
+            // UCS connector errors are handled by the wrapper — see `ucs_logging_wrapper`.
+            let response = ucs_client
                 .refund_get(grpc_request, connector_auth_metadata, grpc_headers)
                 .await
-            {
-                Ok(resp) => resp,
-                Err(report) => {
-                    // Recorded before the connector-error branch below returns `Ok`, so a refund
-                    // decline is classified on the same footing as a payment one.
-                    kill_switch::record_failure(
-                        state,
-                        kill_switch::UcsFailureContext {
-                            merchant_id: merchant_id_for_kill_switch.get_string_repr(),
-                            connector_name: &connector_name_for_kill_switch,
-                            flow_name: "RSync",
-                            payment_id: &payment_id_for_kill_switch,
-                            payment_method: payment_method_for_kill_switch,
-                            payment_method_type: payment_method_type_for_kill_switch,
-                        },
-                        execution_mode,
-                        report.current_context(),
-                    )
-                    .await;
-
-                    if let UnifiedConnectorServiceError::ConnectorError(inner) =
-                        report.current_context()
-                    {
-                        let (code, message, status_code, reason, connector,
-                             network_decline_code, network_advice_code, network_error_message) = (
-                            &inner.code, &inner.message, inner.status_code, &inner.reason,
-                            &inner.connector, &inner.network_decline_code,
-                            &inner.network_advice_code, &inner.network_error_message,
-                        );
-                        logger::info!(
-                            "Connector error via UCS for refund sync (connector {}, status {}): {} - {}",
-                            connector,
-                            status_code,
-                            code,
-                            message
-                        );
-                        router_data.response = Err(ErrorResponse {
-                            code: code.clone(),
-                            message: message.clone(),
-                            reason: reason.clone(),
-                            status_code,
-                            attempt_status: None,
-                            connector_transaction_id: inner.connector_transaction_id.clone(),
-                            connector_response_reference_id: None,
-                            network_decline_code: network_decline_code.clone(),
-                            network_advice_code: network_advice_code.clone(),
-                            network_error_message: network_error_message.clone(),
-                            connector_metadata: None,
-                        });
-                        router_data.connector_http_status_code = Some(status_code);
-                        return Ok((router_data, (), payments_grpc::RefundResponse::default()));
-                    }
-                    let api_error = report.current_context().switch();
-                    return Err(report
-                        .change_context(api_error)
-                        .attach_printable("UCS refund sync execution failed"));
-                }
-            };
+                .attach_printable("UCS refund sync execution failed")?;
 
             let grpc_response = response.into_inner();
 
@@ -3596,7 +3595,6 @@ pub async fn call_unified_connector_service_for_refund_sync(
                     grpc_response.clone(),
                     prev_refund_status,
                 )
-                .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Failed to transform UCS refund get response")?;
 
             router_data.response = refund_response_data;

--- a/crates/router/src/core/unified_connector_service/kill_switch.rs
+++ b/crates/router/src/core/unified_connector_service/kill_switch.rs
@@ -1,9 +1,9 @@
-//! Returns a rollout scope to the direct connector integration when a Unified Connector Service
-//! call fails.
+//! Returns a rollout scope to the shadow connector integration when a Unified Connector Service
+//! call fails more than a configurable threshold number of times.
 //!
-//! Trips live in redis, keyed on the rollout scope; `ucs_rollout_config` rows are never written
-//! to. Ambiguous outcomes resolve towards the direct path, which is what the scope used before
-//! UCS.
+//! Failures are counted in Redis via HINCRBY on a hash key scoped to the rollout scope. The read
+//! path (`is_kill_switched`) compares the counter against the threshold from the RolloutConfig.
+//! When the counter exceeds the threshold, the scope falls back to shadow mode.
 
 use std::str::FromStr;
 
@@ -18,7 +18,6 @@ use crate::{
     consts,
     core::{
         errors, metrics,
-        payments::helpers::is_config_flag_enabled,
         unified_connector_service::{
             build_merchant_rollout_scope, determine_connector_integration_type,
         },
@@ -26,8 +25,16 @@ use crate::{
     routes::SessionState,
 };
 
-/// Redis key holding the trip for a scope.
-fn trip_key(rollout_scope: &str) -> String {
+/// Hash field name for the failure counter.
+const COUNTER_FIELD: &str = "counter";
+
+/// Whether the counter has reached or exceeded the threshold.
+fn exceeds_threshold(count: u64, threshold: u64) -> bool {
+    count >= threshold
+}
+
+/// Redis key holding the failure counter for a scope.
+fn counter_key(rollout_scope: &str) -> String {
     format!("{}_{rollout_scope}", consts::UCS_KILL_SWITCH_REDIS_PREFIX)
 }
 
@@ -44,49 +51,67 @@ fn rollout_scope_in(key_or_scope: &str) -> &str {
     }
 }
 
-/// Whether the kill switch has tripped for this scope.
+/// Whether the kill switch should divert this scope to shadow mode.
 ///
-/// Fails closed: a redis error routes to the direct integration. Only reached once the rollout
-/// config resolved to primary, so shadow traffic never pays for the lookup.
-pub async fn is_tripped(state: &SessionState, rollout_scope: &str) -> bool {
-    if is_config_flag_enabled(state, consts::UCS_KILL_SWITCH_ENABLED).await {
-        match read_trip(state, rollout_scope).await {
-            Ok(tripped) => tripped,
-            // Fails closed: the scope goes to the direct integration when redis cannot answer.
+/// Checks: per-scope `kill_switch_enabled` from RolloutConfig must be true. Then reads the
+/// failure counter from Redis and compares against the threshold.
+///
+/// Fails closed: a Redis error routes to shadow (the safe path).
+pub async fn is_kill_switched(
+    state: &SessionState,
+    rollout_scope: &str,
+    kill_switch_enabled: bool,
+    kill_switch_threshold: u64,
+) -> bool {
+    if kill_switch_enabled {
+        match read_counter(state, rollout_scope).await {
+            Ok(count) => {
+                let exceeded = exceeds_threshold(count, kill_switch_threshold);
+                if exceeded {
+                    logger::debug!(
+                        rollout_scope = %rollout_scope,
+                        count = count,
+                        threshold = kill_switch_threshold,
+                        "ucs_kill_switch: counter exceeds threshold, routing to shadow"
+                    );
+                }
+                exceeded
+            }
+            // Fails closed: the scope goes to shadow when Redis cannot answer.
             Err(error) => {
                 logger::error!(
                     ?error,
                     rollout_scope = %rollout_scope,
-                    "ucs_kill_switch: trip unreadable, routing to the direct integration"
+                    "ucs_kill_switch: counter unreadable, routing to shadow"
                 );
                 true
             }
         }
     } else {
+        logger::debug!(
+            rollout_scope = %rollout_scope,
+            kill_switch_enabled = kill_switch_enabled,
+            "ucs_kill_switch: kill switch is disabled for this scope"
+        );
         false
     }
 }
 
-/// Reads the trip. Redis failures short-circuit to the caller, which decides the safe answer.
-async fn read_trip(
+/// Reads the failure counter from the hash. Returns 0 if the key or field does not exist.
+/// Redis connection or read errors are propagated so the caller can fail closed.
+async fn read_counter(
     state: &SessionState,
     rollout_scope: &str,
-) -> error_stack::Result<bool, storage_impl::errors::RedisError> {
-    let tripped = state
+) -> error_stack::Result<u64, storage_impl::errors::RedisError> {
+    let key: redis_interface::RedisKey = counter_key(rollout_scope).as_str().into();
+    let count: u64 = state
         .store
         .get_redis_conn()?
-        .exists::<()>(&trip_key(rollout_scope).as_str().into())
-        .await?;
+        .get_hash_field::<Option<u64>>(&key, COUNTER_FIELD)
+        .await?
+        .unwrap_or(0);
 
-    if tripped {
-        // Every request for a tripped scope reaches here; the trip is logged once elsewhere.
-        logger::debug!(
-            rollout_scope = %rollout_scope,
-            "ucs_kill_switch: scope is tripped, routing to the direct integration"
-        );
-    }
-
-    Ok(tripped)
+    Ok(count)
 }
 
 /// What a failing UCS call was for. A struct because transposing two of six positional strings
@@ -100,13 +125,13 @@ pub struct UcsFailureContext<'a> {
     pub payment_method_type: Option<common_enums::PaymentMethodType>,
 }
 
-/// A failure that qualifies to trip, and the scope it would trip.
+/// A failure that qualifies to increment the counter, and the scope it targets.
 struct TrippableFailure {
     rollout_scope: String,
     reason: UcsKillSwitchReason,
 }
 
-/// Records a qualifying UCS failure, and trips its scope when the switch is turned on.
+/// Records a qualifying UCS failure by incrementing its scope's counter.
 ///
 /// Never returns an error: it runs on an already-failing path and must not fail the request.
 pub async fn record_failure(
@@ -120,7 +145,7 @@ pub async fn record_failure(
     }
 }
 
-/// Counts the failure, trips its scope when the switch is turned on, and reports what happened.
+/// Increments the counter and logs the failure.
 async fn record_trippable_failure(
     state: &SessionState,
     failure: &TrippableFailure,
@@ -136,16 +161,8 @@ async fn record_trippable_failure(
         ),
     );
 
-    let outcome = if is_config_flag_enabled(state, consts::UCS_KILL_SWITCH_ENABLED).await {
-        trip(state, failure, context).await
-    } else {
-        TripOutcome::SwitchOff
-    };
+    let outcome = increment_counter(state, failure, context).await;
 
-    // The one line this path emits, carrying every dimension of the decision. Alert on `outcome`
-    // rather than on a message: `tripped` means a scope left UCS, `write_failed` means one should
-    // have and did not. While the switch is off every line reads `switch_off`, which is the feed
-    // for validating the classifier against real traffic before turning it on.
     logger::warn!(
         rollout_scope = %failure.rollout_scope,
         merchant_id = %context.merchant_id,
@@ -157,7 +174,7 @@ async fn record_trippable_failure(
         reason = %failure.reason,
         outcome = %outcome,
         ucs_error = ?error,
-        "ucs_kill_switch"
+        "UCS_KILL_SWITCH_COUNTER_INCREMENTED"
     );
 }
 
@@ -202,110 +219,94 @@ async fn is_ucs_only_connector(state: &SessionState, connector_name: &str) -> bo
     }
 }
 
-/// What came of a trippable failure. Reported as a field on the one line the recording path
-/// emits, so an alert keys on the outcome rather than on several message strings.
+/// What came of a counter increment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
 #[strum(serialize_all = "snake_case")]
-enum TripOutcome {
-    /// This pod wrote the trip. The scope now serves from the direct integration.
-    Tripped,
-    /// Another pod wrote it first.
-    AlreadyTripped,
-    /// The failure qualified, but enforcement is turned off.
-    SwitchOff,
-    /// Redis refused the write, so the scope stays on UCS.
+enum IncrementOutcome {
+    /// Counter was incremented successfully.
+    Incremented,
+    /// Redis refused the write.
     WriteFailed,
 }
 
-/// Writes the trip. `SET NX` makes it exactly-once: one concurrent writer wins, the rest no-op.
-async fn trip(
+/// Increments the failure counter and refreshes its TTL.
+async fn increment_counter(
     state: &SessionState,
     failure: &TrippableFailure,
     context: &UcsFailureContext<'_>,
-) -> TripOutcome {
-    let TrippableFailure {
-        rollout_scope,
-        reason,
-    } = failure;
-
-    let record = TripRecord {
-        reason: reason.to_string(),
-        request_id: state.request_id.as_ref().map(|id| id.to_string()),
-        tripped_at: common_utils::date_time::now_unix_timestamp(),
-    };
-
-    match write_trip(state, rollout_scope, &record).await {
-        Ok(redis_interface::SetnxReply::KeySet) => {
+) -> IncrementOutcome {
+    match write_counter(state, &failure.rollout_scope).await {
+        Ok(counts) => {
             metrics::UCS_KILL_SWITCH_TRIPPED.add(
                 1,
                 router_env::metric_attributes!(
                     ("connector", context.connector_name.to_string()),
                     ("flow", context.flow_name.to_string()),
-                    ("reason", reason.to_string())
+                    ("reason", failure.reason.to_string())
                 ),
             );
 
-            TripOutcome::Tripped
+            logger::info!(
+                rollout_scope = %failure.rollout_scope,
+                count = ?counts,
+                "ucs_kill_switch: counter incremented"
+            );
+
+            IncrementOutcome::Incremented
         }
-        Ok(redis_interface::SetnxReply::KeyNotSet) => TripOutcome::AlreadyTripped,
-        // The cause does not belong on the summary line, and it is the one thing an operator
-        // cannot act on without it.
         Err(error) => {
             logger::error!(
                 ?error,
-                rollout_scope = %rollout_scope,
-                "ucs_kill_switch: could not persist the trip"
+                rollout_scope = %failure.rollout_scope,
+                "ucs_kill_switch: could not increment counter"
             );
 
-            TripOutcome::WriteFailed
+            IncrementOutcome::WriteFailed
         }
     }
 }
 
-/// Writes the trip if no other pod got there first. Serialisation and redis failures alike
-/// short-circuit to the caller, which logs them on one path.
-async fn write_trip(
+/// Increments the failure counter (HINCRBY) and refreshes its TTL (EXPIRE).
+/// Two separate Redis calls — not atomic, but harmless: worst case the TTL refresh
+/// fails and the counter expires on its previous TTL.
+async fn write_counter(
     state: &SessionState,
     rollout_scope: &str,
-    record: &TripRecord,
-) -> error_stack::Result<redis_interface::SetnxReply, storage_impl::errors::RedisError> {
-    let record = serde_json::to_string(record)
-        .change_context(storage_impl::errors::RedisError::JsonSerializationFailed)?;
+) -> error_stack::Result<Vec<usize>, storage_impl::errors::RedisError> {
+    let conn = state.store.get_redis_conn()?;
+    let key: redis_interface::RedisKey = counter_key(rollout_scope).as_str().into();
 
-    state
-        .store
-        .get_redis_conn()?
-        .set_key_if_not_exists_with_expiry(
-            &trip_key(rollout_scope).as_str().into(),
-            record,
-            Some(consts::UCS_KILL_SWITCH_TTL_IN_SECONDS),
-        )
+    let result = conn
+        .increment_fields_in_hash(&key, &[(COUNTER_FIELD, 1)])
+        .await?;
+
+    conn.set_expiry(&key, consts::UCS_KILL_SWITCH_TTL_IN_SECONDS)
         .await
+        .inspect_err(|error| {
+            logger::warn!(
+                ?error,
+                rollout_scope = %rollout_scope,
+                "ucs_kill_switch: failed to refresh counter TTL"
+            );
+        })
+        .ok();
+
+    Ok(result)
 }
 
-/// What was written when a scope tripped. Enough to find the originating request; the error
-/// itself stays out, being unbounded and unmasked connector text that the alert log already
-/// carries against the same request id.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct TripRecord {
-    pub reason: String,
-    pub request_id: Option<String>,
-    pub tripped_at: i64,
-}
-
-/// Whether a scope is tripped, and what tripped it. `trip` is absent when the scope is not
-/// tripped, or when its record predates this shape.
+/// Whether this scope has a counter, its current value, and whether it exceeds the threshold.
 #[derive(Debug, serde::Serialize)]
 pub struct KillSwitchStatusResponse {
     pub rollout_scope: String,
+    pub counter: u64,
+    /// `None` when no `RolloutConfig` exists for this scope — falls back to trip-on-first-failure.
+    pub threshold: Option<u64>,
     pub tripped: bool,
-    pub trip: Option<TripRecord>,
 }
 
 impl common_utils::events::ApiEventMetric for KillSwitchStatusResponse {}
 
-/// Clears the trip, returning the scope to whatever its rollout config says. Takes either form
-/// the list endpoint hands back.
+/// Clears the counter, returning the scope to whatever its rollout config says.
 pub async fn reset(state: SessionState, listed_key: String) -> errors::RouterResponse<()> {
     let rollout_scope = rollout_scope_in(&listed_key);
 
@@ -314,56 +315,82 @@ pub async fn reset(state: SessionState, listed_key: String) -> errors::RouterRes
         .get_redis_conn()
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to get a redis connection to clear the UCS kill switch")?
-        .delete_key(&trip_key(rollout_scope).as_str().into())
+        .delete_key(&counter_key(rollout_scope).as_str().into())
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Failed to delete the UCS kill switch trip")?;
+        .attach_printable("Failed to delete the UCS kill switch counter")?;
 
     match reply {
         redis_interface::DelReply::KeyDeleted => {
             logger::info!(
                 rollout_scope = %rollout_scope,
-                "ucs_kill_switch: trip cleared via api"
+                "ucs_kill_switch: counter cleared via api"
             );
 
             Ok(crate::services::ApplicationResponse::StatusOk)
         }
-        // Redis reports a missing key as a successful delete of nothing. Reporting that as
-        // success would tell an operator a scope is back on UCS when a mistyped scope left it
-        // tripped.
         redis_interface::DelReply::KeyNotDeleted => {
             Err(errors::ApiErrorResponse::GenericNotFoundError {
-                message: format!("No UCS kill switch trip found for scope {rollout_scope}"),
+                message: format!("No UCS kill switch counter found for scope {rollout_scope}"),
             }
             .into())
         }
     }
 }
 
-/// Whether this scope is tripped, and what tripped it. Reads the trip record so an on-call
-/// engineer has that without redis or log access. One key, so no keyspace walk.
+/// Reads the counter so an on-call engineer can inspect it without Redis or log access.
 pub async fn trip_status(
     state: SessionState,
     key_or_scope: String,
 ) -> errors::RouterResponse<KillSwitchStatusResponse> {
     let rollout_scope = rollout_scope_in(&key_or_scope);
 
-    let record = state
-        .store
-        .get_redis_conn()
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Failed to get a redis connection to read the UCS kill switch trip")?
-        .get_key::<Option<String>>(&trip_key(rollout_scope).as_str().into())
+    let counter_value: u64 = read_counter(&state, rollout_scope)
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Failed to read the UCS kill switch trip")?;
+        .attach_printable("Failed to read the UCS kill switch counter")?;
+
+    // Fetch the kill_switch_threshold from the RolloutConfig for this scope.
+    // Uses the scope-level config key (without org prefix) since trip_status
+    // doesn't have org context.
+    let config_key = format!(
+        "{}_{}",
+        consts::UCS_ROLLOUT_PERCENT_CONFIG_PREFIX,
+        rollout_scope
+    );
+    let threshold: Option<u64> = state
+        .store
+        .find_config_by_key_unwrap_or(
+            &config_key,
+            Some(consts::UCS_ROLLOUT_CONFIG_NOT_CONFIGURED.to_string()),
+        )
+        .await
+        .ok()
+        .filter(|config| config.config != consts::UCS_ROLLOUT_CONFIG_NOT_CONFIGURED)
+        .and_then(|config| {
+            serde_json::from_str::<crate::core::payments::helpers::RolloutConfig>(&config.config)
+                .inspect_err(|err| {
+                    logger::warn!(
+                        ?err,
+                        config_key = %config_key,
+                        "ucs_kill_switch: failed to parse RolloutConfig for threshold lookup"
+                    );
+                })
+                .ok()
+        })
+        .map(|rc| rc.kill_switch_threshold);
+
+    let tripped = match threshold {
+        Some(t) => exceeds_threshold(counter_value, t),
+        None => counter_value > 0,
+    };
 
     Ok(crate::services::ApplicationResponse::Json(
         KillSwitchStatusResponse {
             rollout_scope: rollout_scope.to_string(),
-            tripped: record.is_some(),
-            // A record written by an older build may not parse; the scope is still tripped.
-            trip: record.and_then(|record| serde_json::from_str::<TripRecord>(&record).ok()),
+            counter: counter_value,
+            threshold,
+            tripped,
         },
     ))
 }
@@ -438,8 +465,6 @@ mod tests {
 
     #[test]
     fn an_unreachable_ucs_trips() {
-        // While UCS is unreachable the payment has no fallback and fails outright, so serving
-        // from the direct integration is strictly better.
         assert_eq!(
             UnifiedConnectorServiceError::ConnectionError("dial".into()).ucs_kill_switch_reason(),
             Some(UcsKillSwitchReason::UcsUnreachable)
@@ -448,8 +473,6 @@ mod tests {
 
     #[test]
     fn connector_outcomes_trip_conservatively() {
-        // A false bypass to the direct path is safe — it served merchants for years.
-        // A missed trip leaves merchants on a potentially broken UCS path.
         let cases = [
             connector_error(402),
             connector_error(504),
@@ -467,12 +490,10 @@ mod tests {
 
     #[test]
     fn scope_is_the_rollout_key_without_its_prefix() {
-        // A trip must target exactly the rollout key that enabled the traffic.
         assert_eq!(
             rollout_scope(PaymentMethod::Card, None, "Authorize"),
             "merchant_1_cybersource_card_Authorize"
         );
-        // Wallets carry a payment method type, exactly as their rollout keys do.
         assert_eq!(
             rollout_scope(
                 PaymentMethod::Wallet,
@@ -481,7 +502,6 @@ mod tests {
             ),
             "merchant_1_cybersource_wallet_google_pay_Authorize"
         );
-        // Refund keys carry no payment method.
         assert_eq!(
             rollout_scope(PaymentMethod::Card, None, "Execute"),
             "merchant_1_cybersource_Execute"
@@ -490,8 +510,6 @@ mod tests {
 
     #[test]
     fn independently_enabled_keys_trip_independently() {
-        // Card and wallet are enabled by separate rollout keys, and wallets fail differently,
-        // so a wallet trip must not take card traffic with it.
         let card = rollout_scope(PaymentMethod::Card, None, "Authorize");
 
         assert_ne!(
@@ -526,8 +544,8 @@ mod tests {
     }
 
     #[test]
-    fn trip_key_cannot_collide_with_a_rollout_config_key() {
-        let key = trip_key(&rollout_scope(PaymentMethod::Card, None, "Authorize"));
+    fn counter_key_cannot_collide_with_a_rollout_config_key() {
+        let key = counter_key(&rollout_scope(PaymentMethod::Card, None, "Authorize"));
 
         assert!(key.starts_with(consts::UCS_KILL_SWITCH_REDIS_PREFIX));
         assert!(!key.starts_with(consts::UCS_ROLLOUT_PERCENT_CONFIG_PREFIX));

--- a/crates/router/src/core/unified_connector_service/kill_switch.rs
+++ b/crates/router/src/core/unified_connector_service/kill_switch.rs
@@ -1,0 +1,551 @@
+//! Returns a rollout scope to the direct connector integration when a Unified Connector Service
+//! call fails.
+//!
+//! Trips live in redis, keyed on the rollout scope; `ucs_rollout_config` rows are never written
+//! to. Ambiguous outcomes resolve towards the direct path, which is what the scope used before
+//! UCS.
+
+use std::str::FromStr;
+
+use common_enums::{connector_enums::Connector, ConnectorIntegrationType, ExecutionMode};
+use error_stack::ResultExt;
+use hyperswitch_interfaces::unified_connector_service::transformers::{
+    UcsKillSwitchReason, UnifiedConnectorServiceError,
+};
+use router_env::logger;
+
+use crate::{
+    consts,
+    core::{
+        errors, metrics,
+        payments::helpers::is_config_flag_enabled,
+        unified_connector_service::{
+            build_merchant_rollout_scope, determine_connector_integration_type,
+        },
+    },
+    routes::SessionState,
+};
+
+/// Redis key holding the trip for a scope.
+fn trip_key(rollout_scope: &str) -> String {
+    format!("{}_{rollout_scope}", consts::UCS_KILL_SWITCH_REDIS_PREFIX)
+}
+
+/// The rollout scope inside a redis key, or the input unchanged when it is already a scope.
+///
+/// `scan` hands back whole keys with the tenant prefix in front, and an operator may paste one of
+/// those into the reset endpoint, so both callers need the scope back out.
+fn rollout_scope_in(key_or_scope: &str) -> &str {
+    let prefix = format!("{}_", consts::UCS_KILL_SWITCH_REDIS_PREFIX);
+
+    match key_or_scope.split_once(prefix.as_str()) {
+        Some((_, rollout_scope)) => rollout_scope,
+        None => key_or_scope,
+    }
+}
+
+/// Whether the kill switch has tripped for this scope.
+///
+/// Fails closed: a redis error routes to the direct integration. Only reached once the rollout
+/// config resolved to primary, so shadow traffic never pays for the lookup.
+pub async fn is_tripped(state: &SessionState, rollout_scope: &str) -> bool {
+    if is_config_flag_enabled(state, consts::UCS_KILL_SWITCH_ENABLED).await {
+        match read_trip(state, rollout_scope).await {
+            Ok(tripped) => tripped,
+            // Fails closed: the scope goes to the direct integration when redis cannot answer.
+            Err(error) => {
+                logger::error!(
+                    ?error,
+                    rollout_scope = %rollout_scope,
+                    "ucs_kill_switch: trip unreadable, routing to the direct integration"
+                );
+                true
+            }
+        }
+    } else {
+        false
+    }
+}
+
+/// Reads the trip. Redis failures short-circuit to the caller, which decides the safe answer.
+async fn read_trip(
+    state: &SessionState,
+    rollout_scope: &str,
+) -> error_stack::Result<bool, storage_impl::errors::RedisError> {
+    let tripped = state
+        .store
+        .get_redis_conn()?
+        .exists::<()>(&trip_key(rollout_scope).as_str().into())
+        .await?;
+
+    if tripped {
+        // Every request for a tripped scope reaches here; the trip is logged once elsewhere.
+        logger::debug!(
+            rollout_scope = %rollout_scope,
+            "ucs_kill_switch: scope is tripped, routing to the direct integration"
+        );
+    }
+
+    Ok(tripped)
+}
+
+/// What a failing UCS call was for. A struct because transposing two of six positional strings
+/// would key trips under the wrong scope.
+pub struct UcsFailureContext<'a> {
+    pub merchant_id: &'a str,
+    pub connector_name: &'a str,
+    pub flow_name: &'a str,
+    pub payment_id: &'a str,
+    pub payment_method: common_enums::PaymentMethod,
+    pub payment_method_type: Option<common_enums::PaymentMethodType>,
+}
+
+/// A failure that qualifies to trip, and the scope it would trip.
+struct TrippableFailure {
+    rollout_scope: String,
+    reason: UcsKillSwitchReason,
+}
+
+/// Records a qualifying UCS failure, and trips its scope when the switch is turned on.
+///
+/// Never returns an error: it runs on an already-failing path and must not fail the request.
+pub async fn record_failure(
+    state: &SessionState,
+    context: UcsFailureContext<'_>,
+    execution_mode: ExecutionMode,
+    error: &UnifiedConnectorServiceError,
+) {
+    if let Some(failure) = trippable_failure(state, &context, execution_mode, error).await {
+        record_trippable_failure(state, &failure, &context, error).await;
+    }
+}
+
+/// Counts the failure, trips its scope when the switch is turned on, and reports what happened.
+async fn record_trippable_failure(
+    state: &SessionState,
+    failure: &TrippableFailure,
+    context: &UcsFailureContext<'_>,
+    error: &UnifiedConnectorServiceError,
+) {
+    metrics::UCS_KILL_SWITCH_FAILURE.add(
+        1,
+        router_env::metric_attributes!(
+            ("connector", context.connector_name.to_string()),
+            ("flow", context.flow_name.to_string()),
+            ("reason", failure.reason.to_string())
+        ),
+    );
+
+    let outcome = if is_config_flag_enabled(state, consts::UCS_KILL_SWITCH_ENABLED).await {
+        trip(state, failure, context).await
+    } else {
+        TripOutcome::SwitchOff
+    };
+
+    // The one line this path emits, carrying every dimension of the decision. Alert on `outcome`
+    // rather than on a message: `tripped` means a scope left UCS, `write_failed` means one should
+    // have and did not. While the switch is off every line reads `switch_off`, which is the feed
+    // for validating the classifier against real traffic before turning it on.
+    logger::warn!(
+        rollout_scope = %failure.rollout_scope,
+        merchant_id = %context.merchant_id,
+        connector = %context.connector_name,
+        flow = %context.flow_name,
+        payment_method = %context.payment_method,
+        payment_id = %context.payment_id,
+        request_id = ?state.request_id,
+        reason = %failure.reason,
+        outcome = %outcome,
+        ucs_error = ?error,
+        "ucs_kill_switch"
+    );
+}
+
+/// What this failure would trip, or `None` when nothing can come of it: shadow traffic, a
+/// UCS-only connector the gate never diverts, or a failure the classifier does not qualify.
+async fn trippable_failure(
+    state: &SessionState,
+    context: &UcsFailureContext<'_>,
+    execution_mode: ExecutionMode,
+    error: &UnifiedConnectorServiceError,
+) -> Option<TrippableFailure> {
+    // Only the path serving merchant traffic can trip, and only a connector that has a direct
+    // integration to fall back to. `&&` keeps the cheap check first.
+    let scope_can_trip = matches!(execution_mode, ExecutionMode::Primary)
+        && !is_ucs_only_connector(state, context.connector_name).await;
+
+    scope_can_trip
+        .then(|| error.ucs_kill_switch_reason())
+        .flatten()
+        .map(|reason| TrippableFailure {
+            rollout_scope: build_merchant_rollout_scope(
+                context.merchant_id,
+                context.connector_name,
+                context.flow_name,
+                context.payment_method,
+                context.payment_method_type,
+            ),
+            reason,
+        })
+}
+
+/// A UCS-only connector has no direct integration to fall back to, so the gate never diverts one.
+/// An unparseable connector name counts as having one, rather than silently dropping a scope that
+/// can trip.
+async fn is_ucs_only_connector(state: &SessionState, connector_name: &str) -> bool {
+    match Connector::from_str(connector_name) {
+        Ok(connector) => matches!(
+            determine_connector_integration_type(state, connector).await,
+            Ok(ConnectorIntegrationType::UcsConnector)
+        ),
+        Err(_) => false,
+    }
+}
+
+/// What came of a trippable failure. Reported as a field on the one line the recording path
+/// emits, so an alert keys on the outcome rather than on several message strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "snake_case")]
+enum TripOutcome {
+    /// This pod wrote the trip. The scope now serves from the direct integration.
+    Tripped,
+    /// Another pod wrote it first.
+    AlreadyTripped,
+    /// The failure qualified, but enforcement is turned off.
+    SwitchOff,
+    /// Redis refused the write, so the scope stays on UCS.
+    WriteFailed,
+}
+
+/// Writes the trip. `SET NX` makes it exactly-once: one concurrent writer wins, the rest no-op.
+async fn trip(
+    state: &SessionState,
+    failure: &TrippableFailure,
+    context: &UcsFailureContext<'_>,
+) -> TripOutcome {
+    let TrippableFailure {
+        rollout_scope,
+        reason,
+    } = failure;
+
+    let record = TripRecord {
+        reason: reason.to_string(),
+        request_id: state.request_id.as_ref().map(|id| id.to_string()),
+        tripped_at: common_utils::date_time::now_unix_timestamp(),
+    };
+
+    match write_trip(state, rollout_scope, &record).await {
+        Ok(redis_interface::SetnxReply::KeySet) => {
+            metrics::UCS_KILL_SWITCH_TRIPPED.add(
+                1,
+                router_env::metric_attributes!(
+                    ("connector", context.connector_name.to_string()),
+                    ("flow", context.flow_name.to_string()),
+                    ("reason", reason.to_string())
+                ),
+            );
+
+            TripOutcome::Tripped
+        }
+        Ok(redis_interface::SetnxReply::KeyNotSet) => TripOutcome::AlreadyTripped,
+        // The cause does not belong on the summary line, and it is the one thing an operator
+        // cannot act on without it.
+        Err(error) => {
+            logger::error!(
+                ?error,
+                rollout_scope = %rollout_scope,
+                "ucs_kill_switch: could not persist the trip"
+            );
+
+            TripOutcome::WriteFailed
+        }
+    }
+}
+
+/// Writes the trip if no other pod got there first. Serialisation and redis failures alike
+/// short-circuit to the caller, which logs them on one path.
+async fn write_trip(
+    state: &SessionState,
+    rollout_scope: &str,
+    record: &TripRecord,
+) -> error_stack::Result<redis_interface::SetnxReply, storage_impl::errors::RedisError> {
+    let record = serde_json::to_string(record)
+        .change_context(storage_impl::errors::RedisError::JsonSerializationFailed)?;
+
+    state
+        .store
+        .get_redis_conn()?
+        .set_key_if_not_exists_with_expiry(
+            &trip_key(rollout_scope).as_str().into(),
+            record,
+            Some(consts::UCS_KILL_SWITCH_TTL_IN_SECONDS),
+        )
+        .await
+}
+
+/// What was written when a scope tripped. Enough to find the originating request; the error
+/// itself stays out, being unbounded and unmasked connector text that the alert log already
+/// carries against the same request id.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct TripRecord {
+    pub reason: String,
+    pub request_id: Option<String>,
+    pub tripped_at: i64,
+}
+
+/// Whether a scope is tripped, and what tripped it. `trip` is absent when the scope is not
+/// tripped, or when its record predates this shape.
+#[derive(Debug, serde::Serialize)]
+pub struct KillSwitchStatusResponse {
+    pub rollout_scope: String,
+    pub tripped: bool,
+    pub trip: Option<TripRecord>,
+}
+
+impl common_utils::events::ApiEventMetric for KillSwitchStatusResponse {}
+
+/// Clears the trip, returning the scope to whatever its rollout config says. Takes either form
+/// the list endpoint hands back.
+pub async fn reset(state: SessionState, listed_key: String) -> errors::RouterResponse<()> {
+    let rollout_scope = rollout_scope_in(&listed_key);
+
+    let reply = state
+        .store
+        .get_redis_conn()
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to get a redis connection to clear the UCS kill switch")?
+        .delete_key(&trip_key(rollout_scope).as_str().into())
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to delete the UCS kill switch trip")?;
+
+    match reply {
+        redis_interface::DelReply::KeyDeleted => {
+            logger::info!(
+                rollout_scope = %rollout_scope,
+                "ucs_kill_switch: trip cleared via api"
+            );
+
+            Ok(crate::services::ApplicationResponse::StatusOk)
+        }
+        // Redis reports a missing key as a successful delete of nothing. Reporting that as
+        // success would tell an operator a scope is back on UCS when a mistyped scope left it
+        // tripped.
+        redis_interface::DelReply::KeyNotDeleted => {
+            Err(errors::ApiErrorResponse::GenericNotFoundError {
+                message: format!("No UCS kill switch trip found for scope {rollout_scope}"),
+            }
+            .into())
+        }
+    }
+}
+
+/// Whether this scope is tripped, and what tripped it. Reads the trip record so an on-call
+/// engineer has that without redis or log access. One key, so no keyspace walk.
+pub async fn trip_status(
+    state: SessionState,
+    key_or_scope: String,
+) -> errors::RouterResponse<KillSwitchStatusResponse> {
+    let rollout_scope = rollout_scope_in(&key_or_scope);
+
+    let record = state
+        .store
+        .get_redis_conn()
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to get a redis connection to read the UCS kill switch trip")?
+        .get_key::<Option<String>>(&trip_key(rollout_scope).as_str().into())
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to read the UCS kill switch trip")?;
+
+    Ok(crate::services::ApplicationResponse::Json(
+        KillSwitchStatusResponse {
+            rollout_scope: rollout_scope.to_string(),
+            tripped: record.is_some(),
+            // A record written by an older build may not parse; the scope is still tripped.
+            trip: record.and_then(|record| serde_json::from_str::<TripRecord>(&record).ok()),
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use common_enums::{PaymentMethod, PaymentMethodType};
+
+    use super::*;
+
+    /// A connector's own answer, arriving through UCS.
+    fn connector_error(status_code: u16) -> UnifiedConnectorServiceError {
+        UnifiedConnectorServiceError::ConnectorError(Box::new(
+            hyperswitch_interfaces::unified_connector_service::transformers::ConnectorErrorInner {
+                code: "card_declined".to_string(),
+                message: "Card was declined".to_string(),
+                status_code,
+                reason: None,
+                connector: "cybersource".to_string(),
+                connector_transaction_id: None,
+                network_decline_code: None,
+                network_advice_code: None,
+                network_error_message: None,
+            },
+        ))
+    }
+
+    /// One merchant and connector, so a case reads as just its payment method and flow.
+    fn rollout_scope(
+        payment_method: PaymentMethod,
+        pmt: Option<PaymentMethodType>,
+        flow: &str,
+    ) -> String {
+        build_merchant_rollout_scope("merchant_1", "cybersource", flow, payment_method, pmt)
+    }
+
+    #[test]
+    fn failures_are_labelled_by_where_they_originated() {
+        let cases = [
+            (
+                UnifiedConnectorServiceError::ResponseDeserializationFailed,
+                UcsKillSwitchReason::HyperswitchResponseUndecodable,
+            ),
+            (
+                UnifiedConnectorServiceError::ParsingFailed,
+                UcsKillSwitchReason::HyperswitchResponseUndecodable,
+            ),
+            (
+                UnifiedConnectorServiceError::RequestEncodingFailed,
+                UcsKillSwitchReason::HyperswitchRequestInvalid,
+            ),
+            (
+                UnifiedConnectorServiceError::FailedToObtainAuthType,
+                UcsKillSwitchReason::HyperswitchRequestInvalid,
+            ),
+            (
+                UnifiedConnectorServiceError::MissingRequiredField {
+                    field_name: "payment_method_data",
+                },
+                UcsKillSwitchReason::HyperswitchRequestInvalid,
+            ),
+            (
+                UnifiedConnectorServiceError::NotImplemented("PSync".into()),
+                UcsKillSwitchReason::UcsFlowUnsupported,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.ucs_kill_switch_reason(), Some(expected), "{error:?}");
+        }
+    }
+
+    #[test]
+    fn an_unreachable_ucs_trips() {
+        // While UCS is unreachable the payment has no fallback and fails outright, so serving
+        // from the direct integration is strictly better.
+        assert_eq!(
+            UnifiedConnectorServiceError::ConnectionError("dial".into()).ucs_kill_switch_reason(),
+            Some(UcsKillSwitchReason::UcsUnreachable)
+        );
+    }
+
+    #[test]
+    fn connector_outcomes_trip_conservatively() {
+        // A false bypass to the direct path is safe — it served merchants for years.
+        // A missed trip leaves merchants on a potentially broken UCS path.
+        let cases = [
+            connector_error(402),
+            connector_error(504),
+            connector_error(500),
+        ];
+
+        for error in cases {
+            assert_eq!(
+                error.ucs_kill_switch_reason(),
+                Some(UcsKillSwitchReason::ConnectorOutcome),
+                "{error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn scope_is_the_rollout_key_without_its_prefix() {
+        // A trip must target exactly the rollout key that enabled the traffic.
+        assert_eq!(
+            rollout_scope(PaymentMethod::Card, None, "Authorize"),
+            "merchant_1_cybersource_card_Authorize"
+        );
+        // Wallets carry a payment method type, exactly as their rollout keys do.
+        assert_eq!(
+            rollout_scope(
+                PaymentMethod::Wallet,
+                Some(PaymentMethodType::GooglePay),
+                "Authorize"
+            ),
+            "merchant_1_cybersource_wallet_google_pay_Authorize"
+        );
+        // Refund keys carry no payment method.
+        assert_eq!(
+            rollout_scope(PaymentMethod::Card, None, "Execute"),
+            "merchant_1_cybersource_Execute"
+        );
+    }
+
+    #[test]
+    fn independently_enabled_keys_trip_independently() {
+        // Card and wallet are enabled by separate rollout keys, and wallets fail differently,
+        // so a wallet trip must not take card traffic with it.
+        let card = rollout_scope(PaymentMethod::Card, None, "Authorize");
+
+        assert_ne!(
+            card,
+            rollout_scope(
+                PaymentMethod::Wallet,
+                Some(PaymentMethodType::GooglePay),
+                "Authorize"
+            )
+        );
+        assert_ne!(card, rollout_scope(PaymentMethod::Card, None, "PSync"));
+        assert_ne!(
+            card,
+            build_merchant_rollout_scope(
+                "merchant_2",
+                "cybersource",
+                "Authorize",
+                PaymentMethod::Card,
+                None
+            )
+        );
+        assert_ne!(
+            card,
+            build_merchant_rollout_scope(
+                "merchant_1",
+                "adyen",
+                "Authorize",
+                PaymentMethod::Card,
+                None
+            )
+        );
+    }
+
+    #[test]
+    fn trip_key_cannot_collide_with_a_rollout_config_key() {
+        let key = trip_key(&rollout_scope(PaymentMethod::Card, None, "Authorize"));
+
+        assert!(key.starts_with(consts::UCS_KILL_SWITCH_REDIS_PREFIX));
+        assert!(!key.starts_with(consts::UCS_ROLLOUT_PERCENT_CONFIG_PREFIX));
+    }
+
+    #[test]
+    fn failure_reasons_have_distinct_tags() {
+        let tags = [
+            UcsKillSwitchReason::HyperswitchResponseUndecodable.to_string(),
+            UcsKillSwitchReason::HyperswitchRequestInvalid.to_string(),
+            UcsKillSwitchReason::UcsRejectedRequest.to_string(),
+            UcsKillSwitchReason::UcsFlowUnsupported.to_string(),
+            UcsKillSwitchReason::UcsInternalError.to_string(),
+            UcsKillSwitchReason::UcsUnreachable.to_string(),
+            UcsKillSwitchReason::ConnectorOutcome.to_string(),
+        ];
+        let unique: std::collections::HashSet<_> = tags.iter().collect();
+
+        assert_eq!(unique.len(), tags.len());
+    }
+}

--- a/crates/router/src/core/webhooks/gateway.rs
+++ b/crates/router/src/core/webhooks/gateway.rs
@@ -576,11 +576,16 @@ fn spawn_shadow_ucs_run(
                 logger::warn!(?error, "UCS shadow webhook run failed");
             }
             let shadow_snapshot = WebhookShadowSnapshot::from_result(&shadow_result);
+            let merchant_id = inner_ctx
+                .merchant_connector_account
+                .as_ref()
+                .map(|mca| mca.merchant_id.clone());
             report_shadow_diff(
                 &inner_ctx.state,
                 &inner_ctx.connector_name,
                 &primary_snapshot,
                 &shadow_snapshot,
+                merchant_id,
             )
             .await;
         }
@@ -687,6 +692,7 @@ async fn report_shadow_diff(
     connector_name: &str,
     primary: &WebhookShadowSnapshot,
     shadow: &WebhookShadowSnapshot,
+    merchant_id: Option<common_utils::id_type::MerchantId>,
 ) {
     logger::info!(
         primary_event_type = ?primary.event_type,
@@ -708,6 +714,7 @@ async fn report_shadow_diff(
             config,
             connector_name.to_string(),
             state.get_request_id_str(),
+            merchant_id.as_ref(),
         )
         .await;
     }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -300,6 +300,7 @@ pub fn mk_app(
             .service(routes::User::server(state.clone()))
             .service(routes::ApiKeys::server(state.clone()))
             .service(routes::Routing::server(state.clone()))
+            .service(routes::UnifiedConnectorService::server(state.clone()))
             .service(routes::Chat::server(state.clone()));
 
         #[cfg(all(feature = "olap", any(feature = "v1", feature = "v2")))]

--- a/crates/router/src/routes.rs
+++ b/crates/router/src/routes.rs
@@ -60,6 +60,8 @@ pub mod superposition_sdk_config;
 pub mod three_ds_decision_rule;
 pub mod tokenization;
 #[cfg(feature = "olap")]
+pub mod unified_connector_service;
+#[cfg(feature = "olap")]
 pub mod user;
 #[cfg(feature = "olap")]
 pub mod user_role;
@@ -100,7 +102,9 @@ pub use self::app::{
     Webhooks,
 };
 #[cfg(feature = "olap")]
-pub use self::app::{Blocklist, Organization, Routing, Subscription, Verify, WebhookEvents};
+pub use self::app::{
+    Blocklist, Organization, Routing, Subscription, UnifiedConnectorService, Verify, WebhookEvents,
+};
 #[cfg(feature = "payouts")]
 pub use self::app::{PayoutLink, Payouts};
 #[cfg(feature = "v2")]

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -62,6 +62,8 @@ use super::refunds;
 use super::routing;
 #[cfg(all(feature = "oltp", feature = "v2"))]
 use super::tokenization as tokenization_routes;
+#[cfg(feature = "olap")]
+use super::unified_connector_service as unified_connector_service_routes;
 #[cfg(all(feature = "olap", any(feature = "v1", feature = "v2")))]
 use super::verification::{apple_pay_merchant_registration, retrieve_apple_pay_verified_domains};
 #[cfg(feature = "oltp")]
@@ -2323,6 +2325,21 @@ impl Configs {
                     .route(web::get().to(config_key_retrieve))
                     .route(web::post().to(config_key_update))
                     .route(web::delete().to(config_key_delete)),
+            )
+    }
+}
+
+pub struct UnifiedConnectorService;
+
+#[cfg(feature = "olap")]
+impl UnifiedConnectorService {
+    pub fn server(state: AppState) -> Scope {
+        web::scope("/unified-connector-service")
+            .app_data(web::Data::new(state))
+            .service(
+                web::resource("/kill-switch/{scope}")
+                    .route(web::get().to(unified_connector_service_routes::kill_switch_status))
+                    .route(web::delete().to(unified_connector_service_routes::reset_kill_switch)),
             )
     }
 }

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -203,23 +203,12 @@ impl SessionState {
             ExecutionMode::Shadow => Some("shadow"),
             ExecutionMode::NotApplicable => None,
         };
-        let config_override = match unified_connector_service_execution_mode {
-            ExecutionMode::Shadow => Some(
-                serde_json::json!({
-                    "events": {
-                        "enabled": false
-                    }
-                })
-                .to_string(),
-            ),
-            _ => None,
-        };
         GrpcHeadersUcs::builder()
             .tenant_id(tenant_id)
             .request_id(request_id)
             .shadow_mode(shadow_mode)
             .proxy_name(proxy_name)
-            .config_override(config_override)
+            .config_override(None)
     }
     #[cfg(all(feature = "revenue_recovery", feature = "v2"))]
     pub fn get_recovery_grpc_headers(&self) -> GrpcRecoveryHeaders {

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -119,7 +119,9 @@ impl From<Flow> for ApiIdentifier {
             | Flow::ConfigKeyFetch
             | Flow::ConfigKeyUpdate
             | Flow::ConfigKeyDelete
-            | Flow::CreateConfigKey => Self::Configs,
+            | Flow::CreateConfigKey
+            | Flow::UnifiedConnectorServiceKillSwitchStatus
+            | Flow::UnifiedConnectorServiceKillSwitchReset => Self::Configs,
             Flow::CustomersCreate
             | Flow::CustomersRetrieve
             | Flow::CustomersRetrieveByReferenceId

--- a/crates/router/src/routes/unified_connector_service.rs
+++ b/crates/router/src/routes/unified_connector_service.rs
@@ -1,0 +1,53 @@
+use actix_web::{web, HttpRequest, Responder};
+use router_env::{instrument, tracing, Flow};
+
+use super::app::AppState;
+use crate::{
+    core::{api_locking, unified_connector_service::kill_switch},
+    services::{api as oss_api, authentication as auth},
+};
+
+/// Reports whether the UCS kill switch has tripped a scope, and what tripped it.
+///
+/// `scope` is the `rollout_scope` the trip logs, or the whole redis key.
+#[instrument(skip_all, fields(flow = ?Flow::UnifiedConnectorServiceKillSwitchStatus))]
+pub async fn kill_switch_status(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+) -> impl Responder {
+    let flow = Flow::UnifiedConnectorServiceKillSwitchStatus;
+
+    Box::pin(oss_api::server_wrap(
+        flow,
+        state,
+        &req,
+        path.into_inner(),
+        |state, _, scope, _| kill_switch::trip_status(state, scope),
+        &auth::AdminApiAuth,
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
+/// Clears a UCS kill switch trip, returning the scope to whatever its rollout config says.
+/// Takes the same `scope` as the status endpoint.
+#[instrument(skip_all, fields(flow = ?Flow::UnifiedConnectorServiceKillSwitchReset))]
+pub async fn reset_kill_switch(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    path: web::Path<String>,
+) -> impl Responder {
+    let flow = Flow::UnifiedConnectorServiceKillSwitchReset;
+
+    Box::pin(oss_api::server_wrap(
+        flow,
+        state,
+        &req,
+        path.into_inner(),
+        |state, _, scope, _| kill_switch::reset(state, scope),
+        &auth::AdminApiAuth,
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -661,6 +661,10 @@ pub enum Flow {
     RoutingEvaluateRule,
     /// Reset the Decision Engine routing diff kill-switch counter for a profile
     DecisionEngineDiffCounterReset,
+    /// Report whether the Unified Connector Service kill switch has tripped a scope
+    UnifiedConnectorServiceKillSwitchStatus,
+    /// Clear a Unified Connector Service kill switch cutover
+    UnifiedConnectorServiceKillSwitchReset,
     /// Relay flow
     Relay,
     /// Relay retrieve flow


### PR DESCRIPTION
## Summary

Fixes #13721

- Cherry-picks UCS kill switch feature and related fixes onto the hotfix branch (`2026.08.12.0`)
- Includes automatic kill switch circuit breaker for deterministic UCS failures (`#13639`)
- Fixes shadow event publishing for kill-switched scopes (`#13611`)
- Fires kill switch on connector errors returned in `Ok(RouterData)` path (`#13683`)

## Cherry-picked commits
1. `9cb2e6e83e` — feat(ucs): add automatic kill switch for deterministic UCS failures (#13639)
2. `b68f937887` — fix(ucs): allow shadow event publishing (#13611)
3. `3aae4545e2` — fix(ucs): fire kill switch on connector errors in Ok(RouterData) (#13683)

## Test plan
- [ ] Verify UCS kill switch triggers on repeated connector failures
- [ ] Verify shadow event publishing works for kill-switched scopes
- [ ] Verify kill switch fires on connector errors in Ok(RouterData) response path
- [ ] Regression test existing UCS flows