### PR TITLE
chore: address Rust 1.98.0 clippy lints

### DIFF
--- a/crates/analytics/src/opensearch.rs
+++ b/crates/analytics/src/opensearch.rs
@@ -919,7 +919,7 @@ impl OpenSearchQueryBuilder {
                                     "should": v.iter().map(|value| {
                                         json!({
                                             "term": {
-                                                format!("{}", key): {
+                                                key.to_string(): {
                                                     "value": value,
                                                     "case_insensitive": true
                                                 }

--- a/crates/common_utils/src/crypto.rs
+++ b/crates/common_utils/src/crypto.rs
@@ -1282,10 +1282,7 @@ mod crypto_tests {
     fn test_md5_digest() {
         let message = "abcdefghijklmnopqrstuvwxyz".as_bytes();
         assert_eq!(
-            format!(
-                "{}",
-                hex::encode(super::Md5.generate_digest(message).expect("Digest"))
-            ),
+            hex::encode(super::Md5.generate_digest(message).expect("Digest")),
             "c3fcd3d76192e4007dfb496cca67e13b"
         );
     }

--- a/crates/hyperswitch_connectors/src/connectors/nomupay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nomupay.rs
@@ -124,7 +124,7 @@ fn get_signature(
             };
 
             let mut option_map = Map::new();
-            option_map.insert("alg".to_string(), json!(format!("ES256")));
+            option_map.insert("alg".to_string(), json!("ES256"));
             option_map.insert("aud".to_string(), json!(format!("{} {}", method, path)));
             option_map.insert("exp".to_string(), json!(expires_in));
             option_map.insert("kid".to_string(), json!(auth.kid));

--- a/crates/router/src/core/merchant_connector_webhook_management.rs
+++ b/crates/router/src/core/merchant_connector_webhook_management.rs
@@ -38,9 +38,9 @@ use crate::{
     types::{self, api, domain},
 };
 
-fn to_error_response<E: std::fmt::Display>(err: E) -> types::ErrorResponse {
+fn to_error_response<E: std::fmt::Display>(err: E) -> Box<types::ErrorResponse> {
     router_env::logger::error!(error=%err, "Webhook access token error");
-    types::ErrorResponse {
+    Box::new(types::ErrorResponse {
         code: "WEBHOOK_ACCESS_TOKEN_ERROR".to_string(),
         message: "Failed to obtain access token for webhook registration".to_string(),
         status_code: 500,
@@ -52,7 +52,7 @@ fn to_error_response<E: std::fmt::Display>(err: E) -> types::ErrorResponse {
         network_decline_code: None,
         network_error_message: None,
         connector_metadata: None,
-    }
+    })
 }
 
 async fn fetch_access_token_for_webhook(
@@ -64,7 +64,7 @@ async fn fetch_access_token_for_webhook(
         ConnectorWebhookRegisterResponse,
     >,
     current_flow_info: Option<CurrentFlowInfo>,
-) -> Result<Option<types::AccessToken>, types::ErrorResponse> {
+) -> Result<Option<types::AccessToken>, Box<types::ErrorResponse>> {
     if !connector_data
         .connector_name
         .supports_access_token(router_data.payment_method)
@@ -145,7 +145,7 @@ async fn fetch_access_token_for_webhook(
                     connector=%connector_data.connector_name,
                     "Access token response contained an error"
                 );
-                err
+                Box::new(err)
             })?;
 
             let modified_token = types::AccessToken {

--- a/crates/router/src/core/user/dashboard_metadata.rs
+++ b/crates/router/src/core/user/dashboard_metadata.rs
@@ -48,13 +48,12 @@ pub async fn get_multiple_metadata(
     let mut response = Vec::with_capacity(metadata_keys.len());
     for key in metadata_keys {
         let data = metadata.iter().find(|ele| ele.data_key == key);
-        let resp;
-        if data.is_none() && utils::is_backfill_required(key) {
+        let resp = if data.is_none() && utils::is_backfill_required(key) {
             let backfill_data = backfill_metadata(&state, &user, &key).await?;
-            resp = into_response(backfill_data.as_ref(), key)?;
+            into_response(backfill_data.as_ref(), key)?
         } else {
-            resp = into_response(data, key)?;
-        }
+            into_response(data, key)?
+        };
         response.push(resp);
     }
 

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -461,10 +461,10 @@ pub trait ConnectorActions: Connector {
                 minor_amount: MinorUnit::new(1),
                 connector_payout_id,
                 destination_currency: payment_info.to_owned().map_or(enums::Currency::EUR, |pi| {
-                    pi.currency.map_or(enums::Currency::EUR, |c| c)
+                    pi.currency.unwrap_or(enums::Currency::EUR)
                 }),
                 source_currency: payment_info.to_owned().map_or(enums::Currency::EUR, |pi| {
-                    pi.currency.map_or(enums::Currency::EUR, |c| c)
+                    pi.currency.unwrap_or(enums::Currency::EUR)
                 }),
                 entity_type: enums::PayoutEntityType::Individual,
                 payout_type: Some(payout_type),
@@ -513,8 +513,7 @@ pub trait ConnectorActions: Connector {
             auth_type: info
                 .clone()
                 .map_or(enums::AuthenticationType::NoThreeDs, |a| {
-                    a.auth_type
-                        .map_or(enums::AuthenticationType::NoThreeDs, |a| a)
+                    a.auth_type.unwrap_or(enums::AuthenticationType::NoThreeDs)
                 }),
             payment_method: enums::PaymentMethod::Card,
             payment_method_type: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR addresses clippy lints due to Rust 1.98.0.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This PR addresses clippy lints arising due to a new Rust version. Closes #13828.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

`just clippy` and `just clippy_v2` pass locally when run with Rust 1.98 locally.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
