### PR TITLE
fix(devcontainer): use lightweight Dockerfile instead of production Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM public.ecr.aws/docker/library/rust:trixie
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpq-dev \
+        libssl-dev \
+        pkg-config \
+        protobuf-compiler \
+        git \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,14 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
-  "name": "Existing Dockerfile",
+  "name": "hyperswitch",
   "build": {
-    // Sets the run context to one level up instead of the .devcontainer folder.
+    // Uses a dedicated devcontainer Dockerfile that only installs the system
+    // dependencies (libpq, protobuf, etc.) instead of the repo root
+    // Dockerfile, which runs a full `cargo build --release` during the
+    // image build and can take 20-40+ minutes.
     "context": "..",
-    // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-    "dockerfile": "../Dockerfile"
+    "dockerfile": "Dockerfile"
   },
   "features": {
     "ghcr.io/devcontainers-contrib/features/redis-homebrew:1": {}


### PR DESCRIPTION
Adds a dedicated `.devcontainer/Dockerfile` so the dev container no longer builds from the repo root `Dockerfile`.

- The root `Dockerfile` is a two-stage production build: the final stage does `COPY --from=builder`, so it depends on the `builder` stage regardless of which stage is targeted. That stage runs `cargo build --profile release --features release`, which is what makes the dev container take 20-40+ minutes and often exceed Docker's default memory limit
- The new `.devcontainer/Dockerfile` only installs the system dependencies the project needs to compile locally (`libpq-dev`, `libssl-dev`, `pkg-config`, `protobuf-compiler`), matching the packages the root Dockerfile's builder stage installs, without copying the source or invoking `cargo build`
- `devcontainer.json` now points at this file instead of `../Dockerfile`; the workspace is still bind-mounted as usual, so `cargo build`/`cargo run` work the same as a manual local setup, they just aren't triggered at image-build time

Closes #10788