### PR TITLE
fix(ucs): let the gRPC boundary stand in for a transport replay never…

### DIFF
--- a/crates/external_services/src/grpc_client/deja_transport.rs
+++ b/crates/external_services/src/grpc_client/deja_transport.rs
@@ -40,17 +40,139 @@ const OPERATION: &str = "unary";
 /// The transport wrapper. Generic over the inner tower service so the same
 /// type serves the shared hyper pool (dynamic routing / health / recovery)
 /// and the UCS `tonic::transport::Channel`s.
+///
+/// The inner transport is optional because a host may build its transport
+/// eagerly and fallibly — `tonic::transport::Endpoint::connect` is a perfectly
+/// reasonable choice — and under replay that connect is ceremony: every unary
+/// rpc is substituted here and the transport beneath is never driven. Rather
+/// than ask such a host to become lazy (which would change what it does in
+/// production, and make a recording diverge from the thing it records), the
+/// boundary can stand in for a transport that was never built. See
+/// [`DejaGrpcTransport::substituted`] and [`connect_or_substitute`].
 #[derive(Debug, Clone)]
 pub struct DejaGrpcTransport<S> {
-    inner: S,
+    inner: Option<S>,
 }
 
 impl<S> DejaGrpcTransport<S> {
-    /// Wraps a transport. Call at the construction site, never per request.
+    /// Wraps a live transport. Call at the construction site, never per request.
     pub fn new(inner: S) -> Self {
-        Self { inner }
+        Self { inner: Some(inner) }
+    }
+
+    /// A boundary with no transport beneath it.
+    ///
+    /// Valid ONLY where every call is substituted, i.e. replay. Nothing here is
+    /// a fault: the host's connect legitimately did not succeed (the service is
+    /// unreachable from a replay namespace, and it does not need to be), and
+    /// replay never issues the call live, so there is nothing for a transport to
+    /// do. Readiness is answered directly and every call is served from the
+    /// recording; a call the recording cannot answer fail-stops via
+    /// [`fail_stop_absent_transport`] rather than silently attempting to connect.
+    pub fn substituted() -> Self {
+        Self { inner: None }
     }
 }
+
+/// Wrap a transport the host builds eagerly, standing in for it when replay
+/// makes it unnecessary.
+///
+/// This is the seam for a host whose construction is eager and fallible. Under
+/// replay the `connect` closure is never run — no rpc is issued live, so the
+/// transport is dead weight and its connect cannot succeed in a namespace where
+/// the service is deliberately absent. In every other mode `connect` runs
+/// exactly as the host wrote it and its failure means exactly what the host
+/// means by it, so **record behaves identically to production**. That symmetry
+/// is the point: a recorder that changes the thing it observes is worse than the
+/// gap it closes.
+///
+/// `None` propagates the host's own "could not build the client" outcome
+/// unchanged.
+pub async fn connect_or_substitute<S, F, Fut>(connect: F) -> Option<DejaGrpcTransport<S>>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Option<S>>,
+{
+    if deja::__private::runtime_mode().is_replay() {
+        return Some(DejaGrpcTransport::substituted());
+    }
+    connect().await.map(DejaGrpcTransport::new)
+}
+
+/// Replay fail-stop for a boundary that deliberately has no transport.
+///
+/// Distinct from `deja::__private::fail_stop_substitute_miss` on purpose. That
+/// message tells the reader re-running is unsafe and offers
+/// `replay_strategy = Execute` as the remedy; with no transport there is nothing
+/// to re-run and `Execute` is not available, so reusing it would hand a reader
+/// an instruction that cannot work.
+///
+/// The distinction also decides who is on the hook. A miss with a transport
+/// present may be a genuine novel call — the candidate did something the
+/// recording has no answer for, and its author may need to look. A miss with the
+/// transport absent establishes nothing about the candidate at all: this
+/// boundary could not have served the call whatever the candidate did. Reporting
+/// both with one message re-creates the triage failure where an
+/// instrumentation-parity problem is indistinguishable from a candidate defect.
+///
+/// Carries [`deja::FAIL_STOP_SENTINEL`] like every other fail-stop, so
+/// `catch_fail_stop_async` still converts it into the response that records the
+/// divergence and a censored run stays detectable from the diff artifact alone.
+///
+/// Names the rpc path and authority, not just the boundary and component: this
+/// wrapper is installed on the shared hyper pool (dynamic routing / health /
+/// recovery) as well as on the UCS channels, and those share every module-level
+/// constant. The rpc path is the only part of the identity that says WHICH
+/// transport was absent, and a reader who cannot tell a dynamic-routing miss
+/// from a UCS one pays for it in triage time.
+// The panic is not incidental: it IS deja's fail-stop mechanism. `catch_fail_stop_async`
+// classifies a caught payload by `FAIL_STOP_SENTINEL` and renders it as the response that
+// records the divergence, so a censored run stays detectable from the diff artifact alone.
+// Returning an error instead would erase the stop from that artifact. Same reason
+// `deja::__private::fail_stop_substitute_miss` panics.
+#[allow(clippy::panic)]
+#[cold]
+#[inline(never)]
+fn fail_stop_absent_transport(
+    boundary: &str,
+    component: &str,
+    rpc: &str,
+    authority: Option<&str>,
+) -> ! {
+    let target = match authority {
+        Some(authority) => format!("`{rpc}` at `{authority}`"),
+        None => format!("`{rpc}`"),
+    };
+    panic!(
+        "{} Substitute boundary `{boundary}` in `{component}` has no transport for \
+         {target}. It was constructed for substitution only: the host builds this \
+         transport eagerly, that connect did not succeed, and replay never issues \
+         this call live. The recording has no entry for these args, so there is \
+         nothing to substitute and nothing this boundary could have executed. This \
+         says nothing about the candidate — the call could not have been served \
+         here whatever the candidate did.",
+        deja::FAIL_STOP_SENTINEL
+    );
+}
+
+/// A boundary with no transport asked to issue a call live.
+///
+/// Unreachable in practice: [`DejaGrpcTransport::substituted`] is only produced
+/// under replay, where the `run` thunk is never invoked. Named rather than
+/// silent so that if the invariant is ever broken the reason is legible.
+#[derive(Debug)]
+pub struct AbsentTransportError;
+
+impl std::fmt::Display for AbsentTransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            "deja: gRPC boundary has no transport (constructed for substitution only) \
+             and cannot issue this call live",
+        )
+    }
+}
+
+impl std::error::Error for AbsentTransportError {}
 
 /// Envelope smuggled through `http::Extensions` from the buffering `run`
 /// closure to the recording `extract` closure — the same trick the HTTP
