### PR TITLE
fix(core): align refund connector error mapping with payment

### DIFF
--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -143,17 +143,6 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
                         message: errors::NotImplementedMessage::Reason(reason.to_string()),
                     }
                 }
-                errors::ConnectorError::MismatchedPaymentData => {
-                    errors::ApiErrorResponse::InvalidDataValue {
-                        field_name:
-                            "payment_method_data, payment_method_type and payment_experience does not match",
-                    }
-                }
-                errors::ConnectorError::MandatePaymentDataMismatch { fields } => {
-                    errors::ApiErrorResponse::MandatePaymentDataMismatch {
-                        fields: fields.to_owned(),
-                    }
-                }
                 errors::ConnectorError::NotSupported { message, connector } => {
                     errors::ApiErrorResponse::NotSupported {
                         message: format!("{message} is not supported by {connector}"),
@@ -179,21 +168,9 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
                 errors::ConnectorError::InvalidDataFormat { field_name } => {
                     errors::ApiErrorResponse::InvalidDataValue { field_name }
                 }
-                errors::ConnectorError::CaptureMethodNotSupported => {
-                    errors::ApiErrorResponse::NotSupported {
-                        message: "Capture Method Not Supported".to_owned(),
-                    }
-                }
                 errors::ConnectorError::InvalidWalletToken { wallet_name } => {
                     errors::ApiErrorResponse::InvalidWalletToken {
                         wallet_name: wallet_name.to_string(),
-                    }
-                }
-                errors::ConnectorError::CurrencyNotSupported { message, connector } => {
-                    errors::ApiErrorResponse::CurrencyNotSupported {
-                        message: format!(
-                            "Credentials for the currency {message} are not configured with the connector {connector}/hyperswitch"
-                        ),
                     }
                 }
                 errors::ConnectorError::FailedToObtainAuthType => {
@@ -246,6 +223,10 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
                 | errors::ConnectorError::InSufficientBalanceInPaymentMethod
                 | errors::ConnectorError::RequestTimeoutReceived
                 | errors::ConnectorError::ProcessingStepFailed(None)
+                | errors::ConnectorError::MismatchedPaymentData
+                | errors::ConnectorError::MandatePaymentDataMismatch { .. }
+                | errors::ConnectorError::CaptureMethodNotSupported
+                | errors::ConnectorError::CurrencyNotSupported { .. }
                 | errors::ConnectorError::GenericError { .. }
                 | errors::ConnectorError::AmountConversionFailed => {
                     errors::ApiErrorResponse::InternalServerError

--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -113,95 +113,145 @@ pub trait ConnectorErrorExt<T> {
 
 impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> {
     fn to_refund_failed_response(self) -> error_stack::Result<T, errors::ApiErrorResponse> {
-        self.map_err(|err| match err.current_context() {
-            errors::ConnectorError::ProcessingStepFailed(Some(bytes)) => {
-                let response_str = std::str::from_utf8(bytes);
-                let data = match response_str {
-                    Ok(s) => serde_json::from_str(s)
-                        .map_err(
-                            |error| logger::error!(%error,"Failed to convert response to JSON"),
-                        )
-                        .ok(),
-                    Err(error) => {
-                        logger::error!(%error,"Failed to convert response to UTF8 string");
-                        None
+        self.map_err(|err| {
+            let error = match err.current_context() {
+                errors::ConnectorError::ProcessingStepFailed(Some(bytes)) => {
+                    let response_str = std::str::from_utf8(bytes);
+                    let data = match response_str {
+                        Ok(s) => serde_json::from_str(s)
+                            .map_err(
+                                |error| logger::error!(%error,"Failed to convert response to JSON"),
+                            )
+                            .ok(),
+                        Err(error) => {
+                            logger::error!(%error,"Failed to convert response to UTF8 string");
+                            None
+                        }
+                    };
+                    errors::ApiErrorResponse::RefundFailed { data }
+                }
+                errors::ConnectorError::MissingRequiredField { field_name } => {
+                    errors::ApiErrorResponse::MissingRequiredField { field_name }
+                }
+                errors::ConnectorError::MissingRequiredFields { field_names } => {
+                    errors::ApiErrorResponse::MissingRequiredFields {
+                        field_names: field_names.to_vec(),
                     }
-                };
-                err.change_context(errors::ApiErrorResponse::RefundFailed { data })
-            }
-            errors::ConnectorError::NotImplemented(reason) => {
-                errors::ApiErrorResponse::NotImplemented {
-                    message: errors::NotImplementedMessage::Reason(reason.to_string()),
                 }
-                .into()
-            }
-            errors::ConnectorError::NotSupported { message, connector } => {
-                errors::ApiErrorResponse::NotSupported {
-                    message: format!("{message} is not supported by {connector}"),
+                errors::ConnectorError::NotImplemented(reason) => {
+                    errors::ApiErrorResponse::NotImplemented {
+                        message: errors::NotImplementedMessage::Reason(reason.to_string()),
+                    }
                 }
-                .into()
-            }
-            errors::ConnectorError::CaptureMethodNotSupported => {
-                errors::ApiErrorResponse::NotSupported {
-                    message: "Capture Method Not Supported".to_owned(),
+                errors::ConnectorError::MismatchedPaymentData => {
+                    errors::ApiErrorResponse::InvalidDataValue {
+                        field_name:
+                            "payment_method_data, payment_method_type and payment_experience does not match",
+                    }
                 }
-                .into()
-            }
-            errors::ConnectorError::FailedToObtainIntegrationUrl
-            | errors::ConnectorError::RequestEncodingFailed
-            | errors::ConnectorError::RequestEncodingFailedWithReason(_)
-            | errors::ConnectorError::ParsingFailed
-            | errors::ConnectorError::ResponseDeserializationFailed
-            | errors::ConnectorError::UnexpectedResponseError(_)
-            | errors::ConnectorError::RoutingRulesParsingError
-            | errors::ConnectorError::FailedToObtainPreferredConnector
-            | errors::ConnectorError::ProcessingStepFailed(_)
-            | errors::ConnectorError::InvalidConnectorName
-            | errors::ConnectorError::InvalidWallet
-            | errors::ConnectorError::ResponseHandlingFailed
-            | errors::ConnectorError::MissingRequiredField { .. }
-            | errors::ConnectorError::MissingRequiredFields { .. }
-            | errors::ConnectorError::FailedToObtainAuthType
-            | errors::ConnectorError::FailedToObtainCertificate
-            | errors::ConnectorError::NoConnectorMetaData
-            | errors::ConnectorError::NoConnectorWalletDetails
-            | errors::ConnectorError::FailedToObtainCertificateKey
-            | errors::ConnectorError::MaxFieldLengthViolated { .. }
-            | errors::ConnectorError::FlowNotSupported { .. }
-            | errors::ConnectorError::MissingConnectorMandateID
-            | errors::ConnectorError::MissingConnectorMandateMetadata
-            | errors::ConnectorError::MissingConnectorTransactionID
-            | errors::ConnectorError::MissingConnectorRefundID
-            | errors::ConnectorError::MissingApplePayTokenData
-            | errors::ConnectorError::WebhooksNotImplemented
-            | errors::ConnectorError::WebhookBodyDecodingFailed
-            | errors::ConnectorError::WebhookSignatureNotFound
-            | errors::ConnectorError::WebhookSourceVerificationFailed
-            | errors::ConnectorError::WebhookVerificationSecretNotFound
-            | errors::ConnectorError::WebhookVerificationSecretInvalid
-            | errors::ConnectorError::WebhookReferenceIdNotFound
-            | errors::ConnectorError::WebhookEventTypeNotFound
-            | errors::ConnectorError::WebhookResourceObjectNotFound
-            | errors::ConnectorError::WebhookResponseEncodingFailed
-            | errors::ConnectorError::InvalidDateFormat
-            | errors::ConnectorError::DateFormattingFailed
-            | errors::ConnectorError::InvalidDataFormat { .. }
-            | errors::ConnectorError::MismatchedPaymentData
-            | errors::ConnectorError::MandatePaymentDataMismatch { .. }
-            | errors::ConnectorError::InvalidWalletToken { .. }
-            | errors::ConnectorError::MissingConnectorRelatedTransactionID { .. }
-            | errors::ConnectorError::FileValidationFailed { .. }
-            | errors::ConnectorError::MissingConnectorRedirectionPayload { .. }
-            | errors::ConnectorError::FailedAtConnector { .. }
-            | errors::ConnectorError::MissingPaymentMethodType
-            | errors::ConnectorError::InSufficientBalanceInPaymentMethod
-            | errors::ConnectorError::RequestTimeoutReceived
-            | errors::ConnectorError::CurrencyNotSupported { .. }
-            | errors::ConnectorError::InvalidConnectorConfig { .. }
-            | errors::ConnectorError::AmountConversionFailed
-            | errors::ConnectorError::GenericError { .. } => {
-                err.change_context(errors::ApiErrorResponse::RefundFailed { data: None })
-            }
+                errors::ConnectorError::MandatePaymentDataMismatch { fields } => {
+                    errors::ApiErrorResponse::MandatePaymentDataMismatch {
+                        fields: fields.to_owned(),
+                    }
+                }
+                errors::ConnectorError::NotSupported { message, connector } => {
+                    errors::ApiErrorResponse::NotSupported {
+                        message: format!("{message} is not supported by {connector}"),
+                    }
+                }
+                errors::ConnectorError::FlowNotSupported { flow, connector } => {
+                    errors::ApiErrorResponse::FlowNotSupported {
+                        flow: flow.to_owned(),
+                        connector: connector.to_owned(),
+                    }
+                }
+                errors::ConnectorError::MaxFieldLengthViolated {
+                    connector,
+                    field_name,
+                    max_length,
+                    received_length,
+                } => errors::ApiErrorResponse::MaxFieldLengthViolated {
+                    connector: connector.to_string(),
+                    field_name: field_name.to_string(),
+                    max_length: *max_length,
+                    received_length: *received_length,
+                },
+                errors::ConnectorError::InvalidDataFormat { field_name } => {
+                    errors::ApiErrorResponse::InvalidDataValue { field_name }
+                }
+                errors::ConnectorError::CaptureMethodNotSupported => {
+                    errors::ApiErrorResponse::NotSupported {
+                        message: "Capture Method Not Supported".to_owned(),
+                    }
+                }
+                errors::ConnectorError::InvalidWalletToken { wallet_name } => {
+                    errors::ApiErrorResponse::InvalidWalletToken {
+                        wallet_name: wallet_name.to_string(),
+                    }
+                }
+                errors::ConnectorError::CurrencyNotSupported { message, connector } => {
+                    errors::ApiErrorResponse::CurrencyNotSupported {
+                        message: format!(
+                            "Credentials for the currency {message} are not configured with the connector {connector}/hyperswitch"
+                        ),
+                    }
+                }
+                errors::ConnectorError::FailedToObtainAuthType => {
+                    errors::ApiErrorResponse::InvalidConnectorConfiguration {
+                        config: "connector_account_details".to_string(),
+                    }
+                }
+                errors::ConnectorError::InvalidConnectorConfig { config } => {
+                    errors::ApiErrorResponse::InvalidConnectorConfiguration {
+                        config: config.to_string(),
+                    }
+                }
+                errors::ConnectorError::FailedToObtainIntegrationUrl
+                | errors::ConnectorError::RequestEncodingFailed
+                | errors::ConnectorError::RequestEncodingFailedWithReason(_)
+                | errors::ConnectorError::ParsingFailed
+                | errors::ConnectorError::ResponseDeserializationFailed
+                | errors::ConnectorError::UnexpectedResponseError(_)
+                | errors::ConnectorError::RoutingRulesParsingError
+                | errors::ConnectorError::FailedToObtainPreferredConnector
+                | errors::ConnectorError::InvalidConnectorName
+                | errors::ConnectorError::InvalidWallet
+                | errors::ConnectorError::ResponseHandlingFailed
+                | errors::ConnectorError::FailedToObtainCertificate
+                | errors::ConnectorError::NoConnectorMetaData
+                | errors::ConnectorError::NoConnectorWalletDetails
+                | errors::ConnectorError::FailedToObtainCertificateKey
+                | errors::ConnectorError::MissingConnectorMandateID
+                | errors::ConnectorError::MissingConnectorMandateMetadata
+                | errors::ConnectorError::MissingConnectorTransactionID
+                | errors::ConnectorError::MissingConnectorRefundID
+                | errors::ConnectorError::MissingApplePayTokenData
+                | errors::ConnectorError::WebhooksNotImplemented
+                | errors::ConnectorError::WebhookBodyDecodingFailed
+                | errors::ConnectorError::WebhookSignatureNotFound
+                | errors::ConnectorError::WebhookSourceVerificationFailed
+                | errors::ConnectorError::WebhookVerificationSecretNotFound
+                | errors::ConnectorError::WebhookVerificationSecretInvalid
+                | errors::ConnectorError::WebhookReferenceIdNotFound
+                | errors::ConnectorError::WebhookEventTypeNotFound
+                | errors::ConnectorError::WebhookResourceObjectNotFound
+                | errors::ConnectorError::WebhookResponseEncodingFailed
+                | errors::ConnectorError::InvalidDateFormat
+                | errors::ConnectorError::DateFormattingFailed
+                | errors::ConnectorError::MissingConnectorRelatedTransactionID { .. }
+                | errors::ConnectorError::FileValidationFailed { .. }
+                | errors::ConnectorError::MissingConnectorRedirectionPayload { .. }
+                | errors::ConnectorError::FailedAtConnector { .. }
+                | errors::ConnectorError::MissingPaymentMethodType
+                | errors::ConnectorError::InSufficientBalanceInPaymentMethod
+                | errors::ConnectorError::RequestTimeoutReceived
+                | errors::ConnectorError::ProcessingStepFailed(None)
+                | errors::ConnectorError::GenericError { .. }
+                | errors::ConnectorError::AmountConversionFailed => {
+                    errors::ApiErrorResponse::InternalServerError
+                }
+            };
+            err.change_context(error)
         })
     }
 


### PR DESCRIPTION
## Description

Refund connector errors in `to_refund_failed_response` (`crates/router/src/core/errors/utils.rs`) were broadly mapped to `RefundFailed` (HTTP 400, CE_06 — "Refund failed while processing with connector. Retry refund."). This misclassified most **Hyperswitch-internal failures** as connector refund rejections:

- `ResponseDeserializationFailed` / `ParsingFailed` / `UnexpectedResponseError`
- `RequestEncodingFailed` / `FailedToObtainIntegrationUrl`
- certificate / config / auth-type lookup errors
- webhook helper, date-formatting, missing-internal-ID errors
- `FailedAtConnector`, `RequestTimeoutReceived`, `GenericError`, `AmountConversionFailed`, etc.

## Problem this fixes

A connector returning a 5xx whose error body could not be deserialized into the connector's error struct (e.g. Adyen's `AdyenErrorResponse`, Santander) produced a misleading **400 CE_06** "Refund failed while processing with connector. Retry refund.", while the underlying cause was a Hyperswitch-side parse/internal defect — and the refund could be left un-updated.

## Change

Mirror `to_payment_failed_response` arm-for-arm:

- **Only** `ProcessingStepFailed(Some(bytes))` (a genuine connector error payload) maps to `RefundFailed { data }`.
- Feature/config/validation variants now map to their specific errors (`NotImplemented`, `NotSupported`, `FlowNotSupported`, `MissingRequiredField(s)`, `InvalidDataFormat`, `MaxFieldLengthViolated`, `InvalidWalletToken`, `CurrencyNotSupported`, `InvalidConnectorConfig`, `FailedToObtainAuthType`, `CaptureMethodNotSupported`, `MismatchedPaymentData`, `MandatePaymentDataMismatch`).
- All remaining internal variants map to `InternalServerError` (matching payout convention).

## Verification

- `cargo clippy --all-targets` (v1) — clean
- whole-workspace `cargo clippy` with `-D warnings` (v2) — clean

## Scope

Direct connector path only (single shared helper). No changes to UCS/gRPC translation, no tests/docs, fix only.