### PR TITLE
feat(blocklist): widen card_bin to 6-10 digits and deprecate extended_card_bin

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -15425,6 +15425,7 @@
       },
       "BlocklistDataKind": {
         "type": "string",
+        "description": "`card_bin` (6 digits) and `extended_card_bin` (8 digits) are deprecated, use\n`generic_card_bin`, which accepts 6 to 10 digits.",
         "enum": [
           "payment_method",
           "card_bin",
@@ -15449,6 +15450,7 @@
               },
               "data": {
                 "type": "string",
+                "description": "Deprecated, use `generic_card_bin`. A card number prefix of exactly 6 digits.",
                 "deprecated": true
               }
             }
@@ -15486,6 +15488,7 @@
               },
               "data": {
                 "type": "string",
+                "description": "Deprecated, use `generic_card_bin`. A card number prefix of exactly 8 digits.",
                 "deprecated": true
               }
             }
@@ -15504,7 +15507,8 @@
                 ]
               },
               "data": {
-                "type": "string"
+                "type": "string",
+                "description": "A card number prefix of 6 to 10 digits."
               }
             }
           }

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -6776,7 +6776,7 @@
           }
         ],
         "requestBody": {
-          "description": "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). The CSV must have a header row: `type,data,metadata`. `type`: one of `card_bin` (6 digits), `extended_card_bin` (8 digits), `fingerprint`. `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). Maximum 100,000 data rows.",
+          "description": "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). The CSV must have a header row: `type,data,metadata`. `type`: one of `card_bin` (6 to 10 digits), `fingerprint`. `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). Maximum 100,000 data rows.",
           "content": {
             "multipart/form-data": {
               "schema": {
@@ -15483,7 +15483,8 @@
                 ]
               },
               "data": {
-                "type": "string"
+                "type": "string",
+                "deprecated": true
               }
             }
           }

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -6776,7 +6776,7 @@
           }
         ],
         "requestBody": {
-          "description": "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). The CSV must have a header row: `type,data,metadata`. `type`: one of `card_bin` (6 to 10 digits), `fingerprint`. `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). Maximum 100,000 data rows.",
+          "description": "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). The CSV must have a header row: `type,data,metadata`. `type`: one of `generic_card_bin` (6 to 10 digits), `fingerprint`. `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). Maximum 100,000 data rows.",
           "content": {
             "multipart/form-data": {
               "schema": {
@@ -15428,7 +15428,8 @@
         "enum": [
           "payment_method",
           "card_bin",
-          "extended_card_bin"
+          "extended_card_bin",
+          "generic_card_bin"
         ]
       },
       "BlocklistRequest": {
@@ -15447,7 +15448,8 @@
                 ]
               },
               "data": {
-                "type": "string"
+                "type": "string",
+                "deprecated": true
               }
             }
           },
@@ -15485,6 +15487,24 @@
               "data": {
                 "type": "string",
                 "deprecated": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "data"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "generic_card_bin"
+                ]
+              },
+              "data": {
+                "type": "string"
               }
             }
           }

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -10079,6 +10079,7 @@
       },
       "BlocklistDataKind": {
         "type": "string",
+        "description": "`card_bin` (6 digits) and `extended_card_bin` (8 digits) are deprecated, use\n`generic_card_bin`, which accepts 6 to 10 digits.",
         "enum": [
           "payment_method",
           "card_bin",
@@ -10103,6 +10104,7 @@
               },
               "data": {
                 "type": "string",
+                "description": "Deprecated, use `generic_card_bin`. A card number prefix of exactly 6 digits.",
                 "deprecated": true
               }
             }
@@ -10140,6 +10142,7 @@
               },
               "data": {
                 "type": "string",
+                "description": "Deprecated, use `generic_card_bin`. A card number prefix of exactly 8 digits.",
                 "deprecated": true
               }
             }
@@ -10158,7 +10161,8 @@
                 ]
               },
               "data": {
-                "type": "string"
+                "type": "string",
+                "description": "A card number prefix of 6 to 10 digits."
               }
             }
           }

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -10137,7 +10137,8 @@
                 ]
               },
               "data": {
-                "type": "string"
+                "type": "string",
+                "deprecated": true
               }
             }
           }

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -10082,7 +10082,8 @@
         "enum": [
           "payment_method",
           "card_bin",
-          "extended_card_bin"
+          "extended_card_bin",
+          "generic_card_bin"
         ]
       },
       "BlocklistRequest": {
@@ -10101,7 +10102,8 @@
                 ]
               },
               "data": {
-                "type": "string"
+                "type": "string",
+                "deprecated": true
               }
             }
           },
@@ -10139,6 +10141,24 @@
               "data": {
                 "type": "string",
                 "deprecated": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "data"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "generic_card_bin"
+                ]
+              },
+              "data": {
+                "type": "string"
               }
             }
           }

--- a/crates/api_models/src/blocklist.rs
+++ b/crates/api_models/src/blocklist.rs
@@ -11,6 +11,7 @@ const DEFAULT_BATCH_LIST_LIMIT: u8 = 10;
 pub enum BlocklistRequest {
     CardBin(String),
     Fingerprint(String),
+    #[deprecated(note = "use CardBin, which accepts 6 to 10 digits")]
     ExtendedCardBin(String),
 }
 

--- a/crates/api_models/src/blocklist.rs
+++ b/crates/api_models/src/blocklist.rs
@@ -9,10 +9,12 @@ const DEFAULT_BATCH_LIST_LIMIT: u8 = 10;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case", tag = "type", content = "data")]
 pub enum BlocklistRequest {
+    #[deprecated(note = "use GenericCardBin, which accepts 6 to 10 digits")]
     CardBin(String),
     Fingerprint(String),
-    #[deprecated(note = "use CardBin, which accepts 6 to 10 digits")]
+    #[deprecated(note = "use GenericCardBin, which accepts 6 to 10 digits")]
     ExtendedCardBin(String),
+    GenericCardBin(String),
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/crates/api_models/src/blocklist.rs
+++ b/crates/api_models/src/blocklist.rs
@@ -9,11 +9,14 @@ const DEFAULT_BATCH_LIST_LIMIT: u8 = 10;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case", tag = "type", content = "data")]
 pub enum BlocklistRequest {
+    /// Deprecated, use `generic_card_bin`. A card number prefix of exactly 6 digits.
     #[deprecated(note = "use GenericCardBin, which accepts 6 to 10 digits")]
     CardBin(String),
     Fingerprint(String),
+    /// Deprecated, use `generic_card_bin`. A card number prefix of exactly 8 digits.
     #[deprecated(note = "use GenericCardBin, which accepts 6 to 10 digits")]
     ExtendedCardBin(String),
+    /// A card number prefix of 6 to 10 digits.
     GenericCardBin(String),
 }
 

--- a/crates/cards/src/validate.rs
+++ b/crates/cards/src/validate.rs
@@ -28,12 +28,16 @@ pub struct CardNumber(StrongSecret<String, CardNumberStrategy>);
 pub struct NetworkToken(StrongSecret<String, CardNumberStrategy>);
 
 impl CardNumber {
+    pub fn get_bin_prefix(&self, len: usize) -> String {
+        self.0.peek().chars().take(len).collect::<String>()
+    }
+
     pub fn get_card_isin(&self) -> String {
-        self.0.peek().chars().take(6).collect::<String>()
+        self.get_bin_prefix(6)
     }
 
     pub fn get_extended_card_bin(&self) -> String {
-        self.0.peek().chars().take(8).collect::<String>()
+        self.get_bin_prefix(8)
     }
     pub fn get_card_no(&self) -> String {
         self.0.peek().chars().collect::<String>()

--- a/crates/cards/src/validate.rs
+++ b/crates/cards/src/validate.rs
@@ -15,6 +15,13 @@ pub const MIN_CARD_NUMBER_LENGTH: usize = 8;
 /// Maximum limit of a card number will not exceed 19 by ISO standards
 pub const MAX_CARD_NUMBER_LENGTH: usize = 19;
 
+/// Narrowest card number prefix that may be blocklisted
+pub const MIN_CARD_BIN_LENGTH: usize = 6;
+
+/// Widest card number prefix that may be blocklisted. Bounded well short of a full card number
+/// because blocklist prefixes are stored in plaintext, unlike vault-hashed card numbers.
+pub const MAX_CARD_BIN_LENGTH: usize = 10;
+
 #[derive(Debug, Deserialize, Serialize, Error)]
 #[error("{0}")]
 pub struct CardNumberValidationErr(&'static str);
@@ -28,7 +35,7 @@ pub struct CardNumber(StrongSecret<String, CardNumberStrategy>);
 pub struct NetworkToken(StrongSecret<String, CardNumberStrategy>);
 
 impl CardNumber {
-    pub fn get_bin_prefix(&self, len: usize) -> String {
+    fn get_bin_prefix(&self, len: usize) -> String {
         self.0.peek().chars().take(len).collect::<String>()
     }
 
@@ -38,6 +45,12 @@ impl CardNumber {
 
     pub fn get_extended_card_bin(&self) -> String {
         self.get_bin_prefix(8)
+    }
+
+    pub fn get_blocklist_bin_prefixes(&self) -> Vec<String> {
+        (MIN_CARD_BIN_LENGTH..=MAX_CARD_BIN_LENGTH)
+            .map(|len| self.get_bin_prefix(len))
+            .collect()
     }
     pub fn get_card_no(&self) -> String {
         self.0.peek().chars().collect::<String>()

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -687,8 +687,11 @@ impl PaymentResourceUpdateStatus {
 #[strum(serialize_all = "snake_case")]
 pub enum BlocklistDataKind {
     PaymentMethod,
+    /// Deprecated, superseded by `GenericCardBin`
     CardBin,
+    /// Deprecated, superseded by `GenericCardBin`
     ExtendedCardBin,
+    GenericCardBin,
 }
 
 #[derive(Debug)]

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -669,6 +669,8 @@ impl PaymentResourceUpdateStatus {
     }
 }
 
+/// `card_bin` (6 digits) and `extended_card_bin` (8 digits) are deprecated, use
+/// `generic_card_bin`, which accepts 6 to 10 digits.
 #[derive(
     Clone,
     Copy,

--- a/crates/diesel_models/src/query/blocklist.rs
+++ b/crates/diesel_models/src/query/blocklist.rs
@@ -10,6 +10,21 @@ use crate::{
     DatabaseConnectionWithContext, StorageResult,
 };
 
+/// The generic kind also matches the deprecated fixed-width kinds, so rows written before
+/// `generic_card_bin` existed stay visible.
+fn equivalent_data_kinds(
+    data_kind: common_enums::BlocklistDataKind,
+) -> Vec<common_enums::BlocklistDataKind> {
+    match data_kind {
+        common_enums::BlocklistDataKind::GenericCardBin => vec![
+            common_enums::BlocklistDataKind::GenericCardBin,
+            common_enums::BlocklistDataKind::CardBin,
+            common_enums::BlocklistDataKind::ExtendedCardBin,
+        ],
+        other => vec![other],
+    }
+}
+
 impl BlocklistNew {
     pub async fn insert(
         self,
@@ -146,13 +161,7 @@ impl Blocklist {
         limit: i64,
         offset: i64,
     ) -> StorageResult<Vec<Self>> {
-        let data_kinds = match data_kind {
-            common_enums::BlocklistDataKind::CardBin => vec![
-                common_enums::BlocklistDataKind::CardBin,
-                common_enums::BlocklistDataKind::ExtendedCardBin,
-            ],
-            other => vec![other],
-        };
+        let data_kinds = equivalent_data_kinds(data_kind);
         generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
             conn,
             dsl::processor_merchant_id
@@ -176,13 +185,7 @@ impl Blocklist {
         limit: i64,
         offset: i64,
     ) -> StorageResult<Vec<Self>> {
-        let data_kinds = match data_kind {
-            common_enums::BlocklistDataKind::CardBin => vec![
-                common_enums::BlocklistDataKind::CardBin,
-                common_enums::BlocklistDataKind::ExtendedCardBin,
-            ],
-            other => vec![other],
-        };
+        let data_kinds = equivalent_data_kinds(data_kind);
         generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
             conn,
             dsl::processor_merchant_id
@@ -208,13 +211,7 @@ impl Blocklist {
         processor_merchant_id: &common_utils::id_type::MerchantId,
         data_kind: common_enums::BlocklistDataKind,
     ) -> StorageResult<usize> {
-        let data_kinds = match data_kind {
-            common_enums::BlocklistDataKind::CardBin => vec![
-                common_enums::BlocklistDataKind::CardBin,
-                common_enums::BlocklistDataKind::ExtendedCardBin,
-            ],
-            other => vec![other],
-        };
+        let data_kinds = equivalent_data_kinds(data_kind);
         generics::generic_count::<<Self as HasTable>::Table, _>(
             conn,
             dsl::processor_merchant_id
@@ -233,13 +230,7 @@ impl Blocklist {
         profile_id: &common_utils::id_type::ProfileId,
         data_kind: common_enums::BlocklistDataKind,
     ) -> StorageResult<usize> {
-        let data_kinds = match data_kind {
-            common_enums::BlocklistDataKind::CardBin => vec![
-                common_enums::BlocklistDataKind::CardBin,
-                common_enums::BlocklistDataKind::ExtendedCardBin,
-            ],
-            other => vec![other],
-        };
+        let data_kinds = equivalent_data_kinds(data_kind);
         generics::generic_count::<<Self as HasTable>::Table, _>(
             conn,
             dsl::processor_merchant_id

--- a/crates/diesel_models/src/query/blocklist.rs
+++ b/crates/diesel_models/src/query/blocklist.rs
@@ -82,7 +82,7 @@ impl Blocklist {
     }
 
     pub async fn find_by_processor_merchant_id_profile_id_fingerprint_ids(
-        conn: &PgPooledConn,
+        conn: &DatabaseConnectionWithContext<'_>,
         processor_merchant_id: &common_utils::id_type::MerchantId,
         profile_id: &common_utils::id_type::ProfileId,
         fingerprint_ids: Vec<String>,

--- a/crates/diesel_models/src/query/blocklist.rs
+++ b/crates/diesel_models/src/query/blocklist.rs
@@ -81,6 +81,29 @@ impl Blocklist {
         .await
     }
 
+    pub async fn find_by_processor_merchant_id_profile_id_fingerprint_ids(
+        conn: &PgPooledConn,
+        processor_merchant_id: &common_utils::id_type::MerchantId,
+        profile_id: &common_utils::id_type::ProfileId,
+        fingerprint_ids: Vec<String>,
+    ) -> StorageResult<Option<Self>> {
+        generics::generic_find_one_optional::<<Self as HasTable>::Table, _, _>(
+            conn,
+            dsl::processor_merchant_id
+                .eq(processor_merchant_id.to_owned())
+                .or(dsl::processor_merchant_id
+                    .is_null()
+                    .and(dsl::merchant_id.eq(processor_merchant_id.to_owned())))
+                .and(dsl::fingerprint_id.eq_any(fingerprint_ids))
+                .and(
+                    dsl::profile_id
+                        .eq(profile_id.to_owned())
+                        .or(dsl::profile_id.is_null()),
+                ),
+        )
+        .await
+    }
+
     // Fallback function for stagger release - finds by merchant_id when processor_merchant_id is NULL
     pub async fn find_by_merchant_id_fingerprint_id(
         conn: &DatabaseConnectionWithContext<'_>,
@@ -123,6 +146,13 @@ impl Blocklist {
         limit: i64,
         offset: i64,
     ) -> StorageResult<Vec<Self>> {
+        let data_kinds = match data_kind {
+            common_enums::BlocklistDataKind::CardBin => vec![
+                common_enums::BlocklistDataKind::CardBin,
+                common_enums::BlocklistDataKind::ExtendedCardBin,
+            ],
+            other => vec![other],
+        };
         generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
             conn,
             dsl::processor_merchant_id
@@ -130,7 +160,7 @@ impl Blocklist {
                 .or(dsl::processor_merchant_id
                     .is_null()
                     .and(dsl::merchant_id.eq(processor_merchant_id.to_owned())))
-                .and(dsl::data_kind.eq(data_kind.to_owned())),
+                .and(dsl::data_kind.eq_any(data_kinds)),
             Some(limit),
             Some(offset),
             Some(dsl::created_at.desc()),
@@ -146,6 +176,13 @@ impl Blocklist {
         limit: i64,
         offset: i64,
     ) -> StorageResult<Vec<Self>> {
+        let data_kinds = match data_kind {
+            common_enums::BlocklistDataKind::CardBin => vec![
+                common_enums::BlocklistDataKind::CardBin,
+                common_enums::BlocklistDataKind::ExtendedCardBin,
+            ],
+            other => vec![other],
+        };
         generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
             conn,
             dsl::processor_merchant_id
@@ -153,7 +190,7 @@ impl Blocklist {
                 .or(dsl::processor_merchant_id
                     .is_null()
                     .and(dsl::merchant_id.eq(processor_merchant_id.to_owned())))
-                .and(dsl::data_kind.eq(data_kind.to_owned()))
+                .and(dsl::data_kind.eq_any(data_kinds))
                 .and(
                     dsl::profile_id
                         .eq(profile_id.to_owned())
@@ -171,6 +208,13 @@ impl Blocklist {
         processor_merchant_id: &common_utils::id_type::MerchantId,
         data_kind: common_enums::BlocklistDataKind,
     ) -> StorageResult<usize> {
+        let data_kinds = match data_kind {
+            common_enums::BlocklistDataKind::CardBin => vec![
+                common_enums::BlocklistDataKind::CardBin,
+                common_enums::BlocklistDataKind::ExtendedCardBin,
+            ],
+            other => vec![other],
+        };
         generics::generic_count::<<Self as HasTable>::Table, _>(
             conn,
             dsl::processor_merchant_id
@@ -178,7 +222,7 @@ impl Blocklist {
                 .or(dsl::processor_merchant_id
                     .is_null()
                     .and(dsl::merchant_id.eq(processor_merchant_id.to_owned())))
-                .and(dsl::data_kind.eq(data_kind.to_owned())),
+                .and(dsl::data_kind.eq_any(data_kinds)),
         )
         .await
     }
@@ -189,6 +233,13 @@ impl Blocklist {
         profile_id: &common_utils::id_type::ProfileId,
         data_kind: common_enums::BlocklistDataKind,
     ) -> StorageResult<usize> {
+        let data_kinds = match data_kind {
+            common_enums::BlocklistDataKind::CardBin => vec![
+                common_enums::BlocklistDataKind::CardBin,
+                common_enums::BlocklistDataKind::ExtendedCardBin,
+            ],
+            other => vec![other],
+        };
         generics::generic_count::<<Self as HasTable>::Table, _>(
             conn,
             dsl::processor_merchant_id
@@ -196,7 +247,7 @@ impl Blocklist {
                 .or(dsl::processor_merchant_id
                     .is_null()
                     .and(dsl::merchant_id.eq(processor_merchant_id.to_owned())))
-                .and(dsl::data_kind.eq(data_kind.to_owned()))
+                .and(dsl::data_kind.eq_any(data_kinds))
                 .and(
                     dsl::profile_id
                         .eq(profile_id.to_owned())

--- a/crates/openapi/src/routes/blocklist.rs
+++ b/crates/openapi/src/routes/blocklist.rs
@@ -83,7 +83,7 @@ pub async fn list_blocked_payment_methods() {}
         content_type = "multipart/form-data",
         description = "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). \
             The CSV must have a header row: `type,data,metadata`. \
-            `type`: one of `card_bin` (6 digits), `extended_card_bin` (8 digits), `fingerprint`. \
+            `type`: one of `card_bin` (6 to 10 digits), `fingerprint`. \
             `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). \
             Maximum 100,000 data rows.",
     ),

--- a/crates/openapi/src/routes/blocklist.rs
+++ b/crates/openapi/src/routes/blocklist.rs
@@ -83,7 +83,7 @@ pub async fn list_blocked_payment_methods() {}
         content_type = "multipart/form-data",
         description = "A multipart/form-data request with a `file` field containing a UTF-8 CSV (max 5 MiB). \
             The CSV must have a header row: `type,data,metadata`. \
-            `type`: one of `card_bin` (6 to 10 digits), `fingerprint`. \
+            `type`: one of `generic_card_bin` (6 to 10 digits), `fingerprint`. \
             `metadata`: optional, `key=value` pairs separated by `;` (e.g. `reason=fraud;source=manual`). \
             Maximum 100,000 data rows.",
     ),

--- a/crates/router/src/core/blocklist/batch.rs
+++ b/crates/router/src/core/blocklist/batch.rs
@@ -84,10 +84,11 @@ impl BlocklistRow {
         }
     }
 
-    // `extended_card_bin` is deprecated - it is accepted so existing CSVs keep working, but it is stored as a card bin
     fn parse_kind(kind: &str) -> Option<common_enums::BlocklistDataKind> {
         match kind {
-            "card_bin" | "extended_card_bin" => Some(common_enums::BlocklistDataKind::CardBin),
+            "card_bin" => Some(common_enums::BlocklistDataKind::CardBin),
+            "extended_card_bin" => Some(common_enums::BlocklistDataKind::ExtendedCardBin),
+            "generic_card_bin" => Some(common_enums::BlocklistDataKind::GenericCardBin),
             "fingerprint" => Some(common_enums::BlocklistDataKind::PaymentMethod),
             _ => None,
         }
@@ -106,7 +107,7 @@ impl BlocklistRow {
                 common_enums::BlocklistDataKind::CardBin,
                 data.clone(),
                 format!(
-                    "unknown type `{kind}`; expected card_bin, extended_card_bin, or fingerprint"
+                    "unknown type `{kind}`; expected generic_card_bin, card_bin, extended_card_bin, or fingerprint"
                 ),
             )
         })?;
@@ -120,12 +121,16 @@ impl BlocklistRow {
             ));
         }
 
+        let is_invalid = super::utils::validate_bin(&data, parsed_kind).is_err();
         let format_error = match parsed_kind {
-            common_enums::BlocklistDataKind::CardBin
-            | common_enums::BlocklistDataKind::ExtendedCardBin => {
-                super::utils::validate_card_bin(&data)
-                    .is_err()
-                    .then_some(super::utils::CARD_BIN_EXPECTED_FORMAT)
+            common_enums::BlocklistDataKind::CardBin => {
+                is_invalid.then_some("card_bin must be exactly 6 digits")
+            }
+            common_enums::BlocklistDataKind::ExtendedCardBin => {
+                is_invalid.then_some("extended_card_bin must be exactly 8 digits")
+            }
+            common_enums::BlocklistDataKind::GenericCardBin => {
+                is_invalid.then_some("generic_card_bin must be a 6 to 10 digit number")
             }
             common_enums::BlocklistDataKind::PaymentMethod => None,
         };
@@ -219,8 +224,9 @@ fn rows_to_csv_bytes(rows: &[BlocklistRow]) -> RouterResult<Vec<u8>> {
             })
             .unwrap_or_default();
         let type_str = match row.data_kind {
-            common_enums::BlocklistDataKind::CardBin
-            | common_enums::BlocklistDataKind::ExtendedCardBin => "card_bin",
+            common_enums::BlocklistDataKind::CardBin => "card_bin",
+            common_enums::BlocklistDataKind::ExtendedCardBin => "extended_card_bin",
+            common_enums::BlocklistDataKind::GenericCardBin => "generic_card_bin",
             common_enums::BlocklistDataKind::PaymentMethod => "fingerprint",
         };
         writer

--- a/crates/router/src/core/blocklist/batch.rs
+++ b/crates/router/src/core/blocklist/batch.rs
@@ -84,10 +84,10 @@ impl BlocklistRow {
         }
     }
 
+    // `extended_card_bin` is deprecated - it is accepted so existing CSVs keep working, but it is stored as a card bin
     fn parse_kind(kind: &str) -> Option<common_enums::BlocklistDataKind> {
         match kind {
-            "card_bin" => Some(common_enums::BlocklistDataKind::CardBin),
-            "extended_card_bin" => Some(common_enums::BlocklistDataKind::ExtendedCardBin),
+            "card_bin" | "extended_card_bin" => Some(common_enums::BlocklistDataKind::CardBin),
             "fingerprint" => Some(common_enums::BlocklistDataKind::PaymentMethod),
             _ => None,
         }
@@ -121,19 +121,11 @@ impl BlocklistRow {
         }
 
         let format_error = match parsed_kind {
-            common_enums::BlocklistDataKind::CardBin => {
-                if data.len() == 6 && data.chars().all(|c| c.is_ascii_digit()) {
-                    None
-                } else {
-                    Some("card_bin must be exactly 6 digits")
-                }
-            }
-            common_enums::BlocklistDataKind::ExtendedCardBin => {
-                if data.len() == 8 && data.chars().all(|c| c.is_ascii_digit()) {
-                    None
-                } else {
-                    Some("extended_card_bin must be exactly 8 digits")
-                }
+            common_enums::BlocklistDataKind::CardBin
+            | common_enums::BlocklistDataKind::ExtendedCardBin => {
+                super::utils::validate_card_bin(&data)
+                    .is_err()
+                    .then_some(super::utils::CARD_BIN_EXPECTED_FORMAT)
             }
             common_enums::BlocklistDataKind::PaymentMethod => None,
         };
@@ -227,8 +219,8 @@ fn rows_to_csv_bytes(rows: &[BlocklistRow]) -> RouterResult<Vec<u8>> {
             })
             .unwrap_or_default();
         let type_str = match row.data_kind {
-            common_enums::BlocklistDataKind::CardBin => "card_bin",
-            common_enums::BlocklistDataKind::ExtendedCardBin => "extended_card_bin",
+            common_enums::BlocklistDataKind::CardBin
+            | common_enums::BlocklistDataKind::ExtendedCardBin => "card_bin",
             common_enums::BlocklistDataKind::PaymentMethod => "fingerprint",
         };
         writer

--- a/crates/router/src/core/blocklist/utils.rs
+++ b/crates/router/src/core/blocklist/utils.rs
@@ -23,6 +23,11 @@ use crate::{
     types::{domain, storage, transformers::ForeignInto},
 };
 
+const CARD_BIN_MIN_LEN: usize = 6;
+const CARD_BIN_MAX_LEN: usize = 10;
+pub(super) const CARD_BIN_EXPECTED_FORMAT: &str = "a 6 to 10 digit number";
+
+#[allow(deprecated)]
 pub async fn delete_entry_from_blocklist(
     state: &SessionState,
     processor: &domain::Processor,
@@ -41,13 +46,9 @@ pub async fn delete_entry_from_blocklist(
     .await?;
 
     let blocklist_entry = match request {
-        api_blocklist::DeleteFromBlocklistRequest::CardBin(bin) => {
+        api_blocklist::DeleteFromBlocklistRequest::CardBin(bin)
+        | api_blocklist::DeleteFromBlocklistRequest::ExtendedCardBin(bin) => {
             delete_card_bin_blocklist_entry(state, &bin, processor_merchant_id, &profile_id).await?
-        }
-
-        api_blocklist::DeleteFromBlocklistRequest::ExtendedCardBin(xbin) => {
-            delete_card_bin_blocklist_entry(state, &xbin, processor_merchant_id, &profile_id)
-                .await?
         }
 
         api_blocklist::DeleteFromBlocklistRequest::Fingerprint(fingerprint_id) => state
@@ -152,30 +153,21 @@ pub async fn list_blocklist_entries_for_merchant(
     })
 }
 
-fn validate_card_bin(bin: &str) -> RouterResult<()> {
-    if bin.len() == 6 && bin.chars().all(|c| c.is_ascii_digit()) {
+pub(super) fn validate_card_bin(bin: &str) -> RouterResult<()> {
+    if (CARD_BIN_MIN_LEN..=CARD_BIN_MAX_LEN).contains(&bin.len())
+        && bin.chars().all(|c| c.is_ascii_digit())
+    {
         Ok(())
     } else {
         Err(errors::ApiErrorResponse::InvalidDataFormat {
             field_name: "data".to_string(),
-            expected_format: "a 6 digit number".to_string(),
+            expected_format: CARD_BIN_EXPECTED_FORMAT.to_string(),
         }
         .into())
     }
 }
 
-fn validate_extended_card_bin(bin: &str) -> RouterResult<()> {
-    if bin.len() == 8 && bin.chars().all(|c| c.is_ascii_digit()) {
-        Ok(())
-    } else {
-        Err(errors::ApiErrorResponse::InvalidDataFormat {
-            field_name: "data".to_string(),
-            expected_format: "an 8 digit number".to_string(),
-        }
-        .into())
-    }
-}
-
+#[allow(deprecated)]
 pub async fn insert_entry_into_blocklist(
     state: &SessionState,
     platform: &domain::Platform,
@@ -194,7 +186,8 @@ pub async fn insert_entry_into_blocklist(
     .await?;
 
     let blocklist_entry = match &to_block {
-        api_blocklist::AddToBlocklistRequest::CardBin(bin) => {
+        api_blocklist::AddToBlocklistRequest::CardBin(bin)
+        | api_blocklist::AddToBlocklistRequest::ExtendedCardBin(bin) => {
             validate_card_bin(bin)?;
             duplicate_check_insert_bin(
                 bin,
@@ -202,18 +195,6 @@ pub async fn insert_entry_into_blocklist(
                 platform,
                 &profile_id,
                 common_enums::BlocklistDataKind::CardBin,
-            )
-            .await?
-        }
-
-        api_blocklist::AddToBlocklistRequest::ExtendedCardBin(bin) => {
-            validate_extended_card_bin(bin)?;
-            duplicate_check_insert_bin(
-                bin,
-                state,
-                platform,
-                &profile_id,
-                common_enums::BlocklistDataKind::ExtendedCardBin,
             )
             .await?
         }
@@ -422,26 +403,18 @@ pub async fn should_payment_be_blocked(
             None
         };
 
-    // Hashed Cardbin to check whether or not this payment should be blocked.
-    let card_bin_fingerprint = payment_method_data
+    let card_bin_prefixes = payment_method_data
         .as_ref()
         .and_then(|pm_data| match pm_data {
-            domain::EligibilityPaymentMethodData::Card(card) => {
-                Some(card.card_number.get_card_isin())
-            }
+            domain::EligibilityPaymentMethodData::Card(card) => Some(&card.card_number),
             _ => None,
-        });
-
-    // Hashed Extended Cardbin to check whether or not this payment should be blocked.
-    let extended_card_bin_fingerprint =
-        payment_method_data
-            .as_ref()
-            .and_then(|pm_data| match pm_data {
-                domain::EligibilityPaymentMethodData::Card(card) => {
-                    Some(card.card_number.get_extended_card_bin())
-                }
-                _ => None,
-            });
+        })
+        .map(|card_number| {
+            (CARD_BIN_MIN_LEN..=CARD_BIN_MAX_LEN)
+                .map(|len| card_number.get_bin_prefix(len))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
 
     // Extended bin of the wallet's decrypted token, to check whether or not this payment should be blocked.
     let decrypted_token_extended_bin = payment_method_data
@@ -449,56 +422,25 @@ pub async fn should_payment_be_blocked(
         .and_then(|pm_data| pm_data.get_decrypted_token_extended_bin());
 
     //validating the payment method.
-    let mut blocklist_futures = Vec::new();
     let profile_id = business_profile.get_id();
-
-    if let Some(card_number_fingerprint) = card_number_fingerprint.as_ref() {
-        blocklist_futures.push(
-            db.find_blocklist_entry_by_processor_merchant_id_profile_id_fingerprint_id(
-                processor_merchant_id,
-                profile_id,
-                card_number_fingerprint,
-            ),
-        );
-    }
-
-    if let Some(card_bin_fingerprint) = card_bin_fingerprint.as_ref() {
-        blocklist_futures.push(
-            db.find_blocklist_entry_by_processor_merchant_id_profile_id_fingerprint_id(
-                processor_merchant_id,
-                profile_id,
-                card_bin_fingerprint,
-            ),
-        );
-    }
-
-    if let Some(extended_card_bin_fingerprint) = extended_card_bin_fingerprint.as_ref() {
-        blocklist_futures.push(
-            db.find_blocklist_entry_by_processor_merchant_id_profile_id_fingerprint_id(
-                processor_merchant_id,
-                profile_id,
-                extended_card_bin_fingerprint,
-            ),
-        );
-    }
-
-    if let Some(decrypted_token_extended_bin) = decrypted_token_extended_bin.as_ref() {
-        blocklist_futures.push(
-            db.find_blocklist_entry_by_processor_merchant_id_profile_id_fingerprint_id(
-                processor_merchant_id,
-                profile_id,
-                decrypted_token_extended_bin,
-            ),
-        );
-    }
-
-    let blocklist_lookups = futures::future::join_all(blocklist_futures).await;
+    let fingerprint_ids = card_number_fingerprint
+        .into_iter()
+        .chain(card_bin_prefixes)
+        .chain(decrypted_token_extended_bin)
+        .collect::<Vec<_>>();
 
     let mut block_reason: Option<BlockReason> = None;
-    for lookup in blocklist_lookups {
-        match lookup {
-            Ok(_) => {
-                block_reason = Some(BlockReason::BlockedBin);
+    if !fingerprint_ids.is_empty() {
+        match db
+            .find_blocklist_entries_by_processor_merchant_id_profile_id_fingerprint_ids(
+                processor_merchant_id,
+                profile_id,
+                fingerprint_ids,
+            )
+            .await
+        {
+            Ok(entry) => {
+                block_reason = entry.is_some().then_some(BlockReason::BlockedBin);
             }
             Err(e) => {
                 logger::error!(blocklist_db_error=?e, "failed db operations for blocklist");

--- a/crates/router/src/core/blocklist/utils.rs
+++ b/crates/router/src/core/blocklist/utils.rs
@@ -23,11 +23,6 @@ use crate::{
     types::{domain, storage, transformers::ForeignInto},
 };
 
-const CARD_BIN_MIN_LEN: usize = 6;
-const CARD_BIN_MAX_LEN: usize = 10;
-pub(super) const CARD_BIN_EXPECTED_FORMAT: &str = "a 6 to 10 digit number";
-
-#[allow(deprecated)]
 pub async fn delete_entry_from_blocklist(
     state: &SessionState,
     processor: &domain::Processor,
@@ -46,8 +41,10 @@ pub async fn delete_entry_from_blocklist(
     .await?;
 
     let blocklist_entry = match request {
+        #[allow(deprecated)]
         api_blocklist::DeleteFromBlocklistRequest::CardBin(bin)
-        | api_blocklist::DeleteFromBlocklistRequest::ExtendedCardBin(bin) => {
+        | api_blocklist::DeleteFromBlocklistRequest::ExtendedCardBin(bin)
+        | api_blocklist::DeleteFromBlocklistRequest::GenericCardBin(bin) => {
             delete_card_bin_blocklist_entry(state, &bin, processor_merchant_id, &profile_id).await?
         }
 
@@ -153,21 +150,34 @@ pub async fn list_blocklist_entries_for_merchant(
     })
 }
 
-pub(super) fn validate_card_bin(bin: &str) -> RouterResult<()> {
-    if (CARD_BIN_MIN_LEN..=CARD_BIN_MAX_LEN).contains(&bin.len())
-        && bin.chars().all(|c| c.is_ascii_digit())
-    {
-        Ok(())
-    } else {
-        Err(errors::ApiErrorResponse::InvalidDataFormat {
-            field_name: "data".to_string(),
-            expected_format: CARD_BIN_EXPECTED_FORMAT.to_string(),
-        }
-        .into())
-    }
+pub(super) fn validate_bin(
+    bin: &str,
+    data_kind: common_enums::BlocklistDataKind,
+) -> RouterResult<()> {
+    let expected = match data_kind {
+        common_enums::BlocklistDataKind::CardBin => Some((6..=6, "a 6 digit number")),
+        common_enums::BlocklistDataKind::ExtendedCardBin => Some((8..=8, "an 8 digit number")),
+        common_enums::BlocklistDataKind::GenericCardBin => Some((
+            cards::validate::MIN_CARD_BIN_LENGTH..=cards::validate::MAX_CARD_BIN_LENGTH,
+            "a 6 to 10 digit number",
+        )),
+        // A fingerprint is an opaque hash, it has no digit format to enforce.
+        common_enums::BlocklistDataKind::PaymentMethod => None,
+    };
+
+    expected.map_or(Ok(()), |(lengths, expected_format)| {
+        (lengths.contains(&bin.len()) && cards::validate::validate_card_number_chars(bin).is_ok())
+            .then_some(())
+            .ok_or_else(|| {
+                errors::ApiErrorResponse::InvalidDataFormat {
+                    field_name: "data".to_string(),
+                    expected_format: expected_format.to_string(),
+                }
+                .into()
+            })
+    })
 }
 
-#[allow(deprecated)]
 pub async fn insert_entry_into_blocklist(
     state: &SessionState,
     platform: &domain::Platform,
@@ -186,15 +196,40 @@ pub async fn insert_entry_into_blocklist(
     .await?;
 
     let blocklist_entry = match &to_block {
-        api_blocklist::AddToBlocklistRequest::CardBin(bin)
-        | api_blocklist::AddToBlocklistRequest::ExtendedCardBin(bin) => {
-            validate_card_bin(bin)?;
+        #[allow(deprecated)]
+        api_blocklist::AddToBlocklistRequest::CardBin(bin) => {
+            validate_bin(bin, common_enums::BlocklistDataKind::CardBin)?;
             duplicate_check_insert_bin(
                 bin,
                 state,
                 platform,
                 &profile_id,
                 common_enums::BlocklistDataKind::CardBin,
+            )
+            .await?
+        }
+
+        #[allow(deprecated)]
+        api_blocklist::AddToBlocklistRequest::ExtendedCardBin(bin) => {
+            validate_bin(bin, common_enums::BlocklistDataKind::ExtendedCardBin)?;
+            duplicate_check_insert_bin(
+                bin,
+                state,
+                platform,
+                &profile_id,
+                common_enums::BlocklistDataKind::ExtendedCardBin,
+            )
+            .await?
+        }
+
+        api_blocklist::AddToBlocklistRequest::GenericCardBin(bin) => {
+            validate_bin(bin, common_enums::BlocklistDataKind::GenericCardBin)?;
+            duplicate_check_insert_bin(
+                bin,
+                state,
+                platform,
+                &profile_id,
+                common_enums::BlocklistDataKind::GenericCardBin,
             )
             .await?
         }
@@ -409,11 +444,7 @@ pub async fn should_payment_be_blocked(
             domain::EligibilityPaymentMethodData::Card(card) => Some(&card.card_number),
             _ => None,
         })
-        .map(|card_number| {
-            (CARD_BIN_MIN_LEN..=CARD_BIN_MAX_LEN)
-                .map(|len| card_number.get_bin_prefix(len))
-                .collect::<Vec<_>>()
-        })
+        .map(cards::CardNumber::get_blocklist_bin_prefixes)
         .unwrap_or_default();
 
     // Extended bin of the wallet's decrypted token, to check whether or not this payment should be blocked.

--- a/crates/router/src/db/blocklist.rs
+++ b/crates/router/src/db/blocklist.rs
@@ -30,6 +30,13 @@ pub trait BlocklistInterface {
         fingerprint_id: &str,
     ) -> CustomResult<storage::Blocklist, errors::StorageError>;
 
+    async fn find_blocklist_entries_by_processor_merchant_id_profile_id_fingerprint_ids(
+        &self,
+        processor_merchant_id: &common_utils::id_type::MerchantId,
+        profile_id: &common_utils::id_type::ProfileId,
+        fingerprint_ids: Vec<String>,
+    ) -> CustomResult<Option<storage::Blocklist>, errors::StorageError>;
+
     async fn delete_blocklist_entry_by_processor_merchant_id_fingerprint_id(
         &self,
         processor_merchant_id: &common_utils::id_type::MerchantId,
@@ -178,6 +185,24 @@ impl BlocklistInterface for Store {
                 }
             }
         }
+    }
+
+    #[instrument(skip_all)]
+    async fn find_blocklist_entries_by_processor_merchant_id_profile_id_fingerprint_ids(
+        &self,
+        processor_merchant_id: &common_utils::id_type::MerchantId,
+        profile_id: &common_utils::id_type::ProfileId,
+        fingerprint_ids: Vec<String>,
+    ) -> CustomResult<Option<storage::Blocklist>, errors::StorageError> {
+        let conn = connection::pg_connection_read(self).await?;
+        storage::Blocklist::find_by_processor_merchant_id_profile_id_fingerprint_ids(
+            &conn,
+            processor_merchant_id,
+            profile_id,
+            fingerprint_ids,
+        )
+        .await
+        .map_err(|error| report!(errors::StorageError::from(error)))
     }
 
     #[instrument(skip_all)]
@@ -415,6 +440,15 @@ impl BlocklistInterface for MockDb {
         Err(errors::StorageError::MockDbError)?
     }
 
+    async fn find_blocklist_entries_by_processor_merchant_id_profile_id_fingerprint_ids(
+        &self,
+        _processor_merchant_id: &common_utils::id_type::MerchantId,
+        _profile_id: &common_utils::id_type::ProfileId,
+        _fingerprint_ids: Vec<String>,
+    ) -> CustomResult<Option<storage::Blocklist>, errors::StorageError> {
+        Err(errors::StorageError::MockDbError)?
+    }
+
     async fn list_blocklist_entries_by_processor_merchant_id(
         &self,
         _processor_merchant_id: &common_utils::id_type::MerchantId,
@@ -543,6 +577,22 @@ impl BlocklistInterface for KafkaStore {
                 processor_merchant_id,
                 profile_id,
                 fingerprint_id,
+            )
+            .await
+    }
+
+    #[instrument(skip_all)]
+    async fn find_blocklist_entries_by_processor_merchant_id_profile_id_fingerprint_ids(
+        &self,
+        processor_merchant_id: &common_utils::id_type::MerchantId,
+        profile_id: &common_utils::id_type::ProfileId,
+        fingerprint_ids: Vec<String>,
+    ) -> CustomResult<Option<storage::Blocklist>, errors::StorageError> {
+        self.diesel_store
+            .find_blocklist_entries_by_processor_merchant_id_profile_id_fingerprint_ids(
+                processor_merchant_id,
+                profile_id,
+                fingerprint_ids,
             )
             .await
     }

--- a/migrations/2026-08-28-120000_add_generic_card_bin_to_blocklist_data_kind/down.sql
+++ b/migrations/2026-08-28-120000_add_generic_card_bin_to_blocklist_data_kind/down.sql
@@ -1,0 +1,3 @@
+-- Postgres does not support removing a value from an enum type without
+-- recreating it; this is a no-op to keep the migration reversible in form.
+SELECT 1;

--- a/migrations/2026-08-28-120000_add_generic_card_bin_to_blocklist_data_kind/up.sql
+++ b/migrations/2026-08-28-120000_add_generic_card_bin_to_blocklist_data_kind/up.sql
@@ -1,0 +1,2 @@
+-- Add the `generic_card_bin` blocklist kind, a card number prefix of 6 to 10 digits.
+ALTER TYPE "BlocklistDataKind" ADD VALUE IF NOT EXISTS 'generic_card_bin';


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Widens the `card_bin` blocklist entry format from an exact 6-digit prefix to a 6-10 digit range, and folds `extended_card_bin` (previously a separate 8-digit type) into `card_bin`. `extended_card_bin` is deprecated but still accepted on read/write paths so existing CSVs and API callers keep working.

This also collapses the four separate per-length fingerprint lookups made on every payment (card bin, extended card bin, wallet decrypted token bin, card number) into a single batched lookup against all candidate bin-prefix fingerprints.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

`extended_card_bin` as a separate 8-digit type duplicated validation logic and required a second, separate blocklist fingerprint lookup on every payment. Widening `card_bin` to a 6-10 digit range covers both cases with one type, one validator, and one DB lookup.

## Linked Issues
<!-- Cloud issues are cross-repo + private, so `Fixes #` does NOT auto-close them. Use full URLs. -->
- Issue: https://github.com/juspay/hyperswitch-cloud/issues/22922


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<details>
<summary>1. Add BIN - Profile A (X-Profile-Id)</summary>

Request
```
curl --location 'http://localhost:8080/blocklist' \
--header 'Content-Type: application/json' \
--header 'X-Profile-Id: pro_7bnfGMz8224YnMppZ3Kg' \
--header 'api-key: [REDACTED]
--header 'Accept: */*' \
--data '{
    "type": "card_bin",
    "data": "41111111"
}'
```

Response
```
{
    "fingerprint_id": "41111111",
    "data_kind": "card_bin",
    "created_at": "2026-08-27T06:13:06.148Z",
    "profile_id": "pro_7bnfGMz8224YnMppZ3Kg"
}
```
</details>

<details>
<summary>2. Delete 522222 as Profile B (expect 404)</summary>

Request
```
curl --location 'http://localhost:8080/blocklist' \
--header 'Content-Type: application/json' \
--header 'X-Profile-Id: pro_7bnfGMz8224YnMppZ3Kg' \
--header 'api-key: [REDACTED]
--header 'Accept: */*' \
--data '{
    "type": "card_bin",
    "data": "41111111"
}'
```

Response
```
{
    "fingerprint_id": "41111111",
    "data_kind": "card_bin",
    "created_at": "2026-08-27T06:13:06.148Z",
    "profile_id": "pro_7bnfGMz8224YnMppZ3Kg"
}
```
</details>


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
