### PR TITLE
fix(cypress): fix Shift4 3DS redirect handling and Stax test config

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Stax.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stax.js
@@ -21,7 +21,7 @@ const successfulThreeDSCardDetails = {
 
 const failedCardDetails = {
   ...successfulNo3DSCardDetails,
-  card_number: "4012888888881881", // Standard decline test card for stax - "Do Not Honor" response
+  card_number: "6011000990139424", // Standard decline test card for stax - "Do Not Honor" response
 };
 
 export const fullNameRequiredField = {
@@ -65,7 +65,7 @@ const payment_method_data_no3ds = {
     last4: "1111",
     card_type: "DEBIT",
     card_network: "Visa",
-    card_issuer: "Conotoxia Sp Z Oo",
+    card_issuer: "CONOTOXIA SP Z OO",
     card_issuing_country: "POLAND",
     card_isin: "411111",
     card_extended_bin: null,
@@ -215,6 +215,7 @@ export const connectorDetails = {
     },
     No3DSFailPayment: {
       Request: {
+        amount: 9999,
         payment_method: "card",
         payment_method_data: {
           card: failedCardDetails,

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -3047,6 +3047,21 @@ function threeDsRedirection(
     return;
   }
 
+  // Shift4 3DS: clicking Submit on api.shift4.com's start page navigates
+  // the top-level page to a different origin (dev.shift4.com). waitForRedirect's
+  // cy.location("host") polling doesn't tolerate that real cross-origin
+  // navigation happening mid-retry and throws a Cypress cross-origin error,
+  // so bypass it entirely for this connector, like paypal/paybox above.
+  if (connectorId === "shift4") {
+    cy.get('input[type="submit"][value="Submit"]', {
+      timeout: CONSTANTS.WAIT_TIME,
+    })
+      .should("be.visible")
+      .click();
+    verifyReturnUrl(redirectionUrl, expectedUrl, true);
+    return;
+  }
+
   // For all other connectors, use the standard flow
   waitForRedirect(redirectionUrl.href);
 


### PR DESCRIPTION
## Summary
- Bypass `waitForRedirect()` for `shift4`'s 3DS flow (same pattern as `paypal`/`paybox`), since clicking Submit causes a real cross-origin navigation that the generic host-polling helper can't tolerate mid-retry.
- Fix Stax's `card_issuer` casing and use a real decline-triggering amount/card for `No3DSFailPayment`.

Closes #13936

## Test plan
- [x] Ran the Shift4 3DS Cypress flow locally; Submit button click now completes without a cross-origin error.
- [x] Ran Stax Cypress specs locally with the updated config.

**Shift4**
<img width="677" height="1005" alt="Screenshot 2026-08-31 at 6 36 04 PM" src="https://github.com/user-attachments/assets/daedd229-d8e1-4001-80b8-19deaae1ad7e" />

**Stax**

<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/c62f512f-9954-4ee2-86b5-4589f1f7ed12" />
