### PR TITLE
fix(router): populate card_network for wallet payment attempts

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4314,6 +4314,36 @@ impl AdditionalPaymentData {
             _ => None,
         }
     }
+
+    /// Wallet providers report the network as a free-form string in their own spelling, so it is
+    /// normalised through `CardNetwork`'s `FromStr`. Apple Pay names the field `network`, the others
+    /// `card_network`.
+    pub fn get_card_network(&self) -> Option<common_enums::CardNetwork> {
+        use std::str::FromStr;
+
+        match self {
+            Self::Card(additional_card_info) => additional_card_info.card_network.clone(),
+            Self::Wallet {
+                apple_pay,
+                google_pay,
+                samsung_pay,
+            } => apple_pay
+                .as_ref()
+                .map(|apple_pay| apple_pay.network.as_str())
+                .or_else(|| {
+                    google_pay
+                        .as_ref()
+                        .and_then(|google_pay| google_pay.card_network.as_deref())
+                })
+                .or_else(|| {
+                    samsung_pay
+                        .as_ref()
+                        .and_then(|samsung_pay| samsung_pay.card_network.as_deref())
+                })
+                .and_then(|network| common_enums::CardNetwork::from_str(network).ok()),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -3391,26 +3391,42 @@ pub enum MandateStatus {
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub enum CardNetwork {
     #[serde(alias = "VISA")]
+    #[strum(to_string = "Visa", serialize = "VISA")]
     Visa,
     #[serde(alias = "MASTERCARD")]
+    #[strum(
+        to_string = "Mastercard",
+        serialize = "MasterCard",
+        serialize = "MASTERCARD"
+    )]
     Mastercard,
     #[serde(alias = "AMERICANEXPRESS")]
     #[serde(alias = "AMEX")]
+    #[strum(
+        to_string = "AmericanExpress",
+        serialize = "AMEX",
+        serialize = "AmEx",
+        serialize = "AMERICAN EXPRESS"
+    )]
     AmericanExpress,
     JCB,
     #[serde(alias = "DINERSCLUB")]
     DinersClub,
     #[serde(alias = "DISCOVER")]
+    #[strum(to_string = "Discover", serialize = "DISCOVER")]
     Discover,
     #[serde(alias = "CARTESBANCAIRES")]
     CartesBancaires,
     #[serde(alias = "UNIONPAY")]
+    // Apple Pay sends UnionPay under its full name. Not seen in production traffic.
+    #[strum(to_string = "UnionPay", serialize = "ChinaUnionPay")]
     UnionPay,
     #[serde(alias = "INTERAC")]
     Interac,
     #[serde(alias = "RUPAY")]
     RuPay,
     #[serde(alias = "MAESTRO")]
+    #[strum(to_string = "Maestro", serialize = "MAESTRO")]
     Maestro,
     #[serde(alias = "STAR")]
     Star,
@@ -3607,6 +3623,37 @@ impl CardNetwork {
             | Self::PrivateLabel
             | Self::Dinacard => false,
         }
+    }
+
+    pub fn from_payment_method_data(payment_method_data: &serde_json::Value) -> Option<Self> {
+        let wallet = payment_method_data.get("wallet");
+
+        // Absent wallet providers serialise as `null` rather than being omitted, so each provider is
+        // matched on the network it yields, not on whether its key is present.
+        let network = match (
+            payment_method_data
+                .get("card")
+                .and_then(|card| card.get("card_network")),
+            wallet
+                .and_then(|wallet| wallet.get("apple_pay"))
+                .and_then(|apple_pay| apple_pay.get("network")),
+            wallet
+                .and_then(|wallet| wallet.get("google_pay"))
+                .and_then(|google_pay| google_pay.get("card_network")),
+            wallet
+                .and_then(|wallet| wallet.get("samsung_pay"))
+                .and_then(|samsung_pay| samsung_pay.get("card_network")),
+        ) {
+            (Some(network), ..)
+            | (_, Some(network), ..)
+            | (_, _, Some(network), _)
+            | (_, _, _, Some(network)) => Some(network),
+            (None, None, None, None) => None,
+        };
+
+        network
+            .and_then(|network| network.as_str())
+            .and_then(|network| Self::from_str(network).ok())
     }
 }
 

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -1193,11 +1193,7 @@ impl PaymentAttemptUpdateInternal {
         update_internal.card_network = update_internal
             .payment_method_data
             .as_ref()
-            .and_then(|data| data.as_object())
-            .and_then(|card| card.get("card"))
-            .and_then(|data| data.as_object())
-            .and_then(|card| card.get("card_network"))
-            .and_then(|network| network.as_str())
+            .and_then(common_enums::CardNetwork::from_payment_method_data)
             .map(|network| network.to_string());
         update_internal
     }

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -1826,8 +1826,7 @@ impl PaymentAttempt {
                     )
                     .ok()
             })
