### PR TITLE
refactor(common_enums): make diesel an optional dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8395,6 +8395,7 @@ dependencies = [
 name = "router_derive"
 version = "0.1.0"
 dependencies = [
+ "common_enums",
  "common_utils",
  "diesel",
  "error-stack 0.4.1",

--- a/crates/common_enums/Cargo.toml
+++ b/crates/common_enums/Cargo.toml
@@ -8,13 +8,22 @@ readme = "README.md"
 license.workspace = true
 
 [features]
+# Diesel ORM impls for these enums. Default-on, so hyperswitch resolves exactly
+# as before. Consumers that never touch a database opt out via
+# `default-features = false` (see common_utils), which is their only path here.
+# Keeping it default-on also keeps diesel on the 128-column tier in every
+# dependency context: diesel_derives is a single shared proc-macro build
+# carrying the highest tier, while diesel only raises its own recursion_limit
+# when it holds 128-column-tables. A mixed 32/128 split fails to compile.
+default = ["diesel"]
+diesel = ["dep:diesel"]
 dummy_connector = []
 openapi = []
 payouts = []
 v2 = []
 
 [dependencies]
-diesel = { version = "2.2.10", features = ["postgres", "128-column-tables"] }
+diesel = { version = "2.2.10", features = ["postgres", "128-column-tables"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 strum = { version = "0.26", features = ["derive"] }

--- a/crates/common_enums/src/connector_enums.rs
+++ b/crates/common_enums/src/connector_enums.rs
@@ -23,7 +23,7 @@ pub use crate::PaymentMethodType;
     Hash,
     SmithyModel,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -519,7 +519,7 @@ impl Connector {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum InvoiceStatus {

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -11,6 +11,7 @@ use std::{
 pub use accounts::{
     MerchantAccountRequestType, MerchantAccountType, MerchantProductType, OrganizationType,
 };
+#[cfg(feature = "diesel")]
 use diesel::{
     backend::Backend,
     deserialize::FromSql,
@@ -27,6 +28,7 @@ use utoipa::ToSchema;
 
 pub use super::connector_enums::InvoiceStatus;
 #[doc(hidden)]
+#[cfg(feature = "diesel")]
 pub mod diesel_exports {
     pub use super::{
         DbApiVersion as ApiVersion, DbAttemptStatus as AttemptStatus,
@@ -138,7 +140,10 @@ impl From<std::io::Error> for ApplicationError {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -308,7 +313,10 @@ impl AttemptStatus {
     strum::EnumIter,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ApplePayPaymentMethodType {
@@ -336,7 +344,10 @@ pub enum ApplePayPaymentMethodType {
     strum::VariantNames,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -362,7 +373,10 @@ pub enum CardDiscovery {
     strum::EnumIter,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RevenueRecoveryAlgorithmType {
@@ -415,7 +429,7 @@ pub enum ApiKeyType {
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 pub enum RecommendedAction {
     DoNotRetry,
     #[serde(rename = "retry_after_10_days")]
@@ -452,7 +466,7 @@ pub enum RecommendedAction {
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 pub enum GsmFeature {
     Retry,
 }
@@ -470,7 +484,7 @@ pub enum GsmFeature {
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 pub enum StandardisedCode {
     AccountClosedOrInvalid,
     AuthenticationFailed,
@@ -542,7 +556,10 @@ pub enum StandardisedCode {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -573,7 +590,10 @@ impl AuthenticationType {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 pub enum FraudCheckStatus {
     Fraud,
@@ -599,7 +619,10 @@ pub enum FraudCheckStatus {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -629,7 +652,7 @@ pub enum CaptureStatus {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -655,7 +678,7 @@ pub enum AuthorizationStatus {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum PaymentResourceUpdateStatus {
@@ -682,7 +705,10 @@ impl PaymentResourceUpdateStatus {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum BlocklistDataKind {
@@ -788,7 +814,10 @@ impl BlockReason {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -819,7 +848,10 @@ pub enum CaptureMethod {
     serde::Serialize,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectorType {
@@ -869,7 +901,7 @@ pub enum ConnectorType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum SurchargeStrategy {
@@ -930,7 +962,10 @@ pub enum IncomingWebhookEventType {
     ToSchema,
     SmithyModel,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub enum Currency {
     AED,
@@ -1825,7 +1860,7 @@ impl Currency {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum EventRecipient {
@@ -1844,7 +1879,10 @@ pub enum EventRecipient {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum EventObjectType {
@@ -1869,7 +1907,10 @@ pub enum EventObjectType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum EventClass {
@@ -1942,7 +1983,10 @@ impl EventClass {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 // Reminder: Whenever an EventType variant is added or removed, make sure to update the `event_types` method in `EventClass`
@@ -2019,7 +2063,10 @@ impl SurchargeEventMapper for EventType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum WebhookDeliveryAttempt {
@@ -2065,7 +2112,10 @@ pub enum OutgoingWebhookEndpointStatus {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum MerchantStorageScheme {
@@ -2092,7 +2142,10 @@ pub enum MerchantStorageScheme {
     strum::EnumIter,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -2209,7 +2262,10 @@ impl IntentStatus {
     strum::EnumIter,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RecoveryStatus {
@@ -2267,7 +2323,10 @@ pub enum RecoveryStatus {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -2307,7 +2366,10 @@ impl FutureUsage {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentMethodIssuerCode {
@@ -2338,7 +2400,7 @@ pub enum PaymentMethodIssuerCode {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -2422,7 +2484,7 @@ impl PaymentMethodStatus {
     Default,
     SmithyModel,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -2475,7 +2537,7 @@ pub enum SamsungPayCardBrand {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -2784,7 +2846,7 @@ impl hyperswitch_masking::SerializableSecret for PaymentMethodType {}
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -2902,7 +2964,7 @@ impl PaymentMethod {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum GatewaySystem {
@@ -2929,7 +2991,7 @@ pub enum GatewaySystem {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 /// Indicates the execution path through which the payment is processed.
@@ -2967,7 +3029,7 @@ impl ExecutionPath {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum UcsAvailability {
@@ -3046,7 +3108,7 @@ pub enum EventDestination {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ConnectorIntegrationType {
@@ -3071,7 +3133,10 @@ pub enum ConnectorIntegrationType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -3099,7 +3164,10 @@ pub enum PaymentType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -3127,7 +3195,7 @@ pub enum ScaExemptionType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -3155,7 +3223,7 @@ pub enum PaymentChannel {
     ToSchema,
     SmithyModel,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -3180,7 +3248,10 @@ pub enum CtpServiceProvider {
     serde::Serialize,
     serde::Deserialize,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum RefundStatus {
@@ -3218,7 +3289,10 @@ impl RefundStatus {
     serde::Deserialize,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum RelayStatus {
@@ -3278,7 +3352,10 @@ impl RelayStatus {
     serde::Deserialize,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum RelayType {
@@ -3303,7 +3380,10 @@ pub enum RelayType {
     serde::Serialize,
     serde::Deserialize,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 pub enum FrmTransactionType {
     #[default]
@@ -3327,7 +3407,10 @@ pub enum FrmTransactionType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -3355,7 +3438,7 @@ pub enum MandateStatus {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub enum CardNetwork {
     #[serde(alias = "VISA")]
@@ -3409,7 +3492,10 @@ pub enum CardNetwork {
     strum::EnumString,
     utoipa::ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 pub enum RegulatedName {
     #[serde(rename = "GOVERNMENT NON-EXEMPT INTERCHANGE FEE (WITH FRAUD)")]
@@ -3435,7 +3521,7 @@ pub enum RegulatedName {
     utoipa::ToSchema,
     Copy,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "lowercase")]
 pub enum PanOrToken {
@@ -3457,7 +3543,7 @@ pub enum PanOrToken {
     utoipa::ToSchema,
     Copy,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "UPPERCASE")]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum FundingSource {
@@ -3508,7 +3594,10 @@ pub enum CardSegmentType {
     utoipa::ToSchema,
     Copy,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "UPPERCASE")]
 #[serde(rename_all = "snake_case")]
 pub enum CardType {
@@ -3595,7 +3684,7 @@ impl CardNetwork {
     utoipa::ToSchema,
     Copy,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 pub enum CoBadgedCardNetwork {
     #[serde(alias = "RUPAY")]
     RuPay,
@@ -3644,7 +3733,10 @@ pub enum CoBadgedCardNetwork {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -3674,7 +3766,10 @@ pub enum DisputeStage {
     strum::EnumIter,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -3691,13 +3786,14 @@ pub enum DisputeStatus {
     DisputeLost,
 }
 
-#[derive(Debug, Clone, AsExpression, PartialEq, ToSchema, Eq)]
+#[derive(Debug, Clone, PartialEq, ToSchema, Eq)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
 #[schema(
     value_type = String,
     title = "4 digit Merchant category code (MCC)",
     example = "5411"
 )]
-#[diesel(sql_type = Text)]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 pub struct MerchantCategoryCode(String);
 
 impl MerchantCategoryCode {
@@ -3783,6 +3879,7 @@ impl MerchantCategoryCode {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<Text, DB> for MerchantCategoryCode
 where
     DB: Backend,
@@ -3792,6 +3889,7 @@ where
         self.0.to_sql(out)
     }
 }
+#[cfg(feature = "diesel")]
 impl<DB: Backend> FromSql<Text, DB> for MerchantCategoryCode
 where
     String: FromSql<Text, DB>,
@@ -3890,7 +3988,7 @@ pub struct MerchantCategoryCodeWithName {
     Copy,
     SmithyModel,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "db_enum"))]
 #[rustfmt::skip]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub enum CountryAlpha2 {
@@ -3929,7 +4027,10 @@ pub enum CountryAlpha2 {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RequestIncrementalAuthorization {
@@ -3953,7 +4054,7 @@ pub enum RequestIncrementalAuthorization {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum SplitTxnsEnabled {
@@ -3976,7 +4077,7 @@ pub enum SplitTxnsEnabled {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ActiveAttemptIDType {
@@ -4286,7 +4387,7 @@ pub enum Country {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum FileUploadProvider {
@@ -8878,7 +8979,10 @@ pub enum BrazilStatesAbbreviation {
     strum::EnumIter,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum PayoutStatus {
@@ -8948,7 +9052,10 @@ impl PayoutStatus {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum PayoutType {
@@ -8974,7 +9081,7 @@ pub enum PayoutType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "PascalCase")]
 #[strum(serialize_all = "PascalCase")]
 pub enum PayoutEntityType {
@@ -9007,7 +9114,7 @@ pub enum PayoutEntityType {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum PayoutSendPriority {
@@ -9033,7 +9140,10 @@ pub enum PayoutSendPriority {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum PaymentSource {
@@ -9085,7 +9195,7 @@ impl PaymentSource {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 pub enum MerchantDecision {
     Approved,
@@ -9106,7 +9216,7 @@ pub enum MerchantDecision {
     strum::EnumIter,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -9151,7 +9261,10 @@ pub enum FrmSuggestion {
     utoipa::ToSchema,
     Copy,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ReconStatus {
@@ -9257,7 +9370,7 @@ pub enum VaultSdk {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum Tokenization {
@@ -9282,7 +9395,7 @@ pub enum Tokenization {
     utoipa::ToSchema,
     Copy,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -9326,7 +9439,7 @@ impl AuthenticationStatus {
     utoipa::ToSchema,
     Copy,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -9350,7 +9463,7 @@ pub enum DecoupledAuthenticationType {
     utoipa::ToSchema,
     Copy,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum AuthenticationLifecycleStatus {
@@ -9373,7 +9486,10 @@ pub enum AuthenticationLifecycleStatus {
     ToSchema,
     Default,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectorStatus {
@@ -9395,7 +9511,10 @@ pub enum ConnectorStatus {
     ToSchema,
     Default,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum TransactionType {
@@ -9423,7 +9542,10 @@ impl TransactionType {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RoleScope {
@@ -9456,7 +9578,7 @@ impl From<RoleScope> for EntityType {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 pub enum TransactionStatus {
     /// Authentication/ Account Verification Successful
     #[serde(rename = "Y")]
@@ -9521,7 +9643,7 @@ impl From<TransactionStatus> for DecoupledAuthenticationType {
     strum::EnumString,
     strum::EnumIter,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum PermissionGroup {
@@ -9845,7 +9967,10 @@ pub enum BankHolderType {
     strum::VariantNames,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum GenericLinkType {
@@ -9885,7 +10010,7 @@ pub enum TokenPurpose {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum UserAuthType {
@@ -9906,7 +10031,7 @@ pub enum UserAuthType {
     strum::Display,
     strum::EnumString,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum Owner {
@@ -9927,7 +10052,10 @@ pub enum Owner {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum ApiVersion {
@@ -9951,7 +10079,7 @@ pub enum ApiVersion {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum EntityType {
@@ -9982,7 +10110,10 @@ pub enum PayoutRetryType {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum OrderFulfillmentTimeOrigin {
@@ -10003,7 +10134,10 @@ pub enum OrderFulfillmentTimeOrigin {
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum UIWidgetFormLayout {
@@ -10024,7 +10158,10 @@ pub enum UIWidgetFormLayout {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum DeleteStatus {
@@ -10047,7 +10184,10 @@ pub enum DeleteStatus {
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 pub enum SuccessBasedRoutingConclusiveState {
     // pc: payment connector
     // sc: success based routing outcome/first connector
@@ -10313,7 +10453,7 @@ impl From<ConnectorTokenStatus> for ConnectorMandateStatus {
     PartialOrd,
     Ord,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ErrorCategory {
@@ -10354,7 +10494,7 @@ impl ErrorCategory {
     PartialOrd,
     Ord,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[allow(non_camel_case_types)]
 pub enum UnifiedCode {
     /// Customer Error - Issue with payment method details
@@ -10619,7 +10759,10 @@ pub enum PaymentConnectorTransmission {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum TriggeredBy {
@@ -10644,7 +10787,7 @@ pub enum TriggeredBy {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -10672,7 +10815,10 @@ pub enum MitCategory {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ProcessTrackerStatus {
@@ -10736,7 +10882,7 @@ pub enum ProcessTrackerRunner {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ApplicationSource {
@@ -10763,7 +10909,10 @@ pub enum CryptoPadding {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum TokenizationFlag {
@@ -10801,7 +10950,10 @@ pub enum TokenDataType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RoutingApproach {
@@ -10845,7 +10997,7 @@ impl RoutingApproach {
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 pub enum CallbackMapperIdType {
     NetworkTokenRequestorReferenceID,
 }
@@ -10864,7 +11016,7 @@ pub enum CallbackMapperIdType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum VaultType {
@@ -10888,7 +11040,7 @@ pub enum VaultType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ExternalVaultEnabled {
@@ -11042,7 +11194,10 @@ pub enum ExemptionIndicator {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum VaultTokenType {
@@ -11083,7 +11238,7 @@ pub enum VaultTokenType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum StorageType {
@@ -11105,7 +11260,7 @@ pub enum StorageType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum AcknowledgementStatus {
@@ -11136,7 +11291,7 @@ impl From<AcknowledgementStatus> for PaymentMethodStatus {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RetryType {
@@ -11223,10 +11378,12 @@ pub enum ExpiryType {
     Scheduled,
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, diesel::FromSqlRow, AsExpression, ToSchema,
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(
+    feature = "diesel",
+    derive(diesel::FromSqlRow, AsExpression),
+    diesel(sql_type = diesel::sql_types::Json)
 )]
-#[diesel(sql_type = diesel::sql_types::Json)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum PixKey {
     #[schema(value_type = String)]
@@ -11287,7 +11444,10 @@ pub enum ConnectorWebhookEventType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[strum(serialize_all = "snake_case")]
 pub enum WebhookRegistrationStatus {
     // Webhook registration is successful
@@ -11338,7 +11498,7 @@ pub enum WebhookSecretGenerationStatus {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -11387,7 +11547,7 @@ pub enum VaultEnv {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum BatchBlocklistJobStatus {

--- a/crates/common_enums/src/enums/accounts.rs
+++ b/crates/common_enums/src/enums/accounts.rs
@@ -13,7 +13,7 @@ use utoipa::ToSchema;
     ToSchema,
     Hash,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum MerchantProductType {
@@ -39,7 +39,7 @@ pub enum MerchantProductType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum MerchantAccountType {
@@ -62,7 +62,7 @@ pub enum MerchantAccountType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum OrganizationType {
@@ -84,7 +84,7 @@ pub enum OrganizationType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "text")]
+#[cfg_attr(feature = "diesel", router_derive::diesel_enum(storage_type = "text"))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum MerchantAccountRequestType {

--- a/crates/common_enums/src/enums/ui.rs
+++ b/crates/common_enums/src/enums/ui.rs
@@ -17,7 +17,10 @@ use utoipa::ToSchema;
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "lowercase")]
 pub enum ElementPosition {
     Left,
@@ -37,7 +40,10 @@ pub enum ElementPosition {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, strum::Display, strum::EnumString, ToSchema)]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 pub enum ElementSize {
     Variants(SizeVariants),
     Percentage(u32),
@@ -58,7 +64,10 @@ pub enum ElementSize {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum SizeVariants {
@@ -81,7 +90,10 @@ pub enum SizeVariants {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum PaymentLinkDetailsLayout {
@@ -104,7 +116,10 @@ pub enum PaymentLinkDetailsLayout {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum PaymentLinkSdkLabelType {
@@ -128,7 +143,10 @@ pub enum PaymentLinkSdkLabelType {
     strum::EnumString,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum PaymentLinkShowSdkTerms {

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -31,7 +31,7 @@ base64 = "0.22.1"
 base64-serde = "0.8.0"
 blake3 = { version = "1.8.2", features = ["serde"] }
 bytes = "1.10.1"
-diesel = "2.2.10"
+diesel = { version = "2.2.10", features = ["postgres"] }
 deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false }
 error-stack = "0.4.1"
 futures = { version = "0.3.31", optional = true }
@@ -69,7 +69,7 @@ uuid = { version = "1.17.0", features = ["v7"] }
 ammonia = "3.3"
 
 # First party crates
-common_enums = { version = "0.1.0", path = "../common_enums" }
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
 hyperswitch_masking = { version = "0.0.1", features = ["diesel", "time"] }
 router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"], optional = true, default-features = false }
 

--- a/crates/router_derive/Cargo.toml
+++ b/crates/router_derive/Cargo.toml
@@ -27,7 +27,13 @@ serde_json = "1.0.140"
 url = { version = "2.5.4", features = ["serde"] }
 utoipa = "4.2.3"
 
+# common_utils (and transitively common_enums) is a dev-dependency only, used by
+# this crate's own tests. Because --all-targets builds those tests, that chain
+# drags diesel onto the proc-macro/host resolution line; pin the 128-column tier
+# here so it matches the shared diesel_derives build. Dev-dependencies are never
+# propagated to consumers, so this does not affect downstream users.
 common_utils = { version = "0.1.0", path = "../common_utils" }
+common_enums = { version = "0.1.0", path = "../common_enums", features = ["diesel"] }
 
 [lints]
 workspace = true

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -3300,7 +3300,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3336,7 +3339,10 @@ Cypress.Commands.add(
                 );
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3402,7 +3408,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3427,7 +3436,10 @@ Cypress.Commands.add(
                 globalState.set("nextActionType", "redirect_to_url");
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4105,7 +4117,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4119,7 +4134,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4166,7 +4184,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4180,7 +4201,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4309,7 +4333,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4366,7 +4393,10 @@ Cypress.Commands.add(
               );
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4443,7 +4473,10 @@ Cypress.Commands.add(
         if (response.body.capture_method !== undefined) {
           expect(response.body.payment_id).to.equal(paymentId);
           for (const key in resData.body) {
-            if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+            if (
+              key === "payment_method_data" &&
+              globalState.get("connectorId") === "checkout"
+            ) {
               expect(response.body[key], [key]).to.not.be.empty;
               expect(
                 response.body[key]?.card?.auth_code,
@@ -5090,7 +5123,10 @@ Cypress.Commands.add(
               // Response body key comparison runs for all three_ds paths, including succeeded status
               // — the redirect URL is extracted above when status !== succeeded, but all response keys are verified here
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -5171,7 +5207,10 @@ Cypress.Commands.add(
               // Response body key comparison runs for all three_ds paths, including succeeded status
               // — the redirect URL is extracted above when status !== succeeded, but all response keys are verified here
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Makes `diesel` an **optional (default-on)** dependency of `common_enums`, so that
consumers which never touch a database do not have to compile it.

`common_enums` annotates ~113 enums with `#[router_derive::diesel_enum(...)]`,
which expands to diesel `ToSql`/`FromSql`/`AsExpression` impls. Because the
dependency was mandatory, *every* consumer of these enums compiled diesel with
`128-column-tables` — including services that never issue a query.

Three changes:

1. **`crates/common_enums`** — `diesel` becomes `optional = true` behind a
   `diesel` feature that is **on by default**, so hyperswitch resolves exactly as
   before. The `diesel_enum` attributes, the `use diesel::{…}` import, the
   `diesel_exports` module and the handful of hand-written `ToSql`/`FromSql`
   impls (`MerchantCategoryCode`, `PixKey`) are gated with `cfg`/`cfg_attr`.

2. **`crates/common_utils`** — now declares `diesel` with `features = ["postgres"]`.
   It uses `diesel::pg::Pg` in 14 places but previously declared bare
   `diesel = "2.2.10"`; it only compiled because `common_enums` happened to enable
   `postgres` through feature unification. This is a latent under-declaration that
   the gating exposes. It also declares `common_enums` with
   `default-features = false` — this is the opt-out edge for downstream consumers.

3. **`crates/router_derive`** — one line in `[dev-dependencies]`. Please see the
   note below; this is the non-obvious part of the PR.

### Why the `router_derive` dev-dependency line is required

Cargo's resolver v2 resolves features **separately for the proc-macro/host
context**, so this workspace resolves two `diesel` lib units. `diesel_derives` is
a **single shared** proc-macro build carrying the highest tier requested anywhere,
while `diesel` only raises its own recursion limit when it holds the tier itself:

```rust
// diesel-2.2.10/src/lib.rs:219
#![cfg_attr(feature = "128-column-tables", recursion_limit = "256")]
```

`common_enums`'s previously-mandatory diesel was silently holding the 128 tier on
*both* resolution lines. Gating it dropped the proc-macro line to the 32 tier
while the shared derive crate stayed at 128, producing:

```
error: recursion limit reached while expanding `impl_sql_type!`
error: could not compile `diesel` (lib)
```

That line exists only because `router_derive` declares `common_utils` (and
transitively `common_enums`) in `[dev-dependencies]`, which `--all-targets`
builds. This is why `cargo check --workspace` passes but `just clippy` fails.
Pinning the tier there restores agreement. Dev-dependencies are never propagated
to consumers, so it has no effect downstream.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

This is a compile-time change only — no runtime behaviour, API surface, schema or
config is affected. `payment_attempt` has 92 columns, so hyperswitch still
requires the `128-column-tables` tier and continues to use it.

## Motivation and Context

The Unified Connector Service (`hyperswitch-prism`) contains **zero** diesel code
— no `table!` blocks, no queries, no `diesel` entry in any of its manifests. It
nevertheless spent **119 s of a 234 s cold build (51 %)** compiling diesel, purely
because it depends on hyperswitch's `common_enums` for shared vocabulary and that
crate mandated diesel.

The cost is concentrated in the `128-column-tables` feature, which generates
trait impls for progressively wider tuples. Measured by compiling diesel in
isolation with nothing else in the dependency graph:

| feature | diesel compile time |
| --- | --- |
| `32-column-tables` | 6.95 s |
| `64-column-tables` | 23.15 s |
| `128-column-tables` | **115.64 s** |

## How did you test it?

### hyperswitch (this PR)

All run on this branch, rebased on `main`:

- `just clippy`, `just clippy fred`, `just clippy_v2`
- `cargo check --workspace`, `cargo check --features "release"`
- `cargo build --package router --bin router`; `cargo build --package drainer --no-default-features --features "redis-rs,v1"`
- `cargo build --package router --bin router --no-default-features --features "release,v2,redis-rs"` (full v2 build)
- `cargo check -p euclid_wasm --target wasm32-unknown-unknown --features "dummy_connector,v1"` (wasm path)
- `cargo hack check --each-feature --all-targets --exclude-features 'v2 payment_v2' -p common_enums -p common_utils`
- `cargo run -p openapi --features v1` and `--features v2`
- `cargo +nightly fmt --all --check` (clean for the files touched here)
- `cargo check -p common_enums --no-default-features` (diesel gated **off**) and
  `--features diesel` (**on**) — both sides of the gate compile

Resolution is verified structurally rather than by inspection, using
`cargo +nightly build --unit-graph -Z unstable-options --all-targets`: both
`diesel` lib units and the shared `diesel_derives` unit carry
`128-column-tables`, identical to a clean-`main` baseline captured before the
change.

### UCS (`hyperswitch-prism`)

`hyperswitch-prism` pins hyperswitch by git tag, so it was tested by pointing it
at this branch with cargo `[patch]` overrides — **prism's own tree was never
modified**:

```bash
cargo --config 'patch."https://github.com/juspay/hyperswitch".common_enums.path="…/crates/common_enums"' \
      --config 'patch."https://github.com/juspay/hyperswitch".common_utils.path="…/crates/common_utils"' \
      build --timings -p grpc-server
```

Verified first that the dependency actually changed shape:

- `cargo tree -e features -p grpc-server` reports only `32-column-tables`
  (previously `128-column-tables`)
- `cargo tree -i diesel -p grpc-server` no longer lists `common_enums` among
  diesel's parents

Then measured a cold build into a fresh target directory:

| metric | before | after |
| --- | --- | --- |
| cold build wall clock | 234 s | **137.7 s** (−41 %) |
| `diesel` compile unit | 118.8 s | **16.1 s** |
| peak RSS | 9.7 GB | **~5.1 GB** |

Measured with `cargo build --timings` on 24 cores / rustc 1.96.0, builds run
strictly serially so they could not contend with one another.

### Note on rollout

UCS only benefits once this is merged and tagged, and prism bumps its pin from
`2026.06.18.0`. **Both manifest changes must ship in the same tag** — the current
`common_utils` relies on `common_enums` supplying diesel's `postgres` feature via
unification, so pairing a new `common_enums` with an old `common_utils` will not
build.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

No new unit tests: this is compile-time feature gating with no runtime behaviour
to assert. The meaningful assertions are that both sides of the gate compile and
that the resolved dependency graph is unchanged for hyperswitch — both covered
above.
