### PR TITLE
fix(connector-config): restore the santander pix_automatico_push array header in production.toml

### DIFF
--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -6714,6 +6714,7 @@ label="Client Secret"
 placeholder="Enter your Client Secret"
 required=true
 type="Text"
+[[santander.metadata.pix_automatico_push]]
 name="pix_key_type"
 label="Chave Key Type"
 placeholder="Enter your Chave/Pix Key Type"


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

Closes #13874

## Description

`production.toml` is missing the `[[santander.metadata.pix_automatico_push]]` header before the `pix_key_type` entry, so that entry merges into the preceding `client_secret` element:

```toml
[[santander.metadata.pix_automatico_push]]
name="client_secret"
...
type="Text"
name="pix_key_type"          # <-- no header, so this joins the element above
```

`development.toml` and `sandbox.toml` both carry the header in that position, and the sibling `santander.metadata.pix_qr` block carries it too — so this is a dropped line in one file rather than an intentional difference. @bsayak03 [confirmed](https://github.com/juspay/hyperswitch/pull/13871#discussion_r3868662555) it was unintentional and got missed in #12185.

**The consequence is not scoped to santander.** `ConnectorConfig::new()` parses a whole file in a single `toml::from_str`, and both public entry points propagate the error with `?`:

```rust
let config = toml::from_str::<Self>(config_str);
```

So while this is present, a **production** build cannot load *any* connector's config — `get_connector_config` and `get_payout_connector_config` fail for every connector.

## Verification

Parsed both revisions with an independent TOML parser rather than asserting from inspection:

```
main (unfixed)   ->  Cannot overwrite a value (at line 6717, column 20)
with this fix    ->  parses; pix_automatico_push has 7 elements:
                     client_id, client_secret, pix_key_type, pix_key_value,
                     account_number, account_type, branch_code
```

Rebased onto current `main` (`7e51536dc`).

## Scope

One line. The regression test that originally came with this has been dropped at @pixincreate's request — happy to bring it back separately if it is ever wanted.