@@ -88,7 +210,23 @@ where
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, BoxError>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(Into::into)
+        match &mut self.inner {
+            // KNOWN FRAGILITY, deliberately left alone. This delegates ungated by
+            // `is_active()`, so on replay the inner service still answers
+            // readiness. That is safe for the transports wrapped today only
+            // because tonic's readiness is buffer-backed, not connection-backed:
+            // `Endpoint::connect_lazy` -> `Channel::new` -> `Buffer::pair`, and
+            // `Buffer::poll_ready` checks worker liveness and queue capacity, not
+            // a connection (tonic 0.14.5). An inner service that instead answered
+            // readiness from a live connection would fail HERE, before `call` can
+            // substitute, and replay would break in a way that looks like a
+            // transport fault. Gating this on a mode predicate is not the fix —
+            // the mode's initialization order makes that a live hazard rather than
+            // a latent one — so it is tracked deja-side where that lifecycle lives.
+            Some(inner) => inner.poll_ready(cx).map_err(Into::into),
+            // Nothing to drive: substitution answers every call.
+            None => Poll::Ready(Ok(())),
+        }
     }
 
     #[track_caller]
@@ -96,14 +234,23 @@ where
         // Standard tower clone-dance: `self.inner` was driven to readiness by
         // poll_ready, so hand THAT instance to the future and keep the fresh
         // clone (which will be polled to readiness before its own use).
-        let clone = self.inner.clone();
-        let inner = std::mem::replace(&mut self.inner, clone);
+        let inner = match self.inner.as_mut() {
+            Some(inner) => {
+                let clone = inner.clone();
+                Some(std::mem::replace(inner, clone))
+            }
+            None => None,
+        };
 
         // Boundary engaged only when a deja hook is live (record or replay);
         // otherwise pure passthrough — no buffering, no dispatch, streaming
         // untouched.
         if !is_active() {
-            return Box::pin(passthrough(inner, request));
+            return match inner {
+                Some(inner) => Box::pin(passthrough(inner, request)),
+                // A transport-less boundary outside replay cannot serve anything.
+                None => Box::pin(async { Err(BoxError::from(AbsentTransportError)) }),
+            };
         }
         let caller = Location::caller();
         Box::pin(boundary_call(inner, request, caller))
