### PR TITLE
fix(connector-config): correct GoTyme payout auth key name

### DIFF
--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -9105,7 +9105,7 @@ key1 = "Worldpay Merchant ID"
 
 [gotyme_sanlam_payout.connector_auth.BodyKey]
 api_key = "API Key"
-profile_id = "Profile Id"
+key1 = "Profile Id"
 [[gotyme_sanlam_payout.bank_transfer]]
 payment_method_type = "payshap"
 [[gotyme_sanlam_payout.bank_transfer]]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -8161,7 +8161,7 @@ key1 = "Worldpay Merchant ID"
 
 [gotyme_sanlam_payout.connector_auth.BodyKey]
 api_key = "API Key"
-profile_id = "Profile Id"
+key1 = "Profile Id"
 [[gotyme_sanlam_payout.bank_transfer]]
 payment_method_type = "payshap"
 [[gotyme_sanlam_payout.bank_transfer]]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -9079,7 +9079,7 @@ key1 = "Worldpay Merchant ID"
 
 [gotyme_sanlam_payout.connector_auth.BodyKey]
 api_key = "API Key"
-profile_id = "Profile Id"
+key1 = "Profile Id"
 [[gotyme_sanlam_payout.bank_transfer]]
 payment_method_type = "payshap"
 [[gotyme_sanlam_payout.bank_transfer]]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Replace the unsupported `profile_id` key with `key1` for the GoTyme Sanlam payout connector
- Apply the correction across development, sandbox, and production connector configurations
- Align the configuration with the expected `BodyKey` authentication schema

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested locally on control center
<img width="989" height="610" alt="Screenshot 2026-08-26 at 6 55 01 PM" src="https://github.com/user-attachments/assets/89a859b7-5379-4cea-ba2d-7eb72bbc54d3" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
