### PR TITLE
fix(offers): resolve saved-card token at offer apply

### DIFF
--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -970,7 +970,7 @@ impl<F: Send + Clone + Sync> GetTracker<F, PaymentData<F>, api::PaymentsRequest>
         let payment_data = Box::pin(apply_offer_engine_offer(
             state,
             request,
-            platform.get_processor(),
+            platform,
             payment_data,
         ))
         .await?;
@@ -3146,7 +3146,7 @@ impl<F: Send + Clone + Sync> ValidateRequest<F, api::PaymentsRequest, PaymentDat
 async fn apply_offer_engine_offer<F: Clone + Send + Sync>(
     state: &SessionState,
     request: &api::PaymentsRequest,
-    processor: &domain::Processor,
+    platform: &domain::Platform,
     payment_data: PaymentData<F>,
 ) -> RouterResult<PaymentData<F>> {
     // First launch supports a single offer; reject multiple rather than picking one.
@@ -3179,8 +3179,9 @@ async fn apply_offer_engine_offer<F: Clone + Send + Sync>(
         (None, Some(requested)) => {
             Box::pin(apply_selected_offer(
                 state,
-                processor,
+                platform,
                 requested,
+                request.payment_token.as_deref(),
                 payment_data,
             ))
             .await
@@ -3193,10 +3194,12 @@ async fn apply_offer_engine_offer<F: Clone + Send + Sync>(
 #[cfg(feature = "v1")]
 async fn apply_selected_offer<F: Clone + Send + Sync>(
     state: &SessionState,
-    processor: &domain::Processor,
+    platform: &domain::Platform,
     offer_quote_id: String,
+    payment_token: Option<&str>,
     mut payment_data: PaymentData<F>,
 ) -> RouterResult<PaymentData<F>> {
+    let processor = platform.get_processor();
     // An offer was selected, so Offer Engine must be available. Target config at
     // merchant/org/profile (same as eligibility) so overrides resolve consistently.
     let profile_id = payment_data
@@ -3209,7 +3212,7 @@ async fn apply_selected_offer<F: Clone + Send + Sync>(
     let offer_dimensions = dimension_state::Dimensions::new()
         .with_processor_merchant_id(processor.get_processor_merchant_id())
         .with_organization_id(processor.get_account().get_org_id().clone())
-        .with_profile_id(profile_id);
+        .with_profile_id(profile_id.clone());
     let offer_config = offer_engine::resolve_offer_engine_config(state, &offer_dimensions)
         .await
         .ok()
@@ -3248,10 +3251,38 @@ async fn apply_selected_offer<F: Clone + Send + Sync>(
         .ok_or(report!(errors::ApiErrorResponse::PreconditionFailed {
             message: "Payment method is required to apply an offer".to_string(),
         }))?;
-    let offer_card = payment_data
+    // Resolve the card exactly as `/eligibility` did, so `/apply` forwards the same
+    // BIN + `card_alias` and matches the stored quote. A fresh card carries the full
+    // PAN in the request; use it directly.
+    let mut offer_pmd = payment_data
         .payment_method_data
+        .clone()
+        .map(domain::EligibilityPaymentMethodData::from)
+        .filter(|offer_pmd| offer_pmd.get_card_data().is_some());
+
+    // Saved card (repeat customer): the request carries only a token, so de-reference
+    // it to the real card from the locker exactly as `/eligibility` did. This restores
+    // the real BIN + `card_alias` so BIN-based offers and once-per-card velocity match.
+    if offer_pmd.is_none() {
+        if let (Some(payment_token), Some(payment_method)) =
+            (payment_token, payment_data.payment_attempt.payment_method)
+        {
+            offer_pmd = Box::pin(
+                payments::PaymentEligibilityData::resolve_payment_token_to_method_data(
+                    state,
+                    platform,
+                    &hyperswitch_masking::Secret::new(payment_token.to_owned()),
+                    payment_method,
+                    &profile_id,
+                ),
+            )
+            .await?;
+        }
+    }
+
+    let offer_card = offer_pmd
         .as_ref()
-        .and_then(|payment_method_data| payment_method_data.get_card_data());
+        .and_then(|offer_pmd| offer_pmd.get_card_data());
 
     let card_alias = match offer_card.map(|card| &card.card_number) {
         Some(card_number) => Some(
@@ -3280,10 +3311,9 @@ async fn apply_selected_offer<F: Clone + Send + Sync>(
                 .as_ref()
                 .map(|network| network.to_string())
         }),
-        card_bin: payment_data
-            .payment_method_data
+        card_bin: offer_pmd
             .as_ref()
-            .and_then(|payment_method_data| payment_method_data.get_card_iin()),
+            .and_then(|offer_pmd| offer_pmd.get_card_iin()),
         card_type: offer_card.and_then(|card| card.card_type.clone()),
         bank_code: offer_card.and_then(|card| card.bank_code.clone()),
         card_country: offer_card.and_then(|card| card.card_issuing_country.clone()),

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -3251,34 +3251,34 @@ async fn apply_selected_offer<F: Clone + Send + Sync>(
         .ok_or(report!(errors::ApiErrorResponse::PreconditionFailed {
             message: "Payment method is required to apply an offer".to_string(),
         }))?;
-    // Resolve the card exactly as `/eligibility` did, so `/apply` forwards the same
-    // BIN + `card_alias` and matches the stored quote. A fresh card carries the full
-    // PAN in the request; use it directly.
-    let mut offer_pmd = payment_data
+    // Reconstruct the card `/eligibility` quoted against, so `/apply` sends the same
+    // BIN + `card_alias`: use the request card (fresh) if present, else dereference the
+    // saved `payment_token` to the real card from the locker (same as `/eligibility`).
+    let offer_pmd = match payment_data
         .payment_method_data
         .clone()
         .map(domain::EligibilityPaymentMethodData::from)
-        .filter(|offer_pmd| offer_pmd.get_card_data().is_some());
-
-    // Saved card (repeat customer): the request carries only a token, so de-reference
-    // it to the real card from the locker exactly as `/eligibility` did. This restores
-    // the real BIN + `card_alias` so BIN-based offers and once-per-card velocity match.
-    if offer_pmd.is_none() {
-        if let (Some(payment_token), Some(payment_method)) =
-            (payment_token, payment_data.payment_attempt.payment_method)
-        {
-            offer_pmd = Box::pin(
-                payments::PaymentEligibilityData::resolve_payment_token_to_method_data(
-                    state,
-                    platform,
-                    &hyperswitch_masking::Secret::new(payment_token.to_owned()),
-                    payment_method,
-                    &profile_id,
-                ),
-            )
-            .await?;
-        }
-    }
+        .filter(|offer_pmd| offer_pmd.get_card_data().is_some())
+    {
+        Some(offer_pmd) => Some(offer_pmd),
+        None => payment_token
+            .zip(payment_data.payment_attempt.payment_method)
+            .async_map(|(payment_token, payment_method)| async move {
+                Box::pin(
+                    payments::PaymentEligibilityData::resolve_payment_token_to_method_data(
+                        state,
+                        platform,
+                        &hyperswitch_masking::Secret::new(payment_token.to_owned()),
+                        payment_method,
+                        &profile_id,
+                    ),
+                )
+                .await
+            })
+            .await
+            .transpose()?
+            .flatten(),
+    };
 
     let offer_card = offer_pmd
         .as_ref()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes an Offer Engine failure for **repeat customers paying with a saved card**.

A saved-card confirm carries only a `payment_token` + `card_token` (CVC) — not the PAN. The confirm-time Offer Engine `/apply` runs early, inside `get_trackers` (`apply_selected_offer`), and read the card straight off `payment_data.payment_method_data`. At that point the saved card is still the `CardToken` variant — the token is only dereferenced to the real card much later, in `make_pm_data` (the connector-call phase). As a result `/apply` was sent with `card_bin`, `card_network` and `card_alias` all `null`.

Since offers are BIN-based (and velocity is keyed on a per-card `card_alias`), that null card could not match the offer that `/eligibility` had already quoted against the **real** BIN, so `run_offer_apply` rejected it and the payment failed with:

```
IR_16 "Offer Engine /apply failed or did not match the eligibility quote"
```

Fresh ("add card") payments were unaffected because the full PAN is present in the confirm request.

The root cause is an asymmetry: `/eligibility` already resolves a saved `payment_token` to the real card via the locker (`PaymentEligibilityData::resolve_payment_token_to_method_data`), but confirm `/apply` did not. This PR makes `/apply` reconstruct the card from the **same two inputs `/eligibility` accepts**:

- fresh card → the request card is used directly;
- saved card → the `payment_token` is dereferenced to the real card via the shared eligibility resolver.

This restores the real BIN + `card_alias` at `/apply`, so BIN-based offers and once-per-card velocity match the eligibility quote for saved cards. The change is a single file (`payment_confirm.rs`); `payments.rs` is untouched (the resolver is reached via normal module visibility).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Repeat-customer (saved-card) checkouts could never apply an Offer Engine offer — every such confirm returned `IR_16`, even though `/eligibility` correctly surfaced the offer. This broke the core offer flow for returning customers while leaving first-time (fresh-card) customers working, making the failure easy to miss.

Internal tracking: juspay/hyperswitch-cloud#22763.

## How did you test it?

Tested manually end-to-end against a locally-built router (this branch) with a real Stripe test connector and the Offer Engine sandbox, driving `create → eligibility → confirm` for each case. A Postman collection + shell runner reproduce all of the below.

**1. Saved card / repeat customer (the fix)** — `create (setup_future_usage=on_session)` → save card → new payment → `GET /customers/payment_methods` to get the saved `payment_token` → `/eligibility` (by token) → `/confirm` (token + `offer_details`):
- **Before the fix:** confirm returns `IR_16 "Offer Engine /apply failed or did not match the eligibility quote"`.
- **After the fix:** confirm succeeds — `applied_offer` present, `net_amount = amount − offer_amount` (e.g. `6500 → 6370`, offer `130`). Server logs show a real `POST /offers/apply → 200` to the Offer Engine.

<details>
<summary>Repeat-card (saved-card) flow — exact curls (placeholders)</summary>

> Prerequisite: the customer must already have a saved card. Run one fresh-card payment with `setup_future_usage=on_session` for `{{customer_id}}` first (or the earlier fresh-card scenario), which stores the card in the locker.

```bash
# 1) Create a new payment for the returning customer (confirm=false)
curl -X POST '{{base_url}}/payments' \
  -H 'api-key: {{secret_api_key}}' -H 'Content-Type: application/json' \
  -d '{"amount":6500,"currency":"USD","confirm":false,"capture_method":"automatic",
       "authentication_type":"no_three_ds","customer_id":"{{customer_id}}",
       "setup_future_usage":"on_session","profile_id":"{{profile_id}}"}'
# -> capture .payment_id ({{payment_id}}) and .client_secret ({{client_secret}})

# 2) List the customer's saved payment methods to get the reusable token
curl '{{base_url}}/customers/payment_methods?client_secret={{client_secret}}' \
  -H 'api-key: {{publishable_key}}'
# -> capture .customer_payment_methods[0].payment_token ({{payment_token}})

# 3) Eligibility for the saved card (by token) — mints the offer quote
curl -X POST '{{base_url}}/payments/{{payment_id}}/eligibility' \
  -H 'api-key: {{publishable_key}}' -H 'Content-Type: application/json' \
  -d '{"client_secret":"{{client_secret}}","payment_method_type":"card",
       "payment_token":"{{payment_token}}"}'
# -> capture .offer_details.uplifted_offer_quote_ids[0] ({{offer_quote_id}})

# 4) Confirm the saved card WITH the offer  <-- the path this PR fixes
curl -X POST '{{base_url}}/payments/{{payment_id}}/confirm' \
  -H 'api-key: {{publishable_key}}' -H 'Content-Type: application/json' \
  -d '{"client_secret":"{{client_secret}}","payment_method":"card",
       "payment_token":"{{payment_token}}","customer_id":"{{customer_id}}",
       "payment_method_data":{"card_token":{"card_cvc":"{{card_cvc}}"}},
       "customer_acceptance":{"acceptance_type":"online","online":{"user_agent":"curl"}},
       "offer_details":{"offer_quote_ids":["{{offer_quote_id}}"]}}'
# Before fix -> 400 IR_16 "Offer Engine /apply failed or did not match the eligibility quote"
# After  fix -> 200 status=succeeded, applied_offer present, net_amount=6370 (6500 - 130)

# 5) (optional) Verify the persisted offer
curl '{{base_url}}/payments/{{payment_id}}' -H 'api-key: {{secret_api_key}}'
# -> .applied_offer present, .net_amount == .amount - .applied_offer.offer_amount
```

</details>

**2. Fresh card (control / no regression)** — `/eligibility` (raw PAN) → `/confirm` (PAN + offer): offer applies, `net_amount 6370`, `applied_offer` present — unchanged before and after the fix.

**3. Regression — no offer selected (fresh & saved)** — `/confirm` **without** `offer_details`: payment succeeds, `applied_offer` is `null`, `net_amount == amount` (`6500`). Confirms the no-op path is untouched for both card types.

**4. Persistence** — `GET /payments/{id}` after each confirm shows the persisted `applied_offer` / net amount (or absence of it for the no-offer runs).

Also verified: `cargo check -p router` and `cargo clippy -p router` are clean (the new `/apply` future is boxed to satisfy `large_futures`).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
