### PR TITLE
refactor(common_utils): make diesel an optional dependency

### DIFF
--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -8,7 +8,11 @@ readme = "README.md"
 license.workspace = true
 
 [features]
-default = []
+# Diesel ORM impls for the types defined here. Default-on so hyperswitch is
+# unaffected. Consumers that never touch a database (e.g. UCS, via injector)
+# opt out with `default-features = false` and then compile no diesel at all.
+default = ["diesel"]
+diesel = ["dep:diesel", "hyperswitch_masking/diesel"]
 keymanager = ["dep:router_env"]
 keymanager_mtls = ["reqwest/rustls-tls"]
 encryption_service = ["dep:router_env"]
@@ -31,7 +35,7 @@ base64 = "0.22.1"
 base64-serde = "0.8.0"
 blake3 = { version = "1.8.2", features = ["serde"] }
 bytes = "1.10.1"
-diesel = { version = "2.2.10", features = ["postgres"] }
+diesel = { version = "2.2.10", features = ["postgres"], optional = true }
 deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false }
 error-stack = "0.4.1"
 futures = { version = "0.3.31", optional = true }
@@ -60,7 +64,7 @@ serde_urlencoded = "0.7.1"
 signal-hook = { version = "0.3.18", optional = true }
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "1.0.69"
-time = { version = "0.3.41", features = ["serde", "serde-well-known", "std"] }
+time = { version = "0.3.41", features = ["macros", "serde", "serde-well-known", "std"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"], optional = true }
 url = { version = "2.5.4", features = ["serde"] }
 urlencoding = "2.1.3"
@@ -70,7 +74,7 @@ ammonia = "3.3"
 
 # First party crates
 common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
-hyperswitch_masking = { version = "0.0.1", features = ["diesel", "time"] }
+hyperswitch_masking = { version = "0.0.1", features = ["time"] }
 router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"], optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.uuid]

--- a/crates/common_utils/src/encryption.rs
+++ b/crates/common_utils/src/encryption.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "diesel")]
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql, Queryable},
@@ -9,6 +10,7 @@ use hyperswitch_masking::Secret;
 
 use crate::{crypto::Encryptable, pii::EncryptionStrategy};
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Binary, DB> for Encryption
 where
     DB: Backend,
@@ -19,6 +21,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Binary, DB> for Encryption
 where
     DB: Backend,
@@ -32,6 +35,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Binary, DB> for Encryption
 where
     DB: Backend,
@@ -43,8 +47,9 @@ where
     }
 }
 
