### PR TITLE
fix(config): route ilixium through UCS in sandbox and production

### DIFF
--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -1043,7 +1043,7 @@ click_to_pay = {connector_list = "adyen, cybersource, trustpay"}
 connector_list = "juspaythreedsserver, ctp_mastercard, ctp_visa"
 
 [grpc_client.unified_connector_service]
-ucs_only_connectors = "imerchantsolutions, paytm, phonepe, hyperpg, revolv3, fiservcommercehub, absa_sanlam, interpayments, payconex, dlocal, barclaycard, jpmorgan, datatrans, tsys_transit, givepayments, citigate, moneris, elavon, worldpayraft"    # Comma-separated list of connectors that use UCS only
+ucs_only_connectors = "imerchantsolutions, paytm, phonepe, hyperpg, revolv3, fiservcommercehub, absa_sanlam, interpayments, payconex, dlocal, barclaycard, jpmorgan, datatrans, tsys_transit, givepayments, citigate, ilixium, moneris, elavon, worldpayraft"    # Comma-separated list of connectors that use UCS only
 ucs_psync_disabled_connectors = "cashtocode, trustly"    # Comma-separated list of connectors to disable UCS PSync call
 
 # Merchant Advice Code Configuration

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -1054,7 +1054,7 @@ connector_list = "juspaythreedsserver, ctp_mastercard, ctp_visa"
 connector_list = "worldpayvantiv"
 
 [grpc_client.unified_connector_service]
-ucs_only_connectors = "imerchantsolutions, paytm, phonepe, hyperpg, revolv3, fiservcommercehub, absa_sanlam, interpayments, payconex, dlocal, barclaycard, jpmorgan, datatrans, tsys_transit, givepayments, citigate, moneris, elavon, worldpayraft"    # Comma-separated list of connectors that use UCS only
+ucs_only_connectors = "imerchantsolutions, paytm, phonepe, hyperpg, revolv3, fiservcommercehub, absa_sanlam, interpayments, payconex, dlocal, barclaycard, jpmorgan, datatrans, tsys_transit, givepayments, citigate, ilixium, moneris, elavon, worldpayraft"    # Comma-separated list of connectors that use UCS only
 ucs_psync_disabled_connectors = "cashtocode, trustly"    # Comma-separated list of connectors to disable UCS PSync call
 
 # Merchant Advice Code Configuration


### PR DESCRIPTION
## Summary

`ilixium` is in `ucs_only_connectors` for `development.toml`, `config.example.toml`, `deployments/env_specific.toml` and `deployments/integration_test.toml` — but **not** in `deployments/sandbox.toml` or `deployments/production.toml`.

Ilixium is a UCS-only connector. Its Hyperswitch-side implementation is a stub:

```rust
// crates/hyperswitch_connectors/src/connectors/ilixium/transformers.rs
PaymentMethodData::Card(_) => Err(errors::ConnectorError::NotImplemented(
    "Card payment method not implemented".to_string(),
).into()),
```

with its own comment stating *"Ilixium is routed through the Unified Connector Service (UCS)"*.

With the connector absent from `ucs_only_connectors`, Hyperswitch never forwards to UCS and calls that stub instead — so **every Ilixium payment in sandbox and production fails with `NotImplemented`, while working fine locally.**

This is the same failure mode previously seen with `payconex`.

## Change

Adds `ilixium` to the two lists, positioned between `citigate` and `moneris` to match the ordering already used in the four configs that carry it.

After this change all six configs agree:

| Config | ilixium in `ucs_only_connectors` |
|---|---|
| `config/development.toml` | ✅ (already) |
| `config/config.example.toml` | ✅ (already) |
| `config/deployments/env_specific.toml` | ✅ (already) |
| `config/deployments/integration_test.toml` | ✅ (already) |
| `config/deployments/sandbox.toml` | ✅ **this PR** |
| `config/deployments/production.toml` | ✅ **this PR** |

## Testing

Config-only change; no code paths altered. Verified by diffing the `ucs_only_connectors` value across all six configs before and after — see the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjdN7QzdMY55U4LBcrZAcB