### PR TITLE
fix(connector): send paypal billing agreements as billing_agreement_id

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
@@ -150,6 +150,9 @@ pub mod auth_headers {
 }
 
 const ORDER_QUANTITY: u16 = 1;
+/// Express Checkout billing agreement ids carry this prefix. Payment Method Tokens v3 vault ids
+/// do not, which is how the two are told apart when a stored token is reused.
+const BILLING_AGREEMENT_ID_PREFIX: &str = "B-";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
@@ -537,6 +540,15 @@ pub enum ShippingPreference {
 pub enum PaypalRedirectionRequest {
     PaypalRedirectionStruct(PaypalRedirectionStruct),
     PaypalVaultStruct(VaultStruct),
+    PaypalBillingAgreementStruct(BillingAgreementStruct),
+}
+
+/// Express Checkout billing agreement, as opposed to a Payment Method Tokens v3 vault entry.
+/// Orders v2 accepts both but under different keys, and rejects a billing agreement sent as a
+/// `vault_id`.
+#[derive(Debug, Serialize)]
+pub struct BillingAgreementStruct {
+    billing_agreement_id: Secret<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1274,16 +1286,28 @@ impl TryFrom<&PaypalRouterData<&PaymentsAuthorizeRouterData>> for PaypalPayments
                         }),
                     ))),
                     enums::PaymentMethodType::Paypal => Ok(Some(PaymentSourceItem::Paypal(
-                        PaypalRedirectionRequest::PaypalVaultStruct(VaultStruct {
-                            vault_id: connector_mandate_id.into(),
-                            attributes: item.router_data.get_optional_customer_id().as_ref().map(
-                                |customer_id| VaultRequestAttributes {
-                                    customer: Some(CustomerRequestData {
-                                        merchant_customer_id: Some(customer_id.clone()),
-                                    }),
+                        // Billing agreement ids carry a `B-` prefix; vault tokens do not. Orders v2
+                        // rejects a billing agreement sent as `vault_id` with PERMISSION_DENIED.
+                        if connector_mandate_id.starts_with(BILLING_AGREEMENT_ID_PREFIX) {
+                            PaypalRedirectionRequest::PaypalBillingAgreementStruct(
+                                BillingAgreementStruct {
+                                    billing_agreement_id: connector_mandate_id.into(),
                                 },
-                            ),
-                        }),
+                            )
+                        } else {
+                            PaypalRedirectionRequest::PaypalVaultStruct(VaultStruct {
+                                vault_id: connector_mandate_id.into(),
+                                attributes: item
+                                    .router_data
+                                    .get_optional_customer_id()
+                                    .as_ref()
+                                    .map(|customer_id| VaultRequestAttributes {
+                                        customer: Some(CustomerRequestData {
+                                            merchant_customer_id: Some(customer_id.clone()),
+                                        }),
+                                    }),
+                            })
+                        },
                     ))),
                     enums::PaymentMethodType::Ach
                     | enums::PaymentMethodType::Affirm


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

Orders v2 accepts a stored PayPal payment method under two different keys:

| stored thing | key | id shape |
|---|---|---|
| Payment Method Tokens v3 vault entry | `vault_id` | no fixed prefix |
| Express Checkout billing agreement | `billing_agreement_id` | `B-...` |

The connector sends both as `vault_id`. For a merchant migrating existing billing agreements from another provider, every MIT fails.

The two keys are not interchangeable. Probing Orders v2 with the same made-up `B-` id under each key gives different failures, so PayPal routes them separately:

```
payment_source.paypal.vault_id              -> NOT_AUTHORIZED / PERMISSION_DENIED
payment_source.paypal.billing_agreement_id  -> UNPROCESSABLE_ENTITY / BILLING_AGREEMENT_NOT_FOUND
```

`BILLING_AGREEMENT_NOT_FOUND` is the expected answer for an id that does not exist, so the format is recognised under that key and not under the other. A real billing agreement charged successfully through `billing_agreement_id` against live PayPal.

This picks the key by prefix, so v3 vault tokens keep their current behaviour.

## Additional Changes

- [ ] API modification
- [ ] Config modification

## Motivation and Context

Closes #13768

Merchants moving to Hyperswitch from a provider that stored Express Checkout billing agreements cannot charge those agreements today. Their subscribers would have to re-authorise, even though PayPal keeps the agreements valid until the buyer cancels them.

## How did you test it?

Manually, against PayPal.

Sent the same `B-` id to Orders v2 under each key and compared the errors, as above. Charged a real Express Checkout billing agreement through `billing_agreement_id` and it completed, confirming the key works for reference transactions.

`cargo check -p hyperswitch_connectors --features v1` reports no errors in `paypal`. The remaining errors in that run are in `trustly` and `worldpayxml` and need feature flags unrelated to this change.

## Checklist

- [x] I formatted the code (`cargo fmt --all` on stable; nightly was not available, so the
  nightly-only import rules are unverified)
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
