### PR TITLE
refactor(common_types, euclid): stop 12 crates compiling an unused ORM

### DIFF
--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -51,10 +51,13 @@ superposition_types = "0.115.5"
 
 # First party crates
 cards = { version = "0.1.0", path = "../cards" }
-common_enums = { version = "0.1.0", path = "../common_enums" }
-common_types = { version = "0.1.0", path = "../common_types" }
-common_utils = { version = "0.1.0", path = "../common_utils" }
-euclid = { version = "0.1.0", path = "../euclid" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
+common_types = { version = "0.1.0", path = "../common_types", default-features = false }
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
+euclid = { version = "0.1.0", path = "../euclid", default-features = false }
 hyperswitch_masking = { version = "0.0.1", default-features = false, features = [
     "alloc",
     "serde",

--- a/crates/cards/Cargo.toml
+++ b/crates/cards/Cargo.toml
@@ -17,7 +17,10 @@ time = "0.3.41"
 regex = "1.11.1"
 
 # First party crates
-common_utils = { version = "0.1.0", path = "../common_utils" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
 hyperswitch_masking = "0.0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/common_types/Cargo.toml
+++ b/crates/common_types/Cargo.toml
@@ -7,13 +7,18 @@ rust-version.workspace = true
 license.workspace = true
 
 [features]
-default = []
+# Diesel ORM impls for these types. Default-on so hyperswitch is unaffected.
+# Must forward common_utils/diesel: the `impl_to_sql_from_sql_json!` macro this
+# crate calls 34 times is gated at its definition in common_utils, so it does
+# not exist as a symbol unless that feature is on.
+default = ["diesel"]
+diesel = ["dep:diesel", "common_utils/diesel"]
 v1 = ["common_utils/v1"]
 v2 = ["common_utils/v2"]
 tokenization_v2 = ["common_utils/tokenization_v2"]
 
 [dependencies]
-diesel = "2.2.10"
+diesel = { version = "2.2.10", features = ["postgres"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 utoipa = { version = "4.2.3", features = ["preserve_order", "preserve_path_order"] }
@@ -22,10 +27,10 @@ error-stack = "0.4.1"
 cpf_cnpj = "0.3"
 rust_decimal = { version = "1.37", features = ["maths"] }
 
-common_enums = { version = "0.1.0", path = "../common_enums" }
-common_utils = { version = "0.1.0", path = "../common_utils"}
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
 cards = { version = "0.1.0", path = "../cards"}
-euclid = { version = "0.1.0", path = "../euclid" }
+euclid = { version = "0.1.0", path = "../euclid", default-features = false }
 hyperswitch_masking = "0.0.1"
 smithy = { version = "0.1.0", path = "../smithy" }
 smithy-core = { version = "0.1.0", path = "../smithy-core" }

--- a/crates/common_types/src/callback_mapper.rs
+++ b/crates/common_types/src/callback_mapper.rs
@@ -1,10 +1,10 @@
 use common_utils::id_type;
+#[cfg(feature = "diesel")]
 use diesel::{AsExpression, FromSqlRow};
 
-#[derive(
-    Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize, AsExpression, FromSqlRow,
-)]
-#[diesel(sql_type = diesel::sql_types::Jsonb)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Jsonb))]
 /// Represents the data associated with a callback mapper.
 pub enum CallbackMapperData {
     /// data variant used while processing the network token webhook
@@ -37,4 +37,5 @@ impl CallbackMapperData {
     }
 }
 
+#[cfg(feature = "diesel")]
 common_utils::impl_to_sql_from_sql_json!(CallbackMapperData);

--- a/crates/common_types/src/customers.rs
+++ b/crates/common_types/src/customers.rs
@@ -5,8 +5,9 @@ use cpf_cnpj::{cnpj, cpf};
 use utoipa::ToSchema;
 /// HashMap containing MerchantConnectorAccountId and corresponding customer id
 #[cfg(feature = "v2")]
-#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, diesel::AsExpression)]
-#[diesel(sql_type = diesel::sql_types::Jsonb)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(diesel::AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Jsonb))]
 #[serde(transparent)]
 pub struct ConnectorCustomerMap(
     std::collections::HashMap<common_utils::id_type::MerchantConnectorAccountId, String>,
@@ -22,7 +23,7 @@ impl ConnectorCustomerMap {
     }
 }
 
-#[cfg(feature = "v2")]
+#[cfg(all(feature = "v2", feature = "diesel"))]
 common_utils::impl_to_sql_from_sql_json!(ConnectorCustomerMap);
 
 #[cfg(feature = "v2")]

--- a/crates/common_types/src/domain.rs
+++ b/crates/common_types/src/domain.rs
@@ -3,7 +3,10 @@
 use std::collections::HashMap;
 
 use common_enums::enums;
-use common_utils::{impl_to_sql_from_sql_json, types::MinorUnit};
+#[cfg(feature = "diesel")]
+use common_utils::impl_to_sql_from_sql_json;
+use common_utils::types::MinorUnit;
+#[cfg(feature = "diesel")]
 use diesel::{sql_types::Jsonb, AsExpression, FromSqlRow};
 #[cfg(feature = "v2")]
 use hyperswitch_masking::Secret;
@@ -11,19 +14,9 @@ use serde::{Deserialize, Serialize};
 use smithy::SmithyModel;
 use utoipa::ToSchema;
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// Fee information for Split Payments to be charged on the payment being collected for Adyen
@@ -35,21 +28,12 @@ pub struct AdyenSplitData {
     #[smithy(value_type = "Vec<AdyenSplitItem>")]
     pub split_items: Vec<AdyenSplitItem>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(AdyenSplitData);
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// Data for the split items
@@ -72,22 +56,13 @@ pub struct AdyenSplitItem {
     #[smithy(value_type = "Option<String>")]
     pub description: Option<String>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(AdyenSplitItem);
 
 /// Fee information to be charged on the payment being collected for sub-merchant via xendit
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct XenditSplitSubMerchantData {
@@ -95,6 +70,7 @@ pub struct XenditSplitSubMerchantData {
     #[smithy(value_type = "String")]
     pub for_user_id: String,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(XenditSplitSubMerchantData);
 
 /// Acquirer configuration
@@ -123,8 +99,9 @@ pub struct AcquirerConfig {
     pub acquirer_country_code: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, FromSqlRow, AsExpression, ToSchema)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 /// Acquirer config buckets: each ProfileAcquirerId maps to an array of per-network configs
 pub struct AcquirerConfigBucket {
     /// The default acquirer config id
@@ -146,6 +123,7 @@ pub struct AcquirerConfigBucket {
     pub configs: HashMap<common_utils::id_type::ProfileAcquirerId, Vec<AcquirerConfig>>,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(AcquirerConfigBucket);
 
 /// Merchant connector details
@@ -174,8 +152,9 @@ pub struct ConnectorResponseData {
     pub raw_connector_response: Option<Secret<String>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, AsExpression, ToSchema)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(rename_all = "snake_case")]
 /// Contains the data relevant to the specified GSM feature, if applicable.
 /// For example, if the `feature` is `Retry`, this will include configuration
@@ -186,8 +165,9 @@ pub enum GsmFeatureData {
 }
 
 /// Represents the data associated with a retry feature in GSM.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, AsExpression, ToSchema)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct RetryFeatureData {
     /// indicates if step_up retry is possible
     pub step_up_possible: bool,
@@ -200,7 +180,9 @@ pub struct RetryFeatureData {
     pub decision: common_enums::GsmDecision,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(GsmFeatureData);
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(RetryFeatureData);
 
 impl GsmFeatureData {

--- a/crates/common_types/src/payment_methods.rs
+++ b/crates/common_types/src/payment_methods.rs
@@ -1,5 +1,6 @@
 //! Common types to be used in payment methods
 
+#[cfg(feature = "diesel")]
 use diesel::{
     backend::Backend,
     deserialize,
@@ -17,9 +18,10 @@ use utoipa::ToSchema;
 // This is a performance optimization to avoid json validation at database level.
 // jsonb enables faster querying on json columns, but it doesn't justify here since we are not querying on this column.
 // https://docs.rs/diesel/latest/diesel/sql_types/struct.Jsonb.html
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, AsExpression)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
 #[serde(deny_unknown_fields)]
-#[diesel(sql_type = Json)]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Json))]
 pub struct PaymentMethodsEnabled {
     /// Type of payment method.
     #[schema(value_type = PaymentMethod,example = "card")]
@@ -30,6 +32,7 @@ pub struct PaymentMethodsEnabled {
 }
 
 // Custom FromSql implementation to handle deserialization of v1 data format
+#[cfg(feature = "diesel")]
 impl FromSql<Json, diesel::pg::Pg> for PaymentMethodsEnabled {
     fn from_sql(bytes: <diesel::pg::Pg as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         let helper: PaymentMethodsEnabledHelper = serde_json::from_slice(bytes.as_bytes())
@@ -39,6 +42,7 @@ impl FromSql<Json, diesel::pg::Pg> for PaymentMethodsEnabled {
 }
 
 // In this ToSql implementation, we are directly serializing the PaymentMethodsEnabled struct to JSON
+#[cfg(feature = "diesel")]
 impl ToSql<Json, diesel::pg::Pg> for PaymentMethodsEnabled {
     fn to_sql<'b>(
         &'b self,
@@ -234,6 +238,7 @@ pub enum AcceptedCurrencies {
     AllAccepted,
 }
 
+#[cfg(feature = "diesel")]
 impl<DB> Queryable<Jsonb, DB> for PaymentMethodsEnabled
 where
     DB: Backend,

--- a/crates/common_types/src/payments.rs
+++ b/crates/common_types/src/payments.rs
@@ -5,10 +5,12 @@ use std::{
 };
 
 use common_enums::enums;
+#[cfg(feature = "diesel")]
+use common_utils::impl_to_sql_from_sql_json;
 use common_utils::{
-    consts, date_time, errors, events, ext_traits::OptionExt, impl_to_sql_from_sql_json, pii,
-    types::MinorUnit,
+    consts, date_time, errors, events, ext_traits::OptionExt, pii, types::MinorUnit,
 };
+#[cfg(feature = "diesel")]
 use diesel::{
     sql_types::{Jsonb, Text},
     AsExpression, FromSqlRow,
@@ -32,19 +34,9 @@ use crate::{
     consts::PERCENTAGE_BASE,
     domain::{AdyenSplitData, PostCaptureVoidData, XenditSplitSubMerchantData},
 };
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -63,21 +55,12 @@ pub enum SplitPaymentsRequest {
     #[smithy(value_type = "PayloadSplitPaymentRequest")]
     PayloadSplitPayment(PayloadSplitPaymentRequest),
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(SplitPaymentsRequest);
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// Fee information for Split Payments to be charged on the payment being collected for Stripe
 pub struct StripeSplitPaymentRequest {
@@ -100,21 +83,12 @@ pub struct StripeSplitPaymentRequest {
     #[smithy(value_type = "Option<String>")]
     pub on_behalf_of: Option<String>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(StripeSplitPaymentRequest);
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// A single ledger entry distributing payment to one receiver for Payload split payments
 pub struct PayloadLedgerItem {
@@ -126,21 +100,12 @@ pub struct PayloadLedgerItem {
     #[smithy(value_type = "String")]
     pub receiver_id: String,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(PayloadLedgerItem);
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// Split payment configuration for Payload — distributes a payment across multiple receivers via ledger entries
 pub struct PayloadSplitPaymentRequest {
@@ -148,17 +113,18 @@ pub struct PayloadSplitPaymentRequest {
     #[smithy(value_type = "Vec<PayloadLedgerItem>")]
     pub ledger: Vec<PayloadLedgerItem>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(PayloadSplitPaymentRequest);
 
-#[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(deny_unknown_fields)]
 /// Hashmap to store mca_id's with product names
 pub struct AuthenticationConnectorAccountMap(
     HashMap<enums::AuthenticationProduct, common_utils::id_type::MerchantConnectorAccountId>,
 );
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(AuthenticationConnectorAccountMap);
 
 impl AuthenticationConnectorAccountMap {
@@ -180,10 +146,9 @@ impl AuthenticationConnectorAccountMap {
 ///
 /// This type stores a country code as a string and provides methods to validate it
 /// and convert it to a `Country` enum variant.
-#[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Text)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(deny_unknown_fields)]
 pub struct MerchantCountryCode(String);
 
@@ -223,6 +188,7 @@ impl MerchantCountryCode {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl diesel::serialize::ToSql<Text, diesel::pg::Pg> for MerchantCountryCode {
     fn to_sql<'b>(
         &'b self,
@@ -232,6 +198,7 @@ impl diesel::serialize::ToSql<Text, diesel::pg::Pg> for MerchantCountryCode {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl diesel::deserialize::FromSql<Text, diesel::pg::Pg> for MerchantCountryCode {
     fn from_sql(bytes: diesel::pg::PgValue<'_>) -> diesel::deserialize::Result<Self> {
         let s = <String as diesel::deserialize::FromSql<Text, diesel::pg::Pg>>::from_sql(bytes)?;
@@ -239,10 +206,9 @@ impl diesel::deserialize::FromSql<Text, diesel::pg::Pg> for MerchantCountryCode 
     }
 }
 
-#[derive(
-    Serialize, Default, Deserialize, Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Default, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 /// ConditionalConfigs
 pub struct ConditionalConfigs {
     /// Override 3DS
@@ -263,6 +229,7 @@ impl EuclidDirFilter for ConditionalConfigs {
     ];
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(ConditionalConfigs);
 
 /// This "CustomerAcceptance" object is passed during Payments-Confirm request, it enlists the type, time, and mode of acceptance properties related to an acceptance done by the customer. The customer_acceptance sub object is usually passed by the SDK or client.
@@ -274,12 +241,12 @@ impl_to_sql_from_sql_json!(ConditionalConfigs);
     serde::Deserialize,
     serde::Serialize,
     Clone,
-    AsExpression,
     ToSchema,
     SmithyModel,
 )]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
 #[serde(deny_unknown_fields)]
-#[diesel(sql_type = Jsonb)]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct CustomerAcceptance {
     /// Type of acceptance provided by the
@@ -296,6 +263,7 @@ pub struct CustomerAcceptance {
     pub online: Option<OnlineMandate>,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(CustomerAcceptance);
 
 impl CustomerAcceptance {
@@ -349,14 +317,14 @@ pub enum AcceptanceType {
     Debug,
     serde::Deserialize,
     serde::Serialize,
-    AsExpression,
     Clone,
     ToSchema,
     SmithyModel,
 )]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
 #[serde(deny_unknown_fields)]
 /// Details of online mandate
-#[diesel(sql_type = Jsonb)]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct OnlineMandate {
     /// Ip address of the customer machine from which the mandate was created
@@ -368,10 +336,12 @@ pub struct OnlineMandate {
     pub user_agent: String,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(OnlineMandate);
 
-#[derive(Serialize, Deserialize, Debug, Clone, FromSqlRow, AsExpression, ToSchema)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 /// DecisionManagerRecord
 pub struct DecisionManagerRecord {
     /// Name of the Decision Manager
@@ -387,25 +357,16 @@ impl events::ApiEventMetric for DecisionManagerRecord {
         Some(events::ApiEventsType::Routing)
     }
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(DecisionManagerRecord);
 
 /// DecisionManagerResponse
 pub type DecisionManagerResponse = DecisionManagerRecord;
 
 /// Fee information to be charged on the payment being collected via Stripe
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct StripeChargeResponseData {
     /// Identifier for charge created for the payment
@@ -431,22 +392,13 @@ pub struct StripeChargeResponseData {
     #[smithy(value_type = "Option<String>")]
     pub on_behalf_of: Option<String>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(StripeChargeResponseData);
 
 /// Charge Information
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -465,22 +417,13 @@ pub enum ConnectorChargeResponseData {
     PayloadSplitPayment(PayloadSplitPaymentRequest),
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(ConnectorChargeResponseData);
 
 /// Fee information to be charged on the payment being collected via xendit
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct XenditSplitRoute {
@@ -501,22 +444,13 @@ pub struct XenditSplitRoute {
     #[smithy(value_type = "String")]
     pub reference_id: String,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(XenditSplitRoute);
 
 /// Fee information to be charged on the payment being collected via xendit
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct XenditMultipleSplitRequest {
@@ -533,22 +467,13 @@ pub struct XenditMultipleSplitRequest {
     #[smithy(value_type = "Vec<XenditSplitRoute>")]
     pub routes: Vec<XenditSplitRoute>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(XenditMultipleSplitRequest);
 
 /// Xendit Charge Request
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -561,22 +486,13 @@ pub enum XenditSplitRequest {
     SingleSplit(XenditSplitSubMerchantData),
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(XenditSplitRequest);
 
 /// Charge Information
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -589,22 +505,13 @@ pub enum XenditChargeResponseData {
     SingleSplit(XenditSplitSubMerchantData),
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(XenditChargeResponseData);
 
 /// Fee information charged on the payment being collected via xendit
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct XenditMultipleSplitResponse {
@@ -624,6 +531,7 @@ pub struct XenditMultipleSplitResponse {
     #[smithy(value_type = "Vec<XenditSplitRoute>")]
     pub routes: Vec<XenditSplitRoute>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(XenditMultipleSplitResponse);
 
 #[derive(
@@ -971,10 +879,9 @@ pub enum RecoveryAction {
 }
 
 /// Billing Descriptor information to be sent to the payment gateway
-#[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, AsExpression, FromSqlRow, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct BillingDescriptor {
     /// name to be put in billing description
     #[schema(value_type = Option<String>, example = "The Online Retailer")]
@@ -993,13 +900,13 @@ pub struct BillingDescriptor {
     pub reference: Option<String>,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(BillingDescriptor);
 
 ///  Information identifying partner / external platform details
-#[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, AsExpression, FromSqlRow, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct PartnerApplicationDetails {
     /// Name of the partner/external platform
     #[schema(value_type = Option<String>)]
@@ -1011,13 +918,13 @@ pub struct PartnerApplicationDetails {
     #[schema(value_type = Option<String>)]
     pub integrator: Option<String>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(PartnerApplicationDetails);
 
 ///  Information identifying merchant details
-#[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, AsExpression, FromSqlRow, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct MerchantApplicationDetails {
     /// Name of the the merchant application
     #[schema(value_type = Option<String>)]
@@ -1026,13 +933,13 @@ pub struct MerchantApplicationDetails {
     #[schema(value_type = Option<String>)]
     pub version: Option<String>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(MerchantApplicationDetails);
 
 /// Information identifying partner and merchant application initiating the request
-#[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, AsExpression, FromSqlRow, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct PartnerMerchantIdentifierDetails {
     ///  Information identifying partner/external platform details
     #[schema(value_type = Option<PartnerApplicationDetails>)]
@@ -1042,22 +949,13 @@ pub struct PartnerMerchantIdentifierDetails {
     pub merchant_details: Option<MerchantApplicationDetails>,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(PartnerMerchantIdentifierDetails);
 
 /// Additional metadata for payment intent state containing refunded and disputed amounts
-#[derive(
-    Default,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    AsExpression,
-    FromSqlRow,
-    utoipa::ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, utoipa::ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct PaymentIntentStateMetadata {
     /// Shows up the total refunded amount for a payment
     pub total_refunded_amount: Option<MinorUnit>,
@@ -1068,10 +966,9 @@ pub struct PaymentIntentStateMetadata {
 }
 
 /// Additional metadata for payment intent state containing refunded and disputed amounts
-#[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, AsExpression, FromSqlRow, utoipa::ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, utoipa::ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct PostCaptureVoidResponse {
     /// Status of post capture void
     #[schema(value_type = PostCaptureVoidStatus)]
@@ -1156,6 +1053,7 @@ impl PaymentIntentStateMetadata {
     }
 }
 
+#[cfg(feature = "diesel")]
 common_utils::impl_to_sql_from_sql_json!(PaymentIntentStateMetadata);
 
 /// List of custom T&C messages grouped by payment method
@@ -1579,33 +1477,17 @@ pub struct InstallmentOption {
 }
 
 /// A list of installment options stored as a single JSONB column value.
-#[derive(
-    Debug,
-    Clone,
-    serde::Serialize,
-    serde::Deserialize,
-    ToSchema,
-    PartialEq,
-    FromSqlRow,
-    AsExpression,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct InstallmentOptions(pub Vec<InstallmentOption>);
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(InstallmentOptions);
 
 /// Installment selection made by the customer during payment confirmation.
-#[derive(
-    Debug,
-    Clone,
-    serde::Serialize,
-    serde::Deserialize,
-    ToSchema,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct InstallmentData {
     /// Number of installments chosen by the customer
     #[schema(value_type = u8)]
@@ -1615,6 +1497,7 @@ pub struct InstallmentData {
     /// Total interest amount applied for this installment plan
     pub installment_interest: Option<MinorUnit>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(InstallmentData);
 
 #[derive(
@@ -1631,17 +1514,9 @@ pub enum TokenSource {
 }
 
 /// External surcharge details from InterPayments (stored as JSONB)
-#[derive(
-    Clone,
-    Debug,
-    serde::Deserialize,
-    Eq,
-    ToSchema,
-    PartialEq,
-    serde::Serialize,
-    diesel::AsExpression,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Clone, Debug, serde::Deserialize, Eq, ToSchema, PartialEq, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(diesel::AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct ExternalSurchargeDetails {
     /// sTxId from InterPayments (the last one received before confirm)
     pub external_surcharge_id: String,
@@ -1651,21 +1526,14 @@ pub struct ExternalSurchargeDetails {
     pub sale_notified: bool,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(ExternalSurchargeDetails);
 
 /// Applied-offer details from Offer Engine `/apply`, persisted on `payment_attempt`
 /// as JSONB. Versioned (tagged by `version`) for forward-compatible schema evolution.
-#[derive(
-    Clone,
-    Debug,
-    serde::Deserialize,
-    Eq,
-    ToSchema,
-    PartialEq,
-    serde::Serialize,
-    diesel::AsExpression,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Clone, Debug, serde::Deserialize, Eq, ToSchema, PartialEq, serde::Serialize)]
+#[cfg_attr(feature = "diesel", derive(diesel::AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(tag = "version", rename_all = "snake_case")]
 pub enum AppliedOfferDetails {
     /// Version 1 of the applied-offer details.
@@ -1706,4 +1574,5 @@ pub struct AppliedOfferDetailsV1 {
     pub currency: enums::Currency,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(AppliedOfferDetails);

--- a/crates/common_types/src/payouts.rs
+++ b/crates/common_types/src/payouts.rs
@@ -1,15 +1,16 @@
 //! Payout related types.
 
+#[cfg(feature = "diesel")]
 use common_utils::impl_to_sql_from_sql_json;
+#[cfg(feature = "diesel")]
 use diesel::{sql_types::Jsonb, AsExpression, FromSqlRow};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Billing descriptor information for a payout.
-#[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, AsExpression, FromSqlRow, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct PayoutsBillingDescriptor {
     /// Reference displayed on the beneficiary's bank statement.
     pub reference: Option<String>,
@@ -17,4 +18,5 @@ pub struct PayoutsBillingDescriptor {
     pub statement_descriptor: Option<String>,
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(PayoutsBillingDescriptor);

--- a/crates/common_types/src/primitive_wrappers.rs
+++ b/crates/common_types/src/primitive_wrappers.rs
@@ -7,10 +7,9 @@ mod bool_wrappers {
 
     use serde::{Deserialize, Serialize};
     /// Bool that represents if Extended Authorization is Applied or not
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, diesel::expression::AsExpression,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct ExtendedAuthorizationAppliedBool(bool);
     impl Deref for ExtendedAuthorizationAppliedBool {
         type Target = bool;
@@ -24,6 +23,7 @@ mod bool_wrappers {
             Self(value)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for ExtendedAuthorizationAppliedBool
     where
         DB: diesel::backend::Backend,
@@ -36,6 +36,7 @@ mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB>
         for ExtendedAuthorizationAppliedBool
     where
@@ -48,10 +49,9 @@ mod bool_wrappers {
     }
 
     /// Bool that represents if Extended Authorization is Requested or not
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, diesel::expression::AsExpression,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct RequestExtendedAuthorizationBool(bool);
     impl Deref for RequestExtendedAuthorizationBool {
         type Target = bool;
@@ -71,6 +71,7 @@ mod bool_wrappers {
             self.0
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for RequestExtendedAuthorizationBool
     where
         DB: diesel::backend::Backend,
@@ -83,6 +84,7 @@ mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB>
         for RequestExtendedAuthorizationBool
     where
@@ -95,10 +97,9 @@ mod bool_wrappers {
     }
 
     /// Bool that represents if Enable Partial Authorization is Requested or not
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, diesel::expression::AsExpression,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct EnablePartialAuthorizationBool(bool);
     impl Deref for EnablePartialAuthorizationBool {
         type Target = bool;
@@ -118,6 +119,7 @@ mod bool_wrappers {
             self.0
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for EnablePartialAuthorizationBool
     where
         DB: diesel::backend::Backend,
@@ -130,6 +132,7 @@ mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB>
         for EnablePartialAuthorizationBool
     where
@@ -142,10 +145,9 @@ mod bool_wrappers {
     }
 
     /// Bool that represents if Extended Authorization is always Requested or not
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, diesel::expression::AsExpression, Serialize, Deserialize,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct AlwaysRequestExtendedAuthorization(bool);
     impl Deref for AlwaysRequestExtendedAuthorization {
         type Target = bool;
@@ -154,6 +156,7 @@ mod bool_wrappers {
             &self.0
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB>
         for AlwaysRequestExtendedAuthorization
     where
@@ -167,6 +170,7 @@ mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB>
         for AlwaysRequestExtendedAuthorization
     where
@@ -178,10 +182,9 @@ mod bool_wrappers {
         }
     }
     /// Bool that represents if Cvv should be collected during payment or not. Default is true
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, diesel::expression::AsExpression, Serialize, Deserialize,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct ShouldCollectCvvDuringPayment(bool);
     impl Deref for ShouldCollectCvvDuringPayment {
         type Target = bool;
@@ -190,6 +193,7 @@ mod bool_wrappers {
             &self.0
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for ShouldCollectCvvDuringPayment
     where
         DB: diesel::backend::Backend,
@@ -202,6 +206,7 @@ mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB> for ShouldCollectCvvDuringPayment
     where
         DB: diesel::backend::Backend,
@@ -220,10 +225,9 @@ mod bool_wrappers {
     }
 
     /// Bool that represents if overcapture should always be requested
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, diesel::expression::AsExpression, Serialize, Deserialize,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct AlwaysEnableOvercaptureBool(bool);
     impl AlwaysEnableOvercaptureBool {
         /// returns the inner bool value
@@ -231,6 +235,7 @@ mod bool_wrappers {
             self.0
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for AlwaysEnableOvercaptureBool
     where
         DB: diesel::backend::Backend,
@@ -243,6 +248,7 @@ mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB> for AlwaysEnableOvercaptureBool
     where
         DB: diesel::backend::Backend,
@@ -261,10 +267,9 @@ mod bool_wrappers {
     }
 
     /// Bool that represents if overcapture is requested for this payment
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, diesel::expression::AsExpression, Serialize, Deserialize,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct EnableOvercaptureBool(bool);
 
     impl From<bool> for EnableOvercaptureBool {
@@ -286,6 +291,7 @@ mod bool_wrappers {
             &self.0
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for EnableOvercaptureBool
     where
         DB: diesel::backend::Backend,
@@ -298,6 +304,7 @@ mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB> for EnableOvercaptureBool
     where
         DB: diesel::backend::Backend,
@@ -316,10 +323,9 @@ mod bool_wrappers {
     }
 
     /// Bool that represents if overcapture is applied for a payment by the connector
-    #[derive(
-        Clone, Copy, Debug, Eq, PartialEq, diesel::expression::AsExpression, Serialize, Deserialize,
-    )]
-    #[diesel(sql_type = diesel::sql_types::Bool)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Bool))]
     pub struct OvercaptureEnabledBool(bool);
 
     impl OvercaptureEnabledBool {
@@ -343,6 +349,7 @@ mod bool_wrappers {
             &self.0
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Bool, DB> for OvercaptureEnabledBool
     where
         DB: diesel::backend::Backend,
@@ -355,6 +362,7 @@ mod bool_wrappers {
             self.0.to_sql(out)
         }
     }
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Bool, DB> for OvercaptureEnabledBool
     where
         DB: diesel::backend::Backend,
@@ -375,8 +383,9 @@ mod u32_wrappers {
         DEFAULT_DISPUTE_POLLING_INTERVAL_IN_HOURS, MAX_DISPUTE_POLLING_INTERVAL_IN_HOURS,
     };
     /// Time interval in hours for polling disputes
-    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, diesel::expression::AsExpression)]
-    #[diesel(sql_type = diesel::sql_types::Integer)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+    #[cfg_attr(feature = "diesel", derive(diesel::expression::AsExpression))]
+    #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Integer))]
     pub struct DisputePollingIntervalInHours(i32);
 
     impl Deref for DisputePollingIntervalInHours {
@@ -407,6 +416,7 @@ mod u32_wrappers {
         }
     }
 
+    #[cfg(feature = "diesel")]
     impl diesel::deserialize::FromSql<diesel::sql_types::Integer, diesel::pg::Pg>
         for DisputePollingIntervalInHours
     {
@@ -415,6 +425,7 @@ mod u32_wrappers {
         }
     }
 
+    #[cfg(feature = "diesel")]
     impl diesel::serialize::ToSql<diesel::sql_types::Integer, diesel::pg::Pg>
         for DisputePollingIntervalInHours
     {
@@ -573,6 +584,7 @@ mod safe_string {
     impl SerializableSecret for SafeString {}
 
     // Diesel implementations for database operations
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::serialize::ToSql<diesel::sql_types::Text, DB> for SafeString
     where
         DB: diesel::backend::Backend,
@@ -586,6 +598,7 @@ mod safe_string {
         }
     }
 
+    #[cfg(feature = "diesel")]
     impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Text, DB> for SafeString
     where
         DB: diesel::backend::Backend,

--- a/crates/common_types/src/refunds.rs
+++ b/crates/common_types/src/refunds.rs
@@ -1,6 +1,8 @@
 //! Refund related types
 
+#[cfg(feature = "diesel")]
 use common_utils::impl_to_sql_from_sql_json;
+#[cfg(feature = "diesel")]
 use diesel::{sql_types::Jsonb, AsExpression, FromSqlRow};
 use serde::{Deserialize, Serialize};
 use smithy::SmithyModel;
@@ -8,19 +10,9 @@ use utoipa::ToSchema;
 
 use crate::domain::{AdyenSplitData, XenditSplitSubMerchantData};
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -36,21 +28,12 @@ pub enum SplitRefund {
     #[smithy(value_type = "XenditSplitSubMerchantData")]
     XenditSplitRefund(XenditSplitSubMerchantData),
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(SplitRefund);
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    SmithyModel,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SmithyModel)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// Charge specific fields for controlling the revert of funds from either platform or connected account for Stripe. Check sub-fields for more details.
@@ -65,4 +48,5 @@ pub struct StripeSplitRefundRequest {
     #[smithy(value_type = "Option<bool>")]
     pub revert_transfer: Option<bool>,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(StripeSplitRefundRequest);

--- a/crates/common_types/src/three_ds_decision_rule_engine.rs
+++ b/crates/common_types/src/three_ds_decision_rule_engine.rs
@@ -1,24 +1,15 @@
+#[cfg(feature = "diesel")]
 use common_utils::impl_to_sql_from_sql_json;
+#[cfg(feature = "diesel")]
 use diesel::{sql_types::Jsonb, AsExpression, FromSqlRow};
 use euclid::frontend::dir::{DirKeyKind, EuclidDirFilter};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Enum representing the possible outcomes of the 3DS Decision Rule Engine.
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    FromSqlRow,
-    AsExpression,
-    ToSchema,
-    Default,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, ToSchema, Default)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 #[serde(rename_all = "snake_case")]
 pub enum ThreeDSDecision {
     /// No 3DS authentication required
@@ -37,6 +28,7 @@ pub enum ThreeDSDecision {
     /// No challenge requested by merchant (e.g., delegated authentication)
     IssuerThreeDsExemptionRequested,
 }
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(ThreeDSDecision);
 
 impl ThreeDSDecision {
@@ -47,10 +39,9 @@ impl ThreeDSDecision {
 }
 
 /// Struct representing the output configuration for the 3DS Decision Rule Engine.
-#[derive(
-    Serialize, Default, Deserialize, Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression, ToSchema,
-)]
-#[diesel(sql_type = Jsonb)]
+#[derive(Serialize, Default, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = Jsonb))]
 pub struct ThreeDSDecisionRule {
     /// The decided 3DS action based on the rules
     pub decision: ThreeDSDecision,
@@ -63,6 +54,7 @@ impl ThreeDSDecisionRule {
     }
 }
 
+#[cfg(feature = "diesel")]
 impl_to_sql_from_sql_json!(ThreeDSDecisionRule);
 
 impl EuclidDirFilter for ThreeDSDecisionRule {

--- a/crates/connector_configs/Cargo.toml
+++ b/crates/connector_configs/Cargo.toml
@@ -17,7 +17,10 @@ v1 = ["api_models/v1", "common_utils/v1"]
 [dependencies]
 # First party crates
 api_models = { version = "0.1.0", path = "../api_models", package = "api_models" }
-common_utils = { version = "0.1.0", path = "../common_utils" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
 
 # Third party crates
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/currency_conversion/Cargo.toml
+++ b/crates/currency_conversion/Cargo.toml
@@ -8,7 +8,10 @@ license.workspace = true
 
 [dependencies]
 # First party crates
-common_enums = { version = "0.1.0", path = "../common_enums", package = "common_enums" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_enums = { version = "0.1.0", path = "../common_enums", package = "common_enums", default-features = false }
 
 # Third party crates
 rust_decimal = "1.40"

--- a/crates/euclid/Cargo.toml
+++ b/crates/euclid/Cargo.toml
@@ -14,17 +14,21 @@ serde_json = "1.0.140"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "1.0.69"
 utoipa = { version = "4.2.3", features = ["preserve_order", "preserve_path_order"] }
-diesel = { version = "2.2.10", features = ["postgres", "128-column-tables"] }
+diesel = { version = "2.2.10", features = ["postgres", "128-column-tables"], optional = true }
 
 # First party dependencies
-common_enums = { version = "0.1.0", path = "../common_enums" }
-common_utils = { version = "0.1.0", path = "../common_utils" }
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
 euclid_macros = { version = "0.1.0", path = "../euclid_macros" }
 router_derive = { version = "0.1.0", path = "../router_derive" }
 hyperswitch_constraint_graph = { version = "0.1.0", path = "../hyperswitch_constraint_graph", features = ["viz"] }
 
 [features]
-default = []
+# euclid has exactly one diesel usage (the RoutableConnectors enum). Gate it so
+# consumers that never touch a database do not compile diesel. Default-on keeps
+# hyperswitch resolving exactly as before.
+default = ["diesel"]
+diesel = ["dep:diesel"]
 ast_parser = ["dep:nom"]
 valued_jit = []
 dummy_connector = []

--- a/crates/euclid/src/enums.rs
+++ b/crates/euclid/src/enums.rs
@@ -187,7 +187,10 @@ pub enum PayoutType {
     strum::VariantNames,
     ToSchema,
 )]
-#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[cfg_attr(
+    feature = "diesel",
+    router_derive::diesel_enum(storage_type = "db_enum")
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 /// RoutableConnectors are the subset of Connectors that are eligible for payments routing

--- a/crates/euclid_wasm/Cargo.toml
+++ b/crates/euclid_wasm/Cargo.toml
@@ -22,11 +22,14 @@ v2 = []
 [dependencies]
 api_models = { version = "0.1.0", path = "../api_models", package = "api_models" }
 card_metadata = { version = "0.1.0", path = "../card_metadata" }
-common_enums = { version = "0.1.0", path = "../common_enums" }
-common_types = { version = "0.1.0", path = "../common_types" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
+common_types = { version = "0.1.0", path = "../common_types", default-features = false }
 connector_configs = { version = "0.1.0", path = "../connector_configs" }
 currency_conversion = { version = "0.1.0", path = "../currency_conversion" }
-euclid = { version = "0.1.0", path = "../euclid", features = [] }
+euclid = { version = "0.1.0", path = "../euclid", features = [], default-features = false }
 hyperswitch_constraint_graph = { version = "0.1.0", path = "../hyperswitch_constraint_graph" }
 kgraph_utils = { version = "0.1.0", path = "../kgraph_utils" }
 

--- a/crates/kgraph_utils/Cargo.toml
+++ b/crates/kgraph_utils/Cargo.toml
@@ -13,10 +13,13 @@ v2 = ["api_models/v2", "common_utils/v2", "common_types/v2", "common_enums/v2"]
 
 [dependencies]
 api_models = { version = "0.1.0", path = "../api_models", package = "api_models" }
-common_enums = { version = "0.1.0", path = "../common_enums" }
-common_utils = { version = "0.1.0", path = "../common_utils" }
-common_types = {version = "0.1.0", path = "../common_types" }
-euclid = { version = "0.1.0", path = "../euclid" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
+common_types = {version = "0.1.0", path = "../common_types", default-features = false }
+euclid = { version = "0.1.0", path = "../euclid", default-features = false }
 hyperswitch_constraint_graph = { version = "0.1.0", path = "../hyperswitch_constraint_graph", features = ["viz"] }
 hyperswitch_masking = { version = "0.0.1" }
 

--- a/crates/openapi/Cargo.toml
+++ b/crates/openapi/Cargo.toml
@@ -12,10 +12,13 @@ utoipa = { version = "4.2.3", features = ["preserve_order", "preserve_path_order
 
 # First party crates
 api_models = { version = "0.1.0", path = "../api_models", features = ["frm", "payouts", "openapi", "errors"] }
-common_utils = { version = "0.1.0", path = "../common_utils", features = ["logs"] }
-common_types = { version = "0.1.0", path = "../common_types" }
+common_utils = { version = "0.1.0", path = "../common_utils", features = ["logs"], default-features = false }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_types = { version = "0.1.0", path = "../common_types", default-features = false }
 router_env = { version = "0.1.0", path = "../router_env" }
-euclid = { version = "0.1.0", path = "../euclid" }
+euclid = { version = "0.1.0", path = "../euclid", default-features = false }
 
 [features]
 v2 = ["api_models/v2", "common_utils/v2", "api_models/tokenization_v2"]

--- a/crates/payment_link/Cargo.toml
+++ b/crates/payment_link/Cargo.toml
@@ -29,7 +29,10 @@ tracing = { workspace = true }
 
 # First party crates
 api_models = { path = "../api_models", default-features = false }
-common_utils = { path = "../common_utils" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_utils = { path = "../common_utils", default-features = false }
 getrandom = { version = "0.3", optional = true }
 
 [build-dependencies]

--- a/crates/pm_auth/Cargo.toml
+++ b/crates/pm_auth/Cargo.toml
@@ -13,8 +13,11 @@ v1 = ["api_models/v1", "common_utils/v1"]
 [dependencies]
 # First party crates
 api_models = { version = "0.1.0", path = "../api_models" }
-common_enums = { version = "0.1.0", path = "../common_enums" }
-common_utils = { version = "0.1.0", path = "../common_utils" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
 hyperswitch_masking = "0.0.1"
 
 # Third party crates

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -34,7 +34,10 @@ fred = { version = "8.0.6", optional = true, features = [
 ]}
 
 # First party crates
-common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"] }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"], default-features = false }
 deja = { git = "https://github.com/juspay/deja", rev = "2c3a795ef4d8d2a5eebc47bbe7134984b75be6b3", optional = true, default-features = false, features = ["error-stack"] }
 router_env = { version = "0.1.0", path = "../router_env", optional = true }
 

--- a/crates/smithy-generator/Cargo.toml
+++ b/crates/smithy-generator/Cargo.toml
@@ -14,9 +14,12 @@ v2 = ["api_models/v2", "common_utils/v2"]
 [dependencies]
 smithy-core = { path = "../smithy-core" }
 api_models = { version = "0.1.0", path = "../api_models" }
-common_enums = { version = "0.1.0", path = "../common_enums" }
-common_types = { version = "0.1.0", path = "../common_types" }
-common_utils = { version = "0.1.0", path = "../common_utils" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
+common_types = { version = "0.1.0", path = "../common_types", default-features = false }
+common_utils = { version = "0.1.0", path = "../common_utils", default-features = false }
 router_env = { version = "0.1.0", path = "../router_env" }
 
 [build-dependencies]

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -31,7 +31,10 @@ toml = "0.8.22"
 
 # First party crates
 hyperswitch_masking = "0.0.1"
-common_enums = { version = "0.1.0", path = "../common_enums" }
+# This crate has no diesel references; decline the default features of the
+# shared crates so it does not compile the ORM. Within hyperswitch other
+# crates request the defaults and feature unification restores them.
+common_enums = { version = "0.1.0", path = "../common_enums", default-features = false }
 
 [lints]
 workspace = true

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -3300,7 +3300,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3336,7 +3339,10 @@ Cypress.Commands.add(
                 );
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3402,7 +3408,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -3427,7 +3436,10 @@ Cypress.Commands.add(
                 globalState.set("nextActionType", "redirect_to_url");
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4105,7 +4117,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4119,7 +4134,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4166,7 +4184,10 @@ Cypress.Commands.add(
                 }
               }
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4180,7 +4201,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4309,7 +4333,10 @@ Cypress.Commands.add(
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4366,7 +4393,10 @@ Cypress.Commands.add(
               );
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -4443,7 +4473,10 @@ Cypress.Commands.add(
         if (response.body.capture_method !== undefined) {
           expect(response.body.payment_id).to.equal(paymentId);
           for (const key in resData.body) {
-            if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+            if (
+              key === "payment_method_data" &&
+              globalState.get("connectorId") === "checkout"
+            ) {
               expect(response.body[key], [key]).to.not.be.empty;
               expect(
                 response.body[key]?.card?.auth_code,
@@ -5090,7 +5123,10 @@ Cypress.Commands.add(
               // Response body key comparison runs for all three_ds paths, including succeeded status
               // — the redirect URL is extracted above when status !== succeeded, but all response keys are verified here
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,
@@ -5171,7 +5207,10 @@ Cypress.Commands.add(
               // Response body key comparison runs for all three_ds paths, including succeeded status
               // — the redirect URL is extracted above when status !== succeeded, but all response keys are verified here
               for (const key in resData.body) {
-                if (key === "payment_method_data" && globalState.get("connectorId") === "checkout") {
+                if (
+                  key === "payment_method_data" &&
+                  globalState.get("connectorId") === "checkout"
+                ) {
                   expect(response.body[key], [key]).to.not.be.empty;
                   expect(
                     response.body[key]?.card?.auth_code,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

> **Stacked on #13791** (which is itself stacked on #13790). Base branch is
> `refactor/common-utils-optional-diesel`, so the diff here is only this change.

## Description

An audit of all 38 workspace crates found **18 that compile `diesel` at the
128-column tier while referencing it zero times**. This makes 12 of them
diesel-free.

Two shared crates still had diesel as a mandatory dependency and are gated here,
following the pattern of #13790/#13791:

- **`euclid`** — its *only* diesel usage is one
  `#[router_derive::diesel_enum(storage_type = "db_enum")]` on `RoutableConnectors`
  (`crates/euclid/src/enums.rs:190`), yet it declared the full
  `128-column-tables` tier for it.
- **`common_types`** — 164 references: ~70 derive-list entries, 46
  `#[diesel(...)]` attributes, 34 `impl_to_sql_from_sql_json!` calls, and a
  handful of hand-written impls.

Then `default-features = false` on 28 dependency edges across the consumer
crates.

### Two details a reviewer should check

**1. `common_types/diesel` must forward `common_utils/diesel`.**
`impl_to_sql_from_sql_json!` is gated *at its definition* in `common_utils`
(#13791), so it does not exist as a symbol when that feature is off.
`common_types` calls it 34 times. Without the forward, those call sites fail with
"unresolved import".

**2. Three of the edges are inside the carrier crates themselves** —
`common_types → euclid`, `euclid → common_enums`, `euclid → common_utils`.
Declining defaults at the consumer is useless if an intermediate still enables
them; without these three, all eight of the deeper crates stayed dirty. This is
the easiest thing to get wrong when extending the pattern.

### Third instance of a latent under-declaration

`common_types` declared bare `diesel = "2.2.10"` while using `diesel::pg::Pg` in
four places — it compiled only because feature unification happened to supply
`postgres`. Now declared explicitly. Same class as `common_utils`'s missing
`postgres` (#13790) and missing `time/macros` (#13791).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

Compile-time only. The generated OpenAPI spec is verified byte-identical.

## Motivation and Context

Inside a full workspace build this changes nothing — cargo compiles diesel once
and `diesel_models`/`router`/`storage_impl` need it regardless.

It matters because **two CI jobs build a single crate on every PR with no build
cache** (neither workflow uses `Swatinem/rust-cache` or sccache):

| workflow | command | crate |
| --- | --- | --- |
| `validate-openapi-spec.yml:55,59` | `cargo run -p openapi --features v1` / `v2` | `openapi` |
| `wasm-bulild-check.yml:34` | `make euclid-wasm` | `euclid_wasm` |

Both compiled a 128-tier diesel they never reference.

**Measured cold, in fresh target dirs, same command before and after:**

| job | before | after | saved |
| --- | --- | --- | --- |
| `cargo build -p openapi --features v1` | 142 s | **56 s** | −86 s (−61 %) |
| `cargo check -p euclid_wasm` (wasm32) | 125 s | **32 s** | −93 s (−74 %) |

`diesel` is no longer built in either (verified in the build logs).

**To be explicit: this is not a general speed-up.** Full workspace builds,
`just clippy`, `cargo check --features release` and `just ci_hack` are all
unchanged.

## How did you test it?

**All 19 gates green** on this branch:

| check | result |
| --- | --- |
| all 12 target crates compile diesel-free | 0 |
| `common_types` diesel **off** / **on** | 0 / 0 |
| `euclid` diesel **off** | 0 |
| **OpenAPI spec byte-identical** (`git diff --exit-code api-reference/`) | 0 |
| `euclid_wasm` → `wasm32-unknown-unknown` | 0 |
| `just clippy` / `just clippy fred` / `just clippy_v2` | 0 / 0 / 0 |
| `cargo check --workspace` / `--features release` | 0 / 0 |
| `cargo build -p router --bin router` / full v2 build | 0 / 0 |
| `cargo build -p drainer --features "redis-rs,v1"` | 0 |
| `cargo hack --each-feature` on common_types, euclid, api_models, openapi | 0 |
| `cargo +nightly fmt --all --check` | 0 |

The `cargo hack --each-feature` run is the important one: it compiles those
crates in every feature combination, **including with diesel entirely absent**.

Resolution is checked structurally rather than by eye — all 12 crates verified
with `cargo tree -p <crate> -e normal | grep -qx diesel`, and the workspace tree
confirmed unchanged.

The ~70 rewritten derive lists in `common_types` were checked with a
derive-preservation pass: the multiset of derives per file is identical before
and after, so nothing was silently dropped — only relocated into `cfg_attr`.

Note for anyone re-running these locally: 8 of the 12 crates have a `v1` feature
and must be given one (`cargo check -p api_models --features v1`), exactly like
`drainer` and `diesel_models`. A bare `cargo check -p api_models` fails with
v1/v2 items configured out — that is pre-existing, not caused by this PR.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

No new unit tests: this is compile-time feature gating with no runtime behaviour
to assert. The meaningful assertions are that both sides of each gate compile,
that the dependency graph changed as intended, and that the generated OpenAPI
spec is unchanged — all covered above.
