### PR TITLE
feat(ucs): send the connector tokenize token with its payment method type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.08.27.1#abb401132fc2c3e3ea1fc3c67429e8fc2c713a70"
+source = "git+https://github.com/juspay/connector-service?tag=2026.08.28.0#3bea51390626fc87df551c625d70fb1f1b8e604a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4261,7 +4261,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.08.27.1#abb401132fc2c3e3ea1fc3c67429e8fc2c713a70"
+source = "git+https://github.com/juspay/connector-service?tag=2026.08.28.0#3bea51390626fc87df551c625d70fb1f1b8e604a"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.08.27.1#abb401132fc2c3e3ea1fc3c67429e8fc2c713a70"
+source = "git+https://github.com/juspay/connector-service?tag=2026.08.28.0#3bea51390626fc87df551c625d70fb1f1b8e604a"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11421,7 +11421,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.08.27.1#abb401132fc2c3e3ea1fc3c67429e8fc2c713a70"
+source = "git+https://github.com/juspay/connector-service?tag=2026.08.28.0#3bea51390626fc87df551c625d70fb1f1b8e604a"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11437,7 +11437,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.08.27.1#abb401132fc2c3e3ea1fc3c67429e8fc2c713a70"
+source = "git+https://github.com/juspay/connector-service?tag=2026.08.28.0#3bea51390626fc87df551c625d70fb1f1b8e604a"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11448,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.08.27.1#abb401132fc2c3e3ea1fc3c67429e8fc2c713a70"
+source = "git+https://github.com/juspay/connector-service?tag=2026.08.28.0#3bea51390626fc87df551c625d70fb1f1b8e604a"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -94,7 +94,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.08.27.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.08.28.0", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 bytes = { version = "1.10.1", optional = true }
 superposition_provider = { version = "0.115.5", optional = true }

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -35,7 +35,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.08.27.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.08.28.0", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -531,7 +531,7 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
                     network_txn_id: response.network_transaction_id.clone(),
                     network_txn_link_id: response.network_txn_link_id.clone(),
                     connector_response_reference_id: response.connector_reference_id,
