### PR TITLE
fix(payment_methods): add missing required fields for Citigate

### DIFF
--- a/crates/payment_methods/src/configs/payment_connector_required_fields.rs
+++ b/crates/payment_methods/src/configs/payment_connector_required_fields.rs
@@ -1887,6 +1887,32 @@ fn get_cards_required_fields() -> HashMap<Connector, RequiredFieldFinal> {
                 common: HashMap::new(),
             },
         ),
+        (
+            Connector::Citigate,
+            fields(
+                vec![],
+                vec![],
+                [
+                    card_basic(),
+                    // `billing_address()` is exactly Citigate's address set: StreetLine1, City,
+                    // PostalCode, Country and StateProvince. StateProvince is flagged `Y` in the
+                    // API Card field table and is additionally called out as mandatory for
+                    // `Country = "US"`, which the connector enforces at request-build time.
+                    billing_address(),
+                    vec![
+                        // Read from the top-level `email`, falling back to the billing address.
+                        RequiredField::Email,
+                        // Citigate sends `Firstname`/`Surname` as fields distinct from
+                        // `CardholderName`, so the cardholder name cannot stand in for them.
+                        RequiredField::BillingFirstName("first_name", FieldType::UserFullName),
+                        RequiredField::BillingLastName("last_name", FieldType::UserFullName),
+                        // `Telephone` is `R` in the field table but mandatory for `Country = "US"`.
+                        RequiredField::BillingPhone,
+                    ],
+                ]
+                .concat(),
+            ),
+        ),
     ])
 }
 


### PR DESCRIPTION
## Summary

Citigate was merged in #13704 without an entry in `get_cards_required_fields`. A connector absent from that map returns **no required fields at all**, so the SDK and Control Center never collect the billing address, email or name the connector needs — and every payment then fails inside UCS with `MissingRequiredField` rather than at the point of collection.

Ilixium, added around the same time, does have an entry; Citigate was simply missed.

## How the field list was derived

From what the connector's Authorize transformer actually propagates with `?`, not from the API Card alone:

| Citigate field | RequiredField |
|---|---|
| `Firstname` / `Surname` | `BillingFirstName` / `BillingLastName` |
| `Email` | `Email` (top-level, falls back to billing email) |
| `StreetLine1`, `City`, `PostalCode`, `Country`, `StateProvince` | `billing_address()` |
| `Telephone` | `BillingPhone` |
| `CardNo`, `ExpiryMonth`, `ExpiryYear`, `CVV` | `card_basic()` |

`StreetLine2` is intentionally excluded — the transformer reads it with an optional getter.

Reuses the existing `card_basic()` and `billing_address()` helpers; `billing_address()` happens to be exactly Citigate's address set.

## Two decisions worth reviewing

**Conditionally-mandatory fields declared unconditionally.** The API Card marks `StateProvince` and `Telephone` as "Mandatory for `Country = "US"`" on top of their `Y`/`R` flag, and the connector enforces exactly that when building the request. `RequiredField` has no way to express a country-conditional requirement, so both are declared unconditionally. Over-collecting one address field seemed a far smaller cost than a hard payment failure for every US cardholder — happy to revisit if there's a preferred idiom.

**Placed in `common`, not `non_mandate`.** `common` is applied on every payment; `non_mandate` is skipped when `is_cit_transaction` is true, which includes any payment carrying `setup_future_usage=off_session`. Putting these in `non_mandate` would collect nothing in that case. This also matches the dominant convention here — 29 card connectors use `common`.

`UserIP` is deliberately absent: it comes from `browser_info`, which the SDK populates itself and which `RequiredField` cannot describe.

## Testing

- `cargo fmt -p payment_methods -- --check` passes.
- `cargo check -p payment_methods` does not build **on unmodified `main` either** — `redis_interface` fails with `cannot find type RedisConnectionPool` because the `redis-rs`/`fred` backend feature isn't resolved when the crate is checked in isolation with `-p`. Verified identical with the change stashed, so it is pre-existing and unrelated. CI's `cargo check --features "release"` resolves features correctly and is the real gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjdN7QzdMY55U4LBcrZAcB