### PR TITLE
test: pin the two serde asymmetries the deja changes turn on

### DIFF
--- a/crates/common_utils/src/crypto.rs
+++ b/crates/common_utils/src/crypto.rs
@@ -967,6 +967,157 @@ impl SignMessage for RsaPssSha256 {
 }
 
 #[cfg(test)]
+mod encryptable_exact_tests {
+    use hyperswitch_masking::{PeekInterface, Secret};
+    use serde::{Deserialize, Serialize};
+
+    use super::Encryptable;
+
+    #[derive(Serialize, Deserialize)]
+    struct Holder {
+        #[serde(with = "super::encryptable_exact")]
+        required: Encryptable<Secret<String>>,
+        #[serde(with = "super::encryptable_exact::optional")]
+        optional: Option<Encryptable<Secret<String>>>,
+    }
+
+    fn holder(inner: &str, ciphertext: Vec<u8>) -> Holder {
+        Holder {
+            required: Encryptable::new(Secret::new(inner.to_owned()), Secret::new(ciphertext)),
+            optional: None,
+        }
+    }
+
+    /// The exactness that matters: the CIPHERTEXT survives the round trip.
+    ///
+    /// `Encryptable`'s own impls drop it on purpose — an API response must
+    /// never expose it — so capturing a cached decrypted value through them
+    /// yields something the source never held. `into_encrypted()` has callers
+    /// on write-back paths (`common_utils::encryption`, the `type_encryption`
+    /// conversions), which would persist the empty bytes and call it
+    /// reproduction.
+    #[test]
+    fn both_halves_survive_the_round_trip() {
+        let ciphertext = vec![7_u8, 8, 9, 250];
+        let subject = Holder {
+            required: Encryptable::new(
+                Secret::new("plaintext".to_owned()),
+                Secret::new(ciphertext.clone()),
+            ),
+            optional: Some(Encryptable::new(
+                Secret::new("other".to_owned()),
+                Secret::new(vec![1_u8, 2]),
+            )),
+        };
+
+        let wire = serde_json::to_value(&subject).expect("serializes");
+        let back: Holder = serde_json::from_value(wire).expect("deserializes");
+
+        assert_eq!(back.required.get_inner().peek(), "plaintext");
+        assert_eq!(
+            back.required.clone().into_encrypted().peek(),
+            &ciphertext,
+            "the encrypted half must round-trip, not come back empty"
+        );
+        let optional = back.optional.expect("optional present");
+        assert_eq!(optional.get_inner().peek(), "other");
+        assert_eq!(optional.into_encrypted().peek(), &vec![1_u8, 2]);
+    }
+
+    /// A `None` optional stays `None` rather than becoming an empty value.
+    #[test]
+    fn an_absent_optional_stays_absent() {
+        let subject = holder("x", vec![]);
+        let wire = serde_json::to_value(&subject).expect("serializes");
+        let back: Holder = serde_json::from_value(wire).expect("deserializes");
+        assert!(back.optional.is_none());
+    }
+
+    /// The type's own impls stay lossy — this is the contract the helper
+    /// exists to work around, and a change to it would silently re-break
+    /// capture rather than failing anything.
+    #[test]
+    fn the_types_own_serde_still_drops_the_ciphertext() {
+        let value: Encryptable<Secret<String>> =
+            Encryptable::new(Secret::new("v".to_owned()), Secret::new(vec![1_u8, 2, 3]));
+        let wire = serde_json::to_value(&value).expect("serializes");
+        let back: Encryptable<Secret<String>> = serde_json::from_value(wire).expect("deserializes");
+        assert!(
+            back.into_encrypted().peek().is_empty(),
+            "documented lossiness: the public impls carry only the value"
+        );
+    }
+
+    /// An EMPTY ciphertext must round-trip as empty, distinguishably.
+    ///
+    /// Without this, a regression to the lossy path is only caught by cases
+    /// that happen to carry bytes: `into_encrypted().peek().is_empty()` would
+    /// hold for "the source was empty" and for "the helper dropped it", and
+    /// the two are different facts. Pairing this with the non-empty case
+    /// pins both directions.
+    #[test]
+    fn an_empty_ciphertext_round_trips_as_empty() {
+        let subject = holder("v", Vec::new());
+        let wire = serde_json::to_value(&subject).expect("serializes");
+        let back: Holder = serde_json::from_value(wire).expect("deserializes");
+        assert!(back.required.into_encrypted().peek().is_empty());
+    }
+
+    /// Ciphertext is arbitrary bytes, not text. A NUL, a 0xFF and a long run
+    /// must survive unaltered — a transport that ever routed these through a
+    /// string would mangle exactly these and nothing else.
+    #[test]
+    fn arbitrary_ciphertext_bytes_survive_unaltered() {
+        let mut ciphertext = vec![0_u8, 255, 1, 254, 128, 127];
+        ciphertext.extend(std::iter::repeat_n(0_u8, 64));
+        ciphertext.extend([0xDE, 0xAD, 0xBE, 0xEF]);
+
+        let subject = holder("v", ciphertext.clone());
+        let wire = serde_json::to_value(&subject).expect("serializes");
+        let back: Holder = serde_json::from_value(wire).expect("deserializes");
+        assert_eq!(back.required.into_encrypted().peek(), &ciphertext);
+    }
+
+    /// The same through a STRING, not only a `Value`.
+    ///
+    /// `serde_json::Value` is a lenient intermediate; the tape is bytes. A
+    /// round trip that only ever goes through `Value` can hide an escaping or
+    /// numeric-representation problem that a real serializer would hit.
+    #[test]
+    fn the_round_trip_holds_through_a_string_too() {
+        let ciphertext = vec![0_u8, 34, 92, 10, 255];
+        let subject = holder("quote\" and \\ backslash", ciphertext.clone());
+        let text = serde_json::to_string(&subject).expect("serializes");
+        let back: Holder = serde_json::from_str(&text).expect("deserializes");
+        assert_eq!(back.required.get_inner().peek(), "quote\" and \\ backslash");
+        assert_eq!(back.required.into_encrypted().peek(), &ciphertext);
+    }
+
+    /// The wire shape is part of the contract: both halves, under names the
+    /// tape already carries. Pinning it means a rename or a re-shaping is a
+    /// failing test rather than a silently unreadable recording.
+    #[test]
+    fn the_wire_carries_both_halves_under_stable_names() {
+        let subject = holder("v", vec![1_u8, 2]);
+        let wire = serde_json::to_value(&subject).expect("serializes");
+        let required = wire.get("required").expect("required field present");
+
+        assert!(
+            required.get("inner").is_some(),
+            "the decrypted half must be present as `inner`, got {required}"
+        );
+        assert_eq!(
+            required
+                .get("encrypted")
+                .and_then(|e| e.as_array())
+                .map(Vec::len),
+            Some(2),
+            "the encrypted half must be present as `encrypted`, got {required}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod crypto_tests {
     use super::{DecodeMessage, EncodeMessage, SignMessage, VerifySignature};
     use crate::crypto::GenerateDigest;

--- a/crates/euclid/src/frontend/dir.rs
+++ b/crates/euclid/src/frontend/dir.rs
@@ -1126,3 +1126,71 @@ mod test {
         assert!(out.is_err())
     }
 }
+#[cfg(test)]
+mod serde_round_trip {
+    use strum::IntoEnumIterator;
+
+    use super::{ast, DirKey, DirKeyKind, DirValue};
+    use crate::enums as euclid_enums;
+
+    /// Every key kind must survive a serde round trip.
+    ///
+    /// A variant that serializes under a tag it refuses to deserialize is
+    /// invisible to the compiler and silent in every test that only ever
+    /// writes. `DirKeyKind::Connector` and `DirValue::Connector` carried
+    /// `skip_deserializing` for years, harmlessly, because nothing read these
+    /// back — until a recorded constraint graph was substituted on replay,
+    /// where reconstruction of the WHOLE graph failed on the one unreadable
+    /// variant and took the request down with it. Enumerating the variants
+    /// keeps the asymmetry from returning silently for any of them.
+    #[test]
+    fn every_key_kind_round_trips() {
+        for kind in DirKeyKind::iter() {
+            let wire = serde_json::to_value(&kind)
+                .unwrap_or_else(|e| panic!("{kind:?} does not serialize: {e}"));
+            let back: DirKeyKind = serde_json::from_value(wire.clone()).unwrap_or_else(|e| {
+                panic!("{kind:?} serializes as {wire} but does not read back: {e}")
+            });
+            assert_eq!(back, kind, "{kind:?} changed identity across a round trip");
+        }
+    }
+
+    /// The same for a full key, which is what a graph's key nodes carry.
+    #[test]
+    fn every_key_round_trips_inside_a_key() {
+        for kind in DirKeyKind::iter() {
+            let key = DirKey::new(kind.clone(), None);
+            let wire = serde_json::to_value(&key).expect("serializes");
+            let back: DirKey = serde_json::from_value(wire.clone()).unwrap_or_else(|e| {
+                panic!("DirKey({kind:?}) serializes as {wire} but does not read back: {e}")
+            });
+            assert_eq!(back, key);
+        }
+    }
+
+    /// `DirValue::Connector` specifically, because it is the variant that was
+    /// unreadable and the enumerating tests above cannot reach it.
+    ///
+    /// `DirValue`'s variants carry data, so it derives `VariantNames` rather
+    /// than `EnumIter` and cannot be iterated into values. The one variant the
+    /// fix was about therefore needs naming outright, or it is the only part
+    /// of the change with no test over it.
+    #[test]
+    fn the_connector_value_round_trips() {
+        let value = DirValue::Connector(Box::new(ast::ConnectorChoice {
+            connector: euclid_enums::RoutableConnectors::Adyen,
+        }));
+
+        let wire = serde_json::to_value(&value).expect("serializes");
+        assert_eq!(
+            wire.get("key").and_then(|k| k.as_str()),
+            Some("connector"),
+            "the tag must stay `connector`; a recorded graph names it that way, got {wire}"
+        );
+
+        let back: DirValue = serde_json::from_value(wire.clone()).unwrap_or_else(|e| {
+            panic!("DirValue::Connector serializes as {wire} but does not read back: {e}")
+        });
+        assert_eq!(back, value);
+    }
+}


### PR DESCRIPTION
test: pin the two serde asymmetries the deja changes turn on

Both of these are write-only asymmetries that were harmless for years and
stopped being harmless the moment something read the data back. Neither is
visible to the compiler, and neither fails any test that only ever writes, so
the code that depends on them is currently the only thing asserting they hold.

`DirKeyKind::Connector` and `DirValue::Connector` serialized under the tag
`connector` and then refused to accept that same tag, because both carried
`skip_deserializing`. Nothing read a `DirValue` back — the DSL parses from its
own AST — so the asymmetry cost nothing until a recorded constraint graph was
substituted on replay. Reconstruction is all or nothing, so the single
unreadable variant failed the whole graph and took the request with it. The
tests enumerate every key kind rather than checking the two that were fixed,
which is what keeps a future variant from reintroducing it quietly, and name
the connector value outright because `DirValue` carries data, derives
`VariantNames` rather than `EnumIter`, and cannot be iterated into values.

`Encryptable` serializes as its inner value alone and deserializes with an
empty ciphertext. That is deliberate and must stay — an API response must
expose the value and never the encrypted half — but it means a value captured
and restored through those impls has lost something the source held, and
`into_encrypted()` has callers on write-back paths, so a replayed flow would
persist the empty bytes and report success. The `encryptable_exact` helper
carries both halves for the one context that needs it. The tests assert the
ciphertext survives, and, in the same module, that the type's own impls still
drop it: the second is the guarantee that no existing behaviour moved, and it
is the one a reviewer asking whether this touches a core flow should read
first.

The additions beyond the round trip are there because a round trip alone is
weaker than it looks. An empty ciphertext is asserted to survive as empty,
since without it `into_encrypted().peek().is_empty()` holds both for a source
that was empty and for a helper that dropped the value, and those are different
facts. Arbitrary bytes including a NUL and a 0xFF are asserted unaltered,
because ciphertext is bytes rather than text and a transport that ever routed
them through a string would mangle exactly these. The trip is taken through a
string as well as a `serde_json::Value`, because a `Value` is a lenient
intermediate and the tape is bytes. And the wire shape is pinned, so renaming
or reshaping a half is a failing test rather than a recording nobody can read.

Every test here fails if the behaviour it describes regresses: reintroducing
`skip_deserializing` fails all three euclid tests, and making the helper lossy
fails six of the seven crypto tests, the exception being the control that
asserts the type's own impls are lossy, which that change does not affect.
