### PR TITLE
fix(routing): dedup decision engine connectors by merchant_connector_id

### DIFF
--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -2886,3 +2886,86 @@ pub fn perform_pre_routing(
     let pmt_allowed = allowed_pmt_for_pre_routing.contains(payment_method_type);
     (pm_allowed || pmt_allowed) && !should_skip_prerouting
 }
+
+#[cfg(test)]
+mod transform_de_output_tests {
+    use super::*;
+
+    fn mca(id: &str) -> id_type::MerchantConnectorAccountId {
+        id_type::MerchantConnectorAccountId::wrap(id.to_string()).unwrap()
+    }
+
+    fn choice(connector: RoutableConnectors, id: &str) -> RoutableConnectorChoice {
+        RoutableConnectorChoice {
+            choice_kind: api_routing::RoutableChoiceKind::FullStruct,
+            connector,
+            merchant_connector_id: Some(mca(id)),
+        }
+    }
+
+    fn info(name: &str, id: &str) -> ConnectorInfo {
+        ConnectorInfo {
+            gateway_name: name.to_string(),
+            gateway_id: Some(id.to_string()),
+        }
+    }
+
+    // The regression this PR fixes: two MCAs of the SAME connector must both survive.
+    #[test]
+    fn keeps_both_mcas_of_the_same_connector() {
+        let out = transform_de_output_for_router(
+            vec![
+                info("paypal", "mca_9pE8yl5LFwGLe3fA2xNZ"),
+                info("paypal", "mca_XLx05llokfkj8Tsb7nMa"),
+            ],
+            vec![choice(
+                RoutableConnectors::Paypal,
+                "mca_XLx05llokfkj8Tsb7nMa",
+            )],
+        )
+        .unwrap();
+
+        assert_eq!(out.len(), 2, "second paypal MCA was dropped");
+        // volume-split winner stays at the front, loser follows as fallback
+        assert_eq!(
+            out[0].merchant_connector_id,
+            Some(mca("mca_XLx05llokfkj8Tsb7nMa"))
+        );
+        assert_eq!(
+            out[1].merchant_connector_id,
+            Some(mca("mca_9pE8yl5LFwGLe3fA2xNZ"))
+        );
+    }
+
+    // Guard against the opposite failure: a true duplicate must still collapse.
+    #[test]
+    fn still_dedups_exact_duplicates() {
+        let out = transform_de_output_for_router(
+            vec![
+                info("paypal", "mca_9pE8yl5LFwGLe3fA2xNZ"),
+                info("paypal", "mca_9pE8yl5LFwGLe3fA2xNZ"),
+            ],
+            vec![choice(
+                RoutableConnectors::Paypal,
+                "mca_9pE8yl5LFwGLe3fA2xNZ",
+            )],
+        )
+        .unwrap();
+
+        assert_eq!(out.len(), 1);
+    }
+
+    // Pre-existing behaviour for distinct connectors must be untouched.
+    #[test]
+    fn preserves_evaluated_first_ordering_for_distinct_connectors() {
+        let out = transform_de_output_for_router(
+            vec![info("adyen", "mca_ady"), info("stripe", "mca_strp")],
+            vec![choice(RoutableConnectors::Stripe, "mca_strp")],
+        )
+        .unwrap();
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].connector, RoutableConnectors::Stripe);
+        assert_eq!(out[1].connector, RoutableConnectors::Adyen);
+    }
+}

