### PR TITLE
fix(payment-methods): remove default profile id usage in modular payment method apis

### DIFF
--- a/crates/router/src/core/payments/operations/payment_confirm_external_vault_proxy.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm_external_vault_proxy.rs
@@ -747,16 +747,31 @@ impl<F: Clone + Send + Sync> Domain<F, PaymentsRequest, PaymentData<F>>
                 .attach_printable("could not resolve a payment_method_id from the payment_token")?;
 
                 // 2. Retrieve the external vault tokens for that payment method from the modular PM
-                //    service.
-                let profile_id = platform
-                    .get_processor()
-                    .get_account()
-                    .get_default_profile()
+                //    service, under the profile the payment intent actually belongs to (this runs
+                //    before `get_trackers`, so the intent is loaded here the same way the regular
+                //    confirm operation's `fetch_payment_method` does).
+                let payment_id = req
+                    .payment_id
+                    .as_ref()
+                    .get_required_value("payment_id")?
+                    .get_payment_intent_id()
+                    .change_context(errors::ApiErrorResponse::PaymentNotFound)?;
+                let payment_intent = state
+                    .store
+                    .find_payment_intent_by_payment_id_processor_merchant_id(
+                        &payment_id,
+                        platform.get_processor().get_account().get_id(),
+                        platform.get_processor().get_key_store(),
+                        platform.get_processor().get_account().storage_scheme,
+                    )
+                    .await
+                    .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+                let profile_id = payment_intent
+                    .profile_id
                     .clone()
                     .get_required_value("profile_id")
-                    .attach_printable(
-                        "profile_id is required to fetch external vault tokens from the modular service",
-                    )?;
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable("'profile_id' not set in payment intent")?;
 
                 let payment_method_with_raw_data =
                     pm_transformers::fetch_payment_method_from_modular_service(

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -1355,15 +1355,19 @@ impl PaymentCreate {
         platform: &domain::Platform,
         payment_method_ref: &str,
     ) -> RouterResult<PaymentMethodWithRawData> {
-        let profile_id = req
-            .profile_id
-            .clone()
-            .or(platform
-                .get_processor()
-                .get_account()
-                .get_default_profile()
-                .clone())
-            .get_required_value("profile_id")?;
+        // Resolve the profile the same way `get_trackers` resolves it for the payment intent,
+        // so the modular service is always called with the profile the intent will actually
+        // belong to (including the `business_country` + `business_label` resolution path).
+        let profile_id = core_utils::get_profile_id_from_business_details(
+            req.business_country,
+            req.business_label.as_ref(),
+            platform.get_processor(),
+            req.profile_id.as_ref(),
+            &*state.store,
+            false,
+        )
+        .await
+        .attach_printable("Failed to resolve profile_id for the modular payment method fetch")?;
 
         let pm_info = pm_transformers::fetch_payment_method_from_modular_service(
             state,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
 remove default profile id usage in modular payment method apis
 the profile id sent in request header should be used instead of default profile id

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
