### PR TITLE
feat(analytics): add org user activity log API

### DIFF
--- a/crates/analytics/src/clickhouse.rs
+++ b/crates/analytics/src/clickhouse.rs
@@ -31,6 +31,7 @@ use crate::{
     auth_events::filters::AuthEventFilterRow,
     connector_events::events::ConnectorEventsResult,
     disputes::{filters::DisputeFilterRow, metrics::DisputeMetricRow},
+    org_activity_log::{OrgActivityLogCountRow, OrgActivityLogRow},
     outgoing_webhook_event::events::OutgoingWebhookLogsResult,
     routing_events::events::RoutingEventsResult,
     sdk_events::events::SdkEventsResult,
@@ -193,6 +194,7 @@ impl super::auth_events::filters::AuthEventFilterAnalytics for ClickhouseClient 
 impl super::api_event::events::ApiLogsFilterAnalytics for ClickhouseClient {}
 impl super::api_event::filters::ApiEventFilterAnalytics for ClickhouseClient {}
 impl super::api_event::metrics::ApiEventMetricAnalytics for ClickhouseClient {}
+impl super::org_activity_log::OrgActivityLogAnalytics for ClickhouseClient {}
 impl super::connector_events::events::ConnectorEventLogAnalytics for ClickhouseClient {}
 impl super::routing_events::events::RoutingEventLogAnalytics for ClickhouseClient {}
 impl super::outgoing_webhook_event::events::OutgoingWebhookLogsFilterAnalytics
@@ -220,6 +222,26 @@ impl TryInto<ApiLogsResult> for serde_json::Value {
     fn try_into(self) -> Result<ApiLogsResult, Self::Error> {
         serde_json::from_value(self).change_context(ParsingError::StructParseFailure(
             "Failed to parse ApiLogsResult in clickhouse results",
+        ))
+    }
+}
+
+impl TryInto<OrgActivityLogRow> for serde_json::Value {
+    type Error = Report<ParsingError>;
+
+    fn try_into(self) -> Result<OrgActivityLogRow, Self::Error> {
+        serde_json::from_value(self).change_context(ParsingError::StructParseFailure(
+            "Failed to parse OrgActivityLogRow in clickhouse results",
+        ))
+    }
+}
+
+impl TryInto<OrgActivityLogCountRow> for serde_json::Value {
+    type Error = Report<ParsingError>;
+
+    fn try_into(self) -> Result<OrgActivityLogCountRow, Self::Error> {
+        serde_json::from_value(self).change_context(ParsingError::StructParseFailure(
+            "Failed to parse OrgActivityLogCountRow in clickhouse results",
         ))
     }
 }

--- a/crates/analytics/src/errors.rs
+++ b/crates/analytics/src/errors.rs
@@ -18,6 +18,8 @@ pub enum AnalyticsError {
     MissingEmail,
     #[error("Invalid URL scheme: {0}")]
     InvalidReturnUrl(String),
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
 }
 
 impl ErrorSwitch<ApiErrorResponse> for AnalyticsError {
@@ -54,6 +56,12 @@ impl ErrorSwitch<ApiErrorResponse> for AnalyticsError {
                 "IR",
                 6,
                 format!("Invalid return URL: {invalid_url_err}"),
+                None,
+            )),
+            Self::InvalidRequest(message) => ApiErrorResponse::BadRequest(ApiError::new(
+                "IR",
+                6,
+                format!("Invalid request: {message}"),
                 None,
             )),
         }

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -11,6 +11,7 @@ pub mod frm;
 pub mod health_check;
 pub mod metrics;
 pub mod opensearch;
+pub mod org_activity_log;
 pub mod outgoing_webhook_event;
 pub mod payment_intents;
 pub mod payments;
@@ -1184,6 +1185,8 @@ pub enum AnalyticsFlow {
     GetSankey,
     GetRoutingEvents,
     GetPaymentListFromOpenSearch,
+    GetOrgActivityLogs,
+    GetOrgActivityLogFilters,
 }
 
 impl FlowMetric for AnalyticsFlow {}

--- a/crates/analytics/src/org_activity_log.rs
+++ b/crates/analytics/src/org_activity_log.rs
@@ -1,0 +1,215 @@
+use api_models::analytics::{Granularity, TimeRange};
+use common_utils::errors::ReportSwitchExt;
+use error_stack::ResultExt;
+use router_env::{instrument, tracing, Flow};
+use time::PrimitiveDateTime;
+
+use crate::{
+    errors::AnalyticsResult,
+    query::{Aggregate, GroupByClause, Order, QueryBuilder, QueryFilter, ToSql, Window},
+    types::{AnalyticsCollection, AnalyticsDataSource, FiltersError, FiltersResult, LoadRow},
+    AnalyticsProvider,
+};
+
+/// Curated allowlist of critical dashboard actions surfaced in the org activity log
+pub const ORG_ACTIVITY_LOG_FLOWS: &[Flow] = &[
+    Flow::MerchantConnectorsCreate,
+    Flow::MerchantConnectorsUpdate,
+    Flow::MerchantConnectorsDelete,
+    Flow::MerchantsAccountUpdate,
+    Flow::ProfileCreate,
+    Flow::ProfileUpdate,
+    Flow::ProfileDelete,
+    Flow::RoutingCreateConfig,
+    Flow::RoutingLinkConfig,
+    Flow::RoutingUnlinkConfig,
+    Flow::ApiKeyCreate,
+    Flow::ApiKeyUpdate,
+    Flow::ApiKeyRevoke,
+    Flow::InviteMultipleUser,
+    Flow::UpdateUserRole,
+    Flow::DeleteUserRole,
+    Flow::CreateRole,
+    Flow::CreateRoleV2,
+    Flow::UpdateRole,
+    Flow::DecisionManagerUpsertConfig,
+    Flow::DecisionManagerDeleteConfig,
+];
+
+pub trait OrgActivityLogAnalytics:
+    LoadRow<OrgActivityLogRow> + LoadRow<OrgActivityLogCountRow>
+{
+}
+
+pub async fn get_org_activity_logs<T>(
+    user_ids: &[String],
+    merchant_ids: &[common_utils::id_type::MerchantId],
+    api_flows: &[Flow],
+    time_range: &TimeRange,
+    limit: u64,
+    offset: u64,
+    pool: &T,
+) -> FiltersResult<Vec<OrgActivityLogRow>>
+where
+    T: AnalyticsDataSource + OrgActivityLogAnalytics,
+    PrimitiveDateTime: ToSql<T>,
+    AnalyticsCollection: ToSql<T>,
+    Granularity: GroupByClause<T>,
+    Aggregate<&'static str>: ToSql<T>,
+    Window<&'static str>: ToSql<T>,
+{
+    let mut query_builder: QueryBuilder<T> =
+        QueryBuilder::new(AnalyticsCollection::ApiEventsAnalytics);
+    for column in [
+        "merchant_id",
+        "auth_user_id",
+        "flow_type",
+        "api_flow",
+        "status_code",
+        "http_method",
+        "url_path",
+        "created_at",
+    ] {
+        query_builder.add_select_column(column).switch()?;
+    }
+
+    time_range
+        .set_filter_clause(&mut query_builder)
+        .attach_printable("Error filtering time range")
+        .switch()?;
+    query_builder
+        .add_filter_in_range_clause("auth_user_id", user_ids)
+        .switch()?;
+    query_builder
+        .add_filter_in_range_clause("merchant_id", merchant_ids)
+        .switch()?;
+    query_builder
+        .add_filter_in_range_clause("api_flow", api_flows)
+        .switch()?;
+
+    query_builder
+        .add_order_by_clause("created_at", Order::Descending)
+        .switch()?;
+    query_builder.set_limit_and_offset(limit, offset);
+
+    query_builder
+        .execute_query::<OrgActivityLogRow, _>(pool)
+        .await
+        .change_context(FiltersError::QueryBuildingError)?
+        .change_context(FiltersError::QueryExecutionFailure)
+}
+
+pub async fn get_org_activity_logs_count<T>(
+    user_ids: &[String],
+    merchant_ids: &[common_utils::id_type::MerchantId],
+    api_flows: &[Flow],
+    time_range: &TimeRange,
+    pool: &T,
+) -> FiltersResult<Vec<OrgActivityLogCountRow>>
+where
+    T: AnalyticsDataSource + OrgActivityLogAnalytics,
+    PrimitiveDateTime: ToSql<T>,
+    AnalyticsCollection: ToSql<T>,
+    Granularity: GroupByClause<T>,
+    Aggregate<&'static str>: ToSql<T>,
+    Window<&'static str>: ToSql<T>,
+{
+    let mut query_builder: QueryBuilder<T> =
+        QueryBuilder::new(AnalyticsCollection::ApiEventsAnalytics);
+    query_builder
+        .add_select_column(Aggregate::Count {
+            field: None,
+            alias: Some("count"),
+        })
+        .switch()?;
+
+    time_range
+        .set_filter_clause(&mut query_builder)
+        .attach_printable("Error filtering time range")
+        .switch()?;
+    query_builder
+        .add_filter_in_range_clause("auth_user_id", user_ids)
+        .switch()?;
+    query_builder
+        .add_filter_in_range_clause("merchant_id", merchant_ids)
+        .switch()?;
+    query_builder
+        .add_filter_in_range_clause("api_flow", api_flows)
+        .switch()?;
+
+    query_builder
+        .execute_query::<OrgActivityLogCountRow, _>(pool)
+        .await
+        .change_context(FiltersError::QueryBuildingError)?
+        .change_context(FiltersError::QueryExecutionFailure)
+}
+
+#[instrument(skip_all)]
+pub async fn org_activity_log_core(
+    pool: &AnalyticsProvider,
+    user_ids: &[String],
+    merchant_ids: &[common_utils::id_type::MerchantId],
+    api_flows: &[Flow],
+    time_range: &TimeRange,
+    limit: u64,
+    offset: u64,
+) -> AnalyticsResult<(Vec<OrgActivityLogRow>, u64)> {
+    let rows = match pool {
+        AnalyticsProvider::Sqlx(_) => Err(FiltersError::NotImplemented(
+            "Org activity logs not implemented for SQLX",
+        ))
+        .attach_printable("SQL Analytics is not implemented for org activity logs"),
+        AnalyticsProvider::Clickhouse(ckh_pool)
+        | AnalyticsProvider::CombinedSqlx(_, ckh_pool)
+        | AnalyticsProvider::CombinedCkh(_, ckh_pool) => {
+            get_org_activity_logs(
+                user_ids,
+                merchant_ids,
+                api_flows,
+                time_range,
+                limit,
+                offset,
+                ckh_pool,
+            )
+            .await
+        }
+    }
+    .switch()?;
+
+    let total_count = match pool {
+        AnalyticsProvider::Sqlx(_) => Err(FiltersError::NotImplemented(
+            "Org activity logs not implemented for SQLX",
+        ))
+        .attach_printable("SQL Analytics is not implemented for org activity logs"),
+        AnalyticsProvider::Clickhouse(ckh_pool)
+        | AnalyticsProvider::CombinedSqlx(_, ckh_pool)
+        | AnalyticsProvider::CombinedCkh(_, ckh_pool) => {
+            get_org_activity_logs_count(user_ids, merchant_ids, api_flows, time_range, ckh_pool)
+                .await
+        }
+    }
+    .switch()?
+    .first()
+    .and_then(|row| row.count)
+    .unwrap_or_default();
+
+    Ok((rows, total_count))
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct OrgActivityLogRow {
+    pub merchant_id: common_utils::id_type::MerchantId,
+    pub auth_user_id: Option<String>,
+    pub flow_type: String,
+    pub api_flow: String,
+    pub status_code: u16,
+    pub http_method: Option<String>,
+    pub url_path: Option<String>,
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub created_at: PrimitiveDateTime,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct OrgActivityLogCountRow {
+    pub count: Option<u64>,
+}

--- a/crates/analytics/src/query.rs
+++ b/crates/analytics/src/query.rs
@@ -412,6 +412,8 @@ where
     order_by: Vec<String>,
     having: Option<Vec<(String, FilterTypes, String)>>,
     limit_by: Option<LimitByClause>,
+    limit: Option<u64>,
+    offset: Option<u64>,
     outer_select: Vec<String>,
     top_n: Option<TopN>,
     table: AnalyticsCollection,
@@ -591,6 +593,8 @@ where
             order_by: Default::default(),
             having: Default::default(),
             limit_by: Default::default(),
+            limit: Default::default(),
+            offset: Default::default(),
             outer_select: Default::default(),
             top_n: Default::default(),
             table,
@@ -767,6 +771,11 @@ where
         Ok(())
     }
 
+    pub fn set_limit_and_offset(&mut self, limit: u64, offset: u64) {
+        self.limit = Some(limit);
+        self.offset = Some(offset);
+    }
+
     pub fn add_granularity_in_mins(&mut self, granularity: Granularity) -> QueryResult<()> {
         let interval = match granularity {
             Granularity::OneMin => "1",
@@ -907,6 +916,13 @@ where
 
         if let Some(limit_by) = &self.limit_by {
             query.push_str(&format!(" {limit_by}"));
+        }
+
+        if let Some(limit) = self.limit {
+            query.push_str(&format!(" LIMIT {limit}"));
+            if let Some(offset) = self.offset {
+                query.push_str(&format!(" OFFSET {offset}"));
+            }
         }
 
         if !self.outer_select.is_empty() {

--- a/crates/api_models/src/analytics.rs
+++ b/crates/api_models/src/analytics.rs
@@ -20,6 +20,7 @@ pub mod auth_events;
 pub mod connector_events;
 pub mod disputes;
 pub mod frm;
+pub mod org_activity_log;
 pub mod outgoing_webhook_event;
 pub mod payment_intents;
 pub mod payments;

--- a/crates/api_models/src/analytics/org_activity_log.rs
+++ b/crates/api_models/src/analytics/org_activity_log.rs
@@ -1,0 +1,56 @@
+use common_utils::pii;
+use hyperswitch_masking::Secret;
+
+use super::TimeRange;
+
+pub const ORG_ACTIVITY_LOG_DEFAULT_LIMIT: u64 = 20;
+pub const ORG_ACTIVITY_LOG_MAX_LIMIT: u64 = 100;
+
+fn default_activity_log_limit() -> u64 {
+    ORG_ACTIVITY_LOG_DEFAULT_LIMIT
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgActivityLogRequest {
+    pub time_range: TimeRange,
+    #[serde(default)]
+    pub offset: u64,
+    #[serde(default = "default_activity_log_limit")]
+    pub limit: u64,
+    #[serde(default)]
+    pub user_ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub api_flows: Option<Vec<String>>,
+    #[serde(default)]
+    pub merchant_ids: Option<Vec<common_utils::id_type::MerchantId>>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgActivityLogResponse {
+    pub total_count: u64,
+    pub activity_logs: Vec<OrgActivityLogEntry>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgActivityLogEntry {
+    pub user_id: Option<String>,
+    pub user_email: Option<pii::Email>,
+    pub user_name: Option<Secret<String>>,
+    pub api_flow: String,
+    pub flow_type: String,
+    pub url_path: Option<String>,
+    pub http_method: Option<String>,
+    pub status_code: u16,
+    pub merchant_id: Option<common_utils::id_type::MerchantId>,
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub created_at: time::PrimitiveDateTime,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgActivityLogFilterValues {
+    pub api_flows: Vec<String>,
+}

--- a/crates/api_models/src/events.rs
+++ b/crates/api_models/src/events.rs
@@ -27,8 +27,8 @@ use crate::{
     admin::*,
     analytics::{
         api_event::*, auth_events::*, connector_events::ConnectorEventsRequest,
-        outgoing_webhook_event::OutgoingWebhookLogsRequest, routing_events::RoutingEventsRequest,
-        sdk_events::*, search::*, *,
+        org_activity_log::*, outgoing_webhook_event::OutgoingWebhookLogsRequest,
+        routing_events::RoutingEventsRequest, sdk_events::*, search::*, *,
     },
     api_keys::*,
     cards_info::*,
@@ -149,7 +149,10 @@ impl_api_event_type!(
         OrganizationUpdateRequest,
         OrganizationId,
         CustomerListRequest,
-        RoutingEventsRequest
+        RoutingEventsRequest,
+        OrgActivityLogRequest,
+        OrgActivityLogResponse,
+        OrgActivityLogFilterValues
     )
 );
 

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -14,6 +14,7 @@ pub mod routes {
         errors::AnalyticsError,
         lambda_utils::invoke_lambda,
         opensearch::OpenSearchError,
+        org_activity_log::{org_activity_log_core, ORG_ACTIVITY_LOG_FLOWS},
         outgoing_webhook_event::outgoing_webhook_events_core,
         routing_events::routing_events_core,
         sdk_events::sdk_events_core,
@@ -21,6 +22,10 @@ pub mod routes {
     };
     use api_models::analytics::{
         api_event::QueryType,
+        org_activity_log::{
+            OrgActivityLogEntry, OrgActivityLogFilterValues, OrgActivityLogRequest,
+            OrgActivityLogResponse, ORG_ACTIVITY_LOG_MAX_LIMIT,
+        },
         search::{
             GetGlobalSearchRequest, GetSearchRequest, GetSearchRequestWithIndex, SearchFilters,
             SearchIndex,
@@ -43,7 +48,7 @@ pub mod routes {
         analytics_validator::{request_validator, validate_report_request},
         consts::opensearch::SEARCH_INDEXES,
         core::{api_locking, errors::user::UserErrors, verification::utils},
-        db::user_role::ListUserRolesByUserIdPayload,
+        db::user_role::{ListUserRolesByOrgIdPayload, ListUserRolesByUserIdPayload},
         routes::{metrics, AppState},
         services::{
             api,
@@ -51,7 +56,10 @@ pub mod routes {
             authorization::{permissions::Permission, roles::RoleInfo},
             ApplicationResponse,
         },
-        types::{domain::UserEmail, storage::UserRole},
+        types::{
+            domain::{UserEmail, UserFromStorage},
+            storage::UserRole,
+        },
         utils::get_payment_response_hash_key,
     };
 
@@ -391,6 +399,14 @@ pub mod routes {
                                 .service(
                                     web::resource("metrics/auth_events/sankey")
                                         .route(web::post().to(get_org_auth_event_sankey)),
+                                )
+                                .service(
+                                    web::resource("activity_logs")
+                                        .route(web::post().to(get_org_activity_logs)),
+                                )
+                                .service(
+                                    web::resource("activity_logs/filters")
+                                        .route(web::get().to(get_org_activity_log_filters)),
                                 ),
                         )
                         .service(
@@ -647,6 +663,223 @@ pub mod routes {
                 analytics::payments::get_metrics(&state.pool, &ex_rates, &auth_info, req)
                     .await
                     .map(ApplicationResponse::Json)
+            },
+            auth::auth_type(
+                &auth::PlatformOrgAdminAuth {
+                    is_admin_auth_allowed: false,
+                    organization_id: None,
+                },
+                &auth::JWTAuth {
+                    permission: Permission::OrganizationAnalyticsRead,
+                    allow_connected: true,
+                    allow_platform: true,
+                },
+                req.headers(),
+            ),
+            api_locking::LockAction::NotApplicable,
+        ))
+        .await
+    }
+
+    #[cfg(feature = "v1")]
+    pub async fn get_org_activity_logs(
+        state: web::Data<AppState>,
+        req: actix_web::HttpRequest,
+        json_payload: web::Json<OrgActivityLogRequest>,
+    ) -> impl Responder {
+        let flow = AnalyticsFlow::GetOrgActivityLogs;
+        Box::pin(api::server_wrap(
+            flow,
+            state,
+            &req,
+            json_payload.into_inner(),
+            |state, auth: AuthenticationData, req, _| async move {
+                let org_id = auth
+                    .platform
+                    .get_processor()
+                    .get_account()
+                    .get_org_id()
+                    .clone();
+
+                let api_flows = match &req.api_flows {
+                    Some(requested) if !requested.is_empty() => {
+                        if let Some(unknown) = requested.iter().find(|flow| {
+                            !ORG_ACTIVITY_LOG_FLOWS
+                                .iter()
+                                .any(|allowed| allowed.to_string() == **flow)
+                        }) {
+                            return Err(report!(AnalyticsError::InvalidRequest(format!(
+                                "unknown api_flow: {unknown}"
+                            ))));
+                        }
+                        ORG_ACTIVITY_LOG_FLOWS
+                            .iter()
+                            .filter(|allowed| requested.contains(&allowed.to_string()))
+                            .cloned()
+                            .collect::<Vec<_>>()
+                    }
+                    _ => ORG_ACTIVITY_LOG_FLOWS.to_vec(),
+                };
+
+                let org_merchant_ids = state
+                    .store
+                    .list_merchant_accounts_by_organization_id(&org_id)
+                    .await
+                    .change_context(AnalyticsError::UnknownError)?
+                    .into_iter()
+                    .map(|merchant_account| merchant_account.get_id().to_owned())
+                    .collect::<Vec<_>>();
+
+                let merchant_ids = match &req.merchant_ids {
+                    Some(requested) if !requested.is_empty() => org_merchant_ids
+                        .into_iter()
+                        .filter(|merchant_id| requested.contains(merchant_id))
+                        .collect::<Vec<_>>(),
+                    // org-level actions are recorded under the sentinel merchant id, so
+                    // keep them only when no explicit merchant filter is requested
+                    _ => {
+                        let mut merchant_ids = org_merchant_ids;
+                        merchant_ids
+                            .push(common_utils::id_type::MerchantId::get_merchant_id_not_found());
+                        merchant_ids
+                    }
+                };
+
+                let org_user_ids = state
+                    .global_store
+                    .list_user_roles_by_org_id(ListUserRolesByOrgIdPayload {
+                        user_id: None,
+                        tenant_id: &state.tenant.tenant_id,
+                        org_id: &org_id,
+                        merchant_id: None,
+                        profile_id: None,
+                        entity_type: None,
+                        version: None,
+                        limit: None,
+                    })
+                    .await
+                    .change_context(AnalyticsError::UnknownError)?
+                    .into_iter()
+                    .map(|user_role| user_role.user_id)
+                    .collect::<HashSet<_>>();
+
+                let user_ids = match &req.user_ids {
+                    Some(requested) if !requested.is_empty() => requested
+                        .iter()
+                        .filter(|user_id| org_user_ids.contains(*user_id))
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    _ => org_user_ids.into_iter().collect(),
+                };
+
+                if user_ids.is_empty() || merchant_ids.is_empty() {
+                    return Ok(ApplicationResponse::Json(OrgActivityLogResponse {
+                        total_count: 0,
+                        activity_logs: Vec::new(),
+                    }));
+                }
+
+                let limit = req.limit.min(ORG_ACTIVITY_LOG_MAX_LIMIT);
+                let (rows, total_count) = org_activity_log_core(
+                    &state.pool,
+                    &user_ids,
+                    &merchant_ids,
+                    &api_flows,
+                    &req.time_range,
+                    limit,
+                    req.offset,
+                )
+                .await?;
+
+                let page_user_ids = rows
+                    .iter()
+                    .filter_map(|row| row.auth_user_id.clone())
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                let users = if page_user_ids.is_empty() {
+                    HashMap::new()
+                } else {
+                    state
+                        .global_store
+                        .list_users_by_user_ids(page_user_ids)
+                        .await
+                        .change_context(AnalyticsError::UnknownError)?
+                        .into_iter()
+                        .map(UserFromStorage::from)
+                        .map(|user| {
+                            (
+                                user.get_user_id().to_string(),
+                                (user.get_name(), user.get_email()),
+                            )
+                        })
+                        .collect::<HashMap<_, _>>()
+                };
+
+                let sentinel_merchant_id =
+                    common_utils::id_type::MerchantId::get_merchant_id_not_found();
+                let activity_logs = rows
+                    .into_iter()
+                    .map(|row| {
+                        let user = row.auth_user_id.as_ref().and_then(|id| users.get(id));
+                        OrgActivityLogEntry {
+                            user_id: row.auth_user_id.clone(),
+                            user_name: user.map(|(name, _)| name.clone()),
+                            user_email: user.map(|(_, email)| email.clone()),
+                            api_flow: row.api_flow,
+                            flow_type: row.flow_type,
+                            url_path: row.url_path,
+                            http_method: row.http_method,
+                            status_code: row.status_code,
+                            merchant_id: (row.merchant_id != sentinel_merchant_id)
+                                .then_some(row.merchant_id),
+                            created_at: row.created_at,
+                        }
+                    })
+                    .collect();
+
+                Ok(ApplicationResponse::Json(OrgActivityLogResponse {
+                    total_count,
+                    activity_logs,
+                }))
+            },
+            auth::auth_type(
+                &auth::PlatformOrgAdminAuth {
+                    is_admin_auth_allowed: false,
+                    organization_id: None,
+                },
+                &auth::JWTAuth {
+                    permission: Permission::OrganizationAnalyticsRead,
+                    allow_connected: true,
+                    allow_platform: true,
+                },
+                req.headers(),
+            ),
+            api_locking::LockAction::NotApplicable,
+        ))
+        .await
+    }
+
+    #[cfg(feature = "v1")]
+    pub async fn get_org_activity_log_filters(
+        state: web::Data<AppState>,
+        req: actix_web::HttpRequest,
+    ) -> impl Responder {
+        let flow = AnalyticsFlow::GetOrgActivityLogFilters;
+        Box::pin(api::server_wrap(
+            flow,
+            state,
+            &req,
+            (),
+            |_state, _auth: AuthenticationData, _req, _| async move {
+                Ok::<_, error_stack::Report<AnalyticsError>>(ApplicationResponse::Json(
+                    OrgActivityLogFilterValues {
+                        api_flows: ORG_ACTIVITY_LOG_FLOWS
+                            .iter()
+                            .map(|flow| flow.to_string())
+                            .collect(),
+                    },
+                ))
             },
             auth::auth_type(
                 &auth::PlatformOrgAdminAuth {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds a paginated, org-admin-only **user activity log API** over the ClickHouse `api_events` table, so organization admins can see who performed critical configuration changes, what the change was, when it happened, and against which merchant.

**New endpoints (v1 `/org` analytics scope):**

- `POST /analytics/v1/org/activity_logs`
  - Request: `{ timeRange, offset (default 0), limit (default 20, clamped to 100), userIds?, apiFlows?, merchantIds? }`
  - Response: `{ totalCount, activityLogs: [{ userId, userEmail, userName, apiFlow, flowType, urlPath, httpMethod, statusCode, merchantId, createdAt }] }`
  - `merchantId` is `null` for org-level actions (rows recorded under the `MERCHANT_ID_NOT_FOUND` sentinel).
- `GET /analytics/v1/org/activity_logs/filters` → `{ apiFlows: [...] }` — server-defined allowlist (constant, no ClickHouse query).

**Key implementation points:**

- Queries the main `api_events` table (`AnalyticsCollection::ApiEventsAnalytics`), not `api_events_audit` — the audit MV only ingests rows with `payment_id IS NOT NULL`, so configuration actions never appear there.
- Curated allowlist of critical flows (`ORG_ACTIVITY_LOG_FLOWS: &[router_env::Flow]`): connector create/update/delete, merchant account update, profile create/update/delete, routing create/link/unlink, API key create/update/revoke, user invites, user role update/delete, custom role create/update, 3DS decision manager upsert/delete. Requested `apiFlows` outside the allowlist are rejected with a 400.
- Org scoping: `auth_user_id IN (org user ids)` AND `merchant_id IN (org merchant ids + sentinel)` AND `api_flow IN (allowlist ∩ requested)` AND time range. Request filters are intersected server-side against the org's own users/merchants; an empty intersection returns an empty page — an unscoped query is never issued. The sentinel is appended only when no explicit merchant filter is requested, so a merchant-filtered view does not include unrelated org-level rows.
- Auth is identical to the existing org analytics endpoints (`get_org_payment_metrics`): `PlatformOrgAdminAuth { is_admin_auth_allowed: false }` + `JWTAuth { permission: OrganizationAnalyticsRead, allow_connected: true, allow_platform: true }`. No new permission or resource is introduced.
- `LIMIT {n} OFFSET {m}` support added to the analytics `QueryBuilder` (new fields default to `None`; zero behavior change for existing queries). Two queries per request: rows (`ORDER BY created_at DESC`) and count — identical WHERE clauses.
- Identity resolution for the returned page only, via a single `list_users_by_user_ids` call (not the active-only variant, so deactivated users remain attributable). Hard-deleted users keep `userId` with `null` name/email.
- Response excludes `request`/`response` bodies, `ip_addr` and `user_agent` (PII / exfiltration surface).
- New `AnalyticsError::InvalidRequest` variant mapping to HTTP 400 (the existing enum had no general-purpose bad-request variant).
- ClickHouse-only, with the same graceful `NotImplemented` handling for the SQLX analytics provider as the existing `api_event` module.

Known v1 limitation (documented in the issue): `api_events` has no `organization_id` column, so a multi-org user's *org-level* (sentinel) actions match in every org they belong to. The proper fix is adding `organization_id` to `api_events` as a follow-up.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

New endpoints only; no existing API surface is modified.

## Motivation and Context

Organization admins have no way to audit who changed critical configuration (connectors, profiles, routing, API keys, users/roles, 3DS rules) across their organization. The data already exists in `api_events` (`auth_user_id` is recorded for every dashboard JWT call); this PR exposes it safely.

Closes #13816.

A dashboard "Audit Trail" screen consuming this API is raised separately in hyperswitch-control-center.

## How did you test it?

Tested manually end-to-end against local ClickHouse (olap compose profile, `api_events.sql` DDL) + Kafka, with dashboard-generated events:

- `POST /analytics/v1/org/activity_logs` with an org-admin JWT returns the org's actions with resolved user name/email, ordered by `created_at DESC` — including failed attempts (400 status rows) as well as successful ones.
- Pagination: with `limit=1`, `totalCount` stays constant while pages advance via `offset`; `offset=1` returns the next row.
- `apiFlows` filter returns only matching rows; a non-allowlisted flow (`PaymentsCreate`) returns 400.
- `GET /analytics/v1/org/activity_logs/filters` returns the 21 allowlisted flows.
- Org isolation: a second organization's events (different user + merchant) do not appear in the response.
- Requests without a JWT are rejected; the endpoint registers only in the v1 `/org` scope.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
