### PR TITLE
fix(cypress): fix Deutschebank test config

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Deutschebank.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Deutschebank.js
@@ -14,7 +14,7 @@ const paymentMethodData3DSResponse = {
     last4: "0088",
     card_type: "DEBIT",
     card_network: "Visa",
-    card_issuer: "INTL HDQTRS-CENTER OWNED",
+    card_issuer: "INTL HDQTRS CENTER OWNED",
     card_issuing_country: "UNITEDSTATES",
     card_isin: "476173",
     card_extended_bin: null,
@@ -288,6 +288,25 @@ export const connectorDetails = {
         body: {
           status: "requires_payment_method",
           setup_future_usage: "off_session",
+        },
+      },
+    },
+    SaveCardUse3DSAutoCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successful3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: customerAcceptance,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          payment_method_data: paymentMethodData3DSResponse,
         },
       },
     },


### PR DESCRIPTION
## Summary
- Fixed `card_issuer` value casing in the 3DS payment method data response.
- Added `SaveCardUse3DSAutoCaptureOffSession` fixture for the Deutschebank connector.

Closes #13842

## Test plan
- [x] Ran Deutschebank Cypress specs locally with the updated config.

<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/2af7245e-87e7-4f93-a8e1-e0d83be1e6fa" />