@@ -133,7 +280,7 @@ where
 
 /// One unary gRPC exchange as one deja boundary crossing.
 async fn boundary_call<S, RB>(
-    inner: S,
+    inner: Option<S>,
     request: http::Request<TonicBody>,
     caller: &'static Location<'static>,
 ) -> Result<http::Response<TonicBody>, BoxError>
@@ -218,14 +365,35 @@ where
         TonicBody::new(BufferedBody::new(request_bytes, None)),
     );
 
-    deja::__private::dispatch_async(
-        observation,
-        move || args_value,
-        move || run_and_capture(inner, rebuilt_request),
-        reconstruct_from_recorded,
-        extract_envelope,
-    )
-    .await
+    match inner {
+        // Transport present: unchanged. A miss here may be a genuine novel call,
+        // so it keeps `dispatch_async`'s default substitute-miss fail-stop.
+        Some(inner) => {
+            deja::__private::dispatch_async(
+                observation,
+                move || args_value,
+                move || run_and_capture(inner, rebuilt_request),
+                reconstruct_from_recorded,
+                extract_envelope,
+            )
+            .await
+        }
+        // Transport deliberately absent: a miss establishes nothing about the
+        // candidate, so it gets its own reason. The `run` thunk is never invoked
+        // on this path — replay + Substitute neither runs nor re-runs — and is an
+        // error rather than an unreachable so a broken invariant stays legible.
+        None => {
+            deja::__private::dispatch_async_or_miss(
+                observation,
+                move || args_value,
+                move || async { Err(BoxError::from(AbsentTransportError)) },
+                reconstruct_from_recorded,
+                extract_envelope,
+                move || fail_stop_absent_transport(BOUNDARY, COMPONENT, &rpc, authority.as_deref()),
+            )
+            .await
+        }
+    }
 }
 
 /// The `run` thunk: forward to the real transport, buffer the response

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -193,39 +193,77 @@ pub struct HyperswitchVaultMetadata {
     pub vault_auth_data: VaultConnectorAuth,
 }
 
+/// Connects `endpoint` eagerly, bounded by `connection_timeout`, naming `client_name` on failure.
+///
+/// `None` means the caller must abandon the whole client: an unreachable service is reported here
+/// and nulls [`UnifiedConnectorServiceClient`], so the router serves from the direct connector
+/// path rather than routing live traffic at a service it cannot reach.
+pub async fn connect_ucs_endpoint(
+    endpoint: &tonic::transport::Endpoint,
+    connection_timeout: UcsConnectionTimeoutInSeconds,
+    client_name: &str,
+) -> Option<tonic::transport::Channel> {
+    match timeout(connection_timeout.as_duration(), endpoint.connect()).await {
+        Ok(Ok(channel)) => Some(channel),
+        Ok(Err(err)) => {
+            logger::error!(
+                "Failed to connect to Unified Connector Service for {}: {:?}",
+                client_name,
+                err
+            );
+            None
+        }
+        Err(err) => {
+            logger::error!(
+                "Connection to Unified Connector Service timed out for {}: {:?}",
+                client_name,
+                err
+            );
+            None
+        }
+    }
+}
+
 /// Builds a gRPC client. `$connection_timeout` bounds connect; `$request_timeout` bounds each RPC.
+///
+/// The connect is eager and gating: an unreachable service is logged and nulls the whole client,
+/// so the router serves from the direct connector path instead of routing live traffic at a
+/// service it cannot reach. That is the behaviour in every mode this router actually runs in,
+/// recording included, so a recording never diverges from the deployment it records.
+///
+/// Under the `deja` feature the connect is handed to `connect_or_substitute`, which runs it
+/// unchanged except under replay — where no rpc is ever issued live, so the transport is dead
+/// weight and the boundary stands in for it. This file expresses no opinion about deja's modes;
+/// that decision lives in the boundary adapter.
 #[macro_export]
 macro_rules! build_grpc_client {
     ($client:ty, $name:expr, $uri:expr, $connection_timeout:expr, $request_timeout:expr) => {{
         let endpoint = tonic::transport::Channel::builder($uri.clone())
             .timeout($request_timeout.as_duration());
-        match timeout($connection_timeout.as_duration(), endpoint.connect()).await {
-            Ok(Ok(channel)) => {
-                // deja: wrap the UCS channel in the gRPC egress boundary at its
-                // construction site so every unary rpc is recorded/substituted at
-                // the wire level (rank-2 identity). Feature-off passes the raw
-                // channel unchanged.
-                #[cfg(feature = "deja")]
-                let channel = $crate::grpc_client::deja_transport::DejaGrpcTransport::new(channel);
-                <$client>::new(channel)
-            }
-            Ok(Err(err)) => {
-                router_env::logger::error!(
-                    "Failed to connect to Unified Connector Service for {}: {:?}",
-                    $name,
-                    err
-                );
-                return None;
-            }
-            Err(err) => {
-                router_env::logger::error!(
-                    "Connection to Unified Connector Service timed out for {}: {:?}",
-                    $name,
-                    err
-                );
-                return None;
-            }
-        }
+
+        // deja: the same eager connect, handed to the gRPC egress boundary so every unary rpc is
+        // recorded/substituted at the wire level (rank-2 identity). The boundary runs the connect
+        // unchanged in every mode but replay, where it stands in for a transport nothing will
+        // use. Feature-off performs the connect directly and passes the raw channel through.
+        #[cfg(feature = "deja")]
+        let channel = $crate::grpc_client::deja_transport::connect_or_substitute(|| {
+            $crate::grpc_client::unified_connector_service::connect_ucs_endpoint(
+                &endpoint,
+                $connection_timeout,
+                $name,
+            )
+        })
+        .await?;
+
+        #[cfg(not(feature = "deja"))]
+        let channel = $crate::grpc_client::unified_connector_service::connect_ucs_endpoint(
+            &endpoint,
+            $connection_timeout,
+            $name,
+        )
+        .await?;
+
+        <$client>::new(channel)
     }};
 }
 