-                    payment_account_reference: None,
+                    payment_account_reference: response.payment_account_reference,
                     incremental_authorization_allowed: response.incremental_authorization_allowed,
                     authentication_data: None,
                     charges: response.splits.map(common_types::payments::ConnectorChargeResponseData::foreign_try_from).transpose()?,

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -243,8 +243,8 @@ rust_decimal = { version = "1.37.1", features = [
 ] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.08.27.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.08.27.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.08.28.0", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.08.28.0", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = { version = "0.23", default-features = false, features = [
     "aws-lc-rs",

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -1441,11 +1441,26 @@ pub fn build_unified_connector_service_payment_method(
     connector_meta_data: Option<&common_utils::pii::SecretSerdeValue>,
 ) -> CustomResult<payments_grpc::PaymentMethod, UnifiedConnectorServiceError> {
     // A connector tokenization token settles for any payment method, including wallets.
+    // The token message carries the payment method it was minted from.
     if let Some(PaymentMethodToken::Token(token)) = payment_method_token {
+        let token_payment_method_type = match &payment_method_data {
+            hyperswitch_domain_models::payment_method_data::PaymentMethodData::Wallet(
+                hyperswitch_domain_models::payment_method_data::WalletData::ApplePay(_),
+            ) => {
+                Some(payments_grpc::token_payment_method_type::TokenPaymentMethod::ApplePay.into())
+            }
+            hyperswitch_domain_models::payment_method_data::PaymentMethodData::Wallet(
+                hyperswitch_domain_models::payment_method_data::WalletData::GooglePay(_),
+            ) => {
+                Some(payments_grpc::token_payment_method_type::TokenPaymentMethod::GooglePay.into())
+            }
+            _ => None,
+        };
         return Ok(payments_grpc::PaymentMethod {
             payment_method: Some(PaymentMethod::Token(
                 payments_grpc::TokenPaymentMethodType {
                     token: Some(token.clone()),
+                    token_payment_method_type,
                 },
             )),
         });
@@ -1621,6 +1636,7 @@ pub fn build_unified_connector_service_payment_method(
                 bank_name: _,
             } => {
                 let open_banking = payments_grpc::OpenBanking {
+                    bank_name: None,
                     account_number: account_number.map(|v| v.expose().into()),
                     sort_code: sort_code.map(|v| v.expose().into()),
                     iban: iban.map(|v| v.expose().into()),
@@ -1628,7 +1644,6 @@ pub fn build_unified_connector_service_payment_method(
                     additional_details: additional_details
                         .and_then(|v| serde_json::to_string(v.peek()).ok())
                         .map(Secret::new),
-                    bank_name: None,
                 };
 
                 Ok(payments_grpc::PaymentMethod {
@@ -2036,6 +2051,10 @@ pub fn build_unified_connector_service_payment_method(
                     Some(PaymentMethodToken::Token(token)) => {
                         let token_payment_method = payments_grpc::TokenPaymentMethodType {
                             token: Some(token.clone()),
+                            token_payment_method_type: Some(
+                                payments_grpc::token_payment_method_type::TokenPaymentMethod::ApplePay
+                                    .into(),
+                            ),
                         };
                         Ok(payments_grpc::PaymentMethod {
                             payment_method: Some(PaymentMethod::Token(token_payment_method)),

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -433,6 +433,7 @@ impl
         let order_details = build_ucs_order_details(router_data.request.order_details.as_deref());
         let l2_l3_data = build_ucs_l2_l3_data(router_data.l2_l3_data.as_deref());
         Ok(Self {
+            split_settlement: None,
             split_payments: router_data
                 .request
                 .split_payments
@@ -573,7 +574,6 @@ impl
                 }),
             // TODO: Populate currency_conversion_data when Dynamic Currency Conversion (DCC) is implemented
             currency_conversion_data: None,
-            split_settlement: None,
         })
     }
 }
@@ -633,6 +633,7 @@ impl
                         payment_method: Some(payments_grpc::payment_method::PaymentMethod::Token(
                             payments_grpc::TokenPaymentMethodType {
                                 token: Some(Secret::new(handle_token.to_string())),
+                                token_payment_method_type: None,
                             },
                         )),
                     })
@@ -709,6 +710,7 @@ impl
             .map(ConnectorState::foreign_from);
 
         Ok(Self {
+            split_settlement: None,
             split_payments: None,
             domain_data: None,
             mit_category: None,
@@ -811,7 +813,6 @@ impl
             partner_merchant_identifier_details: None,
             // TODO: Populate currency_conversion_data when Dynamic Currency Conversion (DCC) is implemented
             currency_conversion_data: None,
-            split_settlement: None,
         })
     }
 }
@@ -1782,6 +1783,7 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
             .map(ConnectorState::foreign_from);
 
         Ok(Self {
+            split_settlement: None,
             connector_transaction_id,
             merchant_capture_id: Some(router_data.connector_request_reference_id.clone()),
             amount_to_capture: Some(payments_grpc::Money {
@@ -1830,7 +1832,6 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
                     currency: currency.into(),
                 }
             }),
-            split_settlement: None,
         })
     }
 }
@@ -1903,6 +1904,7 @@ impl
             .transpose()?;
 
         Ok(Self {
+            split_settlement: None,
             split_payments: None,
             domain_data: None,
             mit_category: None,
@@ -1986,7 +1988,6 @@ impl
             partner_merchant_identifier_details: None,
             // TODO: Populate currency_conversion_data when Dynamic Currency Conversion (DCC) is implemented
             currency_conversion_data: None,
-            split_settlement: None,
         })
     }
 }
