### PR TITLE
fix(revenue_recovery): fix the token fetch for adaptive_retry

### DIFF
--- a/crates/router/src/core/revenue_recovery.rs
+++ b/crates/router/src/core/revenue_recovery.rs
@@ -295,21 +295,28 @@ pub async fn perform_execute_payment(
         types::Decision::Execute => {
             let connector_customer_id = revenue_recovery_metadata.get_connector_customer_id();
 
-            let last_token_used = payment_intent
-                .feature_metadata
-                .as_ref()
-                .and_then(|fm| fm.payment_revenue_recovery_metadata.as_ref())
-                .map(|rr| {
-                    rr.billing_connector_payment_details
-                        .payment_processor_token
-                        .clone()
-                });
+            let last_token_used =
+                revenue_recovery_workflow::get_invoice_payment_processor_token(payment_intent);
+
+            // Resolved here rather than carried on the tracking data so execute reads the same
+            // switch calculate did; a flip between the two rounds costs one empty attempt and
+            // is corrected when calculate reopens.
+            let adaptive_retry_enabled = crate::core::configs::dimension_state::Dimensions::new()
+                .with_processor_merchant_id(payment_intent.merchant_id.clone().into())
+                .with_connector(revenue_recovery_payment_data.billing_mca.connector_name)
+                .get_adaptive_retry_enabled(
+                    state.store.as_ref(),
+                    state.superposition_service.as_ref(),
+                    None,
+                )
+                .await;
 
             let processor_token = storage::revenue_recovery_redis_operation::RedisTokenManager::get_token_based_on_retry_type(
                 state,
                 &connector_customer_id,
                 tracking_data.revenue_recovery_retry,
                 last_token_used.as_deref(),
+                adaptive_retry_enabled,
             )
             .await
             .change_context(errors::ApiErrorResponse::GenericNotFoundError {

--- a/crates/router/src/core/revenue_recovery.rs
+++ b/crates/router/src/core/revenue_recovery.rs
@@ -298,9 +298,7 @@ pub async fn perform_execute_payment(
             let last_token_used =
                 revenue_recovery_workflow::get_invoice_payment_processor_token(payment_intent);
 
-            // Resolved here rather than carried on the tracking data so execute reads the same
-            // switch calculate did; a flip between the two rounds costs one empty attempt and
-            // is corrected when calculate reopens.
+            // Same dimensions calculate resolves the flag on
             let adaptive_retry_enabled = crate::core::configs::dimension_state::Dimensions::new()
                 .with_processor_merchant_id(payment_intent.merchant_id.clone().into())
                 .with_connector(revenue_recovery_payment_data.billing_mca.connector_name)

--- a/crates/router/src/types/storage/revenue_recovery_redis_operation.rs
+++ b/crates/router/src/types/storage/revenue_recovery_redis_operation.rs
@@ -935,8 +935,7 @@ impl RedisTokenManager {
         Ok(all_hard_declined)
     }
 
-    /// The token this invoice last used, looked up by id — the customer's other tokens are
-    /// left alone, so concurrent invoices never contend over which card to charge.
+    // Get the token this invoice last used, by id
     async fn get_invoice_token(
         state: &SessionState,
         connector_customer_id: &str,
@@ -956,12 +955,8 @@ impl RedisTokenManager {
     }
 
     // Get token based on retry type
-    //
-    // `adaptive_retry_enabled` only matters for smart: the decider picks one of the customer's
-    // tokens and names it by writing `scheduled_at`, whereas the adaptive path decides against
-    // the invoice's own token. Reading the marker there would let a concurrent invoice for the
-    // same customer decide which token this one charges, so adaptive resolves by token id the
-    // way cascading does.
+    // Adaptive smart decides against the invoice's own token, so it resolves by id rather than
+    // the `scheduled_at` marker, which only the decider writes and is shared across invoices.
     pub async fn get_token_based_on_retry_type(
         state: &SessionState,
         connector_customer_id: &str,

--- a/crates/router/src/types/storage/revenue_recovery_redis_operation.rs
+++ b/crates/router/src/types/storage/revenue_recovery_redis_operation.rs
@@ -935,12 +935,39 @@ impl RedisTokenManager {
         Ok(all_hard_declined)
     }
 
+    /// The token this invoice last used, looked up by id — the customer's other tokens are
+    /// left alone, so concurrent invoices never contend over which card to charge.
+    async fn get_invoice_token(
+        state: &SessionState,
+        connector_customer_id: &str,
+        last_token_used: Option<&str>,
+    ) -> CustomResult<Option<PaymentProcessorTokenStatus>, errors::StorageError> {
+        match last_token_used {
+            Some(token_id) => {
+                Self::get_payment_processor_token_using_token_id(
+                    state,
+                    connector_customer_id,
+                    token_id,
+                )
+                .await
+            }
+            None => Ok(None),
+        }
+    }
+
     // Get token based on retry type
+    //
+    // `adaptive_retry_enabled` only matters for smart: the decider picks one of the customer's
+    // tokens and names it by writing `scheduled_at`, whereas the adaptive path decides against
+    // the invoice's own token. Reading the marker there would let a concurrent invoice for the
+    // same customer decide which token this one charges, so adaptive resolves by token id the
+    // way cascading does.
     pub async fn get_token_based_on_retry_type(
         state: &SessionState,
         connector_customer_id: &str,
         retry_algorithm_type: RevenueRecoveryAlgorithmType,
         last_token_used: Option<&str>,
+        adaptive_retry_enabled: bool,
     ) -> CustomResult<Option<PaymentProcessorTokenStatus>, errors::StorageError> {
         let mut token = None;
         match retry_algorithm_type {
@@ -949,17 +976,13 @@ impl RedisTokenManager {
             }
 
             RevenueRecoveryAlgorithmType::Cascading => {
-                token = match last_token_used {
-                    Some(token_id) => {
-                        Self::get_payment_processor_token_using_token_id(
-                            state,
-                            connector_customer_id,
-                            token_id,
-                        )
-                        .await?
-                    }
-                    None => None,
-                };
+                token =
+                    Self::get_invoice_token(state, connector_customer_id, last_token_used).await?;
+            }
+
+            RevenueRecoveryAlgorithmType::Smart if adaptive_retry_enabled => {
+                token =
+                    Self::get_invoice_token(state, connector_customer_id, last_token_used).await?;
             }
 
             RevenueRecoveryAlgorithmType::Smart => {

--- a/crates/router/src/workflows/revenue_recovery.rs
+++ b/crates/router/src/workflows/revenue_recovery.rs
@@ -807,7 +807,6 @@ pub async fn get_token_with_schedule_time_based_on_retry_algorithm_type(
     ))
 }
 
-/// The invoice's own payment processor token, as recorded on the intent by the last attempt.
 #[cfg(feature = "v2")]
 pub(crate) fn get_invoice_payment_processor_token(
     payment_intent: &PaymentIntent,

--- a/crates/router/src/workflows/revenue_recovery.rs
+++ b/crates/router/src/workflows/revenue_recovery.rs
@@ -807,6 +807,21 @@ pub async fn get_token_with_schedule_time_based_on_retry_algorithm_type(
     ))
 }
 
+/// The invoice's own payment processor token, as recorded on the intent by the last attempt.
+#[cfg(feature = "v2")]
+pub(crate) fn get_invoice_payment_processor_token(payment_intent: &PaymentIntent) -> Option<String> {
+    payment_intent
+        .feature_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.payment_revenue_recovery_metadata.as_ref())
+        .map(|recovery_metadata| {
+            recovery_metadata
+                .billing_connector_payment_details
+                .payment_processor_token
+                .clone()
+        })
+}
+
 /// Check the invoice's payment processor token against a schedule time already decided.
 /// Shared by the cascading and adaptive paths so both gate on the same conditions
 #[cfg(feature = "v2")]
@@ -816,16 +831,7 @@ async fn get_token_availability_for_schedule_time(
     payment_intent: &PaymentIntent,
     scheduled_time: time::PrimitiveDateTime,
 ) -> CustomResult<PaymentProcessorTokenResponse, errors::ProcessTrackerError> {
-    let payment_processor_token = payment_intent
-        .feature_metadata
-        .as_ref()
-        .and_then(|metadata| metadata.payment_revenue_recovery_metadata.as_ref())
-        .map(|recovery_metadata| {
-            recovery_metadata
-                .billing_connector_payment_details
-                .payment_processor_token
-                .clone()
-        });
+    let payment_processor_token = get_invoice_payment_processor_token(payment_intent);
 
     let payment_processor_tokens_details =
         RedisTokenManager::get_payment_processor_metadata_for_connector_customer(

--- a/crates/router/src/workflows/revenue_recovery.rs
+++ b/crates/router/src/workflows/revenue_recovery.rs
@@ -809,7 +809,9 @@ pub async fn get_token_with_schedule_time_based_on_retry_algorithm_type(
 
 /// The invoice's own payment processor token, as recorded on the intent by the last attempt.
 #[cfg(feature = "v2")]
-pub(crate) fn get_invoice_payment_processor_token(payment_intent: &PaymentIntent) -> Option<String> {
+pub(crate) fn get_invoice_payment_processor_token(
+    payment_intent: &PaymentIntent,
+) -> Option<String> {
     payment_intent
         .feature_metadata
         .as_ref()


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When `adaptive_retry_enabled` is on, the smart retry path scheduled retries that never
executed. CALCULATE and EXECUTE disagreed about how to find the token:

- CALCULATE's adaptive branch decides against **the invoice's own token**, read off the
  intent's `billing_connector_payment_details` (`get_token_availability_for_schedule_time`).
  It writes nothing back to Redis.
- EXECUTE dispatches purely on the algorithm enum, so for `Smart` it called
  `get_payment_processor_token_with_schedule_time`, which selects whichever of the
  customer's tokens carries a `scheduled_at` marker.

Only the decider (non-adaptive) path writes that marker. With adaptive enabled nothing ever
set it, so EXECUTE found no token, logged "No Token fetched from redis", finished
`EXECUTE_WORKFLOW_FAILURE` and reopened CALCULATE. The invoice cycled CALCULATE → EXECUTE →
CALCULATE without ever attempting a payment, burning `retry_count` each round until the
billing MCA ceiling terminated it.

This makes EXECUTE resolve the token the same way the decision was made:

- `get_token_based_on_retry_type` takes an `adaptive_retry_enabled` flag and gains a guarded
  arm — `Smart if adaptive_retry_enabled` resolves by token id, plain `Smart` keeps rea
  the decider's marker.
- Cascading and adaptive-smart now share a `get_invoice_token` helper; both look the to
  by id and leave the customer's other tokens untouched.
- `perform_execute_payment` reads the flag from the same dimension CALCULATE uses
  (`processor_merchant_id` + billing connector), so both halves resolve one switch.
- The token extraction off the intent, previously duplicated in three places, is now a
  `get_invoice_payment_processor_token` helper.

Resulting behaviour:

| Mode | Schedule from | Token resolved by | Customer-wide Redis state |
|---|---|---|---|
| Cascading | static ladder | invoice's token id | none |
| Smart + adaptive | static ladder | invoice's token id | none |
| Smart + decider | gRPC decider, earliest across tokens | `scheduled_at` marker | marker, under the customer lock |

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


## How did you test it?


## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