@@ -364,6 +402,19 @@ impl UnifiedConnectorServiceClient {
                     request_timeout
                 );
 
+                // Replay connected nothing — the boundary stands in for every channel — so the
+                // usual claim would be false there. Every other mode performed the same eager
+                // connect it always did.
+                #[cfg(feature = "deja")]
+                if deja::__private::runtime_mode().is_replay() {
+                    logger::info!(
+                        "Unified Connector Service clients substituted at the deja boundary; no transport connected"
+                    );
+                } else {
+                    logger::info!("Successfully connected to Unified Connector Service");
+                }
+
+                #[cfg(not(feature = "deja"))]
                 logger::info!("Successfully connected to Unified Connector Service");
 
                 Some(Self {


### PR DESCRIPTION
… uses

build_grpc_client! connects each UCS service client eagerly and returns None from build_connections when that connect fails, so one unreachable service nulls the whole unified_connector_service_client. That is the right thing for a deployment: check_ucs_availability then reports Disabled, every request takes ExecutionPath::Direct, and the merchant is served by the direct connector integration rather than routed at a service the router cannot reach.

It is the wrong thing under replay. Every unary rpc is substituted at the deja boundary and never reaches the wire, so the connect is ceremony that cannot succeed in a namespace where UCS is deliberately absent, and its failure removes UCS shadow mode from the run. Replaying a tape recorded with shadow mode on then reports the shadow Authorize rpc, and the comparison POST that follows it, as omissions in every run — including runs driven by the tape's own revision. The comparison never ran, because the client was already None when the first request arrived.

The obvious fix is to build the channel lazily, and it is the wrong one. An eager connect is a legitimate choice, and a recorder that requires the host to abandon it has made itself an argument in the host's transport design. It would also put record and production on different paths: a recording taken over a lazy channel could contain UCS traffic that the eager deployment it claims to stand for would never have produced. A recorder that changes what it observes is a worse defect than the gap it closes.

So the accommodation belongs in the boundary, which is already the deja-specific part. DejaGrpcTransport now holds an optional inner transport. Under replay it never touched that transport in any case — substitution happens in call, before the inner service is reached — so the boundary can stand in for a transport that was never built. connect_or_substitute is generic over the transport and over the host's connect closure: it runs that connect verbatim in every mode except replay, where no rpc is issued live. The UCS constructor keeps its eager connect, keeps returning None when the connect fails, and no longer expresses any opinion about deja's modes.

A boundary with no transport needs its own fail-stop. Reusing the substitute-miss message would tell a reader that re-running is unsafe and to declare replay_strategy = Execute, a remedy that does not exist when there is nothing to run. The two states also put the burden on different people: a miss with the transport present may be a genuine novel call whose author needs to look at it, while a miss with the transport absent establishes nothing about the candidate at all. The new message says so, and names the rpc path and authority, because the boundary and component are module constants shared with the dynamic routing, health check and recovery decider pool and so cannot say which transport was missing.

poll_ready delegates to the inner service ungated, which is safe only because tonic answers readiness from its buffer rather than from a connection. The no-transport case does not delegate at all; the delegating case is left as it was, with the reasoning recorded at the call site.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
