### PR TITLE
fix(connector): [paypal] avoide non zero setup mandates

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
@@ -720,6 +720,13 @@ impl<F, T> TryFrom<ResponseRouterData<F, PaypalSetupMandatesResponse, T, Payment
 impl TryFrom<&SetupMandateRouterData> for PaypalZeroMandateRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &SetupMandateRouterData) -> Result<Self, Self::Error> {
+        if item.request.amount > 0 {
+            return Err(errors::ConnectorError::FlowNotSupported {
+                flow: "Setup Mandate with non zero amount".to_string(),
+                connector: "Paypal".to_string(),
+            }
+            .into());
+        }
         let payment_source = match item.request.payment_method_data.clone() {
             PaymentMethodData::Card(ccard) => ZeroMandateSourceItem::Card(CardMandateRequest {
                 billing_address: get_address_info(item.get_optional_billing()),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

PayPal's setup mandate flow (`v3/vault/payment-tokens`) is strictly a **zero-amount mandate** flow — it only creates a vaulted payment token and must never carry a transaction amount.

This PR adds a guard in `PaypalZeroMandateRequest::try_from` (`crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs`) that rejects non-zero amount setup mandates upfront:

```rust
if item.request.amount > 0 {
    return Err(errors::ConnectorError::FlowNotSupported {
        flow: "Setup Mandate with non zero amount".to_string(),
        connector: "Paypal".to_string(),
    }
    .into());
}
```

Non-zero amounts are now never sent to PayPal in the setup mandate flow; the connector fails early with `FlowNotSupported` instead of propagating an invalid request downstream. This follows the existing convention already used by `nmi`, `peachpayments` and `worldpayxml` for the same restriction.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Previously, a setup mandate request with a non-zero amount was silently accepted and forwarded to PayPal's payment-tokens API, even though the flow is only valid for $0 mandates. This could lead to misleading behavior for merchants. Only **$0 (zero-amount) mandates** are now allowed for PayPal; any non-zero amount is rejected at the connector layer with a clear error before any outbound request is made.


