### PR TITLE
fix(routing): resolve migration profiles under the merchant that owns them

### DIFF
--- a/crates/diesel_models/src/query/routing_algorithm.rs
+++ b/crates/diesel_models/src/query/routing_algorithm.rs
@@ -361,14 +361,16 @@ impl RoutingAlgorithm {
             .change_context(DatabaseError::Others)
             .map(|rows| {
                 rows.into_iter()
-                    .map(|(profile_id, processor_merchant_id, merchant_id, algorithm_id, kind)| {
-                        (
-                            profile_id,
-                            processor_merchant_id.unwrap_or(merchant_id),
-                            algorithm_id,
-                            kind,
-                        )
-                    })
+                    .map(
+                        |(profile_id, processor_merchant_id, merchant_id, algorithm_id, kind)| {
+                            (
+                                profile_id,
+                                processor_merchant_id.unwrap_or(merchant_id),
+                                algorithm_id,
+                                kind,
+                            )
+                        },
+                    )
                     .collect()
             })
     }

--- a/crates/diesel_models/src/query/routing_algorithm.rs
+++ b/crates/diesel_models/src/query/routing_algorithm.rs
@@ -319,9 +319,16 @@ impl RoutingAlgorithm {
             .collect())
     }
 
-    /// Every rule id held by the given profiles, with each profile's merchant — taken from here
-    /// rather than `business_profile`, which is encrypted and needs the merchant to read. The
-    /// kind rides along so callers can tell which rules a migration is expected to carry.
+    /// Every rule id held by the given profiles, with the merchant that owns each profile —
+    /// taken from here rather than `business_profile`, which is encrypted and needs the merchant
+    /// to read. The kind rides along so callers can tell which rules a migration is expected to
+    /// carry.
+    ///
+    /// The owner is `processor_merchant_id`, falling back to `merchant_id`. A rule written
+    /// through a platform records the provider that made the call in `merchant_id` and the
+    /// merchant the profile hangs off in `processor_merchant_id`; callers resolve the business
+    /// profile under what this returns, and under the provider there is no such profile. The
+    /// column is null on rules written before platform support, where the two are the same.
     pub async fn rule_ids_for_profiles(
         conn: &PgPooledConn,
         profile_ids: &[common_utils::id_type::ProfileId],
@@ -336,6 +343,7 @@ impl RoutingAlgorithm {
         Self::table()
             .select((
                 dsl::profile_id,
+                dsl::processor_merchant_id,
                 dsl::merchant_id,
                 dsl::algorithm_id,
                 dsl::kind,
@@ -344,12 +352,25 @@ impl RoutingAlgorithm {
             .order((dsl::profile_id.asc(), dsl::algorithm_id.asc()))
             .load_async::<(
                 common_utils::id_type::ProfileId,
+                Option<common_utils::id_type::MerchantId>,
                 common_utils::id_type::MerchantId,
                 common_utils::id_type::RoutingId,
                 enums::RoutingAlgorithmKind,
             )>(conn)
             .await
             .change_context(DatabaseError::Others)
+            .map(|rows| {
+                rows.into_iter()
+                    .map(|(profile_id, processor_merchant_id, merchant_id, algorithm_id, kind)| {
+                        (
+                            profile_id,
+                            processor_merchant_id.unwrap_or(merchant_id),
+                            algorithm_id,
+                            kind,
+                        )
+                    })
+                    .collect()
+            })
     }
 
     /// A page of the profiles that hold routing rules. Grouped so the page is of profiles —

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -2732,6 +2732,9 @@ pub async fn migrate_rules_for_profiles(
     let limit = request.validated_limit();
     let offset = request.offset.unwrap_or_default();
 
+    // The merchant that owns each profile, which is what the business profile is resolved
+    // under below. For a rule a platform wrote, that is its processor and not the provider the
+    // call was made by — `find_rule_ids_for_profiles` resolves which.
     let merchant_of: HashMap<_, _> = state
         .store
         .find_rule_ids_for_profiles(&request.profile_ids)
@@ -3129,9 +3132,18 @@ pub async fn routing_migration_status(
     // Rules the migration is not expected to carry, counted apart so holding one never leaves a
     // finished profile reading as partial.
     let mut out_of_scope: HashMap<common_utils::id_type::ProfileId, i64> = HashMap::new();
+    // The merchant that owns each profile. The page above is grouped by the rule's
+    // `merchant_id`, which for a platform-written rule is the provider that made the call
+    // rather than the merchant the profile hangs off — reporting that one names an account the
+    // profile is not under, and is the merchant a migration would then fail to find it in.
+    let mut owner_of: HashMap<
+        common_utils::id_type::ProfileId,
+        common_utils::id_type::MerchantId,
+    > = HashMap::new();
     match state.store.find_rule_ids_for_profiles(&page_profiles).await {
         Ok(rows) => {
-            for (profile_id, _, algorithm_id, kind) in rows {
+            for (profile_id, owner_merchant_id, algorithm_id, kind) in rows {
+                owner_of.insert(profile_id.clone(), owner_merchant_id);
                 if routing_types::RoutingAlgorithmKind::foreign_from(kind)
                     .rule_migration_exclusion()
                     .is_some()
@@ -3157,7 +3169,14 @@ pub async fn routing_migration_status(
         ..Default::default()
     };
 
-    for (profile_id, merchant_id) in scopes {
+    for (profile_id, provider_merchant_id) in scopes {
+        // Falls back to the grouping merchant only when the rule rows could not be read at all,
+        // which is the same failure that leaves the rule counts empty.
+        let merchant_id = owner_of
+            .get(&profile_id)
+            .cloned()
+            .unwrap_or_else(|| provider_merchant_id.clone());
+
         // The listing already carries each rule's id, so comparing the sets is free.
         let de_rule_ids = match list_de_euclid_routing_algorithms(
             &state,
@@ -3203,7 +3222,9 @@ pub async fn routing_migration_status(
         let dimensions = dimension_state::Dimensions::new()
             .with_processor_merchant_id(merchant_id.clone().into())
             .with_provider_merchant_id(
-                hyperswitch_domain_models::platform::ProviderMerchantId::new(merchant_id.clone()),
+                hyperswitch_domain_models::platform::ProviderMerchantId::new(
+                    provider_merchant_id,
+                ),
             )
             .with_profile_id(profile_id.clone());
         let routing_source = Some(

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -3136,10 +3136,8 @@ pub async fn routing_migration_status(
     // `merchant_id`, which for a platform-written rule is the provider that made the call
     // rather than the merchant the profile hangs off — reporting that one names an account the
     // profile is not under, and is the merchant a migration would then fail to find it in.
-    let mut owner_of: HashMap<
-        common_utils::id_type::ProfileId,
-        common_utils::id_type::MerchantId,
-    > = HashMap::new();
+    let mut owner_of: HashMap<common_utils::id_type::ProfileId, common_utils::id_type::MerchantId> =
+        HashMap::new();
     match state.store.find_rule_ids_for_profiles(&page_profiles).await {
         Ok(rows) => {
             for (profile_id, owner_merchant_id, algorithm_id, kind) in rows {
@@ -3222,9 +3220,7 @@ pub async fn routing_migration_status(
         let dimensions = dimension_state::Dimensions::new()
             .with_processor_merchant_id(merchant_id.clone().into())
             .with_provider_merchant_id(
-                hyperswitch_domain_models::platform::ProviderMerchantId::new(
-                    provider_merchant_id,
-                ),
+                hyperswitch_domain_models::platform::ProviderMerchantId::new(provider_merchant_id),
             )
             .with_profile_id(profile_id.clone());
         let routing_source = Some(

--- a/crates/router/src/db/routing_algorithm.rs
+++ b/crates/router/src/db/routing_algorithm.rs
@@ -71,6 +71,8 @@ pub trait RoutingAlgorithmInterface {
         )>,
     >;
 
+    /// Each profile's rules, with the merchant that **owns the profile** — the rule's
+    /// `processor_merchant_id` where a platform wrote it, its `merchant_id` otherwise.
     async fn find_rule_ids_for_profiles(
         &self,
         profile_ids: &[common_utils::id_type::ProfileId],


### PR DESCRIPTION
## Problem

`routing_algorithm` records two merchants for a rule written through a platform:

| column | holds |
|---|---|
| `merchant_id` | the **provider** — the merchant whose call created the rule |
| `processor_merchant_id` | the **processor** — the merchant the profile hangs off |

Set that way at creation, in `RoutingAlgorithmUpdate::create_new_routing_algorithm`:

```rust
merchant_id:           platform.get_provider().get_account().get_id().clone(),
processor_merchant_id: Some(platform.get_processor().get_account().get_id().clone()),
```

`business_profile.merchant_id` is the **processor**. Both migration endpoints read `merchant_id`, so for these rules they name an account the profile is not under. `migrate_rules_for_profiles` then resolves the business profile there:

```rust
core_utils::validate_and_get_business_profile(db, &processor, Some(&profile_id))
```

and answers, for a profile that is present and healthy:

```json
{"error":{"type":"object_not_found","code":"HE_02",
  "message":"Business profile with the given id 'pro_...' does not exist in our records"}}
```

Every rule under such a profile is permanently unmigratable — re-running gives the same answer, since nothing in the request influences which merchant is used. The status endpoint reports the same wrong merchant, so the profile also displays under an account it does not belong to.

Seen on sandbox: a profile owned by `sf_da0acce…` whose rules carry `merchant_id = merchant_1783701278`, across all 71 profiles of that platform merchant.

## Fix

`rule_ids_for_profiles` returns `processor_merchant_id` where it is set and `merchant_id` otherwise — the owning merchant in both cases. The column is null on rules written before platform support, where the two are the same, so those are unaffected.

Both callers take the owning merchant from there:

- **`migrate_rules_for_profiles`** already used this value to build `merchant_of`, so it now resolves the profile under the merchant that owns it. No change beyond the query.
- **`routing_migration_status`** already calls `rule_ids_for_profiles` for the same page and discarded the merchant; it now reports it, and keeps the merchant its page is grouped by as the *provider* dimension when reading the routing source. `list_scope_page` is untouched, so grouping and paging behave exactly as before.

## Why it matters beyond the failed migration

`migrate_rules_for_profile` provisions the decision engine scope before migrating:

```rust
helpers::sync_decision_engine_hierarchy(&state, processor.get_account(), &business_profile)
```

That writes `hs_merchant_id` into the decision engine. Had the profile lookup succeeded, a platform profile would have been given the **provider** as its ancestry — wrong, silent, and with no `processor_merchant_id` concept in the decision engine to correct it later. The failed lookup was the only thing preventing it.

This also matters for scope grants: connected merchants share the platform's organization, so an org-level grant expands over them correctly only once each profile records its true `hs_merchant_id`.

## Scope

Deliberately narrow. Two things surfaced alongside this and are **not** addressed here:

- Rules outliving a deleted merchant (`merchant_account_delete` removes the account and key store but not `routing_algorithm`), which reports `merchant account could not be read`. Different cause, separate change.
- Whether the profile lookup should drop merchant scoping entirely and resolve by `profile_id` alone, which is unique. Sturdier, but a wider blast radius than this fix needs.

## Testing

- `cargo check -p diesel_models --features v1` — clean
- `cargo check -p router` — clean
- Verified against sandbox data that `processor_merchant_id` is the merchant owning the profile for the affected rules, and null across the rest of the estate (1337 profiles scanned).