-            .and_then(|data| data.get_additional_card_info())
-            .and_then(|card_info| card_info.card_network)
+            .and_then(|data| data.get_card_network())
     }
 
     pub fn get_payment_method_data(&self) -> Option<api_models::payments::AdditionalPaymentData> {
@@ -2982,13 +2981,7 @@ impl behaviour::Conversion for PaymentAttempt {
 
     async fn convert(self) -> CustomResult<Self::DstType, ValidationError> {
         let card_network = self
-            .payment_method_data
-            .as_ref()
-            .and_then(|data| data.as_object())
-            .and_then(|card| card.get("card"))
-            .and_then(|data| data.as_object())
-            .and_then(|card| card.get("card_network"))
-            .and_then(|network| network.as_str())
+            .extract_card_network()
             .map(|network| network.to_string());
         let (connector_transaction_id, processor_transaction_data) = self
             .connector_transaction_id
@@ -3248,13 +3241,7 @@ impl behaviour::Conversion for PaymentAttempt {
 
     async fn construct_new(self) -> CustomResult<Self::NewDstType, ValidationError> {
         let card_network = self
-            .payment_method_data
-            .as_ref()
-            .and_then(|data| data.as_object())
-            .and_then(|card| card.get("card"))
-            .and_then(|data| data.as_object())
-            .and_then(|card| card.get("card_network"))
-            .and_then(|network| network.as_str())
+            .extract_card_network()
             .map(|network| network.to_string());
         Ok(DieselPaymentAttemptNew {
             payment_id: self.payment_id,

--- a/crates/router/src/services/kafka/payment_attempt.rs
+++ b/crates/router/src/services/kafka/payment_attempt.rs
@@ -128,13 +128,7 @@ impl<'a> KafkaPaymentAttempt<'a> {
             profile_id: &attempt.profile_id,
             organization_id: &attempt.organization_id,
             card_network: attempt
-                .payment_method_data
-                .as_ref()
-                .and_then(|data| data.as_object())
-                .and_then(|pm| pm.get("card"))
-                .and_then(|data| data.as_object())
-                .and_then(|card| card.get("card_network"))
-                .and_then(|network| network.as_str())
+                .extract_card_network()
                 .map(|network| network.to_string()),
             card_discovery: attempt
                 .card_discovery
@@ -342,14 +336,8 @@ impl<'a> KafkaPaymentAttempt<'a> {
             client_version: client_version.as_ref(),
             profile_id,
             organization_id,
-            card_network: payment_method_data
-                .as_ref()
-                .map(|data| data.peek())
-                .and_then(|data| data.as_object())
-                .and_then(|pm| pm.get("card"))
-                .and_then(|data| data.as_object())
-                .and_then(|card| card.get("card_network"))
-                .and_then(|network| network.as_str())
+            card_network: attempt
+                .extract_card_network()
                 .map(|network| network.to_string()),
             card_discovery: card_discovery.map(|discovery| discovery.to_string()),
             payment_token: payment_token.clone(),

--- a/crates/router/src/services/kafka/payment_attempt_event.rs
+++ b/crates/router/src/services/kafka/payment_attempt_event.rs
@@ -129,13 +129,7 @@ impl<'a> KafkaPaymentAttemptEvent<'a> {
             profile_id: &attempt.profile_id,
             organization_id: &attempt.organization_id,
             card_network: attempt
-                .payment_method_data
-                .as_ref()
-                .and_then(|data| data.as_object())
-                .and_then(|pm| pm.get("card"))
-                .and_then(|data| data.as_object())
-                .and_then(|card| card.get("card_network"))
-                .and_then(|network| network.as_str())
+                .extract_card_network()
                 .map(|network| network.to_string()),
             card_discovery: attempt
                 .card_discovery
@@ -344,14 +338,8 @@ impl<'a> KafkaPaymentAttemptEvent<'a> {
             client_version: client_version.as_ref(),
             profile_id,
             organization_id,
-            card_network: payment_method_data
-                .as_ref()
-                .map(|data| data.peek())
-                .and_then(|data| data.as_object())
-                .and_then(|pm| pm.get("card"))
-                .and_then(|data| data.as_object())
-                .and_then(|card| card.get("card_network"))
-                .and_then(|network| network.as_str())
+            card_network: attempt
+                .extract_card_network()
                 .map(|network| network.to_string()),
             card_discovery: card_discovery.map(|discovery| discovery.to_string()),
             payment_token: payment_token.clone(),

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -2109,13 +2109,7 @@ impl Conversion for PaymentAttempt {
         use common_utils::encryption::Encryption;
 
         let card_network = self
-            .payment_method_data
-            .as_ref()
-            .and_then(|data| data.peek().as_object())
-            .and_then(|card| card.get("card"))
-            .and_then(|data| data.as_object())
-            .and_then(|card| card.get("card_network"))
-            .and_then(|network| network.as_str())
+            .extract_card_network()
             .map(|network| network.to_string());
 
         let Self {
@@ -2432,6 +2426,11 @@ impl Conversion for PaymentAttempt {
 
     async fn construct_new(self) -> CustomResult<Self::NewDstType, ValidationError> {
         use common_utils::encryption::Encryption;
+
+        let card_network = self
+            .extract_card_network()
+            .map(|network| network.to_string());
+
         let Self {
             payment_id,
             merchant_id,
@@ -2490,15 +2489,6 @@ impl Conversion for PaymentAttempt {
             applied_offer_details: _,
             payment_account_reference,
         } = self;
-
-        let card_network = payment_method_data
-            .as_ref()
-            .and_then(|data| data.peek().as_object())
-            .and_then(|card| card.get("card"))
-            .and_then(|data| data.as_object())
-            .and_then(|card| card.get("card_network"))
-            .and_then(|network| network.as_str())
-            .map(|network| network.to_string());
 
         let error_details = error;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

`payment_attempt.card_network` is a derived column — recomputed from `payment_method_data` on every
write, rather than set by anyone. Every derivation was hardcoded to the card shape:

```rust
.and_then(|pm| pm.get("card"))
.and_then(|card| card.get("card_network"))
```

`AdditionalPaymentData` is externally tagged, so a wallet attempt stores
`{"wallet": {"apple_pay": {"network": "MasterCard", ...}}}`. The `card` lookup misses, the chain
short-circuits, and the column is written `NULL`. `dsl::card_network.eq_any(...)` then matches
nothing, which is why filtering payments by card network returns no wallet results.

Two things were needed:

1. **Extraction** — read the wallet shape as well as the card shape. Apple Pay names the field
   `network`; Google Pay and Samsung Pay use `card_network`.
2. **Normalisation** — providers send their own spellings. The filter binds `CardNetwork`, whose
   Postgres text form is the bare variant name, so storing the raw `"MasterCard"` would never match
   `'Mastercard'`.

Spellings seen in production over 30 days, and their volume:

| Spelling | Attempts |
|---|---|
| `Visa` / `VISA` | 44,119 |
| `MasterCard` / `MASTERCARD` / `Mastercard` | 25,466 |
| `AMEX` / `AmEx` / `AMERICAN EXPRESS` | 1,782 |
| `DISCOVER` / `Discover` | 508 |
| `MAESTRO`, `Interac` | 5 |

Changes by crate:

- **`common_enums`** — `strum(serialize)` entries on `CardNetwork` for each spelling above.
  `to_string` is pinned to the variant name on every variant that gains a `serialize`, so `Display`
  (this enum's database representation) and `VariantNames` are unchanged; only `FromStr` widens, and
  only additively. Added `CardNetwork::from_payment_method_data` for the update path.
- **`api_models`** — `AdditionalPaymentData::get_card_network()`, covering the card variant and all
  three card-backed wallets.
- **`hyperswitch_domain_models`** — `extract_card_network()` now handles wallets for v1, and is
  implemented for v2 (it was `todo!()`).
- **`diesel_models`, `storage_impl`, kafka event builders** — use the shared extraction instead of
  their own inline card-only JSON walks.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

The public API contract is deliberately unchanged: normalisation is applied via `strum`'s `FromStr`,
not serde, so the set of `card_network` values accepted on request bodies is exactly as before.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

Filtering payments by card network returns nothing for wallet payments. Measured on production over
30 days: **71,880 wallet attempts carry an extractable network, and none of them had
`card_network` populated.**

Worth flagging for review: `extract_card_network()` has 11 pre-existing callers in `retry.rs`,
`payment_response.rs`, `payments.rs`, `helpers.rs` and `payment_sync.rs`. All of them were silently
receiving `None` for wallet payments and will now receive a real network, so retry and GSM decisions
change for wallet traffic.

Two follow-ups, both out of scope here:

- Existing rows are not backfilled — the column starts populating for new attempts only.
- v2 has `card_network` commented out of `PaymentAttemptUpdateInternal`, so it still never updates
  the column after insert.

## Linked Issues

- Issue: https://github.com/juspay/hyperswitch-cloud/issues/22260

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
-->

Verified against production data rather than synthetic cases: the accepted spellings were taken from
`hyperswitch_prod.payment_attempts` over 30 days, so the set covers real traffic instead of guesses.
The same query established the baseline for this bug — 71,880 wallet attempts with an extractable
network, none of them populated.

`just check` passes under `v1`.

Post-deploy this can be confirmed by re-running the baseline query and checking the populated count
moves off zero, with the empty bucket shrinking to roughly the PayPal + AliPay share (~9% of wallet
attempts, which legitimately carry no network):

```sql
SELECT card_network, count() AS attempts
FROM hyperswitch_prod.payment_attempts
PREWHERE created_at >= now() - INTERVAL 1 DAY AND payment_method = 'wallet'
GROUP BY card_network ORDER BY attempts DESC
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
