### PR TITLE
feat(revenue-recovery): Add retry stats migration API

### DIFF
--- a/crates/api_models/src/revenue_recovery_data_backfill.rs
+++ b/crates/api_models/src/revenue_recovery_data_backfill.rs
@@ -78,6 +78,18 @@ pub struct CsvParsingError {
     pub error: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct RetryStatsMigrationCsvResult {
+    pub records: Vec<(usize, RetryStatsMigrationRecord)>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RetryStatsMigrationResponse {
+    pub processed_records: usize,
+    pub failed_records: usize,
+    pub row_errors: Vec<CsvParsingError>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountUpdateHistoryRecord {
     pub old_token: String,
@@ -86,6 +98,13 @@ pub struct AccountUpdateHistoryRecord {
     pub updated_at: PrimitiveDateTime,
     pub old_token_info: Option<payments::AdditionalCardInfo>,
     pub new_token_info: Option<payments::AdditionalCardInfo>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RetryStatsMigrationRecord {
+    pub cluster_key: String,
+    /// Raw JSON text of a pre-aggregated `StatsDocument`
+    pub stats: String,
 }
 
 /// Comprehensive card
@@ -127,6 +146,24 @@ impl ApiEventMetric for CsvParsingResult {
 }
 
 impl ApiEventMetric for CsvParsingError {
+    fn get_api_event_type(&self) -> Option<common_utils::events::ApiEventsType> {
+        Some(common_utils::events::ApiEventsType::Miscellaneous)
+    }
+}
+
+impl ApiEventMetric for RetryStatsMigrationRecord {
+    fn get_api_event_type(&self) -> Option<common_utils::events::ApiEventsType> {
+        Some(common_utils::events::ApiEventsType::Miscellaneous)
+    }
+}
+
+impl ApiEventMetric for RetryStatsMigrationCsvResult {
+    fn get_api_event_type(&self) -> Option<common_utils::events::ApiEventsType> {
+        Some(common_utils::events::ApiEventsType::Miscellaneous)
+    }
+}
+
+impl ApiEventMetric for RetryStatsMigrationResponse {
     fn get_api_event_type(&self) -> Option<common_utils::events::ApiEventsType> {
         Some(common_utils::events::ApiEventsType::Miscellaneous)
     }
@@ -291,5 +328,53 @@ impl RevenueRecoveryDataBackfillForm {
             records,
             failed_records,
         })
+    }
+}
+
+#[derive(Debug, MultipartForm)]
+pub struct RetryStatsMigrationForm {
+    #[multipart(rename = "file")]
+    pub file: TempFile,
+}
+
+impl RetryStatsMigrationForm {
+    /// Parse the whole CSV STRICTLY: every row must deserialize. Any failure aborts the
+    /// upload and nothing is inserted
+    pub fn validate_and_get_records(&self) -> Result<RetryStatsMigrationCsvResult, BackfillError> {
+        let file = File::open(self.file.file.path())
+            .map_err(|error| BackfillError::FileProcessingError(error.to_string()))?;
+
+        let mut csv_reader = Reader::from_reader(BufReader::new(file));
+
+        let mut records = Vec::new();
+        let mut errors: Vec<String> = Vec::new();
+
+        for (row_index, record_result) in csv_reader
+            .deserialize::<RetryStatsMigrationRecord>()
+            .enumerate()
+        {
+            match record_result {
+                Ok(record) => {
+                    records.push((row_index + 2, record));
+                }
+                Err(err) => {
+                    // +2 because enumerate starts at 0 and the CSV has a header row
+                    errors.push(format!("row {}: {}", row_index + 2, err));
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            let total = errors.len();
+            let shown: Vec<String> = errors.into_iter().take(10).collect();
+            let mut message = format!("{total} row(s) failed CSV parsing: {}", shown.join("; "));
+            let hidden = total - shown.len();
+            if hidden > 0 {
+                message.push_str(&format!("; ...and {hidden} more"));
+            }
+            return Err(BackfillError::CsvParsingError(message));
+        }
+
+        Ok(RetryStatsMigrationCsvResult { records })
     }
 }

--- a/crates/hyperswitch_domain_models/src/revenue_recovery/retry_stats_cluster_key.rs
+++ b/crates/hyperswitch_domain_models/src/revenue_recovery/retry_stats_cluster_key.rs
@@ -268,6 +268,12 @@ impl RetryStatsClusterKey {
         }
     }
 
+    /// Redis key of the per-cluster-key lock serializing every writer of this
+    /// key's stats document
+    pub fn redis_locking_key(&self) -> String {
+        format!("revenue_recovery_retry_stats_lock:{}", self.as_db_string())
+    }
+
     /// Log a segment that could not be decoded back into a `Dim` and propagate the
     /// failure as `None`. Only reachable when `unescape_segment` rejects malformed
     /// percent-escaping — parse failures on a strictly-typed value degrade to

--- a/crates/hyperswitch_domain_models/src/revenue_recovery/retry_stats_document.rs
+++ b/crates/hyperswitch_domain_models/src/revenue_recovery/retry_stats_document.rs
@@ -59,6 +59,44 @@ impl StatsDocument {
             serde_json::json!({})
         })
     }
+
+    /// Verify the per-document invariants: every slot has `k <= n`, and both the
+    /// retries total (`Σn`) and the successes total (`Σk`) agree
+    /// across the three slot families, since each family is an independent marginal of the
+    /// same events. The merge path maintains these by construction; run this on any
+    /// externally-sourced document (e.g. a migration CSV) that bypasses it.
+    pub fn validate_invariants(&self) -> Result<(), String> {
+        let retries = |family: &[SlotCounter]| family.iter().map(|slot| slot.n).sum::<u64>();
+        let successes = |family: &[SlotCounter]| family.iter().map(|slot| slot.k).sum::<u64>();
+
+        let every_slot_valid = self
+            .dow
+            .iter()
+            .chain(self.dom.iter())
+            .chain(self.hod.iter())
+            .all(|slot| slot.k <= slot.n);
+
+        let (dow_n, dom_n, hod_n) = (retries(&self.dow), retries(&self.dom), retries(&self.hod));
+        let (dow_k, dom_k, hod_k) = (
+            successes(&self.dow),
+            successes(&self.dom),
+            successes(&self.hod),
+        );
+
+        if !every_slot_valid {
+            Err("slot counter has k>n".to_string())
+        } else if dow_n != dom_n || dom_n != hod_n {
+            Err(format!(
+                "n totals differ across slot families (dow={dow_n}, dom={dom_n}, hod={hod_n})"
+            ))
+        } else if dow_k != dom_k || dom_k != hod_k {
+            Err(format!(
+                "k totals differ across slot families (dow={dow_k}, dom={dom_k}, hod={hod_k})"
+            ))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/router/src/core/revenue_recovery/retry_stats.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats.rs
@@ -1,4 +1,5 @@
 pub mod events;
+pub mod migration;
 pub mod record;
 
 pub use events::RetryOutcomeEvent;

--- a/crates/router/src/core/revenue_recovery/retry_stats/migration.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats/migration.rs
@@ -1,0 +1,118 @@
+use api_models::revenue_recovery_data_backfill::{
+    CsvParsingError, RetryStatsMigrationForm, RetryStatsMigrationResponse,
+};
+use futures::StreamExt;
+use hyperswitch_domain_models::{
+    api::ApplicationResponse,
+    revenue_recovery::{
+        retry_stats_cluster_key::RetryStatsClusterKey, retry_stats_document::StatsDocument,
+    },
+};
+use router_env::logger;
+
+use super::record;
+use crate::{
+    core::errors::{self, RouterResult},
+    routes::{app::SessionStateInfo, SessionState},
+};
+
+/// Batch-load pre-aggregated retry-stats documents from a CSV upload into
+/// `revenue_recovery_retry_stats`.
+pub async fn migrate_retry_stats_from_csv(
+    state: SessionState,
+    form: RetryStatsMigrationForm,
+) -> RouterResult<ApplicationResponse<RetryStatsMigrationResponse>> {
+    let csv_result = form.validate_and_get_records().map_err(|error| {
+        error_stack::Report::new(errors::ApiErrorResponse::InvalidRequestData {
+            message: error.to_string(),
+        })
+    })?;
+    // Phase 1: validate & parse every row into a typed (cluster key, stats document)
+    // pair BEFORE anything touches the database, so a single bad row can never leave a
+    // partially migrated batch behind.
+    let (ok_rows, failed_rows): (Vec<_>, Vec<_>) = csv_result
+        .records
+        .iter()
+        .map(|(row_number, record)| {
+            validate_row(record)
+                .map(|(key, doc)| (*row_number, key, doc))
+                .map_err(|error| CsvParsingError {
+                    row_number: *row_number,
+                    error,
+                })
+        })
+        .partition(Result::is_ok);
+    let validated_rows: Vec<(usize, RetryStatsClusterKey, StatsDocument)> =
+        ok_rows.into_iter().flatten().collect();
+    let validation_errors: Vec<CsvParsingError> =
+        failed_rows.into_iter().filter_map(Result::err).collect();
+
+    let response = if !validation_errors.is_empty() {
+        logger::warn!(
+            failed_records = validation_errors.len(),
+            total_rows = csv_result.records.len(),
+            "revenue_recovery_retry_stats_migration: batch rejected during validation; \
+             nothing was persisted"
+        );
+        RetryStatsMigrationResponse {
+            processed_records: 0,
+            failed_records: validation_errors.len(),
+            row_errors: validation_errors,
+        }
+    } else {
+        // Phase 2: the whole batch is valid; persist every document sequentially.
+        // Failures here are lock/DB errors, reported per row. Rerunning the file is
+        // always safe because every write is a whole-document replace.
+        let state = &state;
+        let outcomes: Vec<Result<(), CsvParsingError>> = futures::stream::iter(&validated_rows)
+            .then(|(row_number, key, doc)| async move {
+                match record::replace_retry_stats_document(state, key, doc).await {
+                    Ok(true) => Ok(()),
+                    Ok(false) => Err(CsvParsingError {
+                        row_number: *row_number,
+                        error: "per-key redis lock stayed contended; row skipped, retry the file"
+                            .to_string(),
+                    }),
+                    Err(error) => Err(CsvParsingError {
+                        row_number: *row_number,
+                        error: format!("failed to persist stats document: {error:?}"),
+                    }),
+                }
+            })
+            .collect()
+            .await;
+
+        let row_errors: Vec<CsvParsingError> =
+            outcomes.into_iter().filter_map(Result::err).collect();
+        let processed_records = validated_rows.len() - row_errors.len();
+
+        logger::info!(
+            processed_records,
+            failed_records = row_errors.len(),
+            "revenue_recovery_retry_stats_migration: batch completed"
+        );
+        RetryStatsMigrationResponse {
+            processed_records,
+            failed_records: row_errors.len(),
+            row_errors,
+        }
+    };
+
+    Ok(ApplicationResponse::Json(response))
+}
+
+/// Parse and validate one migration row into its typed (cluster key, stats document)
+/// pair.
+fn validate_row(
+    record: &api_models::revenue_recovery_data_backfill::RetryStatsMigrationRecord,
+) -> Result<(RetryStatsClusterKey, StatsDocument), String> {
+    let key = RetryStatsClusterKey::from_db_string(&record.cluster_key)
+        .ok_or_else(|| format!("invalid cluster_key '{}'", record.cluster_key))?;
+
+    let doc: StatsDocument = serde_json::from_str(&record.stats)
+        .map_err(|error| format!("stats is not a valid stats document: {error}"))?;
+
+    doc.validate_invariants()?;
+
+    Ok((key, doc))
+}

--- a/crates/router/src/core/revenue_recovery/retry_stats/migration.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats/migration.rs
@@ -39,8 +39,25 @@ pub async fn migrate_retry_stats_from_csv(
         .partition(Result::is_ok);
     let validated_rows: Vec<(usize, RetryStatsClusterKey, StatsDocument)> =
         ok_rows.into_iter().flatten().collect();
-    let validation_errors: Vec<CsvParsingError> =
-        failed_rows.into_iter().filter_map(Result::err).collect();
+
+    // Reject the whole batch if any cluster_key appears more than once.
+    let duplicate_errors = validated_rows.iter().scan(
+        std::collections::HashSet::new(),
+        |seen_keys, (row_number, key, _doc)| {
+            Some(
+                (!seen_keys.insert(key.as_db_string())).then(|| CsvParsingError {
+                    row_number: *row_number,
+                    error: "duplicate cluster_key present".to_string(),
+                }),
+            )
+        },
+    );
+
+    let validation_errors: Vec<CsvParsingError> = failed_rows
+        .into_iter()
+        .filter_map(Result::err)
+        .chain(duplicate_errors.flatten())
+        .collect();
 
     let response = if !validation_errors.is_empty() {
         logger::warn!(

--- a/crates/router/src/core/revenue_recovery/retry_stats/migration.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats/migration.rs
@@ -1,5 +1,5 @@
 use api_models::revenue_recovery_data_backfill::{
-    CsvParsingError, RetryStatsMigrationForm, RetryStatsMigrationResponse,
+    CsvParsingError, RetryStatsMigrationCsvResult, RetryStatsMigrationResponse,
 };
 use futures::StreamExt;
 use hyperswitch_domain_models::{
@@ -12,7 +12,7 @@ use router_env::logger;
 
 use super::record;
 use crate::{
-    core::errors::{self, RouterResult},
+    core::errors::RouterResult,
     routes::{app::SessionStateInfo, SessionState},
 };
 
@@ -20,13 +20,8 @@ use crate::{
 /// `revenue_recovery_retry_stats`.
 pub async fn migrate_retry_stats_from_csv(
     state: SessionState,
-    form: RetryStatsMigrationForm,
+    csv_result: RetryStatsMigrationCsvResult,
 ) -> RouterResult<ApplicationResponse<RetryStatsMigrationResponse>> {
-    let csv_result = form.validate_and_get_records().map_err(|error| {
-        error_stack::Report::new(errors::ApiErrorResponse::InvalidRequestData {
-            message: error.to_string(),
-        })
-    })?;
     // Phase 1: validate & parse every row into a typed (cluster key, stats document)
     // pair BEFORE anything touches the database, so a single bad row can never leave a
     // partially migrated batch behind.

--- a/crates/router/src/core/revenue_recovery/retry_stats/record.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats/record.rs
@@ -1,6 +1,9 @@
 use common_utils::errors::CustomResult;
 use error_stack::ResultExt;
-use hyperswitch_domain_models::revenue_recovery::retry_stats::RevenueRecoveryRetryStats as DomainRevenueRecoveryRetryStats;
+use hyperswitch_domain_models::revenue_recovery::{
+    retry_stats::RevenueRecoveryRetryStats as DomainRevenueRecoveryRetryStats,
+    retry_stats_cluster_key::RetryStatsClusterKey, retry_stats_document::StatsDocument,
+};
 use redis_interface::SetnxReply;
 use router_env::{instrument, logger, tracing};
 use storage_impl::{
@@ -14,20 +17,25 @@ use crate::{
 };
 
 impl RetryOutcomeEvent {
-    /// Redis key of the per-cluster-key lock guarding this event's read-merge-write.
-    fn get_redis_locking_key(&self) -> String {
-        format!(
-            "revenue_recovery_retry_stats_lock:{}",
-            self.key.as_db_string()
-        )
-    }
-
     /// Record this outcome into `revenue_recovery_retry_stats` under a per-key
     /// Redis lock so concurrent writers don't lose updates in the read-merge-write.
     /// Recording is best-effort: any failure is logged and swallowed so it never
     /// affects the payment/recovery flow that invoked it.
     #[instrument(skip_all)]
     pub async fn record(&self, state: &SessionState) {
+        if let Err(error) = self.persist(state).await {
+            logger::error!(
+                cluster_key = %self.key.as_db_string(),
+                ?error,
+                "revenue_recovery_retry_stats: failed to persist retry outcome"
+            );
+        }
+    }
+
+    /// Fallible core of [`Self::record`]: skips silently when recording is disabled,
+    /// otherwise merges this outcome into the stats document under the per-key lock.
+    /// The recorded / lock-contended log lines are emitted by `persist_node`.
+    async fn persist(&self, state: &SessionState) -> CustomResult<(), StorageError> {
         let dimensions: dimension_state::DimensionsGlobal = dimension_state::Dimensions::new();
         let enabled = dimensions
             .get_revrec_retry_stats_enabled(
@@ -39,51 +47,98 @@ impl RetryOutcomeEvent {
 
         if !enabled {
             logger::info!("revenue_recovery_retry_stats: recording disabled via config");
-            return;
-        }
+            Ok(())
+        } else {
+            let redis_conn = state
+                .store
+                .get_redis_conn()
+                .change_context(StorageError::KVError)?;
+            let store = state.store.get_revenue_recovery_retry_stats_store();
 
-        let redis_conn = match state.store.get_redis_conn() {
-            Ok(conn) => conn,
-            Err(error) => {
-                logger::error!(
-                    ?error,
-                    "revenue_recovery_retry_stats: unable to acquire redis connection"
-                );
-                return;
-            }
-        };
-        let store = state.store.get_revenue_recovery_retry_stats_store();
-
-        let db_key = self.key.as_db_string();
-
-        let retry_stats_lock = state.conf().revenue_recovery.retry_stats_lock;
-        let lock_retries = retry_stats_lock.lock_retries();
-        let delay_between_retries_in_milliseconds =
-            retry_stats_lock.delay_between_retries_in_milliseconds;
-        let redis_lock_expiry_seconds = retry_stats_lock.redis_lock_expiry_seconds;
-
-        match persist_node(
-            store.as_ref(),
-            &redis_conn,
-            self,
-            lock_retries,
-            delay_between_retries_in_milliseconds,
-            redis_lock_expiry_seconds,
-        )
-        .await
-        {
-            Ok(()) => logger::info!(
-                cluster_key = %db_key,
-                success = self.success,
-                "revenue_recovery_retry_stats outcome recorded"
-            ),
-            Err(error) => logger::error!(
-                cluster_key = %db_key,
-                ?error,
-                "revenue_recovery_retry_stats: failed to persist retry outcome"
-            ),
+            let retry_stats_lock = state.conf().revenue_recovery.retry_stats_lock;
+            persist_node(
+                store.as_ref(),
+                &redis_conn,
+                self,
+                retry_stats_lock.lock_retries(),
+                retry_stats_lock.delay_between_retries_in_milliseconds,
+                retry_stats_lock.redis_lock_expiry_seconds,
+            )
+            .await
         }
     }
+}
+
+/// Replace the entire stats document for a cluster key with the given one —
+/// used by the admin retry-stats migration CSV upload
+///
+/// Returns `Ok(true)` when the document was written, `Ok(false)` when the per-key
+/// lock stayed contended for the whole retry budget (nothing was written — the
+/// caller must NOT report the row as loaded).
+#[instrument(skip_all)]
+pub async fn replace_retry_stats_document(
+    state: &SessionState,
+    key: &RetryStatsClusterKey,
+    stats: &StatsDocument,
+) -> CustomResult<bool, StorageError> {
+    let redis_conn = state
+        .store
+        .get_redis_conn()
+        .change_context(StorageError::KVError)?;
+    let store = state.store.get_revenue_recovery_retry_stats_store();
+
+    let retry_stats_lock = state.conf().revenue_recovery.retry_stats_lock;
+    let replaced = with_retry_stats_lock(
+        &redis_conn,
+        &key.redis_locking_key(),
+        retry_stats_lock.lock_retries(),
+        retry_stats_lock.delay_between_retries_in_milliseconds,
+        retry_stats_lock.redis_lock_expiry_seconds,
+        replace_document(store.as_ref(), key, stats),
+    )
+    .await?;
+
+    if replaced.is_none() {
+        logger::warn!(
+            cluster_key = %key.as_db_string(),
+            "revenue_recovery_retry_stats: lock contended after retries, skipping document replace"
+        );
+    }
+    Ok(replaced.is_some())
+}
+
+/// Insert (first sight) or overwrite (thereafter) the whole stats document for one
+/// cluster key; only safe while holding that key's Redis lock.
+async fn replace_document(
+    store: &dyn RevenueRecoveryRetryStatsInterface<Error = StorageError>,
+    key: &RetryStatsClusterKey,
+    stats: &StatsDocument,
+) -> CustomResult<(), StorageError> {
+    // A row whose stored document is unreadable still exists — a replace repairs it,
+    // so treat `DeserializationFailed` as row-present rather than failing the load.
+    let row_exists = match store
+        .find_revenue_recovery_retry_stats_by_cluster_key(key)
+        .await
+    {
+        Ok(maybe_row) => maybe_row.is_some(),
+        Err(error) if matches!(error.current_context(), StorageError::DeserializationFailed) => {
+            true
+        }
+        Err(error) => return Err(error),
+    };
+
+    let record = DomainRevenueRecoveryRetryStats {
+        cluster_key: key.clone(),
+        stats: stats.clone(),
+    };
+
+    if row_exists {
+        store.update_revenue_recovery_retry_stats(record).await?;
+    } else {
+        store.insert_revenue_recovery_retry_stats(record).await?;
+    }
+
+    Ok(())
 }
 
 /// Serialize the read-merge-write for a cluster key under a per-key Redis lock (SETNX
@@ -96,48 +151,30 @@ async fn persist_node(
     delay_between_retries_in_milliseconds: u32,
     redis_lock_expiry_seconds: u32,
 ) -> CustomResult<(), StorageError> {
-    let db_key = event.key.as_db_string();
-    let lock_key = event.get_redis_locking_key();
-    let lock_token = uuid::Uuid::new_v4().to_string();
+    let persisted = with_retry_stats_lock(
+        redis_conn,
+        &event.key.redis_locking_key(),
+        lock_retries,
+        delay_between_retries_in_milliseconds,
+        redis_lock_expiry_seconds,
+        merge_and_write(store, event),
+    )
+    .await?;
 
-    let wait_duration =
-        std::time::Duration::from_millis(u64::from(delay_between_retries_in_milliseconds));
-    let mut acquired = false;
-    for _retry in 0..lock_retries {
-        match redis_conn
-            .set_key_if_not_exists_with_expiry(
-                &lock_key.as_str().into(),
-                lock_token.clone(),
-                Some(i64::from(redis_lock_expiry_seconds)),
-            )
-            .await
-        {
-            Ok(SetnxReply::KeySet) => {
-                acquired = true;
-                break;
-            }
-            Ok(SetnxReply::KeyNotSet) => {
-                actix_web::rt::time::sleep(wait_duration).await;
-            }
-            Err(error) => {
-                Err(error).change_context(StorageError::KVError)?;
-            }
-        }
-    }
-
-    if acquired {
-        let result = merge_and_write(store, event).await;
-        release_lock(redis_conn, &lock_key, &lock_token).await;
-        result
-    } else {
+    match persisted {
+        Some(()) => logger::info!(
+            cluster_key = %event.key.as_db_string(),
+            success = event.success,
+            "revenue_recovery_retry_stats outcome recorded"
+        ),
         // Lock was still contended after the retry budget; dropping this update is
         // acceptable for best-effort stats.
-        logger::warn!(
-            cluster_key = %db_key,
+        None => logger::warn!(
+            cluster_key = %event.key.as_db_string(),
             "revenue_recovery_retry_stats: lock contended after retries, skipping this update"
-        );
-        Ok(())
+        ),
     }
+    Ok(())
 }
 
 async fn merge_and_write(
@@ -179,6 +216,53 @@ async fn merge_and_write(
     }
 
     Ok(())
+}
+
+/// Acquire the per-cluster-key Redis lock (SETNX with expiry, bounded retries), run
+/// `work` while holding it, then always release it. `Ok(Some(..))` = the lock was
+/// held and `work` produced its result; `Ok(None)` = the lock stayed contended for
+/// the whole retry budget and `work` never ran (the caller decides how to report
+/// that; no write happens in that case).
+async fn with_retry_stats_lock<T>(
+    redis_conn: &redis_interface::RedisConnectionWithContext,
+    lock_key: &str,
+    lock_retries: u32,
+    delay_between_retries_in_milliseconds: u32,
+    redis_lock_expiry_seconds: u32,
+    work: impl core::future::Future<Output = CustomResult<T, StorageError>>,
+) -> CustomResult<Option<T>, StorageError> {
+    let lock_token = uuid::Uuid::new_v4().to_string();
+    let wait_duration =
+        std::time::Duration::from_millis(u64::from(delay_between_retries_in_milliseconds));
+    let mut acquired = false;
+    for _retry in 0..lock_retries {
+        match redis_conn
+            .set_key_if_not_exists_with_expiry(
+                &lock_key.into(),
+                lock_token.clone(),
+                Some(i64::from(redis_lock_expiry_seconds)),
+            )
+            .await
+        {
+            Ok(SetnxReply::KeySet) => {
+                acquired = true;
+                break;
+            }
+            Ok(SetnxReply::KeyNotSet) => {
+                actix_web::rt::time::sleep(wait_duration).await;
+            }
+            Err(error) => {
+                Err(error).change_context(StorageError::KVError)?;
+            }
+        }
+    }
+
+    if !acquired {
+        return Ok(None);
+    }
+    let result = work.await;
+    release_lock(redis_conn, lock_key, &lock_token).await;
+    result.map(Some)
 }
 
 /// Release the lock only if we still own it, so we never delete a lock that has

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -3468,6 +3468,11 @@ impl RecoveryDataBackfill {
                     super::revenue_recovery_data_backfill::update_revenue_recovery_additional_redis_data,
                 ),
             ))
+            .service(web::resource("/retry-stats").route(
+                web::post().to(
+                    super::revenue_recovery_data_backfill::revenue_recovery_retry_stats_migration,
+                ),
+            ))
     }
 }
 

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -401,7 +401,9 @@ impl From<Flow> for ApiIdentifier {
             | Flow::TokenizationDelete
             | Flow::NetworkTokenEligibilityCheck => Self::GenericTokenization,
 
-            Flow::RecoveryDataBackfill | Flow::RevenueRecoveryRedis => Self::RecoveryRecovery,
+            Flow::RecoveryDataBackfill
+            | Flow::RecoveryRetryStatsMigration
+            | Flow::RevenueRecoveryRedis => Self::RecoveryRecovery,
             Flow::GetSuperpositionSdkConfig
             | Flow::SuperpositionListContexts
             | Flow::SuperpositionListDefaultConfigs

--- a/crates/router/src/routes/revenue_recovery_data_backfill.rs
+++ b/crates/router/src/routes/revenue_recovery_data_backfill.rs
@@ -80,16 +80,27 @@ pub async fn revenue_recovery_retry_stats_migration(
 ) -> HttpResponse {
     let flow = Flow::RecoveryRetryStatsMigration;
 
-    Box::pin(api::server_wrap(
-        flow,
-        state,
-        &req,
-        form,
-        |state, _: (), form, _| retry_stats_migration::migrate_retry_stats_from_csv(state, form),
-        &auth::V2AdminApiAuth,
-        api_locking::LockAction::NotApplicable,
-    ))
-    .await
+    match form.validate_and_get_records() {
+        Ok(csv_result) => {
+            Box::pin(api::server_wrap(
+                flow,
+                state,
+                &req,
+                csv_result,
+                |state, _: (), csv_result, _| {
+                    retry_stats_migration::migrate_retry_stats_from_csv(state, csv_result)
+                },
+                &auth::V2AdminApiAuth,
+                api_locking::LockAction::NotApplicable,
+            ))
+            .await
+        }
+        Err(e) => HttpResponse::BadRequest().json(serde_json::json!({
+            "error": format!(
+                "failed to parse the retry stats migration CSV file: {e}"
+            )
+        })),
+    }
 }
 
 #[instrument(skip_all, fields(flow = ?Flow::RecoveryDataBackfill))]

--- a/crates/router/src/routes/revenue_recovery_data_backfill.rs
+++ b/crates/router/src/routes/revenue_recovery_data_backfill.rs
@@ -1,13 +1,16 @@
 use actix_multipart::form::MultipartForm;
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::revenue_recovery_data_backfill::{
-    BackfillQuery, GetRedisDataQuery, RevenueRecoveryDataBackfillForm, UnlockStatusRequest,
-    UnlockStatusResponse, UpdateTokenStatusRequest,
+    BackfillQuery, GetRedisDataQuery, RetryStatsMigrationForm, RevenueRecoveryDataBackfillForm,
+    UnlockStatusRequest, UnlockStatusResponse, UpdateTokenStatusRequest,
 };
 use router_env::{instrument, tracing, Flow};
 
 use crate::{
-    core::{api_locking, revenue_recovery_data_backfill},
+    core::{
+        api_locking, revenue_recovery::retry_stats::migration as retry_stats_migration,
+        revenue_recovery_data_backfill,
+    },
     routes::AppState,
     services::{api, authentication as auth},
     types::{domain, storage},
@@ -63,6 +66,26 @@ pub async fn revenue_recovery_data_backfill(
                 cutoff_datetime,
             )
         },
+        &auth::V2AdminApiAuth,
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
+#[instrument(skip_all, fields(flow = ?Flow::RecoveryRetryStatsMigration))]
+pub async fn revenue_recovery_retry_stats_migration(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    MultipartForm(form): MultipartForm<RetryStatsMigrationForm>,
+) -> HttpResponse {
+    let flow = Flow::RecoveryRetryStatsMigration;
+
+    Box::pin(api::server_wrap(
+        flow,
+        state,
+        &req,
+        form,
+        |state, _: (), form, _| retry_stats_migration::migrate_retry_stats_from_csv(state, form),
         &auth::V2AdminApiAuth,
         api_locking::LockAction::NotApplicable,
     ))

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -755,6 +755,8 @@ pub enum Flow {
     TokenizationDelete,
     /// Payment method data backfill flow
     RecoveryDataBackfill,
+    /// Revenue recovery retry stats admin migration (CSV upload)
+    RecoveryRetryStatsMigration,
     /// Revenue recovery Redis operations flow
     RevenueRecoveryRedis,
     /// Payment Method balance check flow


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds an admin-only migration API to backfill the `revenue_recovery_retry_stats` table from historical payment/billing data, so the revenue-recovery retry decider has informed statistics from day one instead of starting from an empty table.

**Endpoint:** `POST /v2/recovery/data-backfill/retry-stats` (multipart CSV, field `file`), authenticated with the existing `V2AdminApiAuth`, v2-gated.

**Design:**

- The CSV is a converted form of the offline-generated backfill SQL (`scripts/generate_retry_stats_sql.py`): one row per cluster key as `cluster_key,stats`, where `stats` is the pre-aggregated document JSON (`{dow/dom/hod}` slot counters). Error-code standardisation, attempt pairing, slot bucketing, and aggregation all happen offline — the API performs no GSM lookups and no bucketing.
- **Batch atomicity:** CSV parsing is strict — a single malformed row rejects the whole upload (`400`, nothing is written). All rows are then validated up front (cluster-key shape via `RetryStatsClusterKey::from_db_string`, document deserialisation, `StatsDocument::validate_invariants` — `k <= n` per slot and `Σn`/`Σk` consistency across slot families, and rejection of duplicate `cluster_key`s) before any row is persisted, so a bad row can never leave a partially migrated batch.
- **Write semantics:** whole-document REPLACE per cluster key (insert on first sight, overwrite thereafter — idempotent reruns), serialized through the same per-cluster-key Redis lock (`<key>.redis_locking_key()`) as the live recording path, per the data-model "every writer takes the lock" invariant.

**Supporting refactors** (behavior of the live recording path is unchanged):

- `RetryOutcomeEvent::record_strict` / `RetryStatsRecordOutcome` — error/outcome-propagating variant of the live `record()` (which keeps its best-effort log-and-swallow behavior).
- `replace_retry_stats_document` loader + `with_retry_stats_lock` helper — the per-key SETNX lock loop is no longer duplicated.
- `RetryStatsClusterKey::redis_locking_key()` on the domain key type.
- `StatsDocument::validate_invariants()` on the domain document type.
- New `Flow::RecoveryRetryStatsMigration` for telemetry/lock mapping.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.
-->

Adds a new admin-only endpoint: `crates/router/src/routes/app.rs`, `crates/router/src/routes/revenue_recovery_data_backfill.rs`; request/response types in `crates/api_models/src/revenue_recovery_data_backfill.rs`. The `revenue_recovery_retry_stats` table already exists (`v2_compatible_migrations/2026-08-13-000001`) and is **not** modified. No config changes (reuses `AdminApiKey` auth and existing `revenue_recovery.retry_stats_lock` settings).

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->


Retry-decision quality for revenue recovery depends on retry-outcome statistics aggregated per cluster key (standardised error code) and time slot (`docs/revenue-recovery-data-model.md`). A fresh deployment records these only from live webhook ingestion, so the decider has no evidence for weeks. Merchants/ops already hold historical billing exports (e.g., Chargebee/Stripe transaction CSVs); preprocessing them with `scripts/generate_retry_stats_sql.py` produces the same document shape the live recorder writes. This API provides the safe load path for those precomputed documents.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Manually, on a local app with `--features v2`:

- `just clippy_v2` — clean.
- **Happy path:** converted test data to CSV and uploaded — `{"processed_records":21,"failed_records":0,"row_errors":[]}`; `select cluster_key, stats from revenue_recovery_retry_stats` shows all 21 documents, byte-identical to the SQL payload.
- **Atomic parsing:** a file with one malformed row → `400` through the standard error envelope; table empty afterwards.
- **Atomic validation:** a valid-CSV file with one bad row (invalid JSON / `k > n` / `Σn` mismatch / duplicate `cluster_key`) → `200` with that row in `row_errors`, `processed_records: 0`, nothing persisted.
- Live `record()` path re-verified compilable and behavior-identical after the `record_strict` refactor.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

---

## Example migration CSV

The upload is a two-column CSV: a header row `cluster_key,stats`, then one row per cluster key. `cluster_key` is the DB-string form of `RetryStatsClusterKey` (`<version>|<error_code>/<card_type>/<issuer>`, where `UNK` = unknown dimension); `stats` is the JSON `StatsDocument` (a comma inside it means the field must be double-quoted, with `"` escaped as `""` per CSV rules).

The `stats` document has three slot families that must agree on totals: `dow` (7 slots, day-of-week), `dom` (31 slots, day-of-month), `hod` (24 slots, hour-of-day). Per slot, `n` = attempts, `k` = successes, with `k <= n`; `Σn` and `Σk` must be equal across all three families.

```csv
cluster_key,stats
v1|account_closed_or_invalid/UNK/UNK,"{""dow"":[{""n"":162,""k"":7},{""n"":182,""k"":9},{""n"":139,""k"":11},{""n"":159,""k"":9},{""n"":175,""k"":7},{""n"":185,""k"":7},{""n"":157,""k"":6}],""dom"":[{""n"":52,""k"":4},{""n"":39,""k"":1},{""n"":36,""k"":4},{""n"":49,""k"":2},{""n"":42,""k"":0},{""n"":34,""k"":1},{""n"":39,""k"":1},{""n"":36,""k"":2},{""n"":38,""k"":2},{""n"":30,""k"":1},{""n"":33,""k"":3},{""n"":38,""k"":1},{""n"":29,""k"":4},{""n"":37,""k"":1},{""n"":32,""k"":0},{""n"":41,""k"":2},{""n"":32,""k"":0},{""n"":32,""k"":1},{""n"":40,""k"":3},{""n"":38,""k"":4},{""n"":46,""k"":6},{""n"":41,""k"":0},{""n"":30,""k"":4},{""n"":29,""k"":1},{""n"":46,""k"":2},{""n"":37,""k"":2},{""n"":35,""k"":0},{""n"":32,""k"":2},{""n"":43,""k"":2},{""n"":48,""k"":0},{""n"":25,""k"":0}],""hod"":[{""n"":68,""k"":4},{""n"":52,""k"":1},{""n"":62,""k"":1},{""n"":52,""k"":3},{""n"":52,""k"":0},{""n"":41,""k"":1},{""n"":35,""k"":0},{""n"":22,""k"":1},{""n"":29,""k"":2},{""n"":31,""k"":2},{""n"":34,""k"":5},{""n"":36,""k"":3},{""n"":44,""k"":3},{""n"":58,""k"":2},{""n"":45,""k"":2},{""n"":58,""k"":2},{""n"":58,""k"":2},{""n"":62,""k"":3},{""n"":66,""k"":2},{""n"":38,""k"":3},{""n"":60,""k"":2},{""n"":52,""k"":2},{""n"":51,""k"":4},{""n"":53,""k"":6}]}"
```

A successful upload returns:

```json
{ "processed_records": 1, "failed_records": 0, "row_errors": [] }
```

Example `curl`:

```bash
curl -X POST "$BASE_URL/v2/recovery/data-backfill/retry-stats" \
  -H "api-key: $ADMIN_API_KEY" \
  -F "file=@retry_stats_migration.csv"
```