-#[derive(Debug, AsExpression, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
-#[diesel(sql_type = sql_types::Binary)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Binary))]
 #[repr(transparent)]
 pub struct Encryption {
     inner: Secret<Vec<u8>, EncryptionStrategy>,

--- a/crates/common_utils/src/id_type.rs
+++ b/crates/common_utils/src/id_type.rs
@@ -25,6 +25,7 @@ mod webhook_endpoint;
 
 use std::{borrow::Cow, fmt::Debug};
 
+#[cfg(feature = "diesel")]
 use diesel::{
     backend::Backend,
     deserialize::FromSql,
@@ -128,8 +129,9 @@ impl AlphaNumericId {
 }
 
 /// A common type of id that can be used for reference ids with length constraint
-#[derive(Debug, Clone, Serialize, Hash, PartialEq, Eq, AsExpression)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(Debug, Clone, Serialize, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub(crate) struct LengthId<const MAX_LENGTH: u8, const MIN_LENGTH: u8>(AlphaNumericId);
 
 /// Error generated from violation of constraints for MerchantReferenceId
@@ -219,6 +221,7 @@ impl<'de, const MAX_LENGTH: u8, const MIN_LENGTH: u8> Deserialize<'de>
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB, const MAX_LENGTH: u8, const MIN_LENGTH: u8> ToSql<sql_types::Text, DB>
     for LengthId<MAX_LENGTH, MIN_LENGTH>
 where
@@ -230,6 +233,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB, const MAX_LENGTH: u8, const MIN_LENGTH: u8> FromSql<sql_types::Text, DB>
     for LengthId<MAX_LENGTH, MIN_LENGTH>
 where

--- a/crates/common_utils/src/id_type/global_id.rs
+++ b/crates/common_utils/src/id_type/global_id.rs
@@ -8,6 +8,7 @@ pub(super) mod refunds;
 #[cfg(feature = "v2")]
 pub(super) mod token;
 
+#[cfg(feature = "diesel")]
 use diesel::{backend::Backend, deserialize::FromSql, serialize::ToSql, sql_types};
 use error_stack::ResultExt;
 use thiserror::Error;
@@ -171,6 +172,7 @@ impl GlobalId {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for GlobalId
 where
     DB: Backend,
@@ -184,6 +186,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for GlobalId
 where
     DB: Backend,

--- a/crates/common_utils/src/id_type/global_id/customer.rs
+++ b/crates/common_utils/src/id_type/global_id/customer.rs
@@ -5,8 +5,9 @@ use crate::errors;
 /// The format will be `<cell_id>_<entity_prefix>_<time_ordered_id>`.
 ///
 /// Example: `0a_cus_uu1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p`
-#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, diesel::expression::AsExpression)]
-#[diesel(sql_type = diesel::sql_types::Text)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Text))]
 pub struct GlobalCustomerId(super::GlobalId);
 
 // Database related implementations so that this field can be used directly in the database tables
@@ -16,6 +17,7 @@ crate::impl_queryable_id_type!(GlobalCustomerId);
 // macro generates a strict `FromSql` that validates GlobalId format. During the V1/V2 coexistence
 // period, V1-created rows may store a V1-format CustomerId (e.g. `cus_xxx`).
 // We use `new_unchecked` to accept any string value.
+#[cfg(feature = "diesel")]
 impl<DB> diesel::serialize::ToSql<diesel::sql_types::Text, DB> for GlobalCustomerId
 where
     DB: diesel::backend::Backend,
@@ -29,6 +31,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Text, DB> for GlobalCustomerId
 where
     DB: diesel::backend::Backend,

--- a/crates/common_utils/src/id_type/global_id/payment_methods.rs
+++ b/crates/common_utils/src/id_type/global_id/payment_methods.rs
@@ -6,22 +6,15 @@ use crate::{
 };
 
 /// A global id that can be used to identify a payment method
-#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, diesel::expression::AsExpression)]
-#[diesel(sql_type = diesel::sql_types::Text)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Text))]
 pub struct GlobalPaymentMethodId(GlobalId);
 
 /// A global id that can be used to identify a payment method session
-#[derive(
-    Debug,
-    Clone,
-    Hash,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    diesel::expression::AsExpression,
-)]
-#[diesel(sql_type = diesel::sql_types::Text)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Text))]
 pub struct GlobalPaymentMethodSessionId(GlobalId);
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
@@ -120,6 +113,7 @@ impl<'de> serde::Deserialize<'de> for GlobalPaymentMethodId {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> diesel::Queryable<diesel::sql_types::Text, DB> for GlobalPaymentMethodId
 where
     DB: diesel::backend::Backend,
@@ -131,6 +125,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> diesel::serialize::ToSql<diesel::sql_types::Text, DB> for GlobalPaymentMethodId
 where
     DB: diesel::backend::Backend,
@@ -144,6 +139,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Text, DB> for GlobalPaymentMethodId
 where
     DB: diesel::backend::Backend,
@@ -155,6 +151,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> diesel::Queryable<diesel::sql_types::Text, DB> for GlobalPaymentMethodSessionId
 where
     DB: diesel::backend::Backend,
@@ -166,6 +163,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> diesel::serialize::ToSql<diesel::sql_types::Text, DB> for GlobalPaymentMethodSessionId
 where
     DB: diesel::backend::Backend,
@@ -179,6 +177,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Text, DB> for GlobalPaymentMethodSessionId
 where
     DB: diesel::backend::Backend,

--- a/crates/common_utils/src/id_type/global_id/refunds.rs
+++ b/crates/common_utils/src/id_type/global_id/refunds.rs
@@ -3,17 +3,9 @@ use error_stack::ResultExt;
 use crate::errors;
 
 /// A global id that can be used to identify a refund
-#[derive(
-    Debug,
-    Clone,
-    Hash,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    diesel::expression::AsExpression,
-)]
-#[diesel(sql_type = diesel::sql_types::Text)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Text))]
 pub struct GlobalRefundId(super::GlobalId);
 
 // Database related implementations so that this field can be used directly in the database tables
@@ -46,6 +38,7 @@ impl TryFrom<std::borrow::Cow<'static, str>> for GlobalRefundId {
 }
 
 // TODO: refactor the macro to include this id use case as well
+#[cfg(feature = "diesel")]
 impl<DB> diesel::serialize::ToSql<diesel::sql_types::Text, DB> for GlobalRefundId
 where
     DB: diesel::backend::Backend,
@@ -59,6 +52,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Text, DB> for GlobalRefundId
 where
     DB: diesel::backend::Backend,

--- a/crates/common_utils/src/link_utils.rs
+++ b/crates/common_utils/src/link_utils.rs
@@ -3,6 +3,7 @@
 use std::{collections::HashSet, primitive::i64};
 
 use common_enums::{enums, UIWidgetFormLayout};
+#[cfg(feature = "diesel")]
 use diesel::{
     backend::Backend,
     deserialize,
@@ -11,6 +12,7 @@ use diesel::{
     sql_types::Jsonb,
     AsExpression, FromSqlRow,
 };
+#[cfg(feature = "diesel")]
 use error_stack::{report, ResultExt};
 use hyperswitch_masking::Secret;
 use regex::Regex;
@@ -19,13 +21,14 @@ use router_env::logger;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::{consts, errors::ParsingError, id_type, types::MinorUnit};
+#[cfg(feature = "diesel")]
+use crate::errors::ParsingError;
+use crate::{consts, id_type, types::MinorUnit};
 
-#[derive(
-    Serialize, serde::Deserialize, Debug, Clone, Eq, PartialEq, FromSqlRow, AsExpression, ToSchema,
-)]
+#[derive(Serialize, serde::Deserialize, Debug, Clone, Eq, PartialEq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
-#[diesel(sql_type = Jsonb)]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 /// Link status enum
 pub enum GenericLinkStatus {
     /// Status variants for payment method collect link
@@ -40,13 +43,13 @@ impl Default for GenericLinkStatus {
     }
 }
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(GenericLinkStatus);
 
-#[derive(
-    Serialize, serde::Deserialize, Debug, Clone, Eq, PartialEq, FromSqlRow, AsExpression, ToSchema,
-)]
+#[derive(Serialize, serde::Deserialize, Debug, Clone, Eq, PartialEq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
 #[serde(rename_all = "snake_case")]
