### PR TITLE
feat(revenue-recovery) - add adaptive retry scheduling for revenue recovery

### DIFF
--- a/crates/diesel_models/src/lib.rs
+++ b/crates/diesel_models/src/lib.rs
@@ -7,6 +7,8 @@ pub mod capture;
 pub mod card_issuer;
 pub mod cards_info;
 pub mod configs;
+#[cfg(feature = "v2")]
+pub mod revenue_recovery_retry_stats;
 
 pub mod authentication;
 pub mod authorization;

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -1064,6 +1064,7 @@ pub struct PaymentAttemptUpdateInternal {
     pub network_error_message: Option<String>,
     pub connector_request_reference_id: Option<String>,
     pub amount_captured: Option<MinorUnit>,
+    pub error_details: Option<ErrorDetails>,
 }
 #[cfg(feature = "v1")]
 #[derive(Clone, Debug, AsChangeset, router_derive::DebugAsDisplay)]
@@ -1260,6 +1261,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                     cancellation_reason: None,
                     amount_captured,
                     payment_method_data: None,
+                    error_details: None,
                 }
             }
             PaymentAttemptUpdate::ErrorUpdate {
@@ -1312,6 +1314,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                     cancellation_reason: None,
                     amount_captured,
                     payment_method_data: None,
+                    error_details: None,
                 }
             }
             PaymentAttemptUpdate::UnresolvedResponseUpdate {
@@ -1360,6 +1363,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                     cancellation_reason: None,
                     amount_captured: None,
                     payment_method_data: None,
+                    error_details: None,
                 }
             }
             PaymentAttemptUpdate::PreprocessingUpdate {
@@ -1406,6 +1410,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                     cancellation_reason: None,
                     amount_captured: None,
                     payment_method_data: None,
+                    error_details: None,
                 }
             }
             PaymentAttemptUpdate::ConnectorResponse {
@@ -1448,6 +1453,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                     cancellation_reason: None,
                     amount_captured: None,
                     payment_method_data: None,
+                    error_details: None,
                 }
             }
             PaymentAttemptUpdate::ManualUpdate {
@@ -1496,6 +1502,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                     cancellation_reason: None,
                     amount_captured: None,
                     payment_method_data: None,
+                    error_details: None,
                 }
             }
         }

--- a/crates/diesel_models/src/query.rs
+++ b/crates/diesel_models/src/query.rs
@@ -6,6 +6,8 @@ mod capture;
 pub mod card_issuer;
 pub mod cards_info;
 pub mod configs;
+#[cfg(feature = "v2")]
+pub mod revenue_recovery_retry_stats;
 
 pub mod authentication;
 pub mod authorization;

--- a/crates/diesel_models/src/query/revenue_recovery_retry_stats.rs
+++ b/crates/diesel_models/src/query/revenue_recovery_retry_stats.rs
@@ -1,0 +1,58 @@
+use async_bb8_diesel::AsyncRunQueryDsl;
+use diesel::{associations::HasTable, ExpressionMethods, QueryDsl, TextExpressionMethods};
+use error_stack::ResultExt;
+
+use crate::{
+    errors,
+    revenue_recovery_retry_stats::{RevenueRecoveryRetryStats, RevenueRecoveryRetryStatsNew},
+    schema_v2::revenue_recovery_retry_stats::dsl,
+    PgPooledConn, StorageResult,
+};
+
+impl RevenueRecoveryRetryStatsNew {
+    pub async fn insert(self, conn: &PgPooledConn) -> StorageResult<RevenueRecoveryRetryStats> {
+        diesel::insert_into(<RevenueRecoveryRetryStats as HasTable>::table())
+            .values(self)
+            .get_result_async::<RevenueRecoveryRetryStats>(conn)
+            .await
+            .change_context(errors::DatabaseError::Others)
+            .attach_printable("error inserting revenue_recovery_retry_stats row")
+    }
+}
+
+impl RevenueRecoveryRetryStats {
+    pub async fn update_distribution(
+        conn: &PgPooledConn,
+        cluster_key: String,
+        distribution: serde_json::Value,
+    ) -> StorageResult<Self> {
+        diesel::update(<Self as HasTable>::table().filter(dsl::cluster_key.eq(cluster_key)))
+            .set(dsl::distribution.eq(distribution))
+            .get_result_async::<Self>(conn)
+            .await
+            .change_context(errors::DatabaseError::Others)
+            .attach_printable("error updating revenue_recovery_retry_stats row")
+    }
+
+    pub async fn find_by_key(conn: &PgPooledConn, key: String) -> StorageResult<Option<Self>> {
+        <Self as HasTable>::table()
+            .filter(dsl::cluster_key.eq(key))
+            .get_results_async::<Self>(conn)
+            .await
+            .change_context(errors::DatabaseError::Others)
+            .attach_printable("error fetching revenue_recovery_retry_stats row by key")
+            .map(|mut rows| rows.pop())
+    }
+
+    pub async fn find_by_key_prefix(
+        conn: &PgPooledConn,
+        key_prefix: &str,
+    ) -> StorageResult<Vec<Self>> {
+        <Self as HasTable>::table()
+            .filter(dsl::cluster_key.like(format!("{key_prefix}%")))
+            .get_results_async::<Self>(conn)
+            .await
+            .change_context(errors::DatabaseError::Others)
+            .attach_printable("error scanning revenue_recovery_retry_stats rows by key prefix")
+    }
+}

--- a/crates/diesel_models/src/revenue_recovery_retry_stats.rs
+++ b/crates/diesel_models/src/revenue_recovery_retry_stats.rs
@@ -1,0 +1,20 @@
+use diesel::{Identifiable, Queryable, Selectable};
+
+use crate::schema_v2::revenue_recovery_retry_stats;
+
+#[derive(
+    Clone, Debug, Queryable, Identifiable, Selectable, serde::Serialize, serde::Deserialize,
+)]
+#[diesel(table_name = revenue_recovery_retry_stats, check_for_backend(diesel::pg::Pg))]
+#[diesel(primary_key(cluster_key))]
+pub struct RevenueRecoveryRetryStats {
+    pub cluster_key: String,
+    pub distribution: serde_json::Value,
+}
+
+#[derive(Clone, Debug, diesel::Insertable, serde::Serialize, serde::Deserialize)]
+#[diesel(table_name = revenue_recovery_retry_stats)]
+pub struct RevenueRecoveryRetryStatsNew {
+    pub cluster_key: String,
+    pub distribution: serde_json::Value,
+}

--- a/crates/diesel_models/src/schema_v2.rs
+++ b/crates/diesel_models/src/schema_v2.rs
@@ -465,6 +465,16 @@ diesel::table! {
     use diesel::sql_types::*;
     use crate::enums::diesel_exports::*;
 
+    revenue_recovery_retry_stats (cluster_key) {
+        cluster_key -> Text,
+        distribution -> Jsonb,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use crate::enums::diesel_exports::*;
+
     configs (key) {
         id -> Int4,
         #[max_length = 255]
@@ -1963,6 +1973,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     captures,
     card_issuers,
     cards_info,
+    revenue_recovery_retry_stats,
     configs,
     customers,
     dashboard_metadata,

--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -476,6 +476,11 @@ pub struct ChargebeeTransactionData {
     gateway_account_id: String,
     currency_code: enums::Currency,
     amount: MinorUnit,
+    // Chargebee sends this as a UNIX epoch timestamp. `custom_serde::timestamp` maps
+    // it to a UTC `PrimitiveDateTime` (via `to_offset(UtcOffset::UTC)`), and this value
+    // becomes the recovery attempt's `created_at`. Downstream revenue-recovery logic —
+    // e.g. revenue_recovery_retry_stats day/hour bucketing (`EventSlots::from_utc`) — relies on this
+    // being UTC, so keep the UTC-normalizing serde here.
     #[serde(default, with = "common_utils::custom_serde::timestamp::option")]
     date: Option<PrimitiveDateTime>,
     payment_method: ChargebeeTransactionPaymentMethod,

--- a/crates/hyperswitch_domain_models/src/lib.rs
+++ b/crates/hyperswitch_domain_models/src/lib.rs
@@ -1385,6 +1385,7 @@ impl From<&api_models::payments::RecordAttemptErrorDetails>
             network_advice_code: error.network_advice_code.clone(),
             network_decline_code: error.network_decline_code.clone(),
             network_error_message: error.network_error_message.clone(),
+            standardised_code: None,
         }
     }
 }

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -381,6 +381,8 @@ pub struct ErrorDetails {
     pub network_decline_code: Option<String>,
     /// A string indicating how to proceed with an network error if payment gateway provide one. This is used to understand the network error code better.
     pub network_error_message: Option<String>,
+    /// GSM-resolved standardised code, populated on the same error-update path as `unified_code`.
+    pub standardised_code: Option<storage_enums::StandardisedCode>,
 }
 
 #[cfg(feature = "v2")]
@@ -3300,6 +3302,23 @@ impl behaviour::Conversion for PaymentAttempt {
 }
 
 #[cfg(feature = "v2")]
+fn build_error_details_for_storage(error: &ErrorDetails) -> Option<diesel_models::ErrorDetails> {
+    let unified_details = diesel_models::UnifiedErrorDetails {
+        category: None,
+        message: error.unified_message.clone(),
+        standardised_code: error.standardised_code,
+        description: None,
+        user_guidance_message: None,
+        recommended_action: None,
+    };
+    Some(diesel_models::ErrorDetails {
+        unified_details: Some(unified_details),
+        issuer_details: None,
+        connector_details: None,
+    })
+}
+
+#[cfg(feature = "v2")]
 impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal {
     fn from(update: PaymentAttemptUpdate) -> Self {
         match update {
@@ -3341,6 +3360,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                 cancellation_reason: None,
                 amount_captured: None,
                 payment_method_data: None,
+                error_details: None,
             },
             PaymentAttemptUpdate::ErrorUpdate {
                 status,
@@ -3356,6 +3376,8 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                     .map(ConnectorTransactionId::form_id_and_data)
                     .map(|(txn_id, txn_data)| (Some(txn_id), txn_data))
                     .unwrap_or((None, None));
+
+                let error_details = build_error_details_for_storage(&error);
 
                 Self {
                     status: Some(status),
@@ -3387,6 +3409,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                     cancellation_reason: None,
                     amount_captured: None,
                     payment_method_data,
+                    error_details,
                 }
             }
             PaymentAttemptUpdate::ConfirmIntentResponse(confirm_intent_response_update) => {
@@ -3439,6 +3462,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                     cancellation_reason: None,
                     amount_captured: None,
                     payment_method_data,
+                    error_details: None,
                 }
             }
             PaymentAttemptUpdate::SyncUpdate {
@@ -3477,6 +3501,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                 cancellation_reason: None,
                 amount_captured,
                 payment_method_data: payment_method_data.map(pii::SecretSerdeValue::new),
+                error_details: None,
             },
             PaymentAttemptUpdate::CaptureUpdate {
                 status,
@@ -3512,6 +3537,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                 cancellation_reason: None,
                 amount_captured: None,
                 payment_method_data: None,
+                error_details: None,
             },
             PaymentAttemptUpdate::PreCaptureUpdate {
                 amount_to_capture,
@@ -3546,6 +3572,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                 cancellation_reason: None,
                 amount_captured: None,
                 payment_method_data: None,
+                error_details: None,
             },
             PaymentAttemptUpdate::ConfirmIntentTokenized {
                 status,
@@ -3585,6 +3612,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                 cancellation_reason: None,
                 amount_captured: None,
                 payment_method_data: None,
+                error_details: None,
             },
             PaymentAttemptUpdate::VoidUpdate {
                 status,
@@ -3620,6 +3648,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                 payment_method_id: None,
                 amount_captured: None,
                 payment_method_data: None,
+                error_details: None,
             },
         }
     }

--- a/crates/hyperswitch_domain_models/src/revenue_recovery.rs
+++ b/crates/hyperswitch_domain_models/src/revenue_recovery.rs
@@ -1,3 +1,5 @@
+pub mod retry_stats_cluster_key;
+
 use api_models::{payments as api_payments, webhooks};
 use common_enums::enums as common_enums;
 use common_types::primitive_wrappers;

