### PR TITLE
feat(euclid_wasm): expose funding source and card segment type values

### DIFF
--- a/crates/euclid_wasm/src/lib.rs
+++ b/crates/euclid_wasm/src/lib.rs
@@ -37,8 +37,9 @@ use api_models::payment_methods::CountryCodeWithName;
 #[cfg(feature = "payouts")]
 use common_enums::PayoutStatus;
 use common_enums::{
-    CardType, CountryAlpha2, DisputeStatus, EventClass, EventType, IntentStatus, MandateStatus,
-    MerchantCategoryCode, MerchantCategoryCodeWithName, RefundStatus, SubscriptionStatus,
+    CardSegmentType, CardType, CountryAlpha2, DisputeStatus, EventClass, EventType, FundingSource,
+    IntentStatus, MandateStatus, MerchantCategoryCode, MerchantCategoryCodeWithName, RefundStatus,
+    SubscriptionStatus,
 };
 use strum::IntoEnumIterator;
 
@@ -552,6 +553,18 @@ pub fn get_card_subtype_values() -> JsResult {
 pub fn get_card_type_values() -> JsResult {
     let types: Vec<CardType> = CardType::iter().collect();
     Ok(serde_wasm_bindgen::to_value(&types)?)
+}
+
+#[wasm_bindgen(js_name = getFundingSourceValues)]
+pub fn get_funding_source_values() -> JsResult {
+    let funding_sources: Vec<FundingSource> = FundingSource::iter().collect();
+    Ok(serde_wasm_bindgen::to_value(&funding_sources)?)
+}
+
+#[wasm_bindgen(js_name = getCardSegmentTypeValues)]
+pub fn get_card_segment_type_values() -> JsResult {
+    let segment_types: Vec<CardSegmentType> = CardSegmentType::iter().collect();
+    Ok(serde_wasm_bindgen::to_value(&segment_types)?)
 }
 
 #[wasm_bindgen(js_name = getValidWebhookStatus)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds two `wasm_bindgen` exports to `euclid_wasm` so the dashboard can render dropdowns for the
`funding_sources` and `card_segment_types` attributes of the business profile's
`payment_method_blocking` config:

- `getFundingSourceValues` — every `common_enums::FundingSource` variant (`CREDIT`, `DEBIT`,
  `DEFERRED DEBIT`, `PREPAID`, `CHARGE CARD`).
- `getCardSegmentTypeValues` — every `common_enums::CardSegmentType` variant (`business`,
  `commercial`, `consumer`, `government`).

Both follow the existing `getCardTypeValues` pattern — `::iter()` collected into a `Vec` and
serialized with serde — deliberately, rather than `strum::VariantNames`. `CardSegmentType` carries
no `#[strum(serialize_all = ...)]`, so its strum variant name (`"Business"`) diverges from its serde
wire value (`"business"`); `VARIANTS` would emit values the API rejects. Neither enum derives
`strum::VariantNames` today in any case.

These two attributes were the only gap. The rest of `CardBlockingConfig` is already served:
`issuing_country` by `getTwoLetterCountryCode`, `card_types` by `getCardTypeValues`, `card_subtypes`
by `getCardSubtypeValues`, `card_networks` by `getVariantValues("card_network")`
(`dir_enums::CardNetwork` is a re-export of `common_enums::CardNetwork`), and `issuers` by the
`GET /card_issuers` API. Neither `FundingSource` nor `CardSegmentType` exists in
`euclid::frontend::dir::enums`, so there is no `DirKeyKind` for `getVariantValues` to dispatch on and
it cannot serve them.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

Additive wasm exports only — no existing export changes signature or return value, so the dashboard
is unaffected until it opts in.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The Payment Method Blocking section under Payment Settings exposes only `card_types`, for card and
for wallet. The backend `payment_method_blocking` config supports 11 attributes on
`CardBlockingConfig`, applied three times over (`card`, `wallet.apple_pay`, `wallet.google_pay`), so
a merchant wanting to block by funding source or card segment has to call the API directly today.

This is the backend half of extending that UI to the full contract: the dashboard reads its allowed
values from wasm, and these were the two attributes with no source to read from.

## Linked Issues
<!-- Cloud issues are cross-repo + private, so `Fixes #` does NOT auto-close them. Use full URLs. -->
- Issue: https://github.com/juspay/hyperswitch-cloud/issues/22977

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Built the bundle the same way `make euclid-wasm` does and called the new exports:

```bash
wasm-pack build --target web --out-dir wasm --out-name euclid \
  crates/euclid_wasm -- --features dummy_connector,v1
```

Both appear in the generated `wasm/euclid.d.ts`, and invoking them against the built bundle returns:

```
getFundingSourceValues()   -> ["CREDIT","DEBIT","DEFERRED DEBIT","PREPAID","CHARGE CARD"]
getCardSegmentTypeValues() -> ["business","commercial","consumer","government"]
getCardTypeValues()        -> ["credit","debit"]        # existing export, for comparison
```

These are exactly the values `CardBlockingConfig` deserializes — note `card_segment_types` coming
back lowercase, which is the case `strum::VARIANTS` would have got wrong.

`cargo +nightly fmt` and `cargo clippy -p euclid_wasm --target wasm32-unknown-unknown --features
dummy_connector,v1` both pass.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