@@ -2062,6 +2063,7 @@ impl
         let order_details = build_ucs_order_details(router_data.request.order_details.as_deref());
         let l2_l3_data = build_ucs_l2_l3_data(router_data.l2_l3_data.as_deref());
         Ok(Self {
+            split_settlement: None,
             split_payments: router_data
                 .request
                 .split_payments
@@ -2184,7 +2186,6 @@ impl
             partner_merchant_identifier_details: None,
             // TODO: Populate currency_conversion_data when Dynamic Currency Conversion (DCC) is implemented
             currency_conversion_data: None,
-            split_settlement: None,
         })
     }
 }
@@ -2250,6 +2251,7 @@ impl
             .transpose()?;
 
         Ok(Self {
+            split_settlement: None,
             split_payments: router_data
                 .request
                 .split_payments
@@ -2360,7 +2362,6 @@ impl
             partner_merchant_identifier_details: None,
             // TODO: Populate currency_conversion_data when Dynamic Currency Conversion (DCC) is implemented
             currency_conversion_data: None,
-            split_settlement: None,
         })
     }
 }
@@ -2699,6 +2700,7 @@ impl
             .attach_printable("Failed to convert authentication type")?;
 
         Ok(Self {
+            split_settlement: None,
             split_payments: router_data
                 .request
                 .split_payments
@@ -2830,7 +2832,6 @@ impl
                 .map(payments_grpc::PaymentChannel::foreign_try_from)
                 .transpose()?
                 .map(|payment_channel| payment_channel.into()),
-            split_settlement: None,
         })
     }
 }
@@ -7360,6 +7361,7 @@ impl transformers::ForeignTryFrom<&RouterData<Execute, RefundsData, RefundsRespo
             .map(|payment_method_type| payment_method_type.into());
 
         Ok(Self {
+            split_settlement_refund: None,
             split_refunds: router_data
                 .request
                 .split_refunds
@@ -7420,7 +7422,6 @@ impl transformers::ForeignTryFrom<&RouterData<Execute, RefundsData, RefundsRespo
                 .payment_connector_request_reference_id
                 .clone(),
             payment_method: None,
-            split_settlement_refund: None,
         })
     }
 }
@@ -8213,6 +8214,7 @@ impl
             merchant_payout_id: router_data.payout_id.clone(),
             address: Some(address),
             amount: Some(money),
+            payout_connector_metadata: None,
             destination_currency: destination_currency.into(),
             customer: Some(customer),
             access_token: router_data.access_token.clone().map(|at| at.token),
@@ -8238,7 +8240,6 @@ impl
                 .map(payments_grpc::SourceBankData::foreign_try_from)
                 .transpose()?,
             description: router_data.description.clone(),
-            payout_connector_metadata: None,
         })
     }
 }


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Companion to juspay/hyperswitch-prism#2120 (Stripe wallet decryption and tokenization), released in connector-service `2026.08.28.0`.

A connector tokenize pre-step token now replaces the payment method in the UCS request as the token oneof variant, carrying `token_payment_method_type` — the payment method the token was minted from. The connector reads it to decide how the token is submitted: Stripe puts a wallet token on `payment_method_data[card][token]` and a bare stored token on `payment_method`. The builder stamps the type when a tokenize token supersedes an Apple Pay or Google Pay payload; the paysafe payment-handle path stays untyped (bare token semantics).

Pin bumped to `2026.08.28.0`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

UCS Stripe wallet payments (Apple Pay / Google Pay, decrypted and pre-decrypted) tokenize on `/v1/tokens` before charging; without the source payment method on the token message the connector cannot tell a wallet token from a stored payment method id.

## How did you test it?

Full Stripe e2e through this router against UCS at the pinned rev: card CIT/MIT (3DS and non-3DS), Apple Pay encrypted + predecrypted CIT/MIT, Google Pay DPAN + FPAN CIT/MIT, Google Pay FPAN 3DS, manual capture, void, refund and syncs — all succeeded. Payment ids and the wire evidence are in the prism PR description.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