--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -682,33 +682,24 @@ pub fn transform_de_output_for_router(
     de_output: Vec<ConnectorInfo>,
     de_evaluated_output: Vec<RoutableConnectorChoice>,
 ) -> RoutingResult<Vec<RoutableConnectorChoice>> {
+    // Keyed on the full (connector, merchant_connector_id) pair rather than the connector name
+    // alone: a merchant can hold several MCAs for the same connector, and a rule that spans two
+    // of them (e.g. a volume split across two paypal MCAs) must keep both.
     let mut seen = HashSet::new();
 
     // evaluated connectors on top, to ensure the fallback is based on other connectors.
     let mut ordered = Vec::with_capacity(de_output.len() + de_evaluated_output.len());
     for eval_conn in de_evaluated_output {
-        if seen.insert(eval_conn.connector) {
+        if seen.insert((eval_conn.connector, eval_conn.merchant_connector_id.clone())) {
             ordered.push(eval_conn);
         }
     }
 
     // Add remaining connectors from de_output (only if not already seen), for fallback
     for conn in de_output {
-        let connector_name = conn.gateway_name.clone();
-        let key = RoutableConnectors::from_str(&connector_name).map_err(|error| {
-            logger::error!(
-                error=?error,
-                connector_name = %connector_name,
-                "euclid: failed to parse connector name from decision engine output"
-            );
-            errors::RoutingError::GenericConversionError {
-                from: "String".to_string(),
-                to: "RoutableConnectors".to_string(),
-            }
-        })?;
-        if seen.insert(key) {
-            let de_choice = DeRoutableConnectorChoice::try_from(conn)?;
-            ordered.push(RoutableConnectorChoice::from(de_choice));
+        let choice = RoutableConnectorChoice::from(DeRoutableConnectorChoice::try_from(conn)?);
+        if seen.insert((choice.connector, choice.merchant_connector_id.clone())) {
+            ordered.push(choice);
         }
     }
     Ok(ordered)

--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -2927,13 +2927,16 @@ mod transform_de_output_tests {
 
         assert_eq!(out.len(), 2, "second paypal MCA was dropped");
         // volume-split winner stays at the front, loser follows as fallback
+        let mca_order = out
+            .iter()
+            .map(|c| c.merchant_connector_id.clone())
+            .collect::<Vec<_>>();
         assert_eq!(
-            out[0].merchant_connector_id,
-            Some(mca("mca_XLx05llokfkj8Tsb7nMa"))
-        );
-        assert_eq!(
-            out[1].merchant_connector_id,
-            Some(mca("mca_9pE8yl5LFwGLe3fA2xNZ"))
+            mca_order,
+            vec![
+                Some(mca("mca_XLx05llokfkj8Tsb7nMa")),
+                Some(mca("mca_9pE8yl5LFwGLe3fA2xNZ")),
+            ]
         );
     }
 
@@ -2965,7 +2968,10 @@ mod transform_de_output_tests {
         .unwrap();
 
         assert_eq!(out.len(), 2);
-        assert_eq!(out[0].connector, RoutableConnectors::Stripe);
-        assert_eq!(out[1].connector, RoutableConnectors::Adyen);
+        let connector_order = out.iter().map(|c| c.connector).collect::<Vec<_>>();
+        assert_eq!(
+            connector_order,
+            vec![RoutableConnectors::Stripe, RoutableConnectors::Adyen]
+        );
     }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

`transform_de_output_for_router` builds the router-facing connector list from a decision engine `/routing/evaluate` response: `evaluated_output` first, then the remaining connectors from `output` as fallbacks, deduplicated.

The dedup set was keyed on the connector name alone:

```rust
if seen.insert(eval_conn.connector) { ... }   // merchant_connector_id not part of the key
```

`RoutableConnectorChoice` carries both `connector` and `merchant_connector_id`, but only `connector` went into the set. So for a merchant holding **several MCAs of the same connector**, every MCA after the first is silently dropped.

This shows up on any rule that spans two MCAs of one connector — e.g. a volume split across two paypal MCAs. DE returns the sampled winner in `evaluated_output` and both arms in `output`; the second paypal MCA is then discarded, so the router loses its fallback and the list length disagrees with the legacy euclid result.

Found while investigating a persistent shadow-diff (`is_equal_length=false`) on a sandbox profile with exactly that shape.

### Change

Key the set on the full `(connector, merchant_connector_id)` pair.

The second loop now builds the `RoutableConnectorChoice` before keying off it, which also removes a duplicated `RoutableConnectors::from_str` — the `TryFrom<ConnectorInfo>` impl already performs that parse with equivalent error logging.

Note: entries with `merchant_connector_id: None` no longer collapse into a same-named entry with `Some(id)`. Both lists are serialized from the same `ConnectorInfo` objects in the same rule, so this is not expected to trigger in practice.

## Motivation and Context

Static routing via the decision engine must preserve MCA-level granularity; collapsing by connector name loses both the routing target and its fallbacks for multi-MCA merchants.

## How did you test it?

Unit tests added in `crates/router/src/core/payments/routing/utils.rs` (the file had no test module before):

```
running 3 tests
test ...::still_dedups_exact_duplicates ... ok
test ...::preserves_evaluated_first_ordering_for_distinct_connectors ... ok
test ...::keeps_both_mcas_of_the_same_connector ... ok

test result: ok. 3 passed; 0 failed
```

Verified the coverage is meaningful by reverting the fix and re-running with the tests in place — the regression test fails exactly as the bug predicts, while the two guard tests still pass:

```
test ...::keeps_both_mcas_of_the_same_connector ... FAILED

assertion `left == right` failed: second paypal MCA was dropped
  left: 1
 right: 2

test result: FAILED. 2 passed; 1 failed
```

`left: 1 / right: 2` is the same shape as the sandbox shadow diff that led here (DE one connector, HS two).

Also run: `cargo check -p router`, `cargo clippy -p router`, `cargo +nightly fmt -p router --check` — all clean.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I added unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #13759