-#[diesel(sql_type = Jsonb)]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 /// Status variants for payment method collect links
 pub enum PaymentMethodCollectStatus {
     /// Link was initialized
@@ -57,6 +60,7 @@ pub enum PaymentMethodCollectStatus {
     Submitted,
 }
 
+#[cfg(feature = "diesel")]
 impl<DB: Backend> FromSql<Jsonb, DB> for PaymentMethodCollectStatus
 where
     serde_json::Value: FromSql<Jsonb, DB>,
@@ -74,6 +78,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl ToSql<Jsonb, diesel::pg::Pg> for PaymentMethodCollectStatus
 where
     serde_json::Value: ToSql<Jsonb, diesel::pg::Pg>,
@@ -91,11 +96,10 @@ where
     }
 }
 
-#[derive(
-    Serialize, serde::Deserialize, Debug, Clone, Eq, PartialEq, FromSqlRow, AsExpression, ToSchema,
-)]
+#[derive(Serialize, serde::Deserialize, Debug, Clone, Eq, PartialEq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
 #[serde(rename_all = "snake_case")]
-#[diesel(sql_type = Jsonb)]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 /// Status variants for payout links
 pub enum PayoutLinkStatus {
     /// Link was initialized
@@ -106,6 +110,7 @@ pub enum PayoutLinkStatus {
     Submitted,
 }
 
+#[cfg(feature = "diesel")]
 impl<DB: Backend> FromSql<Jsonb, DB> for PayoutLinkStatus
 where
     serde_json::Value: FromSql<Jsonb, DB>,
@@ -123,6 +128,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl ToSql<Jsonb, diesel::pg::Pg> for PayoutLinkStatus
 where
     serde_json::Value: ToSql<Jsonb, diesel::pg::Pg>,
@@ -140,8 +146,9 @@ where
     }
 }
 
-#[derive(Serialize, serde::Deserialize, Debug, Clone, FromSqlRow, AsExpression, ToSchema)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, serde::Deserialize, Debug, Clone, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 /// Payout link object
 pub struct PayoutLinkData {
     /// Identifier for the payout link
@@ -173,6 +180,7 @@ pub struct PayoutLinkData {
     pub test_mode: Option<bool>,
 }
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(PayoutLinkData);
 
 /// Object for GenericLinkUiConfig

--- a/crates/common_utils/src/macros.rs
+++ b/crates/common_utils/src/macros.rs
@@ -103,6 +103,7 @@ macro_rules! collect_missing_value_keys {
 
 /// Implements the `ToSql` and `FromSql` traits on a type to allow it to be serialized/deserialized
 /// to/from JSON data in the database.
+#[cfg(feature = "diesel")]
 #[macro_export]
 macro_rules! impl_to_sql_from_sql_json {
     ($type:ty, $diesel_type:ty) => {
@@ -150,16 +151,10 @@ mod id_type {
         ($type:ident, $doc:literal, $diesel_type:ty, $max_length:expr, $min_length:expr) => {
             #[doc = $doc]
             #[derive(
-                Clone,
-                Hash,
-                PartialEq,
-                Eq,
-                serde::Serialize,
-                serde::Deserialize,
-                diesel::expression::AsExpression,
-                utoipa::ToSchema,
+                Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize, utoipa::ToSchema,
             )]
-            #[diesel(sql_type = $diesel_type)]
+            #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+            #[cfg_attr(feature = "diesel", diesel(sql_type = $diesel_type))]
             #[schema(value_type = String)]
             pub struct $type($crate::id_type::LengthId<$max_length, $min_length>);
         };
@@ -180,17 +175,9 @@ mod id_type {
     macro_rules! global_id_type {
         ($type:ident, $doc:literal) => {
             #[doc = $doc]
-            #[derive(
-                Debug,
-                Clone,
-                Hash,
-                PartialEq,
-                Eq,
-                serde::Serialize,
-                serde::Deserialize,
-                diesel::expression::AsExpression,
-            )]
-            #[diesel(sql_type = diesel::sql_types::Text)]
+            #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+            #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Text))]
             pub struct $type($crate::id_type::global_id::GlobalId);
         };
     }
@@ -286,6 +273,7 @@ mod id_type {
     #[macro_export]
     macro_rules! impl_to_sql_from_sql_id_type {
         ($type:ty, $diesel_type:ty, $max_length:expr, $min_length:expr) => {
+            #[cfg(feature = "diesel")]
             impl<DB> diesel::serialize::ToSql<$diesel_type, DB> for $type
             where
                 DB: diesel::backend::Backend,
@@ -300,6 +288,7 @@ mod id_type {
                 }
             }
 
+            #[cfg(feature = "diesel")]
             impl<DB> diesel::deserialize::FromSql<$diesel_type, DB> for $type
             where
                 DB: diesel::backend::Backend,
@@ -326,6 +315,7 @@ mod id_type {
     #[macro_export]
     macro_rules! impl_to_sql_from_sql_global_id_type {
         ($type:ty, $diesel_type:ty) => {
+            #[cfg(feature = "diesel")]
             impl<DB> diesel::serialize::ToSql<$diesel_type, DB> for $type
             where
                 DB: diesel::backend::Backend,
@@ -339,6 +329,7 @@ mod id_type {
                 }
             }
 
+            #[cfg(feature = "diesel")]
             impl<DB> diesel::deserialize::FromSql<$diesel_type, DB> for $type
             where
                 DB: diesel::backend::Backend,
@@ -359,6 +350,7 @@ mod id_type {
     #[macro_export]
     macro_rules! impl_queryable_id_type {
         ($type:ty, $diesel_type:ty) => {
+            #[cfg(feature = "diesel")]
             impl<DB> diesel::Queryable<$diesel_type, DB> for $type
             where
                 DB: diesel::backend::Backend,

--- a/crates/common_utils/src/payout_method_utils.rs
+++ b/crates/common_utils/src/payout_method_utils.rs
@@ -1,5 +1,6 @@
 //! This module has common utilities for payout method data in HyperSwitch
 
+#[cfg(feature = "diesel")]
 use diesel::{sql_types::Jsonb, AsExpression, FromSqlRow};
 use hyperswitch_masking::Secret;
 use serde::{Deserialize, Serialize};
@@ -11,10 +12,9 @@ use crate::new_type::{
 };
 
 /// Masked payout method details for storing in db
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub enum AdditionalPayoutMethodData {
     /// Additional data for card payout method
     Card(Box<CardAdditionalData>),
@@ -28,13 +28,13 @@ pub enum AdditionalPayoutMethodData {
     Passthrough(Box<PassthroughAdditionalData>),
 }
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(AdditionalPayoutMethodData);
 
 /// Masked payout method details for card payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Serialize, Deserialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct CardAdditionalData {
     /// Issuer of the card
     pub card_issuer: Option<String>,
@@ -75,10 +75,9 @@ pub struct CardAdditionalData {
 }
 
 /// Masked payout method details for bank payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(untagged)]
 pub enum BankAdditionalData {
     /// Additional data for ach bank transfer payout method
@@ -95,13 +94,13 @@ pub enum BankAdditionalData {
     OpenBanking(Box<OpenBankingAdditionalData>),
 }
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(BankAdditionalData);
 
 /// Masked payout method details for ach bank transfer payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct AchBankTransferAdditionalData {
     /// Partially masked account number for ach bank debit payment
     #[schema(value_type = String, example = "0001****3456")]
@@ -129,10 +128,9 @@ pub struct AchBankTransferAdditionalData {
 }
 
 /// Masked payout method details for bacs bank transfer payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct BacsBankTransferAdditionalData {
     /// Partially masked sort code for Bacs payment method
     #[schema(value_type = String, example = "108800")]
@@ -160,10 +158,9 @@ pub struct BacsBankTransferAdditionalData {
 }
 
 /// Masked payout method details for sepa bank transfer payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct SepaBankTransferAdditionalData {
     /// Partially masked international bank account number (iban) for SEPA
     #[schema(value_type = String, example = "DE8937******013000")]
@@ -191,10 +188,9 @@ pub struct SepaBankTransferAdditionalData {
 }
 
 /// Masked payout method details for pix bank transfer payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct PixBankTransferAdditionalData {
     /// Partially masked unique key for pix transfer
     #[schema(value_type = String, example = "a1f4102e ****** 6fa48899c1d1")]
@@ -238,10 +234,9 @@ pub struct PixBankTransferAdditionalData {
 }
 
 /// Masked payout method details for Trustly bank transfer payout method
-#[derive(
-    Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct TrustlyBankTransferAdditionalData {
     /// International Bank Account Number (iban) - used in many countries for identifying a bank along with it's customer.
     #[schema(value_type = String, example = "token_12345")]
@@ -258,10 +253,9 @@ pub struct TrustlyBankTransferAdditionalData {
 }
 
 /// Masked payout method details for wallet payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(untagged)]
 pub enum WalletAdditionalData {
     /// Additional data for Apple pay decrypt wallet payout method
@@ -275,10 +269,9 @@ pub enum WalletAdditionalData {
 }
 
 /// Masked payout method details for paypal wallet payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(tag = "field_type", rename_all = "snake_case")]
 pub enum PaypalAdditionalData {
     // Exactly one of the three identifiers will always be present
@@ -303,10 +296,9 @@ pub enum PaypalAdditionalData {
 }
 
 /// Masked payout method details for venmo wallet payout method
-#[derive(
-    Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct VenmoAdditionalData {
     /// mobile number linked to venmo account
     #[schema(value_type = Option<String>, example = "******* 3349")]
@@ -314,10 +306,9 @@ pub struct VenmoAdditionalData {
 }
 
 /// Masked payout method details for Apple pay decrypt wallet payout method
-#[derive(
-    Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct ApplePayDecryptAdditionalData {
     /// Card expiry month
     #[schema(value_type = String, example = "01")]
@@ -333,10 +324,9 @@ pub struct ApplePayDecryptAdditionalData {
 }
 
 /// Masked payout method details for Google pay decrypt wallet payout method
-#[derive(
-    Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct GooglePayDecryptAdditionalData {
     /// Card expiry month
     #[schema(value_type = String, example = "01")]
@@ -352,10 +342,9 @@ pub struct GooglePayDecryptAdditionalData {
 }
 
 /// Masked payout method details for wallet payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(untagged)]
 pub enum BankRedirectAdditionalData {
     /// Additional data for OpenBankingUK bank redirect payout method
@@ -365,10 +354,9 @@ pub enum BankRedirectAdditionalData {
 }
 
 /// Masked payout method details for interac bank redirect payout method
-#[derive(
-    Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct InteracAdditionalData {
     /// Email linked with interac account
     #[schema(value_type = Option<String>, example = "john.doe@example.com")]
@@ -376,10 +364,9 @@ pub struct InteracAdditionalData {
 }
 
 /// Masked payout method details for OpenBankingUK bank redirect payout method
-#[derive(
-    Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct OpenBankingUkAdditionalData {
     /// Account holder name
     #[schema(value_type = String, example = "John Doe")]
@@ -390,10 +377,9 @@ pub struct OpenBankingUkAdditionalData {
 }
 
 /// Masked payout method details for OpenBanking bank transfer payout method
-#[derive(
-    Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Default, Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct OpenBankingAdditionalData {
     /// Account holder name
     #[schema(value_type = String, example = "John Doe")]
@@ -404,10 +390,9 @@ pub struct OpenBankingAdditionalData {
 }
 
 /// additional payout method details for passthrough payout method
-#[derive(
-    Eq, PartialEq, Clone, Debug, Deserialize, Serialize, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct PassthroughAdditionalData {
     /// Psp_token of the passthrough flow
     #[schema(value_type = String, example = "token_12345")]

--- a/crates/common_utils/src/pii.rs
+++ b/crates/common_utils/src/pii.rs
@@ -2,6 +2,7 @@
 
 use std::{convert::AsRef, fmt, ops, str::FromStr};
 
+#[cfg(feature = "diesel")]
 use diesel::{
     backend::Backend,
     deserialize,
@@ -86,6 +87,7 @@ impl ops::DerefMut for PhoneNumber {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for PhoneNumber
 where
     DB: Backend,
@@ -98,6 +100,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for PhoneNumber
 where
     DB: Backend,
@@ -109,6 +112,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for PhoneNumber
 where
     DB: Backend,
@@ -235,10 +239,9 @@ where
     }
 }
 /// Email address
-#[derive(
-    serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Default, AsExpression,
-)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 #[serde(try_from = "String")]
 pub struct Email(Secret<String, EmailStrategy>);
 
@@ -276,6 +279,7 @@ impl ops::DerefMut for Email {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for Email
 where
     DB: Backend,
@@ -288,6 +292,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for Email
 where
     DB: Backend,
@@ -299,6 +304,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for Email
 where
     DB: Backend,

--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -23,6 +23,7 @@ use std::{
 };
 
 use common_enums::enums;
+#[cfg(feature = "diesel")]
 use diesel::{
     backend::Backend,
     deserialize,
@@ -200,8 +201,9 @@ pub enum Surcharge {
 }
 
 /// This struct lets us represent a semantic version type
-#[derive(Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression, Ord, PartialOrd)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[derive(Serialize, serde::Deserialize)]
 pub struct SemanticVersion(#[serde(with = "Version")] Version);
 
@@ -237,6 +239,7 @@ impl FromStr for SemanticVersion {
     }
 }
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(SemanticVersion);
 
 /// Amount convertor trait for connector
@@ -375,7 +378,6 @@ impl AmountConvertor for MinorUnitForConnector {
     Default,
     Debug,
     serde::Deserialize,
-    AsExpression,
     serde::Serialize,
     Clone,
     Copy,
@@ -386,7 +388,8 @@ impl AmountConvertor for MinorUnitForConnector {
     PartialOrd,
     Ord,
 )]
-#[diesel(sql_type = sql_types::BigInt)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::BigInt))]
 pub struct MinorUnit(i64);
 
 impl MinorUnit {
@@ -467,6 +470,7 @@ impl Display for MinorUnit {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::BigInt, DB> for MinorUnit
 where
     DB: Backend,
@@ -478,6 +482,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::BigInt, DB> for MinorUnit
 where
     DB: Backend,
@@ -488,6 +493,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::BigInt, DB> for MinorUnit
 where
     DB: Backend,
@@ -541,7 +547,6 @@ impl Sum for MinorUnit {
     Default,
     Debug,
     serde::Deserialize,
-    AsExpression,
     serde::Serialize,
     Clone,
     PartialEq,
@@ -550,7 +555,8 @@ impl Sum for MinorUnit {
     ToSchema,
     PartialOrd,
 )]
-#[diesel(sql_type = sql_types::Text)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub struct StringMinorUnit(String);
 
 impl StringMinorUnit {
@@ -580,6 +586,7 @@ impl Display for StringMinorUnit {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for StringMinorUnit
 where
     DB: Backend,
@@ -591,6 +598,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for StringMinorUnit
 where
     DB: Backend,
@@ -601,6 +609,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for StringMinorUnit
 where
     DB: Backend,
@@ -704,18 +713,10 @@ impl StringMajorUnit {
 }
 
 #[derive(
-    Debug,
-    serde::Deserialize,
-    AsExpression,
-    serde::Serialize,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    ToSchema,
-    PartialOrd,
+    Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, Eq, Hash, ToSchema, PartialOrd,
 )]
-#[diesel(sql_type = sql_types::Text)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 /// This domain type can be used for any url
 pub struct Url(url::Url);
 
@@ -747,6 +748,7 @@ impl Url {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for Url
 where
     DB: Backend,
@@ -758,6 +760,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for Url
 where
     DB: Backend,
@@ -891,10 +894,9 @@ mod amount_conversion_tests {
 }
 
 // Charges structs
-#[derive(
-    Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 /// Charge specific fields for controlling the revert of funds from either platform or connected account. Check sub-fields for more details.
 pub struct ChargeRefunds {
     /// Identifier for charge created for the payment
@@ -909,11 +911,13 @@ pub struct ChargeRefunds {
     pub revert_transfer: Option<bool>,
 }
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(ChargeRefunds);
 
 /// A common type of domain type that can be used for fields that contain a string with restriction of length
-#[derive(Debug, Clone, Serialize, Hash, PartialEq, Eq, AsExpression)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(Debug, Clone, Serialize, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub(crate) struct LengthString<const MAX_LENGTH: u16, const MIN_LENGTH: u16>(String);
 
 /// Error generated from violation of constraints for MerchantReferenceId
@@ -963,6 +967,7 @@ impl<'de, const MAX_LENGTH: u16, const MIN_LENGTH: u16> Deserialize<'de>
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB, const MAX_LENGTH: u16, const MIN_LENGTH: u16> FromSql<sql_types::Text, DB>
     for LengthString<MAX_LENGTH, MIN_LENGTH>
 where
@@ -975,6 +980,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB, const MAX_LENGTH: u16, const MIN_LENGTH: u16> ToSql<sql_types::Text, DB>
     for LengthString<MAX_LENGTH, MIN_LENGTH>
 where
@@ -986,6 +992,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB, const MAX_LENGTH: u16, const MIN_LENGTH: u16> Queryable<sql_types::Text, DB>
     for LengthString<MAX_LENGTH, MIN_LENGTH>
 where
@@ -999,8 +1006,9 @@ where
 }
 
 /// Domain type for description
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, AsExpression)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub struct Description(LengthString<MAX_DESCRIPTION_LENGTH, 1>);
 
 impl Description {
@@ -1017,10 +1025,12 @@ impl Description {
 }
 
 /// Domain type for Statement Descriptor
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, AsExpression)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub struct StatementDescriptor(LengthString<MAX_STATEMENT_DESCRIPTOR_LENGTH, 1>);
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for Description
 where
     DB: Backend,
@@ -1033,6 +1043,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for Description
 where
     DB: Backend,
@@ -1044,6 +1055,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for Description
 where
     DB: Backend,
@@ -1054,6 +1066,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for StatementDescriptor
 where
     DB: Backend,
@@ -1066,6 +1079,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for StatementDescriptor
 where
     DB: Backend,
@@ -1077,6 +1091,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for StatementDescriptor
 where
     DB: Backend,
@@ -1088,10 +1103,9 @@ where
 }
 
 /// Domain type for unified code
-#[derive(
-    Debug, Clone, PartialEq, Eq, Queryable, serde::Deserialize, serde::Serialize, AsExpression,
-)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(Queryable, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub struct UnifiedCode(pub String);
 
 impl TryFrom<String> for UnifiedCode {
@@ -1107,6 +1121,7 @@ impl TryFrom<String> for UnifiedCode {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for UnifiedCode
 where
     DB: Backend,
@@ -1118,6 +1133,7 @@ where
         Ok(row)
     }
 }
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for UnifiedCode
 where
     DB: Backend,
@@ -1129,6 +1145,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for UnifiedCode
 where
     DB: Backend,
@@ -1140,10 +1157,9 @@ where
 }
 
 /// Domain type for unified messages
-#[derive(
-    Debug, Clone, PartialEq, Eq, Queryable, serde::Deserialize, serde::Serialize, AsExpression,
-)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(Queryable, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub struct UnifiedMessage(pub String);
 
 impl TryFrom<String> for UnifiedMessage {
@@ -1159,6 +1175,7 @@ impl TryFrom<String> for UnifiedMessage {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for UnifiedMessage
 where
     DB: Backend,
@@ -1170,6 +1187,7 @@ where
         Ok(row)
     }
 }
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for UnifiedMessage
 where
     DB: Backend,
@@ -1181,6 +1199,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for UnifiedMessage
 where
     DB: Backend,
@@ -1194,17 +1213,9 @@ where
 #[cfg(feature = "v2")]
 /// Browser information to be used for 3DS 2.0
 // If any of the field is PII, then we can make them as secret
-#[derive(
-    ToSchema,
-    Debug,
-    Clone,
-    serde::Deserialize,
-    serde::Serialize,
-    Eq,
-    PartialEq,
-    diesel::AsExpression,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(ToSchema, Debug, Clone, serde::Deserialize, serde::Serialize, Eq, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(diesel::AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct BrowserInformation {
     /// Color depth supported by the browser
     pub color_depth: Option<u8>,
@@ -1257,6 +1268,7 @@ pub struct BrowserInformation {
 }
 
 #[cfg(feature = "v2")]
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(BrowserInformation);
 
 /// A single co-badge / secondary network entry enriched from the Pagos BIN data.
@@ -1294,20 +1306,12 @@ pub struct SecondaryNetwork {
 /// Co-badged card networks for a card BIN, stored as a JSONB array of [`SecondaryNetwork`] objects
 /// in the `co_badged_card_networks` column of `cards_info`. The newtype is serde-transparent, so it
 /// serializes/deserializes as a plain JSON array.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    FromSqlRow,
-    AsExpression,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct CoBadgedCardNetworkMetadata(pub Vec<SecondaryNetwork>);
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(CoBadgedCardNetworkMetadata);
 
 /// A single interchange cap entry within the [`CardCost`] array. All values are kept as strings.
@@ -1340,20 +1344,12 @@ pub struct InterchangeCap {
 }
 
 /// The `cost` column of `cards_info` — a JSON array of interchange caps.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    FromSqlRow,
-    AsExpression,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct CardCost(pub Vec<InterchangeCap>);
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(CardCost);
 
 /// A single customer-authentication requirement within the [`CardAuthentication`] array.
@@ -1367,20 +1363,12 @@ pub struct AuthenticationInfo {
 }
 
 /// The `authentication` column of `cards_info` — a JSON array of required authentication programs.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    FromSqlRow,
-    AsExpression,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct CardAuthentication(pub Vec<AuthenticationInfo>);
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(CardAuthentication);
 
 /// Domain type for connector_transaction_id
@@ -1389,8 +1377,9 @@ crate::impl_to_sql_from_sql_json!(CardAuthentication);
 /// the hash value of such identifiers will be stored as connector_transaction_id.
 /// The actual connector's identifier will be stored in a separate column -
 /// processor_transaction_data or something with a similar name.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, AsExpression)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub enum ConnectorTransactionId {
     /// Actual transaction identifier
     TxnId(String),
@@ -1461,6 +1450,7 @@ impl From<String> for ConnectorTransactionId {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for ConnectorTransactionId
 where
     DB: Backend,
@@ -1473,6 +1463,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for ConnectorTransactionId
 where
     DB: Backend,
@@ -1484,6 +1475,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for ConnectorTransactionId
 where
     DB: Backend,
@@ -1517,8 +1509,9 @@ pub trait ConnectorTransactionIdTrait {
 }
 
 /// Domain type for PublishableKey
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, AsExpression)]
-#[diesel(sql_type = sql_types::Text)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = sql_types::Text))]
 pub struct PublishableKey(LengthString<PUBLISHABLE_KEY_LENGTH, PUBLISHABLE_KEY_LENGTH>);
 
 impl PublishableKey {
@@ -1534,6 +1527,7 @@ impl PublishableKey {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<sql_types::Text, DB> for PublishableKey
 where
     DB: Backend,
@@ -1546,6 +1540,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> FromSql<sql_types::Text, DB> for PublishableKey
 where
     DB: Backend,
@@ -1557,6 +1552,7 @@ where
     }
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> ToSql<sql_types::Text, DB> for PublishableKey
 where
     DB: Backend,

--- a/crates/common_utils/src/types/primitive_wrappers.rs
+++ b/crates/common_utils/src/types/primitive_wrappers.rs
@@ -2,16 +2,16 @@ pub(crate) mod bool_wrappers {
     use serde::{Deserialize, Serialize};
 
     /// Bool that represents if Extended Authorization is Applied or not
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, diesel::expression::AsExpression,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct ExtendedAuthorizationAppliedBool(bool);
     impl From<bool> for ExtendedAuthorizationAppliedBool {
         fn from(value: bool) -> Self {
             Self(value)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for ExtendedAuthorizationAppliedBool
     where
         DB: diesel::backend::Backend,
@@ -24,6 +24,7 @@ pub(crate) mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB>
         for ExtendedAuthorizationAppliedBool
     where
@@ -36,10 +37,9 @@ pub(crate) mod bool_wrappers {
     }
 
     /// Bool that represents if Extended Authorization is Requested or not
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, diesel::expression::AsExpression,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct RequestExtendedAuthorizationBool(bool);
     impl From<bool> for RequestExtendedAuthorizationBool {
         fn from(value: bool) -> Self {
@@ -52,6 +52,7 @@ pub(crate) mod bool_wrappers {
             self.0
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for RequestExtendedAuthorizationBool
     where
         DB: diesel::backend::Backend,
@@ -64,6 +65,7 @@ pub(crate) mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB>
         for RequestExtendedAuthorizationBool
     where
@@ -76,11 +78,11 @@ pub(crate) mod bool_wrappers {
     }
 
     /// Bool that represents if Extended Authorization is always Requested or not
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, diesel::expression::AsExpression, Serialize, Deserialize,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct AlwaysRequestExtendedAuthorization(bool);
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB>
         for AlwaysRequestExtendedAuthorization
     where
@@ -94,6 +96,7 @@ pub(crate) mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB>
         for AlwaysRequestExtendedAuthorization
     where

--- a/crates/common_utils/src/types/user/core.rs
+++ b/crates/common_utils/src/types/user/core.rs
@@ -1,10 +1,12 @@
+#[cfg(feature = "diesel")]
 use diesel::{deserialize::FromSqlRow, expression::AsExpression};
 
 use crate::id_type;
 
 /// Struct for lineageContext
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, AsExpression, FromSqlRow)]
-#[diesel(sql_type = diesel::sql_types::Jsonb)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Jsonb))]
 pub struct LineageContext {
     /// user_id: String
     pub user_id: String,
@@ -25,4 +27,5 @@ pub struct LineageContext {
     pub tenant_id: id_type::TenantId,
 }
 
+#[cfg(feature = "diesel")]
 crate::impl_to_sql_from_sql_json!(LineageContext);

--- a/crates/injector/Cargo.toml
+++ b/crates/injector/Cargo.toml
@@ -13,7 +13,11 @@ serde = []
 tracing-actix-web = []
 
 [dependencies]
-common_utils = { version = "0.1.0", path = "../common_utils" }
+# injector needs common_utils for HTTP/ID/masking helpers, not for database
+# access (it has zero diesel references). Declining the default features keeps
+# diesel out of downstream consumers such as UCS; within hyperswitch, other
+# crates request the defaults and feature unification restores them.
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
 hyperswitch_masking = "0.0.1"
 router_env = { version = "0.1.0", path = "../router_env" }
 

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -3300,7 +3300,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3336,7 +3339,10 @@ Cypress.Commands.add(
                 );
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3402,7 +3408,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3427,7 +3436,10 @@ Cypress.Commands.add(
                 globalState.set("nextActionType", "redirect_to_url");
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4105,7 +4117,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4119,7 +4134,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4166,7 +4184,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4180,7 +4201,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4309,7 +4333,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4366,7 +4393,10 @@ Cypress.Commands.add(
               );
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4443,7 +4473,10 @@ Cypress.Commands.add(
         if (response.body.capture_method !== undefined) {
           expect(response.body.payment_id).to.equal(paymentId);
           for (const key in resData.body) {
-            if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+            if (
+              key === "payment_method_data" &&
+              globalState.get("connectorId") === "checkout"
+            ) {
               expect(response.body[key], [key]).to.not.be.empty;
               expect(
                 response.body[key]?.card?.auth_code,
@@ -5090,7 +5123,10 @@ Cypress.Commands.add(
               // Response body key comparison runs for all three_ds paths, including succeeded status
               // — the redirect URL is extracted above when status !== succeeded, but all response keys are verified here
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -5171,7 +5207,10 @@ Cypress.Commands.add(
               // Response body key comparison runs for all three_ds paths, including succeeded status
               // — the redirect URL is extracted above when status !== succeeded, but all response keys are verified here
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

> **Stacked on #13790** — please review that one first. This PR's base is
> `refactor/common-enums-optional-diesel`, so the diff shown here is only the
> `common_utils` change.

## Description

Follow-up to #13790. `common_utils` fuses domain types (ID types, PII wrappers,
primitive wrappers) with Postgres persistence impls, so every consumer of those
types compiles diesel even when it never issues a query.

This gates the diesel impls behind a **default-on** `diesel` feature, exactly as
#13790 did for `common_enums`.

Most of the surface is generated rather than hand-written, which keeps the diff
small relative to the number of affected items:

- `id_type!`, `global_id_type!`, `impl_queryable_id_type!` and the two id-type
  `ToSql`/`FromSql` emitters produce the impls — gating those **definitions**
  covers roughly **215 call sites** automatically.
- `impl_to_sql_from_sql_json!` is gated at the **definition**, deliberately not
  inside its expansion: `cfg` inside a macro body resolves in the *calling*
  crate, and this macro has ~70 external callers in `common_types` /
  `diesel_models`. Those crates always have the feature on, so they are
  unaffected.

`injector` declines the default features — that is the opt-out path for
downstream consumers. Within hyperswitch, other crates request the defaults, so
feature unification restores diesel and **nothing changes here**.

### Two latent under-declarations fixed

`common_utils` used two features it never declared, relying on unification to
supply them. Gating diesel exposed both:

- `diesel/postgres` — uses `diesel::pg::Pg` in 14 places, previously supplied by
  `common_enums`.
- `time/macros` — uses `time::macros::format_description`, previously supplied
  transitively via diesel's `time` feature.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

Compile-time only. No runtime behaviour, API surface, schema or config changes.

## Motivation and Context

The Unified Connector Service (`hyperswitch-prism`) contains no diesel code —
no `table!` blocks, no queries, no diesel entry in any manifest. After #13790 it
still compiled diesel, because `common_utils` pulled it in unconditionally.

**With this change UCS compiles no diesel at all, and no longer requires `libpq`
to build** (`diesel/postgres` pulls `pq-sys`, which links the Postgres C client).

**On build time, be precise: this is not a speed change.** #13790 delivered the
speedup (234s → 138s) because diesel *was* on UCS's critical path. It no longer
is — the remaining 16s ran fully in parallel behind the `openssl-sys` build
script. Measured before and after this PR: **137.7s → 138.9s**, i.e. unchanged
within noise. The benefit here is dropping a system dependency and finishing the
separation of domain types from persistence code, not wall clock.

## How did you test it?

### hyperswitch — 15/15 green

Run against a checksum-frozen snapshot of the branch, on current `main`:

| check | result |
| --- | --- |
| `cargo +nightly fmt --all --check` | 0 |
| unit-graph diesel-tier invariant | PASS |
| `just clippy` / `just clippy fred` / `just clippy_v2` | 0 / 0 / 0 |
| `cargo check --workspace` | 0 |
| `cargo check --features release` | 0 |
| `cargo build -p router --bin router` | 0 |
| full v2 build (`release,v2,redis-rs`) | 0 |
| `cargo run -p openapi --features v1` / `v2` | 0 / 0 |
| `cargo hack --each-feature -p common_utils` | 0 |
| `cargo hack --each-feature -p common_enums` | 0 |
| `cargo build -p drainer --features "redis-rs,v1"` | 0 |
| `euclid_wasm` → `wasm32-unknown-unknown` | 0 |

`cargo hack --each-feature -p common_utils` is the important one: it compiles the
crate in every feature combination **including with diesel entirely absent**.

The unit-graph check asserts both `diesel` lib units and the shared
`diesel_derives` unit still carry `128-column-tables` — hyperswitch's resolution
is unchanged.

### UCS

Tested by pointing `hyperswitch-prism` at this branch with cargo `[patch]`
overrides for `common_enums`, `common_utils` and `injector`, so prism's own tree
was never modified:

```
$ cargo tree -i diesel -p grpc-server
error: package ID specification `diesel` did not match any packages

$ cargo tree -p grpc-server | grep -c pq-sys
0
```

Cold build into a fresh target dir: **138.9s, 907 units, 0 diesel units.**

### Rollout

UCS benefits once this and #13790 are merged and tagged, and prism bumps its pin
from `2026.06.18.0`. All three manifest changes must ship in the same tag.