--- a/crates/hyperswitch_domain_models/src/revenue_recovery/retry_stats_cluster_key.rs
+++ b/crates/hyperswitch_domain_models/src/revenue_recovery/retry_stats_cluster_key.rs
@@ -1,0 +1,274 @@
+use std::{fmt, str::FromStr};
+
+use common_enums::{CardType, StandardisedCode};
+
+pub const RETRY_STATS_KEY_VERSION: &str = "v1";
+pub const KEY_SEPARATOR: char = '|';
+pub const SEGMENT_SEPARATOR: char = '/';
+pub const WILDCARD_SEGMENT: &str = "*";
+pub const UNKNOWN_SEGMENT: &str = "UNK";
+
+/// A single cluster-key dimension. Generic over the strict type of its resolved
+/// value (`StandardisedCode` for the error code, `CardType` for the funding type,
+/// `String` for the free-text issuer) so a value of the wrong kind cannot be placed
+/// in the wrong slot at construction time. `Unknown` marks a value we could not
+/// resolve; `Any` is the wildcard used by ancestor (root/mid) roll-up nodes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Dim<T> {
+    Val(T),
+    Unknown,
+    Any,
+}
+
+impl<T: fmt::Display> Dim<T> {
+    fn as_segment(&self) -> String {
+        match self {
+            Self::Val(raw) => escape_segment(&raw.to_string()),
+            Self::Unknown => UNKNOWN_SEGMENT.to_string(),
+            Self::Any => WILDCARD_SEGMENT.to_string(),
+        }
+    }
+}
+
+impl<T: FromStr> Dim<T> {
+    /// Build a dimension from a raw event string, normalizing the reserved
+    /// spellings (empty/`*`/`UNK`) to `Unknown` and parsing the remainder into `T`.
+    /// A value that does not parse into `T` also yields `Unknown`.
+    pub fn from_event_value(value: Option<&str>) -> Self {
+        match value.map(str::trim).filter(|v| !v.is_empty()) {
+            None => Self::Unknown,
+            Some(v) if v == WILDCARD_SEGMENT || v.eq_ignore_ascii_case(UNKNOWN_SEGMENT) => {
+                Self::Unknown
+            }
+            Some(v) => T::from_str(v).map(Self::Val).unwrap_or(Self::Unknown),
+        }
+    }
+
+    fn parse_segment(s: &str) -> Option<Self> {
+        match s {
+            WILDCARD_SEGMENT => Some(Self::Any),
+            UNKNOWN_SEGMENT => Some(Self::Unknown),
+            _ => {
+                let decoded = unescape_segment(s)?;
+                Some(
+                    T::from_str(&decoded)
+                        .map(Self::Val)
+                        .unwrap_or(Self::Unknown),
+                )
+            }
+        }
+    }
+}
+
+fn escape_segment(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        match ch {
+            '%' => out.push_str("%25"),
+            '|' => out.push_str("%7C"),
+            '/' => out.push_str("%2F"),
+            '*' => out.push_str("%2A"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn unescape_segment(encoded: &str) -> Option<String> {
+    let mut out = String::with_capacity(encoded.len());
+    let mut chars = encoded.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '%' {
+            let hi = chars.next()?;
+            let lo = chars.next()?;
+            let byte = u8::from_str_radix(&format!("{hi}{lo}"), 16).ok()?;
+            out.push(char::from(byte));
+        } else {
+            out.push(ch);
+        }
+    }
+    Some(out)
+}
+
+/// The three-dimensional key a retry outcome is recorded under. `error_code` and
+/// `card_type` are strictly typed; `issuer` is a free-text bank name resolved from
+/// the card ISIN.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetryStatsClusterKey {
+    pub error_code: Dim<StandardisedCode>,
+    pub card_type: Dim<CardType>,
+    pub issuer: Dim<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NodeDepth {
+    Root,
+    Mid,
+    Leaf,
+}
+
+impl RetryStatsClusterKey {
+    /// Assemble a fully-qualified (leaf) key from already-resolved dimensions.
+    pub fn leaf(
+        error_code: Dim<StandardisedCode>,
+        card_type: Dim<CardType>,
+        issuer: Dim<String>,
+    ) -> Self {
+        Self {
+            error_code,
+            card_type,
+            issuer,
+        }
+    }
+
+    /// Convenience constructor for callers (e.g. a retry algorithm) that already
+    /// hold concrete dimension values rather than `Dim`s.
+    pub fn new(
+        error_code: StandardisedCode,
+        card_type: CardType,
+        issuer: impl Into<String>,
+    ) -> Self {
+        Self {
+            error_code: Dim::Val(error_code),
+            card_type: Dim::Val(card_type),
+            issuer: Dim::Val(issuer.into()),
+        }
+    }
+
+    /// Build a root node keyed on the error code alone (card_type and issuer
+    /// wildcarded). This is the granularity reads currently fetch at.
+    pub fn root_from_error_code(error_code: StandardisedCode) -> Self {
+        Self {
+            error_code: Dim::Val(error_code),
+            card_type: Dim::Any,
+            issuer: Dim::Any,
+        }
+    }
+
+    pub fn root(&self) -> Self {
+        Self {
+            error_code: self.error_code.clone(),
+            card_type: Dim::Any,
+            issuer: Dim::Any,
+        }
+    }
+
+    pub fn mid(&self) -> Self {
+        Self {
+            error_code: self.error_code.clone(),
+            card_type: self.card_type.clone(),
+            issuer: Dim::Any,
+        }
+    }
+
+    pub fn depth(&self) -> NodeDepth {
+        match (&self.card_type, &self.issuer) {
+            (Dim::Any, Dim::Any) => NodeDepth::Root,
+            (_, Dim::Any) => NodeDepth::Mid,
+            _ => NodeDepth::Leaf,
+        }
+    }
+
+    pub fn chain(&self) -> Vec<Self> {
+        match self.depth() {
+            NodeDepth::Leaf => vec![self.root(), self.mid(), self.clone()],
+            NodeDepth::Mid => vec![self.root(), self.clone()],
+            NodeDepth::Root => vec![self.clone()],
+        }
+    }
+
+    pub fn as_db(&self) -> String {
+        let mut out = String::new();
+        out.push_str(RETRY_STATS_KEY_VERSION);
+        out.push(KEY_SEPARATOR);
+        out.push_str(&self.error_code.as_segment());
+        out.push(SEGMENT_SEPARATOR);
+        out.push_str(&self.card_type.as_segment());
+        out.push(SEGMENT_SEPARATOR);
+        out.push_str(&self.issuer.as_segment());
+        out
+    }
+
+    pub fn from_db(raw: &str) -> Option<Self> {
+        let (version, rest) = raw.split_once(KEY_SEPARATOR)?;
+        if version != RETRY_STATS_KEY_VERSION {
+            return None;
+        }
+        let mut parts = rest.split(SEGMENT_SEPARATOR);
+        let error_code = Dim::<StandardisedCode>::parse_segment(parts.next()?)?;
+        let card_type = Dim::<CardType>::parse_segment(parts.next()?)?;
+        let issuer = Dim::<String>::parse_segment(parts.next()?)?;
+        Some(Self {
+            error_code,
+            card_type,
+            issuer,
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leaf_roundtrips() {
+        let key = RetryStatsClusterKey::new(StandardisedCode::DoNotHonor, CardType::Credit, "HDFC");
+        let raw = key.as_db();
+        assert_eq!(raw, "v1|do_not_honor/CREDIT/HDFC");
+        assert_eq!(RetryStatsClusterKey::from_db(&raw), Some(key));
+    }
+
+    #[test]
+    fn chain_is_root_mid_leaf() {
+        let chain =
+            RetryStatsClusterKey::new(StandardisedCode::DoNotHonor, CardType::Credit, "HDFC")
+                .chain();
+        assert_eq!(chain.len(), 3);
+        assert_eq!(chain[0].depth(), NodeDepth::Root);
+        assert_eq!(chain[1].depth(), NodeDepth::Mid);
+        assert_eq!(chain[2].depth(), NodeDepth::Leaf);
+        assert_eq!(chain[0].as_db(), "v1|do_not_honor/*/*");
+        assert_eq!(chain[1].as_db(), "v1|do_not_honor/CREDIT/*");
+        assert_eq!(chain[2].as_db(), "v1|do_not_honor/CREDIT/HDFC");
+    }
+
+    #[test]
+    fn root_from_error_code_wildcards_the_rest() {
+        let key = RetryStatsClusterKey::root_from_error_code(StandardisedCode::InsufficientFunds);
+        assert_eq!(key.depth(), NodeDepth::Root);
+        assert_eq!(key.as_db(), "v1|insufficient_funds/*/*");
+    }
+
+    #[test]
+    fn issuer_delimiters_and_stars_are_percent_escaped() {
+        let key =
+            RetryStatsClusterKey::new(StandardisedCode::DoNotHonor, CardType::Debit, "H|D*F/C");
+        let raw = key.as_db();
+        assert!(raw.contains("%7C"));
+        assert!(raw.contains("%2A"));
+        assert!(raw.contains("%2F"));
+        assert_eq!(RetryStatsClusterKey::from_db(&raw), Some(key));
+    }
+
+    #[test]
+    fn from_db_rejects_foreign_versions_and_wildcards() {
+        assert!(RetryStatsClusterKey::from_db("v2|a/b/c").is_none());
+        assert_eq!(
+            RetryStatsClusterKey::from_db("v1|do_not_honor/*/*").map(|k| k.depth()),
+            Some(NodeDepth::Root)
+        );
+    }
+
+    #[test]
+    fn from_event_value_normalizes_reserved_spellings() {
+        assert_eq!(Dim::<String>::from_event_value(Some("  ")), Dim::Unknown);
+        assert_eq!(Dim::<String>::from_event_value(None), Dim::Unknown);
+        assert_eq!(Dim::<String>::from_event_value(Some("*")), Dim::Unknown);
+        assert_eq!(Dim::<String>::from_event_value(Some("unk")), Dim::Unknown);
+        assert_eq!(
+            Dim::<String>::from_event_value(Some("HDFC")),
+            Dim::Val("HDFC".into())
+        );
+    }
+}

--- a/crates/hyperswitch_domain_models/src/router_data.rs
+++ b/crates/hyperswitch_domain_models/src/router_data.rs
@@ -1125,6 +1125,7 @@ impl
                     network_advice_code,
                     network_decline_code,
                     network_error_message,
+                    standardised_code: None,
                 };
 
                 PaymentAttemptUpdate::ErrorUpdate {
@@ -1452,6 +1453,7 @@ impl
                     network_advice_code,
                     network_decline_code,
                     network_error_message,
+                    standardised_code: None,
                 };
 
                 PaymentAttemptUpdate::ErrorUpdate {
@@ -1789,6 +1791,7 @@ impl
                     network_advice_code,
                     network_decline_code,
                     network_error_message,
+                    standardised_code: None,
                 };
 
                 PaymentAttemptUpdate::ErrorUpdate {
@@ -2085,6 +2088,7 @@ impl
                     network_advice_code,
                     network_decline_code,
                     network_error_message,
+                    standardised_code: None,
                 };
 
                 PaymentAttemptUpdate::ErrorUpdate {
@@ -2337,6 +2341,7 @@ impl
                     network_advice_code,
                     network_decline_code,
                     network_error_message,
+                    standardised_code: None,
                 };
 
                 PaymentAttemptUpdate::ErrorUpdate {
@@ -2522,6 +2527,7 @@ impl
                     network_advice_code,
                     network_decline_code,
                     network_error_message,
+                    standardised_code: None,
                 };
 
                 PaymentAttemptUpdate::ErrorUpdate {

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -430,6 +430,13 @@ pub mod superposition {
         "pt_mapping_outgoing_connector_webhooks";
     /// PCR (Revenue Recovery) payments retry process tracker mapping key
     pub const PT_MAPPING_PCR_RETRIES: &str = "process_tracker.pt_mapping_pcr_retries";
+    /// Whether the adaptive revenue recovery retry algorithm — static ladder combined with
+    /// the smart algorithm — replaces the decider-based smart retry implementation
+    pub const ADAPTIVE_RETRY_ENABLED: &str = "revenue_recovery.adaptive_retry_enabled";
+    /// Days from the first attempt during which an invoice may still be retried
+    pub const RECOVERY_GRACE_PERIOD_DAYS: &str = "revenue_recovery.grace_period_days";
+    /// Total retries an invoice is allowed across its whole recovery lifecycle
+    pub const RECOVERY_MAX_RETRY_COUNT: &str = "revenue_recovery.max_retry_count";
     /// Payment sync (psync) retry process tracker mapping key
     pub const PT_MAPPING_PAYMENT_SYNC: &str = "process_tracker.pt_mapping_payment_sync";
     /// Refund sync retry process tracker mapping key

--- a/crates/router/src/core/configs/dimension_config.rs
+++ b/crates/router/src/core/configs/dimension_config.rs
@@ -645,6 +645,60 @@ impl DatabaseBackedConfig for PtMappingPcrRetries {
 }
 
 config! {
+    superposition_key = ADAPTIVE_RETRY_ENABLED,
+    output = bool,
+    default = false,
+    requires = dimension_state::DimensionsWithProcessorMerchantIdAndConnector,
+    targeting_key = id_type::PaymentId
+}
+
+impl DatabaseBackedConfig for AdaptiveRetryEnabled {
+    const KEY: &'static str = "adaptive_retry_enabled";
+
+    fn db_key(dimensions: &impl dimension_state::DimensionsBase) -> Option<String> {
+        dimensions
+            .get_processor_merchant_id()
+            .map(|merchant_id| format!("{}_{}", merchant_id.get_string_repr(), Self::KEY))
+    }
+}
+
+config! {
+    superposition_key = RECOVERY_GRACE_PERIOD_DAYS,
+    output = i64,
+    default = 30,
+    requires = dimension_state::DimensionsWithProcessorMerchantIdAndConnector,
+    targeting_key = id_type::PaymentId
+}
+
+impl DatabaseBackedConfig for RecoveryGracePeriodDays {
+    const KEY: &'static str = "recovery_grace_period_days";
+
+    fn db_key(dimensions: &impl dimension_state::DimensionsBase) -> Option<String> {
+        dimensions
+            .get_processor_merchant_id()
+            .map(|merchant_id| format!("{}_{}", merchant_id.get_string_repr(), Self::KEY))
+    }
+}
+
+config! {
+    superposition_key = RECOVERY_MAX_RETRY_COUNT,
+    output = i64,
+    default = 15,
+    requires = dimension_state::DimensionsWithProcessorMerchantIdAndConnector,
+    targeting_key = id_type::PaymentId
+}
+
+impl DatabaseBackedConfig for RecoveryMaxRetryCount {
+    const KEY: &'static str = "recovery_max_retry_count";
+
+    fn db_key(dimensions: &impl dimension_state::DimensionsBase) -> Option<String> {
+        dimensions
+            .get_processor_merchant_id()
+            .map(|merchant_id| format!("{}_{}", merchant_id.get_string_repr(), Self::KEY))
+    }
+}
+
+config! {
     superposition_key = PT_MAPPING_PAYMENT_SYNC,
     output = scheduler::types::process_data::ConnectorPTMapping,
     default = scheduler::types::process_data::ConnectorPTMapping::default(),

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -3615,6 +3615,45 @@ impl<F: Clone>
 }
 
 #[cfg(feature = "v2")]
+struct GsmErrorFields {
+    unified_code: Option<String>,
+    unified_message: Option<String>,
+    standardised_code: Option<common_enums::StandardisedCode>,
+}
+
+/// v2 equivalent of the inline GSM lookup v1 performs in `payment_response_update_tracker`
+/// (which v2's domain-layer `get_payment_attempt_update` cannot do — it has no `SessionState`).
+/// Returns `None` when `standardised_code` is already populated.
+#[cfg(feature = "v2")]
+async fn resolve_gsm_error_fields(
+    state: &SessionState,
+    connector: String,
+    card_network: Option<common_enums::CardNetwork>,
+    sub_flow: &str,
+    error: &hyperswitch_domain_models::payments::payment_attempt::ErrorDetails,
+) -> Option<GsmErrorFields> {
+    if error.standardised_code.is_some() {
+        return None;
+    }
+    let option_gsm = payments_helpers::get_gsm_record(
+        state,
+        connector,
+        consts::PAYMENT_FLOW_STR,
+        sub_flow,
+        Some(error.code.clone()),
+        Some(error.message.clone()),
+        error.network_decline_code.clone(),
+        card_network,
+    )
+    .await?;
+    Some(GsmErrorFields {
+        unified_code: option_gsm.unified_code,
+        unified_message: option_gsm.unified_message,
+        standardised_code: option_gsm.standardised_code,
+    })
+}
+
+#[cfg(feature = "v2")]
 #[async_trait]
 impl<F: Clone> PostUpdateTracker<F, PaymentConfirmData<F>, types::PaymentsAuthorizeData>
     for PaymentResponse
@@ -3644,8 +3683,29 @@ impl<F: Clone> PostUpdateTracker<F, PaymentConfirmData<F>, types::PaymentsAuthor
 
         let payment_intent_update = response_router_data
             .get_payment_intent_update(&payment_data, processor.get_account().storage_scheme);
-        let payment_attempt_update = response_router_data
+        let mut payment_attempt_update = response_router_data
             .get_payment_attempt_update(&payment_data, processor.get_account().storage_scheme);
+
+        if let storage::PaymentAttemptUpdate::ErrorUpdate { error, .. } =
+            &mut payment_attempt_update
+        {
+            let sub_flow = core_utils::get_flow_name::<F>()
+                .unwrap_or_else(|_| consts::AUTHORIZE_FLOW_STR.to_string());
+            let card_network = payment_data.payment_attempt.extract_card_network();
+            let gsm = resolve_gsm_error_fields(
+                state,
+                response_router_data.connector.clone(),
+                card_network,
+                &sub_flow,
+                error,
+            )
+            .await;
+            if let Some(gsm) = gsm {
+                error.unified_code = gsm.unified_code;
+                error.unified_message = gsm.unified_message;
+                error.standardised_code = gsm.standardised_code;
+            }
+        }
 
         let updated_payment_intent = db
             .update_payment_intent(
@@ -3834,8 +3894,29 @@ impl<F: Clone> PostUpdateTracker<F, PaymentStatusData<F>, types::PaymentsSyncDat
 
         let payment_intent_update = response_router_data
             .get_payment_intent_update(&payment_data, processor.get_account().storage_scheme);
-        let payment_attempt_update = response_router_data
+        let mut payment_attempt_update = response_router_data
             .get_payment_attempt_update(&payment_data, processor.get_account().storage_scheme);
+
+        if let storage::PaymentAttemptUpdate::ErrorUpdate { error, .. } =
+            &mut payment_attempt_update
+        {
+            let sub_flow = core_utils::get_flow_name::<F>()
+                .unwrap_or_else(|_| consts::AUTHORIZE_FLOW_STR.to_string());
+            let card_network = payment_data.payment_attempt.extract_card_network();
+            let gsm = resolve_gsm_error_fields(
+                state,
+                response_router_data.connector.clone(),
+                card_network,
+                &sub_flow,
+                error,
+            )
+            .await;
+            if let Some(gsm) = gsm {
+                error.unified_code = gsm.unified_code;
+                error.unified_message = gsm.unified_message;
+                error.standardised_code = gsm.standardised_code;
+            }
+        }
 
         let payment_attempt = payment_data.payment_attempt;
 
@@ -4095,8 +4176,31 @@ impl
 
         let payment_intent_update = response_router_data
             .get_payment_intent_update(&payment_data, processor.get_account().storage_scheme);
-        let payment_attempt_update = response_router_data
+        let mut payment_attempt_update = response_router_data
             .get_payment_attempt_update(&payment_data, processor.get_account().storage_scheme);
+
+        if let storage::PaymentAttemptUpdate::ErrorUpdate { error, .. } =
+            &mut payment_attempt_update
+        {
+            let sub_flow = core_utils::get_flow_name::<
+                hyperswitch_domain_models::router_flow_types::ExternalVaultProxy,
+            >()
+            .unwrap_or_else(|_| consts::AUTHORIZE_FLOW_STR.to_string());
+            let card_network = payment_data.payment_attempt.extract_card_network();
+            let gsm = resolve_gsm_error_fields(
+                state,
+                response_router_data.connector.clone(),
+                card_network,
+                &sub_flow,
+                error,
+            )
+            .await;
+            if let Some(gsm) = gsm {
+                error.unified_code = gsm.unified_code;
+                error.unified_message = gsm.unified_message;
+                error.standardised_code = gsm.standardised_code;
+            }
+        }
 
         let updated_payment_intent = db
             .update_payment_intent(
@@ -4159,8 +4263,29 @@ impl<F: Clone> PostUpdateTracker<F, PaymentConfirmData<F>, types::SetupMandateRe
 
         let payment_intent_update = response_router_data
             .get_payment_intent_update(&payment_data, processor.get_account().storage_scheme);
-        let payment_attempt_update = response_router_data
+        let mut payment_attempt_update = response_router_data
             .get_payment_attempt_update(&payment_data, processor.get_account().storage_scheme);
+
+        if let storage::PaymentAttemptUpdate::ErrorUpdate { error, .. } =
+            &mut payment_attempt_update
+        {
+            let sub_flow = core_utils::get_flow_name::<F>()
+                .unwrap_or_else(|_| consts::AUTHORIZE_FLOW_STR.to_string());
+            let card_network = payment_data.payment_attempt.extract_card_network();
+            let gsm = resolve_gsm_error_fields(
+                state,
+                response_router_data.connector.clone(),
+                card_network,
+                &sub_flow,
+                error,
+            )
+            .await;
+            if let Some(gsm) = gsm {
+                error.unified_code = gsm.unified_code;
+                error.unified_message = gsm.unified_message;
+                error.standardised_code = gsm.standardised_code;
+            }
+        }
 
         let updated_payment_intent = db
             .update_payment_intent(

--- a/crates/router/src/core/revenue_recovery.rs
+++ b/crates/router/src/core/revenue_recovery.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod retry_stats;
+pub mod schedule;
 pub mod transformers;
 pub mod types;
 use std::marker::PhantomData;
@@ -129,6 +130,7 @@ pub async fn upsert_calculate_pcr_task(
                 payment_attempt_id,
                 revenue_recovery_retry,
                 invoice_scheduled_time: None,
+                recovery_schedule: schedule::RecoverySchedule::default(),
             };
 
             let tag = ["PCR"];
@@ -495,6 +497,8 @@ async fn insert_psync_pcr_task_to_pt(
         prev_attempt_id,
         revenue_recovery_retry,
         invoice_scheduled_time: Some(schedule_time),
+        // PSYNC has its own row; scheduling state lives on CALCULATE.
+        recovery_schedule: schedule::RecoverySchedule::default(),
     };
     let tag = ["REVENUE_RECOVERY"];
     let process_tracker_entry = storage::ProcessTrackerNew::new(
@@ -595,6 +599,36 @@ pub async fn perform_payments_sync(
     Ok(())
 }
 
+/// Look up the failed attempt that motivated this retry chain by reading it
+/// out of the EXECUTE task's tracking data. `finish_process` only updates
+/// status fields, so the tracking payload remains readable after the EXECUTE
+/// task completes. Best-effort: any miss yields `None` and the recorder falls
+/// back to the dims of the attempt being resolved.
+async fn fetch_prev_attempt_from_execute_tracking_data(
+    db: &dyn StorageInterface,
+    payment_id: &GlobalPaymentId,
+    key_store: &hyperswitch_domain_models::merchant_key_store::MerchantKeyStore,
+    storage_scheme: common_enums::MerchantStorageScheme,
+) -> Option<PaymentAttempt> {
+    let process_tracker_id = payment_id.get_execute_revenue_recovery_id(
+        EXECUTE_WORKFLOW,
+        storage::ProcessTrackerRunner::PassiveRecoveryWorkflow,
+    );
+    let execute_task_process = db
+        .as_scheduler()
+        .find_process_by_id(&process_tracker_id)
+        .await
+        .ok()
+        .flatten()?;
+    let tracking_data = execute_task_process
+        .tracking_data
+        .parse_value::<pcr::RevenueRecoveryWorkflowTrackingData>("PCRWorkflowTrackingData")
+        .ok()?;
+    db.find_payment_attempt_by_id(key_store, &tracking_data.payment_attempt_id, storage_scheme)
+        .await
+        .ok()
+}
+
 pub async fn perform_calculate_workflow(
     state: &SessionState,
     process: &storage::ProcessTracker,
@@ -659,7 +693,7 @@ pub async fn perform_calculate_workflow(
     .await?;
 
     // 2. Get best available token
-    let payment_processor_token_response =
+    let (payment_processor_token_response, next_recovery_schedule) =
         match revenue_recovery_workflow::get_token_with_schedule_time_based_on_retry_algorithm_type(
             state,
             &connector_customer_id,
@@ -667,17 +701,26 @@ pub async fn perform_calculate_workflow(
             revenue_recovery_payment_data.billing_mca.connector_name,
             retry_algorithm_type,
             process.retry_count,
+            &tracking_data.recovery_schedule,
+            tracking_data.prev_attempt_id.as_ref(),
+            &revenue_recovery_payment_data.key_store,
+            revenue_recovery_payment_data
+                .merchant_account
+                .storage_scheme,
         )
         .await
         {
-            Ok(token_opt) => token_opt,
+            Ok(token_and_schedule) => token_and_schedule,
             Err(e) => {
                 logger::error!(
                     error = ?e,
                     connector_customer_id = %connector_customer_id,
                     "Failed to get best PSP token"
                 );
-                revenue_recovery_workflow::PaymentProcessorTokenResponse::None
+                (
+                    revenue_recovery_workflow::PaymentProcessorTokenResponse::None,
+                    None,
+                )
             }
         };
 
@@ -713,20 +756,7 @@ pub async fn perform_calculate_workflow(
             )
             .await?;
 
-            db.as_scheduler()
-                .finish_process_with_business_status(
-                    process.clone(),
-                    business_status::CALCULATE_WORKFLOW_SCHEDULED,
-                )
-                .await
-                .map_err(|e| {
-                    logger::error!(
-                        process_id = %process.id,
-                        error = ?e,
-                        "Failed to update CALCULATE_WORKFLOW status to complete"
-                    );
-                    sch_errors::ProcessTrackerError::ProcessUpdateFailed
-                })?;
+            finish_calculate_workflow_with_schedule(db, process, next_recovery_schedule).await?;
 
             logger::info!(
                 process_id = %process.id,
@@ -846,6 +876,73 @@ pub async fn perform_calculate_workflow(
     ).await;
 
     Ok(())
+}
+
+/// Finish the CALCULATE_WORKFLOW row, carrying any updated adaptive scheduling state.
+///
+/// The row is reopened rather than recreated on the next failure, so its tracking data is
+/// where the ladder position survives between attempts.
+///
+/// State is persisted *before* the row is finished, and the finish itself goes through
+/// `finish_process_with_business_status` unchanged — so every path ends the row exactly the
+/// same way. The ordering also means a crash between the two writes leaves the row `Pending`
+/// and the workflow simply runs again; finishing first would end the row with the state lost.
+async fn finish_calculate_workflow_with_schedule(
+    db: &dyn StorageInterface,
+    process: &storage::ProcessTracker,
+    next_recovery_schedule: Option<schedule::RecoverySchedule>,
+) -> Result<(), sch_errors::ProcessTrackerError> {
+    // `None` on every non-adaptive path — nothing to persist, so nothing extra is written.
+    if let Some(recovery_schedule) = next_recovery_schedule {
+        let mut tracking_data: pcr::RevenueRecoveryWorkflowTrackingData =
+            serde_json::from_value(process.tracking_data.clone())
+                .change_context(errors::RecoveryError::ValueNotFound)
+                .attach_printable("Failed to deserialize the tracking data from process tracker")?;
+
+        tracking_data.recovery_schedule = recovery_schedule;
+
+        let tracking_data = serde_json::to_value(tracking_data)
+            .change_context(errors::RecoveryError::ValueNotFound)
+            .attach_printable("Failed to serialize the tracking data for process tracker")?;
+
+        // Only the tracking data — status and business status are left to the finish below.
+        let pt_update = storage::ProcessTrackerUpdate::Update {
+            name: None,
+            retry_count: None,
+            schedule_time: None,
+            tracking_data: Some(tracking_data),
+            business_status: None,
+            status: None,
+            updated_at: Some(common_utils::date_time::now()),
+        };
+
+        db.as_scheduler()
+            .update_process(process.clone(), pt_update)
+            .await
+            .map_err(|error| {
+                logger::error!(
+                    process_id = %process.id,
+                    error = ?error,
+                    "Failed to persist recovery schedule on CALCULATE_WORKFLOW"
+                );
+                sch_errors::ProcessTrackerError::ProcessUpdateFailed
+            })?;
+    }
+
+    db.as_scheduler()
+        .finish_process_with_business_status(
+            process.clone(),
+            business_status::CALCULATE_WORKFLOW_SCHEDULED,
+        )
+        .await
+        .map_err(|error| {
+            logger::error!(
+                process_id = %process.id,
+                error = ?error,
+                "Failed to update CALCULATE_WORKFLOW status to complete"
+            );
+            sch_errors::ProcessTrackerError::ProcessUpdateFailed
+        })
 }
 
 /// Update the schedule time for a CALCULATE_WORKFLOW process tracker
@@ -1031,6 +1128,8 @@ async fn insert_execute_pcr_task_to_pt(
                 prev_attempt_id: Some(payment_attempt_id.clone()),
                 revenue_recovery_retry,
                 invoice_scheduled_time: Some(schedule_time),
+                // EXECUTE has its own row; scheduling state lives on CALCULATE.
+                recovery_schedule: schedule::RecoverySchedule::default(),
             };
 
             let tag = ["PCR"];

--- a/crates/router/src/core/revenue_recovery.rs
+++ b/crates/router/src/core/revenue_recovery.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod retry_stats;
 pub mod transformers;
 pub mod types;
 use std::marker::PhantomData;
@@ -124,6 +125,7 @@ pub async fn upsert_calculate_pcr_task(
                 global_payment_id: payment_id.clone(),
                 merchant_id: platform.get_processor().get_account().get_id().to_owned(),
                 profile_id: business_profile.get_id().to_owned(),
+                prev_attempt_id: Some(payment_attempt_id.clone()),
                 payment_attempt_id,
                 revenue_recovery_retry,
                 invoice_scheduled_time: None,
@@ -188,6 +190,22 @@ pub async fn record_internal_attempt_and_execute_payment(
 ) -> Result<(), sch_errors::ProcessTrackerError> {
     let db = &*state.store;
 
+    // The attempt whose failure triggered this execute task — used by the
+    // retry-stats recorder for cluster dimensions (NOT the new attempt that
+    // `record_internal_attempt_api` is about to create). Absent it, there is no
+    // prior outcome to attribute this retry to and retry-stats are not recorded.
+    let prev_attempt = match tracking_data.prev_attempt_id.as_ref() {
+        Some(prev_attempt_id) => db
+            .find_payment_attempt_by_id(
+                platform.get_processor().get_key_store(),
+                prev_attempt_id,
+                platform.get_processor().get_account().storage_scheme,
+            )
+            .await
+            .ok(),
+        None => None,
+    };
+
     let card_info = api_models::payments::AdditionalCardInfo::foreign_from(payment_processor_token);
 
     // record attempt call
@@ -224,6 +242,7 @@ pub async fn record_internal_attempt_and_execute_payment(
                 execute_task_process,
                 revenue_recovery_payment_data,
                 revenue_recovery_metadata,
+                prev_attempt.as_ref(),
             ))
             .await?;
         }
@@ -383,6 +402,10 @@ pub async fn perform_execute_payment(
                         payment_intent.get_id().clone(),
                         revenue_recovery_payment_data.profile.get_id().clone(),
                         attempt_id.clone(),
+                        // The EXECUTE tracking row's prev attempt is the failed attempt
+                        // that triggered this retry — carry it into PSYNC so it need not
+                        // re-derive it from the EXECUTE task later.
+                        tracking_data.prev_attempt_id.clone(),
                         storage::ProcessTrackerRunner::PassiveRecoveryWorkflow,
                         tracking_data.revenue_recovery_retry,
                         state.conf.application_source,
@@ -455,6 +478,7 @@ async fn insert_psync_pcr_task_to_pt(
     payment_id: GlobalPaymentId,
     profile_id: id_type::ProfileId,
     payment_attempt_id: id_type::GlobalAttemptId,
+    prev_attempt_id: Option<id_type::GlobalAttemptId>,
     runner: storage::ProcessTrackerRunner,
     revenue_recovery_retry: diesel_enum::RevenueRecoveryAlgorithmType,
     application_source: common_enums::ApplicationSource,
@@ -468,6 +492,7 @@ async fn insert_psync_pcr_task_to_pt(
         merchant_id,
         profile_id,
         payment_attempt_id,
+        prev_attempt_id,
         revenue_recovery_retry,
         invoice_scheduled_time: Some(schedule_time),
     };
@@ -508,6 +533,26 @@ pub async fn perform_payments_sync(
     revenue_recovery_payment_data: &pcr::RevenueRecoveryPaymentData,
     payment_intent: &PaymentIntent,
 ) -> Result<(), errors::ProcessTrackerError> {
+    let db = &*state.store;
+
+    // The failed attempt that motivated this retry chain is carried in the PSYNC
+    // tracking data (stamped at CALCULATE, propagated through EXECUTE), so no
+    // separate EXECUTE-task lookup is needed. It drives the cluster dims for a
+    // success event, where the attempt being resolved carries no error of its own.
+    let prev_attempt = match tracking_data.prev_attempt_id.as_ref() {
+        Some(prev_attempt_id) => db
+            .find_payment_attempt_by_id(
+                &revenue_recovery_payment_data.key_store,
+                prev_attempt_id,
+                revenue_recovery_payment_data
+                    .merchant_account
+                    .storage_scheme,
+            )
+            .await
+            .ok(),
+        None => None,
+    };
+
     let psync_data = api::call_psync_api(
         state,
         &tracking_data.global_payment_id,
@@ -542,6 +587,7 @@ pub async fn perform_payments_sync(
             new_revenue_recovery_payment_data,
             payment_attempt,
             &mut revenue_recovery_metadata,
+            prev_attempt.as_ref(),
         ),
     )
     .await?;
@@ -982,6 +1028,7 @@ async fn insert_execute_pcr_task_to_pt(
                 merchant_id: merchant_id.clone(),
                 profile_id: profile_id.clone(),
                 payment_attempt_id: payment_attempt_id.clone(),
+                prev_attempt_id: Some(payment_attempt_id.clone()),
                 revenue_recovery_retry,
                 invoice_scheduled_time: Some(schedule_time),
             };

--- a/crates/router/src/core/revenue_recovery/retry_stats.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats.rs
@@ -1,0 +1,6 @@
+pub mod document;
+pub mod events;
+pub mod record;
+pub mod stub;
+
+pub use events::RetryOutcomeEvent;

--- a/crates/router/src/core/revenue_recovery/retry_stats/document.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats/document.rs
@@ -1,0 +1,286 @@
+use router_env::logger;
+use serde::{Deserialize, Serialize};
+use time::PrimitiveDateTime;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SlotCounter {
+    #[serde(default)]
+    pub n: u64,
+    #[serde(default)]
+    pub k: u64,
+}
+
+impl SlotCounter {
+    pub fn record(&mut self, success: bool) {
+        self.n = self.n.saturating_add(1);
+        if success {
+            self.k = self.k.saturating_add(1);
+        }
+    }
+}
+
+/// Stats document persisted per key. Each slot family holds a fixed number
+/// of buckets whose count is statically fixed by the [`SlotFamily`] associated
+/// constants, so `dow`/`dom`/`hod` can never carry the wrong number of items.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StatsDocument {
+    #[serde(default)]
+    pub dow: [SlotCounter; SlotFamily::DOW_SLOT_COUNT],
+    #[serde(default)]
+    pub dom: [SlotCounter; SlotFamily::DOM_SLOT_COUNT],
+    #[serde(default)]
+    pub hod: [SlotCounter; SlotFamily::HOD_SLOT_COUNT],
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_event_at: Option<String>,
+}
+
+impl StatsDocument {
+    pub fn from_json(value: &serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value(value.clone())
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EventSlots {
+    pub dow: u8,
+    pub dom: u8,
+    pub hod: u8,
+}
+
+impl EventSlots {
+    /// Derive the day-of-week / day-of-month / hour-of-day bucket indices from an
+    /// event's `created_at`.
+    ///
+    /// Hyperswitch persists `created_at` as a **UTC** `PrimitiveDateTime`, but that
+    /// type carries no offset, so we make the timezone explicit via `assume_utc()`.
+    /// This anchors every bucket to a single, unambiguous timezone — no local-time
+    /// or DST drift can skew which day/hour an event lands in.
+    ///
+    /// Each derived index is then validated against its family's statically-fixed
+    /// bucket count. A value that lands outside the range (which is impossible for a
+    /// well-formed timestamp) is logged as an error and left for `merge_stats` to
+    /// drop, so a malformed/mis-zoned timestamp can never write to the wrong bucket.
+    pub fn from_utc(ts: PrimitiveDateTime) -> Self {
+        let utc = ts.assume_utc();
+        Self {
+            dow: validate_slot(SlotFamily::Dow, utc.weekday().number_days_from_monday(), ts),
+            dom: validate_slot(SlotFamily::Dom, utc.day().saturating_sub(1), ts),
+            hod: validate_slot(SlotFamily::Hod, utc.hour(), ts),
+        }
+    }
+}
+
+/// Guard a derived slot index against its family's static bucket count. Returns the
+/// index unchanged, but logs an error for any out-of-range value so the anomaly is
+/// visible; `merge_stats` then drops out-of-range indices instead of misfiling them.
+fn validate_slot(family: SlotFamily, slot: u8, ts: PrimitiveDateTime) -> u8 {
+    if usize::from(slot) >= family.slot_count() {
+        logger::error!(
+            slot_family = family.name(),
+            slot,
+            bucket_count = family.slot_count(),
+            timestamp = %ts,
+            "revenue_recovery_retry_stats: derived slot index is out of range for its family; \
+             dropping this family's update (possible timezone/timestamp anomaly)"
+        );
+    }
+    slot
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SlotUpdate {
+    pub slot: u8,
+    pub success: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct StatsDelta {
+    pub updates: Vec<(SlotFamily, SlotUpdate)>,
+}
+
+impl StatsDelta {
+    pub fn for_event(slots: EventSlots, success: bool) -> Self {
+        Self {
+            updates: vec![
+                (
+                    SlotFamily::Dow,
+                    SlotUpdate {
+                        slot: slots.dow,
+                        success,
+                    },
+                ),
+                (
+                    SlotFamily::Dom,
+                    SlotUpdate {
+                        slot: slots.dom,
+                        success,
+                    },
+                ),
+                (
+                    SlotFamily::Hod,
+                    SlotUpdate {
+                        slot: slots.hod,
+                        success,
+                    },
+                ),
+            ],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SlotFamily {
+    Dow,
+    Dom,
+    Hod,
+}
+
+impl SlotFamily {
+    /// Day-of-week buckets (Monday..=Sunday).
+    pub const DOW_SLOT_COUNT: usize = 7;
+    /// Day-of-month buckets (day 1..=31 mapped to index 0..=30).
+    pub const DOM_SLOT_COUNT: usize = 31;
+    /// Hour-of-day buckets (0..=23).
+    pub const HOD_SLOT_COUNT: usize = 24;
+
+    /// The statically-known number of buckets for this family.
+    pub const fn slot_count(self) -> usize {
+        match self {
+            Self::Dow => Self::DOW_SLOT_COUNT,
+            Self::Dom => Self::DOM_SLOT_COUNT,
+            Self::Hod => Self::HOD_SLOT_COUNT,
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Dow => "dow",
+            Self::Dom => "dom",
+            Self::Hod => "hod",
+        }
+    }
+}
+
+pub fn merge_stats(current: Option<&StatsDocument>, delta: &StatsDelta) -> StatsDocument {
+    let mut doc = current.cloned().unwrap_or_default();
+    for (family, update) in &delta.updates {
+        let slots: &mut [SlotCounter] = match family {
+            SlotFamily::Dow => &mut doc.dow,
+            SlotFamily::Dom => &mut doc.dom,
+            SlotFamily::Hod => &mut doc.hod,
+        };
+        // Out-of-range slots are dropped rather than panicking; valid time-derived
+        // slots always fall within the statically-sized bucket range.
+        if let Some(counter) = slots.get_mut(usize::from(update.slot)) {
+            counter.record(update.success);
+        }
+    }
+    doc
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    fn delta(slots: &[(SlotFamily, u8, bool)]) -> StatsDelta {
+        StatsDelta {
+            updates: slots
+                .iter()
+                .map(|(f, s, ok)| {
+                    (
+                        *f,
+                        SlotUpdate {
+                            slot: *s,
+                            success: *ok,
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn is_empty(slots: &[SlotCounter]) -> bool {
+        slots.iter().all(|c| *c == SlotCounter::default())
+    }
+
+    #[test]
+    fn from_utc_produces_in_range_slots() {
+        let date = time::Date::from_calendar_date(2026, time::Month::August, 19)
+            .expect("valid calendar date");
+        let clock = time::Time::from_hms(13, 30, 0).expect("valid time");
+        let slots = EventSlots::from_utc(PrimitiveDateTime::new(date, clock));
+
+        assert!(usize::from(slots.dow) < SlotFamily::DOW_SLOT_COUNT);
+        assert!(usize::from(slots.dom) < SlotFamily::DOM_SLOT_COUNT);
+        assert!(usize::from(slots.hod) < SlotFamily::HOD_SLOT_COUNT);
+        // 2026-08-19 is a Wednesday (index 2); day 19 -> index 18; hour 13.
+        assert_eq!(slots.dow, 2);
+        assert_eq!(slots.dom, 18);
+        assert_eq!(slots.hod, 13);
+    }
+
+    #[test]
+    fn slot_arrays_have_statically_fixed_lengths() {
+        let doc = StatsDocument::default();
+        assert_eq!(doc.dow.len(), SlotFamily::DOW_SLOT_COUNT);
+        assert_eq!(doc.dom.len(), SlotFamily::DOM_SLOT_COUNT);
+        assert_eq!(doc.hod.len(), SlotFamily::HOD_SLOT_COUNT);
+    }
+
+    #[test]
+    fn merge_into_empty_creates_entries() {
+        let doc = merge_stats(None, &delta(&[(SlotFamily::Dow, 3, true)]));
+        assert_eq!(doc.dow[3], SlotCounter { n: 1, k: 1 });
+        assert!(is_empty(&doc.dom));
+        assert!(is_empty(&doc.hod));
+    }
+
+    #[test]
+    fn merge_accumulates_across_calls() {
+        let d1 = delta(&[(SlotFamily::Hod, 9, true)]);
+        let d2 = delta(&[(SlotFamily::Hod, 9, false)]);
+        let d3 = delta(&[(SlotFamily::Hod, 10, true)]);
+        let doc = merge_stats(Some(&merge_stats(None, &d1)), &d2);
+        let doc = merge_stats(Some(&doc), &d3);
+        assert_eq!(doc.hod[9], SlotCounter { n: 2, k: 1 });
+        assert_eq!(doc.hod[10], SlotCounter { n: 1, k: 1 });
+    }
+
+    #[test]
+    fn merge_is_associative_over_deltas() {
+        let d1 = delta(&[(SlotFamily::Dom, 9, true)]);
+        let d2 = delta(&[(SlotFamily::Dom, 9, false)]);
+        let d3 = delta(&[(SlotFamily::Dom, 9, true)]);
+        let left = merge_stats(Some(&merge_stats(Some(&merge_stats(None, &d1)), &d2)), &d3);
+        let mut combined = StatsDelta { updates: vec![] };
+        combined.updates.extend(d2.updates.clone());
+        combined.updates.extend(d3.updates.clone());
+        let right = merge_stats(Some(&merge_stats(None, &d1)), &combined);
+        assert_eq!(left.dom[9], right.dom[9]);
+    }
+
+    #[test]
+    fn out_of_range_slot_is_ignored() {
+        // day-of-month index 31 is out of range (valid 0..=30) and must not panic.
+        let doc = merge_stats(None, &delta(&[(SlotFamily::Dom, 31, true)]));
+        assert!(is_empty(&doc.dom));
+    }
+
+    #[test]
+    fn marginal_consistency_holds() {
+        let d = delta(&[
+            (SlotFamily::Dow, 1, true),
+            (SlotFamily::Dom, 5, true),
+            (SlotFamily::Hod, 9, true),
+        ]);
+        let doc = merge_stats(None, &d);
+        let sum = |m: &[SlotCounter]| m.iter().map(|c| c.n).sum::<u64>();
+        assert_eq!(sum(&doc.dow), sum(&doc.dom));
+        assert_eq!(sum(&doc.dom), sum(&doc.hod));
+    }
+}

--- a/crates/router/src/core/revenue_recovery/retry_stats/events.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats/events.rs
@@ -1,0 +1,166 @@
+use api_models::payments::PaymentRevenueRecoveryMetadata;
+use common_enums::{CardNetwork, CardType, PaymentMethodType, StandardisedCode};
+use hyperswitch_domain_models::{
+    payments::payment_attempt::PaymentAttempt,
+    revenue_recovery::retry_stats_cluster_key::{Dim, RetryStatsClusterKey},
+};
+use router_env::logger;
+use time::PrimitiveDateTime;
+
+use super::document::{EventSlots, StatsDelta};
+use crate::{consts, core::payments::helpers, routes::SessionState};
+
+pub struct RetryOutcomeEvent {
+    pub key: RetryStatsClusterKey,
+    pub delta: StatsDelta,
+    pub success: bool,
+}
+
+impl RetryOutcomeEvent {
+    /// Method-agnostic core: build an event from already-resolved dimensions.
+    fn build(
+        error_code_dim: Dim<StandardisedCode>,
+        card_type_dim: Dim<CardType>,
+        issuer_dim: Dim<String>,
+        success: bool,
+        created_at: PrimitiveDateTime,
+    ) -> Self {
+        let slots = EventSlots::from_utc(created_at);
+        let delta = StatsDelta::for_event(slots, success);
+
+        Self {
+            key: RetryStatsClusterKey::leaf(error_code_dim, card_type_dim, issuer_dim),
+            delta,
+            success,
+        }
+    }
+
+    /// The retry's fate (`success`) and event time
+    /// come from the freshly-resolved `payment_attempt`, while the cluster dims
+    /// (error_code, card_type, issuer) are read from `prev_attempt`, the failed
+    /// attempt that triggered this retry. A retry outcome is only meaningful
+    /// relative to a prior attempt, so `prev_attempt` is required — callers that
+    /// have no previous attempt do not record.
+    pub async fn from_attempt(
+        state: &SessionState,
+        payment_attempt: &PaymentAttempt,
+        prev_attempt: &PaymentAttempt,
+        revenue_recovery_metadata: &PaymentRevenueRecoveryMetadata,
+        success: bool,
+    ) -> Self {
+        let card_details = revenue_recovery_metadata
+            .billing_connector_payment_method_details
+            .as_ref()
+            .and_then(|details| details.get_billing_connector_card_info());
+
+        // `card_network` is only needed for the live GSM lookup; the middle dimension is
+        // the card funding type (credit/debit), taken from the attempt's payment method
+        // subtype.
+        let card_network = card_details.and_then(|card| card.card_network.clone());
+
+        let dim_source = prev_attempt;
+        // The middle dimension is the card funding type (credit/debit). Only the two
+        // card funding subtypes map onto a `CardType`; anything else is `Unknown`.
+        let card_type_dim = match dim_source.payment_method_subtype {
+            Some(PaymentMethodType::Credit) => Dim::Val(CardType::Credit),
+            Some(PaymentMethodType::Debit) => Dim::Val(CardType::Debit),
+            _ => Dim::Unknown,
+        };
+
+        let error_code_dim =
+            resolve_error_code_dim_from_attempt(state, dim_source, card_network).await;
+
+        // The card ISIN is stored inside the attempt's `payment_method_data` for card
+        // payments. Read it the same way `PaymentAttempt::extract_card_network` reads the
+        // network, then resolve the issuer from it via the `cards_info` lookup.
+        let card_isin = dim_source
+            .get_payment_method_data()
+            .ok()
+            .flatten()
+            .and_then(|data| data.get_additional_card_info())
+            .and_then(|card| card.card_isin);
+        let issuer_dim = resolve_issuer_dim(state, card_isin.as_deref()).await;
+
+        Self::build(
+            error_code_dim,
+            card_type_dim,
+            issuer_dim,
+            success,
+            payment_attempt.created_at,
+        )
+    }
+}
+
+/// Resolve the issuer dimension solely from the card ISIN via the `cards_info`
+/// lookup table — the single source of truth for the issuer name. We deliberately
+/// do not fall back to any webhook-provided issuer. A missing ISIN, no matching
+/// `cards_info` row, or a lookup error all yield `Unknown`.
+async fn resolve_issuer_dim(state: &SessionState, card_isin: Option<&str>) -> Dim<String> {
+    let Some(isin) = card_isin.map(str::trim).filter(|v| !v.is_empty()) else {
+        return Dim::Unknown;
+    };
+
+    match state.store.get_card_info(isin).await {
+        Ok(Some(card_info)) => Dim::from_event_value(card_info.card_issuer.as_deref()),
+        Ok(None) => Dim::Unknown,
+        Err(error) => {
+            logger::warn!(
+                ?error,
+                "revenue_recovery_retry_stats: issuer lookup by isin failed"
+            );
+            Dim::Unknown
+        }
+    }
+}
+
+fn standardised_code_dim(code: Option<StandardisedCode>) -> Option<Dim<StandardisedCode>> {
+    code.map(Dim::Val)
+}
+
+/// Resolve the error-code dimension for Scenario 2a / 2b.
+///
+/// v2 does not persist `standardised_code` onto the attempt (GSM resolution runs
+/// only on v1 payment paths), so a persisted value is preferred but, when absent,
+/// the standardised code is resolved live from the GSM table using the attempt's
+/// connector + error code — mirroring how Scenario 1 resolves it on the webhook.
+/// The raw connector error code is the final fallback.
+async fn resolve_error_code_dim_from_attempt(
+    state: &SessionState,
+    payment_attempt: &PaymentAttempt,
+    card_network: Option<CardNetwork>,
+) -> Dim<StandardisedCode> {
+    let Some(error) = payment_attempt.error.as_ref() else {
+        return Dim::Unknown;
+    };
+
+    // 1. Prefer a persisted standardised code (future-proof once v2 persists it).
+    if let Some(dim) = standardised_code_dim(error.standardised_code) {
+        return dim;
+    }
+
+    // 2. Fall back to a live GSM lookup keyed on the attempt's connector + error code.
+    //    Use the same flow/sub-flow (Payment/Authorize) the attempt path persists under,
+    //    so a live-resolved code matches what a persisted attempt would carry.
+    if let Some(connector) = payment_attempt.connector.clone() {
+        let gsm_record = helpers::get_gsm_record(
+            state,
+            connector,
+            consts::PAYMENT_FLOW_STR,
+            consts::AUTHORIZE_FLOW_STR,
+            Some(error.code.clone()),
+            Some(error.message.clone()),
+            None, // issuer_error_code
+            card_network,
+        )
+        .await;
+        if let Some(dim) =
+            standardised_code_dim(gsm_record.and_then(|record| record.standardised_code))
+        {
+            return dim;
+        }
+    }
+
+    // 3. No standardised code could be resolved. The raw connector error code is not a
+    //    `StandardisedCode`, so the strictly-typed error-code dimension is `Unknown`.
+    Dim::Unknown
+}

--- a/crates/router/src/core/revenue_recovery/retry_stats/record.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats/record.rs
@@ -1,0 +1,159 @@
+use common_utils::errors::CustomResult;
+use diesel_models::revenue_recovery_retry_stats::RevenueRecoveryRetryStatsNew;
+use redis_interface::SetnxReply;
+use router_env::{instrument, logger, tracing};
+use storage_impl::{
+    errors::StorageError, revenue_recovery_retry_stats::RevenueRecoveryRetryStatsInterface,
+};
+
+use super::{
+    document::{merge_stats, StatsDocument},
+    events::RetryOutcomeEvent,
+};
+use crate::routes::SessionState;
+
+/// Short TTL on the per-key lock so a crashed writer never wedges a key.
+const LOCK_TTL_SECONDS: i64 = 5;
+
+fn lock_key_for(cluster_key: &str) -> String {
+    format!("revenue_recovery_retry_stats_lock:{cluster_key}")
+}
+
+impl RetryOutcomeEvent {
+    /// Record this outcome into `revenue_recovery_retry_stats` (the leaf node / the
+    /// fully-qualified key), under a per-key Redis lock so concurrent writers don't
+    /// lose updates in the read-merge-write.
+    ///
+    /// Only the leaf is written here. The `chain()`/`root()`/`mid()` cluster-key
+    /// helpers and the `find_by_key_prefix` query are reserved for a future
+    /// background roll-up job that will walk leaf rows and maintain ancestor
+    /// aggregations out-of-band; they are intentionally not used on this hot path.
+    ///
+    /// Recording is best-effort: any failure is logged and swallowed so it never
+    /// affects the payment/recovery flow that invoked it.
+    #[instrument(skip_all)]
+    pub async fn record(&self, state: &SessionState) {
+        let redis_conn = match state.store.get_redis_conn() {
+            Ok(conn) => conn,
+            Err(error) => {
+                logger::error!(
+                    ?error,
+                    "revenue_recovery_retry_stats: unable to acquire redis connection"
+                );
+                return;
+            }
+        };
+        let store = state.store.get_revenue_recovery_retry_stats_store();
+
+        let db_key = self.key.as_db();
+        match persist_node(store.as_ref(), &redis_conn, &db_key, self).await {
+            Ok(()) => logger::info!(
+                cluster_key = %db_key,
+                success = self.success,
+                "revenue_recovery_retry_stats outcome recorded"
+            ),
+            Err(error) => logger::error!(
+                cluster_key = %db_key,
+                ?error,
+                "revenue_recovery_retry_stats: failed to persist retry outcome"
+            ),
+        }
+    }
+}
+
+async fn persist_node(
+    store: &dyn RevenueRecoveryRetryStatsInterface<Error = StorageError>,
+    redis_conn: &redis_interface::RedisConnectionWithContext,
+    db_key: &str,
+    event: &RetryOutcomeEvent,
+) -> CustomResult<(), StorageError> {
+    let lock_key = lock_key_for(db_key);
+    let lock_token = uuid::Uuid::new_v4().to_string();
+
+    let lock_acquired = matches!(
+        redis_conn
+            .set_key_if_not_exists_with_expiry(
+                &lock_key.as_str().into(),
+                lock_token.clone(),
+                Some(LOCK_TTL_SECONDS),
+            )
+            .await,
+        Ok(SetnxReply::KeySet)
+    );
+
+    if !lock_acquired {
+        // Another writer holds the key; dropping this rare update is acceptable for stats.
+        logger::warn!(
+            cluster_key = %db_key,
+            "revenue_recovery_retry_stats: lock contended, skipping this update"
+        );
+        return Ok(());
+    }
+
+    let result = merge_and_write(store, db_key, event).await;
+
+    release_lock(redis_conn, &lock_key, &lock_token).await;
+
+    result
+}
+
+async fn merge_and_write(
+    store: &dyn RevenueRecoveryRetryStatsInterface<Error = StorageError>,
+    db_key: &str,
+    event: &RetryOutcomeEvent,
+) -> CustomResult<(), StorageError> {
+    let existing_row = store
+        .find_revenue_recovery_retry_stats_by_key(db_key.to_string())
+        .await?;
+    let row_exists = existing_row.is_some();
+
+    // Treat an unparseable stored document as empty rather than dropping the event.
+    let current_doc = existing_row.and_then(|row| {
+        StatsDocument::from_json(&row.distribution)
+            .map_err(|error| {
+                logger::error!(
+                    cluster_key = %db_key,
+                    ?error,
+                    "revenue_recovery_retry_stats: stored document is corrupt, rebuilding from empty"
+                );
+            })
+            .ok()
+    });
+
+    let distribution = merge_stats(current_doc.as_ref(), &event.delta).to_json();
+
+    // The per-key redis lock plus the read above tell us whether the row exists, so we
+    // insert on first sight and update thereafter — no DB-level upsert/conflict handling.
+    if row_exists {
+        store
+            .update_revenue_recovery_retry_stats(db_key.to_string(), distribution)
+            .await?;
+    } else {
+        store
+            .insert_revenue_recovery_retry_stats(RevenueRecoveryRetryStatsNew {
+                cluster_key: db_key.to_string(),
+                distribution,
+            })
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// Release the lock only if we still own it, so we never delete a lock that has
+/// already expired and been re-acquired by another writer.
+async fn release_lock(
+    redis_conn: &redis_interface::RedisConnectionWithContext,
+    lock_key: &str,
+    lock_token: &str,
+) {
+    let owned = matches!(
+        redis_conn.get_key::<Option<String>>(&lock_key.into()).await,
+        Ok(Some(stored)) if stored == lock_token
+    );
+    if owned {
+        if let Err(error) = redis_conn.delete_key(&lock_key.into()).await {
+            logger::warn!(lock_key = %lock_key, ?error, "revenue_recovery_retry_stats: failed to release lock");
+        }
+    }
+}

--- a/crates/router/src/core/revenue_recovery/schedule.rs
+++ b/crates/router/src/core/revenue_recovery/schedule.rs
@@ -1,0 +1,243 @@
+use time::PrimitiveDateTime;
+
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RecoverySchedule {
+    /// Static ladder positions consumed so far.
+    ///
+    /// Deliberately **not** `process_tracker.retry_count`, which counts every attempt with
+    /// adaptive insertions included: the ladder has far fewer entries than the invoice has
+    /// attempts, so feeding it `retry_count` would run off the end early.
+    ///
+    /// Defaults to `0` — including on rows written before this field existed — so the ladder
+    /// always starts at position 1.
+    #[serde(default)]
+    pub static_rung: i32,
+}
+
+impl RecoverySchedule {
+    /// Ladder position to query for this decision.
+    pub fn next_rung(&self) -> i32 {
+        self.static_rung + 1
+    }
+}
+
+/// Which algorithm produced the scheduled time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduleSource {
+    Static,
+    Adaptive,
+}
+
+/// Outcome of one scheduling decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduleDecision {
+    /// Time to schedule the next retry for.
+    pub schedule_time: PrimitiveDateTime,
+    /// State to persist back onto the tracking data.
+    pub next_schedule: RecoverySchedule,
+    /// Which algorithm won, for logging and analytics.
+    pub source: ScheduleSource,
+}
+
+pub fn decide_next_retry(
+    schedule: &RecoverySchedule,
+    queried_rung: i32,
+    static_time: PrimitiveDateTime,
+    adaptive_time: Option<PrimitiveDateTime>,
+) -> ScheduleDecision {
+    let winning_adaptive_time =
+        adaptive_time.filter(|adaptive_time| adaptive_time.date() < static_time.date());
+
+    match winning_adaptive_time {
+        Some(adaptive_time) => ScheduleDecision {
+            schedule_time: adaptive_time,
+            next_schedule: RecoverySchedule {
+                // No static attempt was spent, so the ladder must not advance — the same
+                // position is offered again on the next decision.
+                static_rung: schedule.static_rung,
+            },
+            source: ScheduleSource::Adaptive,
+        },
+        None => ScheduleDecision {
+            schedule_time: static_time,
+            next_schedule: RecoverySchedule {
+                static_rung: queried_rung,
+            },
+            source: ScheduleSource::Static,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use time::Duration;
+
+    use super::*;
+
+    /// `hours` past a fixed epoch, so tests read as a timeline.
+    fn at(hours: i64) -> PrimitiveDateTime {
+        let epoch = PrimitiveDateTime::new(
+            time::Date::from_calendar_date(2026, time::Month::January, 1)
+                .expect("valid calendar date"),
+            time::Time::MIDNIGHT,
+        );
+        epoch + Duration::hours(hours)
+    }
+
+    fn at_rung(static_rung: i32) -> RecoverySchedule {
+        RecoverySchedule { static_rung }
+    }
+
+    // ---- rung sourcing ----------------------------------------------------
+
+    #[test]
+    fn a_fresh_schedule_starts_the_ladder_at_one() {
+        // Nothing consumed yet, so the first position offered is 1. Never 0 — `get_delay`
+        // returns `None` for a non-positive index, which would fail the very first decision.
+        assert_eq!(RecoverySchedule::default().static_rung, 0);
+        assert_eq!(RecoverySchedule::default().next_rung(), 1);
+    }
+
+    #[test]
+    fn stored_rung_advances_by_one() {
+        // Independent of `retry_count`, which runs ahead as adaptive retries are inserted.
+        // Following it would exhaust a five-entry ladder long before rung 5.
+        assert_eq!(at_rung(3).next_rung(), 4);
+    }
+
+    // ---- adaptive wins ----------------------------------------------------
+
+    #[test]
+    fn adaptive_earlier_day_wins_and_leaves_the_rung_unconsumed() {
+        let schedule = at_rung(2);
+        let decision = decide_next_retry(&schedule, 3, at(240), Some(at(72)));
+
+        assert_eq!(decision.schedule_time, at(72));
+        assert_eq!(decision.source, ScheduleSource::Adaptive);
+        // Rung 3 was offered but not used, so it is offered again next time.
+        assert_eq!(decision.next_schedule.static_rung, 2);
+        assert_eq!(decision.next_schedule.next_rung(), 3);
+    }
+
+    #[test]
+    fn adaptive_the_day_before_static_wins() {
+        let static_time = at(240);
+        let adaptive_time = at(240 - 1);
+        assert!(adaptive_time.date() < static_time.date());
+
+        let decision = decide_next_retry(
+            &RecoverySchedule::default(),
+            1,
+            static_time,
+            Some(adaptive_time),
+        );
+
+        assert_eq!(decision.schedule_time, adaptive_time);
+        assert_eq!(decision.source, ScheduleSource::Adaptive);
+    }
+
+    // ---- static wins ------------------------------------------------------
+
+    #[test]
+    fn adaptive_later_day_loses_and_consumes_the_rung() {
+        let decision = decide_next_retry(&at_rung(2), 3, at(240), Some(at(336)));
+
+        assert_eq!(decision.schedule_time, at(240));
+        assert_eq!(decision.source, ScheduleSource::Static);
+        assert_eq!(decision.next_schedule.static_rung, 3);
+    }
+
+    #[test]
+    fn no_adaptive_opinion_uses_static_and_consumes_the_rung() {
+        let decision = decide_next_retry(&RecoverySchedule::default(), 1, at(240), None);
+
+        assert_eq!(decision.schedule_time, at(240));
+        assert_eq!(decision.source, ScheduleSource::Static);
+        assert_eq!(decision.next_schedule.static_rung, 1);
+    }
+
+    // ---- ties go to static ------------------------------------------------
+
+    #[test]
+    fn adaptive_earlier_on_the_same_day_still_loses() {
+        // Static on day 10 at 18:00, adaptive on day 10 at 09:00. Static already covers that
+        // day, so the earlier instant does not earn a second attempt on it.
+        let static_time = at(240 + 18);
+        let adaptive_time = at(240 + 9);
+        assert_eq!(static_time.date(), adaptive_time.date());
+
+        let decision = decide_next_retry(
+            &RecoverySchedule::default(),
+            1,
+            static_time,
+            Some(adaptive_time),
+        );
+
+        assert_eq!(decision.schedule_time, static_time);
+        assert_eq!(decision.source, ScheduleSource::Static);
+        assert_eq!(decision.next_schedule.static_rung, 1);
+    }
+
+    #[test]
+    fn adaptive_identical_to_static_loses() {
+        let decision =
+            decide_next_retry(&RecoverySchedule::default(), 1, at(240), Some(at(240)));
+
+        assert_eq!(decision.source, ScheduleSource::Static);
+    }
+
+    // ---- successive decisions ---------------------------------------------
+
+    #[test]
+    fn a_rung_survives_repeated_adaptive_wins_and_is_spent_once() {
+        // Driven through `next_rung` exactly as the workflow does, so rung sourcing is under
+        // test rather than assumed.
+        let schedule = RecoverySchedule::default();
+
+        // Fresh invoice: rung 1 is offered, adaptive takes the slot.
+        let queried_rung = schedule.next_rung();
+        assert_eq!(queried_rung, 1);
+        let first = decide_next_retry(&schedule, queried_rung, at(240), Some(at(72)));
+        assert_eq!(first.source, ScheduleSource::Adaptive);
+
+        // The process tracker's retry_count is now 2, but rung 1 was never used, so it is
+        // offered again.
+        let schedule = first.next_schedule;
+        let queried_rung = schedule.next_rung();
+        assert_eq!(queried_rung, 1);
+        let second = decide_next_retry(&schedule, queried_rung, at(240), Some(at(120)));
+        assert_eq!(second.source, ScheduleSource::Adaptive);
+
+        // retry_count 3, and still rung 1.
+        let schedule = second.next_schedule;
+        let queried_rung = schedule.next_rung();
+        assert_eq!(queried_rung, 1);
+        let third = decide_next_retry(&schedule, queried_rung, at(240), None);
+        assert_eq!(third.source, ScheduleSource::Static);
+        assert_eq!(third.next_schedule.static_rung, 1);
+
+        // Three attempts in, exactly one static position spent — the next query is rung 2,
+        // not rung 4 as `retry_count` alone would have given.
+        assert_eq!(third.next_schedule.next_rung(), 2);
+    }
+
+    // ---- persistence ------------------------------------------------------
+
+    #[test]
+    fn round_trips_through_json_and_absent_fields_default() {
+        let schedule = at_rung(3);
+        let encoded = serde_json::to_value(&schedule).expect("serialises");
+        let decoded: RecoverySchedule = serde_json::from_value(encoded).expect("deserialises");
+        assert_eq!(decoded, schedule);
+
+        // Invoices already in flight have no `recovery_schedule` at all.
+        let empty: RecoverySchedule = serde_json::from_value(serde_json::json!({}))
+            .expect("absent fields fall back to defaults");
+        assert_eq!(empty, RecoverySchedule::default());
+        assert_eq!(empty.static_rung, 0);
+        // …and therefore resume at whatever the ladder was already indexed by.
+        assert_eq!(empty.next_rung(), 1);
+    }
+}

--- a/crates/router/src/core/revenue_recovery/types.rs
+++ b/crates/router/src/core/revenue_recovery/types.rs
@@ -1370,15 +1370,32 @@ pub async fn reopen_calculate_workflow_on_payment_failure(
         .filter(|retry_type| *retry_type != common_enums::RevenueRecoveryAlgorithmType::Monitoring) // ignore Monitoring
         .unwrap_or(old_tracking_data.revenue_recovery_retry);
 
+    // Destructured exhaustively on purpose: this row is reopened on every failure, so
+    // anything not carried across here is wiped exactly when it matters most. A new field
+    // on the struct must break this pattern rather than quietly default.
+    let pcr::RevenueRecoveryWorkflowTrackingData {
+        // Both attempt ids are restamped below from the attempt that just failed.
+        payment_attempt_id: _,
+        prev_attempt_id: _,
+        revenue_recovery_retry: _,
+        merchant_id,
+        profile_id,
+        global_payment_id,
+        billing_mca_id,
+        invoice_scheduled_time,
+        recovery_schedule,
+    } = old_tracking_data;
+
     let new_tracking_data = pcr::RevenueRecoveryWorkflowTrackingData {
         payment_attempt_id: latest_attempt_id.clone(),
         prev_attempt_id: Some(latest_attempt_id.clone()),
         revenue_recovery_retry: retry_algorithm_type,
-        merchant_id: old_tracking_data.merchant_id.clone(),
-        profile_id: old_tracking_data.profile_id.clone(),
-        global_payment_id: old_tracking_data.global_payment_id.clone(),
-        billing_mca_id: old_tracking_data.billing_mca_id.clone(),
-        invoice_scheduled_time: old_tracking_data.invoice_scheduled_time,
+        merchant_id,
+        profile_id,
+        global_payment_id,
+        billing_mca_id,
+        invoice_scheduled_time,
+        recovery_schedule,
     };
 
     let tracking_data = serde_json::to_value(new_tracking_data)

--- a/crates/router/src/core/revenue_recovery/types.rs
+++ b/crates/router/src/core/revenue_recovery/types.rs
@@ -116,6 +116,7 @@ impl RevenueRecoveryPaymentIntentStatus {
         revenue_recovery_payment_data: &storage::revenue_recovery::RevenueRecoveryPaymentData,
         payment_attempt: PaymentAttempt,
         revenue_recovery_metadata: &mut PaymentRevenueRecoveryMetadata,
+        prev_attempt: Option<&PaymentAttempt>,
     ) -> Result<(), errors::ProcessTrackerError> {
         let connector_customer_id = payment_intent
             .extract_connector_customer_id_from_payment_intent()
@@ -159,6 +160,21 @@ impl RevenueRecoveryPaymentIntentStatus {
                         business_status::PSYNC_WORKFLOW_COMPLETE,
                     )
                     .await?;
+
+                // Record the psync-resolved retry outcome into revenue_recovery_retry_stats.
+                // Only when there is a previous attempt to attribute this outcome to.
+                if let Some(prev_attempt) = prev_attempt {
+                    super::retry_stats::RetryOutcomeEvent::from_attempt(
+                        state,
+                        &payment_attempt,
+                        prev_attempt,
+                        revenue_recovery_metadata,
+                        true,
+                    )
+                    .await
+                    .record(state)
+                    .await;
+                }
 
                 // publish events to kafka
                 if let Err(e) = recovery_incoming_flow::RecoveryPaymentTuple::publish_revenue_recovery_event_to_kafka(
@@ -298,6 +314,24 @@ impl RevenueRecoveryPaymentIntentStatus {
                         business_status::PSYNC_WORKFLOW_COMPLETE,
                     )
                     .await?;
+
+                // Record the psync-resolved retry outcome into revenue_recovery_retry_stats.
+                // The cluster error dim keys off the failed attempt that triggered this
+                // retry (`prev_attempt`), not the new attempt's error; recorded only when
+                // such a previous attempt exists.
+                if let Some(prev_attempt) = prev_attempt {
+                    super::retry_stats::RetryOutcomeEvent::from_attempt(
+                        state,
+                        &payment_attempt,
+                        prev_attempt,
+                        revenue_recovery_metadata,
+                        false,
+                    )
+                    .await
+                    .record(state)
+                    .await;
+                }
+
                 // publish events to kafka
                 if let Err(e) = recovery_incoming_flow::RecoveryPaymentTuple::publish_revenue_recovery_event_to_kafka(
                     state,
@@ -366,6 +400,7 @@ impl RevenueRecoveryPaymentIntentStatus {
                     &process_tracker,
                     revenue_recovery_metadata,
                     revenue_recovery_payment_data,
+                    prev_attempt,
                 ))
                 .await?;
             }
@@ -774,12 +809,15 @@ impl Action {
         execute_task_process: &storage::ProcessTracker,
         revenue_recovery_payment_data: &storage::revenue_recovery::RevenueRecoveryPaymentData,
         revenue_recovery_metadata: &mut PaymentRevenueRecoveryMetadata,
+        prev_attempt: Option<&PaymentAttempt>,
     ) -> Result<(), errors::ProcessTrackerError> {
         logger::info!("Entering execute_payment_task_response_handler");
 
         let db = &*state.store;
         match self {
             Self::SyncPayment(payment_attempt) => {
+                // Carry the retry chain's prev attempt into the PSYNC task it schedules.
+                let prev_attempt_id = prev_attempt.map(|attempt| attempt.id.clone());
                 revenue_recovery_core::insert_psync_pcr_task_to_pt(
                     revenue_recovery_payment_data.billing_mca.get_id().clone(),
                     db,
@@ -790,6 +828,7 @@ impl Action {
                     payment_intent.id.clone(),
                     revenue_recovery_payment_data.profile.get_id().to_owned(),
                     payment_attempt.id.clone(),
+                    prev_attempt_id,
                     storage::ProcessTrackerRunner::PassiveRecoveryWorkflow,
                     revenue_recovery_payment_data.retry_algorithm,
                     state.conf.application_source,
@@ -846,6 +885,18 @@ impl Action {
                 Ok(())
             }
             Self::TerminalFailure(payment_attempt) => {
+                if let Some(prev_attempt) = prev_attempt {
+                    super::retry_stats::RetryOutcomeEvent::from_attempt(
+                        state,
+                        payment_attempt,
+                        prev_attempt,
+                        revenue_recovery_metadata,
+                        false,
+                    )
+                    .await
+                    .record(state)
+                    .await;
+                }
                 db.as_scheduler()
                     .finish_process_with_business_status(
                         execute_task_process.clone(),
@@ -858,6 +909,18 @@ impl Action {
                 Ok(())
             }
             Self::SuccessfulPayment(payment_attempt) => {
+                if let Some(prev_attempt) = prev_attempt {
+                    super::retry_stats::RetryOutcomeEvent::from_attempt(
+                        state,
+                        payment_attempt,
+                        prev_attempt,
+                        revenue_recovery_metadata,
+                        true,
+                    )
+                    .await
+                    .record(state)
+                    .await;
+                }
                 db.as_scheduler()
                     .finish_process_with_business_status(
                         execute_task_process.clone(),
@@ -916,6 +979,7 @@ impl Action {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn payment_sync_call(
         state: &SessionState,
         revenue_recovery_payment_data: &storage::revenue_recovery::RevenueRecoveryPaymentData,
@@ -1052,6 +1116,7 @@ impl Action {
         psync_task_process: &storage::ProcessTracker,
         revenue_recovery_metadata: &mut PaymentRevenueRecoveryMetadata,
         revenue_recovery_payment_data: &storage::revenue_recovery::RevenueRecoveryPaymentData,
+        prev_attempt: Option<&PaymentAttempt>,
     ) -> Result<(), errors::ProcessTrackerError> {
         logger::info!("Entering psync_response_handler");
 
@@ -1121,6 +1186,18 @@ impl Action {
             Self::TerminalFailure(payment_attempt) => {
                 // TODO: Add support for retrying failed outgoing recordback webhooks
                 // finish the current psync task
+                if let Some(prev_attempt) = prev_attempt {
+                    super::retry_stats::RetryOutcomeEvent::from_attempt(
+                        state,
+                        payment_attempt,
+                        prev_attempt,
+                        revenue_recovery_metadata,
+                        false,
+                    )
+                    .await
+                    .record(state)
+                    .await;
+                }
                 db.as_scheduler()
                     .finish_process_with_business_status(
                         psync_task_process.clone(),
@@ -1133,6 +1210,18 @@ impl Action {
             }
             Self::SuccessfulPayment(payment_attempt) => {
                 // finish the current psync task
+                if let Some(prev_attempt) = prev_attempt {
+                    super::retry_stats::RetryOutcomeEvent::from_attempt(
+                        state,
+                        payment_attempt,
+                        prev_attempt,
+                        revenue_recovery_metadata,
+                        true,
+                    )
+                    .await
+                    .record(state)
+                    .await;
+                }
                 db.as_scheduler()
                     .finish_process_with_business_status(
                         psync_task_process.clone(),
@@ -1283,6 +1372,7 @@ pub async fn reopen_calculate_workflow_on_payment_failure(
 
     let new_tracking_data = pcr::RevenueRecoveryWorkflowTrackingData {
         payment_attempt_id: latest_attempt_id.clone(),
+        prev_attempt_id: Some(latest_attempt_id.clone()),
         revenue_recovery_retry: retry_algorithm_type,
         merchant_id: old_tracking_data.merchant_id.clone(),
         profile_id: old_tracking_data.profile_id.clone(),

--- a/crates/router/src/core/webhooks/recovery_incoming.rs
+++ b/crates/router/src/core/webhooks/recovery_incoming.rs
@@ -643,6 +643,7 @@ impl RevenueRecoveryAttempt {
         let payment_connector_name = payment_connector_account
             .as_ref()
             .map(|account| account.connector_name);
+
         let request_payload: api_payments::PaymentsAttemptRecordRequest = self
             .create_payment_record_request(
                 state,

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -66,6 +66,8 @@ use hyperswitch_domain_models::{
 use hyperswitch_domain_models::{PayoutAttemptInterface, PayoutsInterface};
 use redis_interface::errors::RedisError;
 use router_env::logger;
+#[cfg(feature = "v2")]
+use storage_impl::revenue_recovery_retry_stats;
 use storage_impl::{
     errors::StorageError, redis::kv_store::RedisConnInterface, tokenization, MockDb,
 };
@@ -156,6 +158,12 @@ pub trait StorageInterface:
     + 'static
 {
     fn get_scheduler_db(&self) -> Box<dyn scheduler::SchedulerInterface>;
+    #[cfg(feature = "v2")]
+    fn get_revenue_recovery_retry_stats_store(
+        &self,
+    ) -> Box<
+        dyn revenue_recovery_retry_stats::RevenueRecoveryRetryStatsInterface<Error = StorageError>,
+    >;
     fn get_payment_methods_store(&self) -> Box<dyn PaymentMethodsStorageInterface>;
     fn get_subscription_store(&self)
         -> Box<dyn subscriptions::state::SubscriptionStorageInterface>;
@@ -246,6 +254,14 @@ impl StorageInterface for Store {
     fn get_scheduler_db(&self) -> Box<dyn scheduler::SchedulerInterface> {
         Box::new(self.clone())
     }
+    #[cfg(feature = "v2")]
+    fn get_revenue_recovery_retry_stats_store(
+        &self,
+    ) -> Box<
+        dyn revenue_recovery_retry_stats::RevenueRecoveryRetryStatsInterface<Error = StorageError>,
+    > {
+        Box::new(self.clone())
+    }
     fn get_payment_methods_store(&self) -> Box<dyn PaymentMethodsStorageInterface> {
         Box::new(self.clone())
     }
@@ -279,6 +295,14 @@ impl AccountsStorageInterface for Store {}
 #[async_trait::async_trait]
 impl StorageInterface for MockDb {
     fn get_scheduler_db(&self) -> Box<dyn scheduler::SchedulerInterface> {
+        Box::new(self.clone())
+    }
+    #[cfg(feature = "v2")]
+    fn get_revenue_recovery_retry_stats_store(
+        &self,
+    ) -> Box<
+        dyn revenue_recovery_retry_stats::RevenueRecoveryRetryStatsInterface<Error = StorageError>,
+    > {
         Box::new(self.clone())
     }
     fn get_payment_methods_store(&self) -> Box<dyn PaymentMethodsStorageInterface> {

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -47,6 +47,8 @@ use scheduler::{
 };
 use serde::Serialize;
 use storage_impl::redis::kv_store::RedisConnInterface;
+#[cfg(feature = "v2")]
+use storage_impl::revenue_recovery_retry_stats;
 use time::PrimitiveDateTime;
 
 use super::{
@@ -3640,6 +3642,17 @@ impl UnifiedTranslationsInterface for KafkaStore {
 impl StorageInterface for KafkaStore {
     fn get_scheduler_db(&self) -> Box<dyn SchedulerInterface> {
         Box::new(self.clone())
+    }
+
+    #[cfg(feature = "v2")]
+    fn get_revenue_recovery_retry_stats_store(
+        &self,
+    ) -> Box<
+        dyn revenue_recovery_retry_stats::RevenueRecoveryRetryStatsInterface<
+            Error = errors::StorageError,
+        >,
+    > {
+        self.diesel_store.get_revenue_recovery_retry_stats_store()
     }
 
     fn get_payment_methods_store(&self) -> Box<dyn PaymentMethodsStorageInterface> {

--- a/crates/router/src/types/storage/revenue_recovery.rs
+++ b/crates/router/src/types/storage/revenue_recovery.rs
@@ -23,6 +23,14 @@ pub struct RevenueRecoveryWorkflowTrackingData {
     pub billing_mca_id: id_type::MerchantConnectorAccountId,
     pub revenue_recovery_retry: enums::RevenueRecoveryAlgorithmType,
     pub invoice_scheduled_time: Option<time::PrimitiveDateTime>,
+    /// The failed attempt that motivated the current retry chain. Stamped at
+    /// CALCULATE time and carried verbatim through EXECUTE and PSYNC so the
+    /// retry-stats recorder can source cluster dimensions from it without a
+    /// separate process-tracker lookup. `None` when there is no prior attempt
+    /// (nothing to attribute a retry outcome to), in which case retry-stats are
+    /// not recorded.
+    #[serde(default)]
+    pub prev_attempt_id: Option<id_type::GlobalAttemptId>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/router/src/types/storage/revenue_recovery.rs
+++ b/crates/router/src/types/storage/revenue_recovery.rs
@@ -13,7 +13,10 @@ use hyperswitch_masking::PeekInterface;
 use router_env::logger;
 use serde::{Deserialize, Serialize};
 
-use crate::{db::StorageInterface, routes::SessionState, types, workflows::revenue_recovery};
+use crate::{
+    core::revenue_recovery::schedule::RecoverySchedule, db::StorageInterface,
+    routes::SessionState, types, workflows::revenue_recovery,
+};
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct RevenueRecoveryWorkflowTrackingData {
     pub merchant_id: id_type::MerchantId,
@@ -31,6 +34,12 @@ pub struct RevenueRecoveryWorkflowTrackingData {
     /// not recorded.
     #[serde(default)]
     pub prev_attempt_id: Option<id_type::GlobalAttemptId>,
+
+    /// Adaptive retry scheduling state — how far down the static ladder this invoice has
+    /// been. Only meaningful on the CALCULATE row, which is reopened rather than recreated
+    /// and so survives for the whole recovery lifecycle of an invoice.
+    #[serde(default)]
+    pub recovery_schedule: RecoverySchedule,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/router/src/workflows/revenue_recovery.rs
+++ b/crates/router/src/workflows/revenue_recovery.rs
@@ -28,6 +28,7 @@ use hyperswitch_domain_models::{
     payments::{payment_attempt, PaymentConfirmData, PaymentIntent, PaymentIntentData},
     router_flow_types,
     router_flow_types::Authorize,
+    ApiModelToDieselModelConvertor,
 };
 #[cfg(feature = "v2")]
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
@@ -628,6 +629,142 @@ pub enum PaymentProcessorTokenResponse {
     None,
 }
 
+/// Ask the adaptive algorithm when this invoice is most likely to recover.
+///
+/// Returns `None` for every "no opinion" case — no previous attempt, no stats recorded for
+/// the cluster, or any lookup failure — so the decision always has the static ladder to fall
+/// back on. This runs inside the scheduler consumer, where a propagated error would mean no
+/// retry is scheduled at all and the invoice would silently stop recovering.
+#[cfg(feature = "v2")]
+async fn get_adaptive_retry_time(
+    state: &SessionState,
+    payment_intent: &PaymentIntent,
+    prev_attempt_id: Option<&id_type::GlobalAttemptId>,
+    key_store: &hyperswitch_domain_models::merchant_key_store::MerchantKeyStore,
+    storage_scheme: common_enums::MerchantStorageScheme,
+    dimensions: &crate::core::configs::dimension_state::DimensionsWithProcessorMerchantIdAndConnector,
+) -> Option<time::PrimitiveDateTime> {
+    // The attempt whose failure triggered this retry — its decline is what the statistics
+    // are keyed on.
+    let prev_attempt = state
+        .store
+        .find_payment_attempt_by_id(key_store, prev_attempt_id?, storage_scheme)
+        .await
+        .ok()?;
+
+    let revenue_recovery_metadata = payment_intent
+        .feature_metadata
+        .as_ref()
+        .and_then(|feature_metadata| feature_metadata.payment_revenue_recovery_metadata.clone())?
+        .convert_back();
+
+    let error = prev_attempt.error.as_ref()?;
+
+    let card_network = revenue_recovery_metadata
+        .billing_connector_payment_method_details
+        .as_ref()
+        .and_then(|details| details.get_billing_connector_card_info())
+        .and_then(|card| card.card_network.clone());
+
+    // Look the previous failure's connector error code up in the GSM table. The same flow and
+    // sub-flow the recorder uses, or the two sides resolve different codes and every read
+    // misses a bucket that was never written.
+    let gsm_record = payments::helpers::get_gsm_record(
+        state,
+        prev_attempt.connector.clone()?,
+        consts::PAYMENT_FLOW_STR,
+        consts::AUTHORIZE_FLOW_STR,
+        Some(error.code.clone()),
+        Some(error.message.clone()),
+        None,
+        card_network,
+    )
+    .await?;
+
+    logger::info!(
+        connector_error_code = %error.code,
+        gsm_error_message = %gsm_record.message,
+        gsm_unified_message = ?gsm_record.unified_message,
+        "Resolved GSM mapping for previous failure"
+    );
+
+    // Reads are at root granularity, so the standardised code is the only dimension the key
+    // carries — `Dim<StandardisedCode>` will not accept a message string.
+    let standardised_code = gsm_record.standardised_code?;
+
+    let cluster_key =
+        hyperswitch_domain_models::revenue_recovery::retry_stats_cluster_key::RetryStatsClusterKey::
+            root_from_error_code(standardised_code);
+
+    // `None` when the cluster has no recorded history yet.
+    let stats = state
+        .store
+        .get_revenue_recovery_retry_stats_store()
+        .find_revenue_recovery_retry_stats_by_key(cluster_key.as_db())
+        .await
+        .map_err(|error| {
+            logger::error!(
+                ?error,
+                cluster_key = %cluster_key.as_db(),
+                "Failed to fetch revenue recovery retry stats"
+            );
+        })
+        .ok()??;
+
+    let document = pcr::retry_stats::document::StatsDocument::from_json(&stats.distribution).ok()?;
+
+    // The invoice may only be retried inside its grace period, which runs from the first
+    // attempt for a configured number of days. What the model gets is what is left of it.
+    let grace_period_days = dimensions
+        .get_recovery_grace_period_days(
+            state.store.as_ref(),
+            state.superposition_service.as_ref(),
+            None,
+        )
+        .await;
+
+    let grace_period_ends_at = revenue_recovery_metadata
+        .invoice_billing_started_at_time?
+        .assume_utc()
+        + time::Duration::days(grace_period_days);
+
+    let remaining_grace_days = u32::try_from(
+        (grace_period_ends_at - time::OffsetDateTime::now_utc())
+            .whole_days()
+            .max(0),
+    )
+    .ok()?;
+
+    // Retries the invoice has left: its configured allowance less what it has already spent.
+    let max_retry_count = dimensions
+        .get_recovery_max_retry_count(
+            state.store.as_ref(),
+            state.superposition_service.as_ref(),
+            None,
+        )
+        .await;
+
+    let remaining_budget = u32::try_from(
+        (max_retry_count - i64::from(revenue_recovery_metadata.total_retry_count)).max(0),
+    )
+    .ok()?;
+
+    // Everything the model needs is now resolved. The scoring function itself does not exist
+    // yet, so this returns `None` and the decision falls back to the static ladder — but the
+    // key, the fetch and both budgets are exercised for real, which is what makes a key
+    // mismatch visible before the model can mask it as "no opinion".
+    logger::info!(
+        cluster_key = %cluster_key.as_db(),
+        remaining_budget = remaining_budget,
+        remaining_grace_days = remaining_grace_days,
+        has_stats = true,
+        "Adaptive retry inputs resolved; awaiting math model"
+    );
+    let _ = &document;
+
+    None
+}
+
 #[cfg(feature = "v2")]
 pub async fn get_token_with_schedule_time_based_on_retry_algorithm_type(
     state: &SessionState,
@@ -636,8 +773,22 @@ pub async fn get_token_with_schedule_time_based_on_retry_algorithm_type(
     billing_connector: common_enums::connector_enums::Connector,
     retry_algorithm_type: RevenueRecoveryAlgorithmType,
     retry_count: i32,
-) -> CustomResult<PaymentProcessorTokenResponse, errors::ProcessTrackerError> {
+    recovery_schedule: &pcr::schedule::RecoverySchedule,
+    prev_attempt_id: Option<&id_type::GlobalAttemptId>,
+    key_store: &hyperswitch_domain_models::merchant_key_store::MerchantKeyStore,
+    storage_scheme: common_enums::MerchantStorageScheme,
+) -> CustomResult<
+    (
+        PaymentProcessorTokenResponse,
+        Option<pcr::schedule::RecoverySchedule>,
+    ),
+    errors::ProcessTrackerError,
+> {
     let mut payment_processor_token_response = PaymentProcessorTokenResponse::None;
+    // Updated scheduling state, set only when a retry is actually scheduled by the adaptive
+    // path. The other responses reschedule the CALCULATE job without making an attempt, so
+    // persisting there would consume a pinned static time for a retry that never happened.
+    let mut next_recovery_schedule = None;
     match retry_algorithm_type {
         RevenueRecoveryAlgorithmType::Monitoring => {
             logger::error!("Monitoring type found for Revenue Recovery retry payment");
@@ -656,73 +807,94 @@ pub async fn get_token_with_schedule_time_based_on_retry_algorithm_type(
             .await
             .ok_or(errors::ProcessTrackerError::EApiErrorResponse)?;
 
-            let payment_processor_token = payment_intent
-                .feature_metadata
-                .as_ref()
-                .and_then(|metadata| metadata.payment_revenue_recovery_metadata.as_ref())
-                .map(|recovery_metadata| {
-                    recovery_metadata
-                        .billing_connector_payment_details
-                        .payment_processor_token
-                        .clone()
-                });
-
-            let payment_processor_tokens_details =
-                RedisTokenManager::get_payment_processor_metadata_for_connector_customer(
-                    state,
-                    connector_customer_id,
-                )
-                .await
-                .change_context(errors::ProcessTrackerError::ERedisError(
-                    errors::RedisError::RedisConnectionError.into(),
-                ))?;
-
-            // Get the token info from redis
-            let payment_processor_tokens_details_with_retry_info = payment_processor_token
-                .as_ref()
-                .and_then(|t| payment_processor_tokens_details.get(t));
-
-            // If payment_processor_tokens_details_with_retry_info is None, then no schedule time
-            match payment_processor_tokens_details_with_retry_info {
-                None => {
-                    payment_processor_token_response = PaymentProcessorTokenResponse::None;
-                    logger::debug!("No payment processor token found for cascading retry");
-                }
-                Some(payment_token) => {
-                    if payment_token.token_status.is_hard_decline.unwrap_or(false) {
-                        payment_processor_token_response =
-                            PaymentProcessorTokenResponse::HardDecline;
-                    } else if payment_token.retry_wait_time_hours > 0 {
-                        let utc_schedule_time: time::OffsetDateTime =
-                            time::OffsetDateTime::now_utc()
-                                + time::Duration::hours(payment_token.retry_wait_time_hours);
-                        let next_available_time = time::PrimitiveDateTime::new(
-                            utc_schedule_time.date(),
-                            utc_schedule_time.time(),
-                        );
-
-                        payment_processor_token_response =
-                            PaymentProcessorTokenResponse::NextAvailableTime {
-                                next_available_time,
-                            };
-                    } else {
-                        payment_processor_token_response =
-                            PaymentProcessorTokenResponse::ScheduledTime {
-                                scheduled_time: time,
-                            };
-                    }
-                }
-            }
-        }
-
-        RevenueRecoveryAlgorithmType::Smart => {
-            payment_processor_token_response = get_best_psp_token_available_for_smart_retry(
+            payment_processor_token_response = get_token_availability_for_schedule_time(
                 state,
                 connector_customer_id,
                 payment_intent,
+                time,
             )
-            .await
-            .change_context(errors::ProcessTrackerError::EApiErrorResponse)?;
+            .await?;
+        }
+
+        RevenueRecoveryAlgorithmType::Smart => {
+            let dimensions = crate::core::configs::dimension_state::Dimensions::new()
+                .with_processor_merchant_id(payment_intent.merchant_id.clone().into())
+                .with_connector(billing_connector);
+
+            let adaptive_retry_enabled = dimensions
+                .get_adaptive_retry_enabled(
+                    state.store.as_ref(),
+                    state.superposition_service.as_ref(),
+                    None,
+                )
+                .await;
+
+            if adaptive_retry_enabled {
+                // Same shape as the cascading arm — compute the schedule time, then gate on
+                // the token. The only additions are the adaptive candidate and the choice
+                // between the two.
+                let queried_rung = recovery_schedule.next_rung();
+                let static_time = get_schedule_time_to_retry_mit_payments(
+                    state.store.as_ref(),
+                    state.superposition_service.as_ref(),
+                    &dimensions,
+                    queried_rung,
+                )
+                .await
+                .ok_or(errors::ProcessTrackerError::EApiErrorResponse)?;
+
+                // The one extra call. `None` whenever the algorithm has no opinion, in which
+                // case the decision resolves to the static time exactly as cascading would.
+                let adaptive_time = get_adaptive_retry_time(
+                    state,
+                    payment_intent,
+                    prev_attempt_id,
+                    key_store,
+                    storage_scheme,
+                    &dimensions,
+                )
+                .await;
+
+                let decision = pcr::schedule::decide_next_retry(
+                    recovery_schedule,
+                    queried_rung,
+                    static_time,
+                    adaptive_time,
+                );
+
+                logger::info!(
+                    source = ?decision.source,
+                    queried_rung = queried_rung,
+                    static_time = ?static_time,
+                    schedule_time = ?decision.schedule_time,
+                    "Adaptive retry decision"
+                );
+
+                payment_processor_token_response = get_token_availability_for_schedule_time(
+                    state,
+                    connector_customer_id,
+                    payment_intent,
+                    decision.schedule_time,
+                )
+                .await?;
+
+                // The rung is consumed only when a retry is genuinely scheduled. The other
+                // responses finish or reschedule the CALCULATE job without an attempt.
+                if matches!(
+                    payment_processor_token_response,
+                    PaymentProcessorTokenResponse::ScheduledTime { .. }
+                ) {
+                    next_recovery_schedule = Some(decision.next_schedule);
+                }
+            } else {
+                payment_processor_token_response = get_best_psp_token_available_for_smart_retry(
+                    state,
+                    connector_customer_id,
+                    payment_intent,
+                )
+                .await
+                .change_context(errors::ProcessTrackerError::EApiErrorResponse)?;
+            }
         }
     }
 
@@ -757,6 +929,73 @@ pub async fn get_token_with_schedule_time_based_on_retry_algorithm_type(
             logger::debug!("No retry info available");
         }
     }
+
+    Ok((payment_processor_token_response, next_recovery_schedule))
+}
+
+/// Check the invoice's payment processor token against a schedule time already decided.
+///
+/// Shared by the cascading and adaptive paths so both gate on the same conditions: a hard
+/// declined token terminates, a token still inside its wait window defers, a missing token
+/// reschedules the CALCULATE job, and anything else accepts `scheduled_time` as-is.
+#[cfg(feature = "v2")]
+async fn get_token_availability_for_schedule_time(
+    state: &SessionState,
+    connector_customer_id: &str,
+    payment_intent: &PaymentIntent,
+    scheduled_time: time::PrimitiveDateTime,
+) -> CustomResult<PaymentProcessorTokenResponse, errors::ProcessTrackerError> {
+    let payment_processor_token = payment_intent
+        .feature_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.payment_revenue_recovery_metadata.as_ref())
+        .map(|recovery_metadata| {
+            recovery_metadata
+                .billing_connector_payment_details
+                .payment_processor_token
+                .clone()
+        });
+
+    let payment_processor_tokens_details =
+        RedisTokenManager::get_payment_processor_metadata_for_connector_customer(
+            state,
+            connector_customer_id,
+        )
+        .await
+        .change_context(errors::ProcessTrackerError::ERedisError(
+            errors::RedisError::RedisConnectionError.into(),
+        ))?;
+
+    // Get the token info from redis
+    let payment_processor_tokens_details_with_retry_info = payment_processor_token
+        .as_ref()
+        .and_then(|token| payment_processor_tokens_details.get(token));
+
+    // If payment_processor_tokens_details_with_retry_info is None, then no schedule time
+    let payment_processor_token_response = match payment_processor_tokens_details_with_retry_info {
+        None => {
+            logger::debug!("No payment processor token found for retry");
+            PaymentProcessorTokenResponse::None
+        }
+        Some(payment_token) => {
+            if payment_token.token_status.is_hard_decline.unwrap_or(false) {
+                PaymentProcessorTokenResponse::HardDecline
+            } else if payment_token.retry_wait_time_hours > 0 {
+                let utc_schedule_time: time::OffsetDateTime = time::OffsetDateTime::now_utc()
+                    + time::Duration::hours(payment_token.retry_wait_time_hours);
+                let next_available_time = time::PrimitiveDateTime::new(
+                    utc_schedule_time.date(),
+                    utc_schedule_time.time(),
+                );
+
+                PaymentProcessorTokenResponse::NextAvailableTime {
+                    next_available_time,
+                }
+            } else {
+                PaymentProcessorTokenResponse::ScheduledTime { scheduled_time }
+            }
+        }
+    };
 
     Ok(payment_processor_token_response)
 }

--- a/crates/storage_impl/src/lib.rs
+++ b/crates/storage_impl/src/lib.rs
@@ -44,6 +44,8 @@ pub mod payouts;
 pub mod platform_wrapper;
 pub mod redis;
 pub mod refund;
+#[cfg(feature = "v2")]
+pub mod revenue_recovery_retry_stats;
 mod reverse_lookup;
 pub mod subscription;
 pub mod utils;

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -2347,6 +2347,12 @@ impl Conversion for PaymentAttempt {
                 amount_captured: storage_model.amount_captured,
             };
 
+            let standardised_code = storage_model
+                .error_details
+                .as_ref()
+                .and_then(|error_details| error_details.unified_details.as_ref())
+                .and_then(|unified_details| unified_details.standardised_code);
+
             let error = storage_model
                 .error_code
                 .zip(storage_model.error_message)
@@ -2359,6 +2365,7 @@ impl Conversion for PaymentAttempt {
                     network_advice_code: storage_model.network_advice_code,
                     network_decline_code: storage_model.network_decline_code,
                     network_error_message: storage_model.network_error_message,
+                    standardised_code,
                 });
 
             Ok::<Self, error_stack::Report<common_utils::errors::CryptoError>>(Self {

--- a/crates/storage_impl/src/revenue_recovery_retry_stats.rs
+++ b/crates/storage_impl/src/revenue_recovery_retry_stats.rs
@@ -1,0 +1,141 @@
+use common_utils::errors::CustomResult;
+pub use diesel_models::revenue_recovery_retry_stats::{
+    RevenueRecoveryRetryStats, RevenueRecoveryRetryStatsNew,
+};
+use error_stack::report;
+use router_env::{instrument, tracing};
+
+use crate::{
+    connection, errors::StorageError, kv_router_store::KVRouterStore, DatabaseStore, MockDb,
+    RouterStore,
+};
+
+/// Storage access for the revenue-recovery `revenue_recovery_retry_stats` doc-store.
+#[async_trait::async_trait]
+pub trait RevenueRecoveryRetryStatsInterface: Send + Sync {
+    type Error;
+
+    /// Fetch the stored stats document for a single cluster key (`None` when absent).
+    async fn find_revenue_recovery_retry_stats_by_key(
+        &self,
+        key: String,
+    ) -> CustomResult<Option<RevenueRecoveryRetryStats>, Self::Error>;
+
+    /// Insert a new stats document for a key that does not yet exist.
+    async fn insert_revenue_recovery_retry_stats(
+        &self,
+        revenue_recovery_retry_stats: RevenueRecoveryRetryStatsNew,
+    ) -> CustomResult<RevenueRecoveryRetryStats, Self::Error>;
+
+    /// Overwrite the stats document for a key that already exists.
+    async fn update_revenue_recovery_retry_stats(
+        &self,
+        cluster_key: String,
+        distribution: serde_json::Value,
+    ) -> CustomResult<RevenueRecoveryRetryStats, Self::Error>;
+}
+
+#[async_trait::async_trait]
+impl<T: DatabaseStore> RevenueRecoveryRetryStatsInterface for RouterStore<T> {
+    type Error = StorageError;
+
+    #[instrument(skip_all)]
+    async fn find_revenue_recovery_retry_stats_by_key(
+        &self,
+        key: String,
+    ) -> CustomResult<Option<RevenueRecoveryRetryStats>, StorageError> {
+        // Read from the write primary: callers do read-modify-write on the same row,
+        // so a lagged replica can miss a just-committed INSERT and trigger a duplicate-key violation.
+        let conn = connection::pg_connection_write(self).await?;
+        RevenueRecoveryRetryStats::find_by_key(&conn, key)
+            .await
+            .map_err(|error| report!(StorageError::from(error)))
+    }
+
+    #[instrument(skip_all)]
+    async fn insert_revenue_recovery_retry_stats(
+        &self,
+        revenue_recovery_retry_stats: RevenueRecoveryRetryStatsNew,
+    ) -> CustomResult<RevenueRecoveryRetryStats, StorageError> {
+        let conn = connection::pg_connection_write(self).await?;
+        revenue_recovery_retry_stats
+            .insert(&conn)
+            .await
+            .map_err(|error| report!(StorageError::from(error)))
+    }
+
+    #[instrument(skip_all)]
+    async fn update_revenue_recovery_retry_stats(
+        &self,
+        cluster_key: String,
+        distribution: serde_json::Value,
+    ) -> CustomResult<RevenueRecoveryRetryStats, StorageError> {
+        let conn = connection::pg_connection_write(self).await?;
+        RevenueRecoveryRetryStats::update_distribution(&conn, cluster_key, distribution)
+            .await
+            .map_err(|error| report!(StorageError::from(error)))
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: DatabaseStore> RevenueRecoveryRetryStatsInterface for KVRouterStore<T> {
+    type Error = StorageError;
+
+    #[instrument(skip_all)]
+    async fn find_revenue_recovery_retry_stats_by_key(
+        &self,
+        key: String,
+    ) -> CustomResult<Option<RevenueRecoveryRetryStats>, StorageError> {
+        self.router_store
+            .find_revenue_recovery_retry_stats_by_key(key)
+            .await
+    }
+
+    #[instrument(skip_all)]
+    async fn insert_revenue_recovery_retry_stats(
+        &self,
+        revenue_recovery_retry_stats: RevenueRecoveryRetryStatsNew,
+    ) -> CustomResult<RevenueRecoveryRetryStats, StorageError> {
+        self.router_store
+            .insert_revenue_recovery_retry_stats(revenue_recovery_retry_stats)
+            .await
+    }
+
+    #[instrument(skip_all)]
+    async fn update_revenue_recovery_retry_stats(
+        &self,
+        cluster_key: String,
+        distribution: serde_json::Value,
+    ) -> CustomResult<RevenueRecoveryRetryStats, StorageError> {
+        self.router_store
+            .update_revenue_recovery_retry_stats(cluster_key, distribution)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl RevenueRecoveryRetryStatsInterface for MockDb {
+    type Error = StorageError;
+
+    async fn find_revenue_recovery_retry_stats_by_key(
+        &self,
+        _key: String,
+    ) -> CustomResult<Option<RevenueRecoveryRetryStats>, StorageError> {
+        Err(StorageError::MockDbError)?
+    }
+
+    async fn insert_revenue_recovery_retry_stats(
+        &self,
+        _revenue_recovery_retry_stats: RevenueRecoveryRetryStatsNew,
+    ) -> CustomResult<RevenueRecoveryRetryStats, StorageError> {
+        Err(StorageError::MockDbError)?
+    }
+
+    async fn update_revenue_recovery_retry_stats(
+        &self,
+        _key: String,
+        _distribution: serde_json::Value,
+    ) -> CustomResult<RevenueRecoveryRetryStats, StorageError> {
+        Err(StorageError::MockDbError)?
+    }
+}

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -3316,7 +3316,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3352,7 +3355,10 @@ Cypress.Commands.add(
                 );
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3418,7 +3424,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3443,7 +3452,10 @@ Cypress.Commands.add(
                 globalState.set("nextActionType", "redirect_to_url");
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4121,7 +4133,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4135,7 +4150,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4182,7 +4200,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4196,7 +4217,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4325,7 +4349,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4382,7 +4409,10 @@ Cypress.Commands.add(
               );
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4459,7 +4489,10 @@ Cypress.Commands.add(
         if (response.body.capture_method !== undefined) {
           expect(response.body.payment_id).to.equal(paymentId);
           for (const key in resData.body) {
-            if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+            if (
+              key === "payment_method_data" &&
+              globalState.get("connectorId") === "checkout"
+            ) {
               expect(response.body[key], [key]).to.not.be.empty;
               expect(
                 response.body[key]?.card?.auth_code,
@@ -5106,7 +5139,10 @@ Cypress.Commands.add(
               // Response body key comparison runs for all three_ds paths, including succeeded status
               // — the redirect URL is extracted above when status !== succeeded, but all response keys are verified here
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -5187,7 +5223,10 @@ Cypress.Commands.add(
               // Response body key comparison runs for all three_ds paths, including succeeded status
               // — the redirect URL is extracted above when status !== succeeded, but all response keys are verified here
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,

--- a/v2_compatible_migrations/2026-08-13-000001_create_revenue_recovery_retry_stats/down.sql
+++ b/v2_compatible_migrations/2026-08-13-000001_create_revenue_recovery_retry_stats/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS revenue_recovery_retry_stats;

--- a/v2_compatible_migrations/2026-08-13-000001_create_revenue_recovery_retry_stats/up.sql
+++ b/v2_compatible_migrations/2026-08-13-000001_create_revenue_recovery_retry_stats/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS revenue_recovery_retry_stats (
+    cluster_key  TEXT  NOT NULL PRIMARY KEY,
+    distribution JSONB NOT NULL
+);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds an **adaptive retry scheduling** path to revenue recovery, behind a Superposition flag
that defaults to off.

On each scheduling decision the static cascading ladder and an adaptive algorithm are both
consulted. The **earlier calendar day wins, ties go to static**. A static ladder position is
consumed only when its time is actually used — if the adaptive time wins, the same position
is offered again next time, so inserted adaptive retries never exhaust the ladder early.

```
Smart arm
 ├─ adaptive_retry_enabled == false → existing decider path, unchanged
 └─ true →
      queried_rung  = recovery_schedule.next_rung()      // static_rung + 1
      static_time   = cascading ladder at queried_rung
      adaptive_time = adaptive algorithm
      decision      = earlier day wins, ties → static
      token gate    = same availability check cascading uses
      persist rung  only when a retry is actually scheduled
```

**Files**

| File | Change |
|---|---|
| `core/revenue_recovery/schedule.rs` | **New.** `RecoverySchedule`, `decide_next_retry`. Pure — no state, no I/O, no clock read |
| `workflows/revenue_recovery.rs` | `Smart` arm branches on the flag; `get_adaptive_retry_time`; token-availability block extracted into a shared helper |
| `core/revenue_recovery.rs` | Call site, `finish_calculate_workflow_with_schedule`, tracking-data construction sites |
| `core/revenue_recovery/types.rs` | `reopen_...` now destructures the tracking data exhaustively |
| `types/storage/revenue_recovery.rs` | `recovery_schedule` field on the workflow tracking data |
| `consts.rs`, `core/configs/dimension_config.rs` | Three Superposition config keys |

**Notes for reviewers**

- **`Cascading` is touched.** Its token-availability block moved into
  `get_token_availability_for_schedule_time`, now shared with the `Smart` arm. Same order,
  conditions, precedence and error mapping — the only behavioural difference is a log string
  (`"…for cascading retry"` → `"…for retry"`).
- **`static_rung` is deliberately not `process_tracker.retry_count`.** `retry_count` counts
  every attempt including inserted adaptive ones; feeding it to a short ladder runs off the
  end early and strands the invoice.
- **The exhaustive destructure in `reopen_calculate_workflow_on_payment_failure` is
  intentional.** That row is rebuilt on every failure, so anything not carried across is wiped
  exactly when it matters. It already earned its keep — it forced `prev_attempt_id` to be
  handled explicitly when that field landed, instead of silently defaulting to `None`.
- **This is currently a no-op.** The scoring function is owned separately and does not exist
  yet, so `get_adaptive_retry_time` returns `None` and every decision resolves to the static
  ladder. Even with the flag on, schedule times are identical to `Cascading`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

Three new Superposition keys, resolved on `processor_merchant_id` + `connector`, all with
database fallback:

| Key | Type | Default |
|---|---|---|
| `revenue_recovery.adaptive_retry_enabled` | `bool` | `false` |
| `revenue_recovery.grace_period_days` | `i64` | `30` |
| `revenue_recovery.max_retry_count` | `i64` | `15` |

Defined in `crates/router/src/consts.rs` and
`crates/router/src/core/configs/dimension_config.rs`. No `config/*.toml` changes.

**No schema change** — the scheduling state rides inside the existing
`process_tracker.tracking_data` JSONB, so there is no migration. `#[serde(default)]` means
rows written before this field still deserialize.

## Motivation and Context

Closes #<!-- issue number -->

Revenue recovery retries every invoice on the same fixed ladder, regardless of why it
declined, what card it is, or when that card has historically succeeded. This adds the
scheduling half of an adaptive algorithm that can propose a better date per invoice, while
keeping the static ladder as a floor so an unproven model cannot make recovery worse.

Gating per merchant and connector, defaulting to off, means it can be piloted and rolled back
without a deploy.

## How did you test it?

**Unit tests** — 17 passing in `core::revenue_recovery`, 10 of them new, covering the whole
decision matrix:

```
cargo test --offline --no-default-features --features "v2,redis-rs" \
  -p router --lib core::revenue_recovery
```

The two carrying most weight:

- `stored_rung_advances_by_one` — the ladder index follows `static_rung`, not `retry_count`
- `a_rung_survives_repeated_adaptive_wins_and_is_spent_once` — adaptive → adaptive → static,
  three attempts, exactly one static position consumed

`decide_next_retry` is a pure function of its arguments, so the matrix is covered without a
scheduler or a database.

**Not yet tested end to end.** The adaptive path cannot produce a time until the scoring
function exists, and with the flag off nothing changes. A manual test plan (config setup,
side-by-side `Cascading` vs `Smart` comparison, assertions) is written up separately.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible