### PR TITLE
fix(scheduler): remove drained consumer from redis consumer group after each poll

### DIFF
--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1672,6 +1672,17 @@ impl QueueInterface for KafkaStore {
             .await
     }
 
+    async fn consumer_group_delete_consumer(
+        &self,
+        stream: &str,
+        group: &str,
+        consumer: &str,
+    ) -> CustomResult<usize, RedisError> {
+        self.diesel_store
+            .consumer_group_delete_consumer(stream, group, consumer)
+            .await
+    }
+
     async fn acquire_pt_lock(
         &self,
         tag: &str,

--- a/crates/scheduler/src/consumer.rs
+++ b/crates/scheduler/src/consumer.rs
@@ -157,6 +157,19 @@ pub async fn consumer_operations<T: SchedulerSessionState + 'static>(
         .fetch_consumer_tasks(&stream_name, &group_name, &consumer_name)
         .await?;
 
+    // The entries read by this consumer are acknowledged within the fetch itself, so the
+    // consumer has no pending entries at this point. Remove it from the consumer group, as
+    // Redis never expires consumers on its own and each registration would otherwise remain
+    // in the group forever (one per poll, or one per process restart).
+    if let Err(error) = state
+        .get_db()
+        .as_scheduler()
+        .consumer_group_delete_consumer(&stream_name, &group_name, &consumer_name)
+        .await
+    {
+        logger::warn!(?error, %consumer_name, "Failed to remove consumer from consumer group");
+    }
+
     if !tasks.is_empty() {
         logger::info!("{} picked {} tasks", consumer_name, tasks.len());
     }

--- a/crates/scheduler/src/db/queue.rs
+++ b/crates/scheduler/src/db/queue.rs
@@ -22,6 +22,13 @@ pub trait QueueInterface {
         id: &RedisEntryId,
     ) -> CustomResult<(), RedisError>;
 
+    async fn consumer_group_delete_consumer(
+        &self,
+        stream: &str,
+        group: &str,
+        consumer: &str,
+    ) -> CustomResult<usize, RedisError>;
+
     async fn acquire_pt_lock(
         &self,
         tag: &str,
@@ -71,6 +78,17 @@ impl QueueInterface for Store {
     ) -> CustomResult<(), RedisError> {
         self.get_redis_conn()?
             .consumer_group_create(&stream.into(), group, id)
+            .await
+    }
+
+    async fn consumer_group_delete_consumer(
+        &self,
+        stream: &str,
+        group: &str,
+        consumer: &str,
+    ) -> CustomResult<usize, RedisError> {
+        self.get_redis_conn()?
+            .consumer_group_delete_consumer(&stream.into(), group, consumer)
             .await
     }
 
@@ -156,6 +174,16 @@ impl QueueInterface for MockDb {
     ) -> CustomResult<(), RedisError> {
         // [#172]: Implement function for `MockDb`
         Err(RedisError::ConsumerGroupCreateFailed)?
+    }
+
+    async fn consumer_group_delete_consumer(
+        &self,
+        _stream: &str,
+        _group: &str,
+        _consumer: &str,
+    ) -> CustomResult<usize, RedisError> {
+        // [#172]: Implement function for `MockDb`
+        Err(RedisError::ConsumerGroupRemoveConsumerFailed)?
     }
 
     async fn acquire_pt_lock(

--- a/crates/scheduler/src/utils.rs
+++ b/crates/scheduler/src/utils.rs
@@ -249,6 +249,12 @@ pub async fn get_batches(
     let batches = batches.into_iter().flatten().collect::<Vec<_>>();
     let entry_ids = entry_ids.into_iter().flatten().collect::<Vec<_>>();
 
+    // `XACK` and `XDEL` fail on an empty ID list, and there is nothing to acknowledge or
+    // delete when the read returned no entries
+    if entry_ids.is_empty() {
+        return Ok(batches);
+    }
+
     conn.stream_acknowledge_entries(&stream_name.into(), group_name, entry_ids.clone())
         .await
         .map_err(|error| {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Redis never expires consumer group entries on its own, and the scheduler consumer never deletes them, so every registration made by `XREADGROUP` stays in `SCHEDULER_GROUP` forever. Since `consumer_name` is a fresh UUID for every poll (and at minimum changes on every process restart), the group accumulates dead consumer entries unboundedly.

This PR makes two changes:

1. `consumer_operations` now removes its consumer from the group (`XGROUP DELCONSUMER`) after a successful fetch. All entries read by the consumer are acknowledged inside the fetch itself, so the consumer has no pending entries at that point and deleting it loses nothing. The removal is best-effort: a failure is logged and does not fail the poll, and on a fetch error the consumer is intentionally kept. A `consumer_group_delete_consumer` method is added to `QueueInterface` (implemented for `Store`, `MockDb` and `KafkaStore`) delegating to the existing `RedisConnectionPool::consumer_group_delete_consumer`.

2. `get_batches` now skips acknowledgement when the read returned no entries. Previously an idle poll passed an empty ID list to `XACK`, which Redis rejects with `wrong number of arguments for xack`, so every idle poll failed with `Failed to perform consumer operation` (and would have skipped the consumer removal above).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes #13811.

`XINFO CONSUMERS` on the scheduler group grows by one dead, permanently idle entry per poll / per restart over the lifetime of the deployment. #13690 makes the name stable for the life of the process, which bounds the growth rate but still leaks one entry per restart (deploys, autoscaling, crash restarts). Deleting the drained consumer after each poll keeps the group bounded regardless of how consumer names are generated, and composes fine with #13690 if that lands.

## How did you test it?

Manually, against `redis:7` and `postgres:15` with `config/development.toml`, running `SCHEDULER_FLOW=consumer cargo run --bin scheduler --features release` three times for ~12s each (empty stream, so every poll takes the idle path that leaks in production):

- Before: `XINFO CONSUMERS SCHEDULER_STREAM SCHEDULER_GROUP` shows 4, 7 and 10 consumers after runs 1, 2 and 3, all with `pending=0` and growing idle time, and every poll logs `Error acknowledging batch in stream ... wrong number of arguments for xack`.
- After: 0 consumers after each of the three runs, and no acknowledgement errors in the logs.

Also verified `cargo check --features release`, `cargo check --no-default-features --features "release,v2,redis-rs"` and `cargo clippy --features release` pass.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
