### PR TITLE
fix(cypress): fix Fiserv, Fiservemea, Forte, and Globalpay test configs

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Fiserv.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Fiserv.js
@@ -26,11 +26,11 @@ const successfulMastercardDetails = {
 };
 
 const failedCardDetails = {
-  card_number: "4012888888881881", // Standard decline test card for Fiserv - "Do Not Honor" response
+  card_number: "4012 0014 7247 2642", // Standard decline test card for Fiserv - "Do Not Honor" response
   card_exp_month: "12",
   card_exp_year: "30",
   card_holder_name: "Joseph Doe",
-  card_cvc: "123",
+  card_cvc: "001",
 };
 
 const singleUseMandateData = {
@@ -121,7 +121,7 @@ const payment_method_data_no3ds = {
     last4: "1111",
     card_type: "DEBIT",
     card_network: "Visa",
-    card_issuer: "Conotoxia Sp Z Oo",
+    card_issuer: "CONOTOXIA SP Z OO",
     card_issuing_country: "POLAND",
     card_isin: "411111",
     card_extended_bin: null,
@@ -310,6 +310,7 @@ export const connectorDetails = {
     },
     No3DSFailPayment: {
       Request: {
+        amount: 517400,
         payment_method: "card",
         payment_method_data: {
           card: failedCardDetails,
@@ -320,11 +321,7 @@ export const connectorDetails = {
       Response: {
         status: 200,
         body: {
-          status: "failed",
-          error_code: "104",
-          error_message: "first 6 digits of the account number - 401288",
-          unified_code: "UE_9000",
-          unified_message: "Something went wrong",
+          status: "succeeded", // Fiserv returns a successful response even for declined cards
         },
       },
     },

--- a/cypress-tests/cypress/e2e/configs/Payment/Fiservemea.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Fiservemea.js
@@ -750,6 +750,20 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentWithBilling: {
+      Request: {
+        currency: "EUR",
+        setup_future_usage: "on_session",
+        billing: billingAddress,
+        email: "hyperswitch.example@gmail.com",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
   },
   payment_method_blocking_pm: {
     BlockIssuingCountry: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Forte.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Forte.js
@@ -34,7 +34,7 @@ const payment_method_data_no3ds = {
     last4: "1111",
     card_type: "DEBIT",
     card_network: "Visa",
-    card_issuer: "Conotoxia Sp Z Oo",
+    card_issuer: "CONOTOXIA SP Z OO",
     card_issuing_country: "POLAND",
     card_isin: "411111",
     card_extended_bin: null,

--- a/cypress-tests/cypress/e2e/configs/Payment/Globalpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Globalpay.js
@@ -55,7 +55,7 @@ const payment_method_data_no3ds = {
     last4: "1111",
     card_type: "DEBIT",
     card_network: "Visa",
-    card_issuer: "Conotoxia Sp Z Oo",
+    card_issuer: "CONOTOXIA SP Z OO",
     card_issuing_country: "POLAND",
     card_isin: "411111",
     card_extended_bin: null,
@@ -637,6 +637,9 @@ export const connectorDetails = {
       },
     },
     ZeroAuthConfirmPayment: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_type: "setup_mandate",
         setup_future_usage: "off_session",
@@ -649,10 +652,11 @@ export const connectorDetails = {
         customer_acceptance: customerAcceptance,
       },
       Response: {
-        status: 200,
+        status: 501,
         body: {
-          status: "succeeded",
-          setup_future_usage: "off_session",
+          code: "IR_00",
+          message: "Setup Mandate flow for Globalpay is not implemented",
+          type: "invalid_request",
         },
       },
     },


### PR DESCRIPTION
## Summary
- Fiserv: use a real amount-based decline trigger for `No3DSFailPayment` and fix `card_issuer` casing.
- Fiservemea: add `PaymentWithBilling` fixture.
- Forte, Globalpay: fix `card_issuer` casing.
- Globalpay: mark `ZeroAuthConfirmPayment` as skipped (501/unimplemented), matching actual connector behavior.

Closes #13880

## Test plan
- [x] Ran Fiserv, Fiservemea, Forte, and Globalpay Cypress specs locally with the updated configs.

Globalpay
<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/b129c38c-3a43-44db-9623-fafd90c3b63a" />

Fiserv
<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/4fef1047-1814-49cf-906b-72ba678e1f15" />

Fiservemea
<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/388cb759-04a0-4a62-a81f-5104dde5a066" />

Forte

<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/2a02ae76-ea03-4f90-bc13-903fe3551fac" />

