### PR TITLE
docs: clarify that latest is a git tag, not a branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Each module is independent and purpose-built to optimize different aspects of pa
 
 ```bash
 # One-click local setup
+# Note: `latest` is a git tag (updated on every stable release), not a branch,
+# so this checks out a detached HEAD at the most recent stable release.
 
 git clone --depth 1 --branch latest https://github.com/juspay/hyperswitch
 

--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -37,7 +37,9 @@ Check the Table Of Contents to jump to the relevant section.
 ## Run hyperswitch using Docker Compose
 
 1. Install [Docker Compose][docker-compose-install] or [Podman Compose][podman-compose-install].
-2. Clone the repository and switch to the project directory:
+2. Clone the repository and switch to the project directory.
+   `latest` here is a git tag that always points to the most recent stable
+   release, not a branch, so this checks out a detached HEAD:
 
    ```shell
    git clone --depth 1 --branch latest https://github.com/juspay/hyperswitch


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description

The clone instructions in README.md and docs/try_local_system.md use `git clone --depth 1 --branch latest ...`. `latest` reads like a branch name, but it is actually a git tag that release-stable-version.yml keeps pointed at the newest stable release. It never shows up in the GitHub branch list, so anyone going looking for it there will not find it.

The command itself still works, since git's `--branch` flag resolves tags as well as branches, but it leaves the user on a detached HEAD with no explanation in the docs. This adds a short note at both spots calling out that it is a tag and that the result is a detached HEAD.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Fixes #13913. Filed after actually hitting this: looked for a `latest` branch in the repo and could not find one, then confirmed via the GitHub API that it is a tag, not a branch.

## How did you test it?

Ran the documented command as is and confirmed it clones successfully into a detached HEAD at the tagged commit.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible