### PR TITLE
feat(ucs): forward business_country for the worldpayxml AFT flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log 0.4.27",
  "prettyplease",
  "proc-macro2",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.09.01.1#10f9bfb7d33bb69bd2f5794720e74aa01dfdb679"
+source = "git+https://github.com/juspay/connector-service?rev=38737634498b23ff645c2562de2a438fc59cf933#38737634498b23ff645c2562de2a438fc59cf933"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4261,7 +4261,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.09.01.1#10f9bfb7d33bb69bd2f5794720e74aa01dfdb679"
+source = "git+https://github.com/juspay/connector-service?rev=38737634498b23ff645c2562de2a438fc59cf933#38737634498b23ff645c2562de2a438fc59cf933"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -7536,8 +7536,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log 0.4.27",
  "multimap",
  "petgraph",
@@ -7558,7 +7558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7571,7 +7571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.09.01.1#10f9bfb7d33bb69bd2f5794720e74aa01dfdb679"
+source = "git+https://github.com/juspay/connector-service?rev=38737634498b23ff645c2562de2a438fc59cf933#38737634498b23ff645c2562de2a438fc59cf933"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11421,7 +11421,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.09.01.1#10f9bfb7d33bb69bd2f5794720e74aa01dfdb679"
+source = "git+https://github.com/juspay/connector-service?rev=38737634498b23ff645c2562de2a438fc59cf933#38737634498b23ff645c2562de2a438fc59cf933"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11437,7 +11437,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.09.01.1#10f9bfb7d33bb69bd2f5794720e74aa01dfdb679"
+source = "git+https://github.com/juspay/connector-service?rev=38737634498b23ff645c2562de2a438fc59cf933#38737634498b23ff645c2562de2a438fc59cf933"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11448,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.09.01.1#10f9bfb7d33bb69bd2f5794720e74aa01dfdb679"
+source = "git+https://github.com/juspay/connector-service?rev=38737634498b23ff645c2562de2a438fc59cf933#38737634498b23ff645c2562de2a438fc59cf933"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -94,7 +94,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.09.01.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "38737634498b23ff645c2562de2a438fc59cf933", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 bytes = { version = "1.10.1", optional = true }
 superposition_provider = { version = "0.115.5", optional = true }

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -35,7 +35,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.09.01.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "38737634498b23ff645c2562de2a438fc59cf933", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -243,8 +243,8 @@ rust_decimal = { version = "1.37.1", features = [
 ] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.09.01.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.09.01.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "38737634498b23ff645c2562de2a438fc59cf933", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "38737634498b23ff645c2562de2a438fc59cf933", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = { version = "0.23", default-features = false, features = [
     "aws-lc-rs",

--- a/crates/router/src/core/unified_connector_service/connector_config.rs
+++ b/crates/router/src/core/unified_connector_service/connector_config.rs
@@ -116,12 +116,13 @@ pub struct CalidaMetadata {
     shop_name: Secret<String>,
 }
 
-/// Cardinal 3DS JWT credentials from the Worldpayxml merchant connector account metadata.
 #[derive(Debug, serde::Deserialize)]
 pub struct WorldpayxmlMetadata {
     issuer_id: Option<Secret<String>>,
     organizational_unit_id: Option<Secret<String>>,
     jwt_mac_key: Option<Secret<String>>,
+    funding_transaction_type: Option<String>,
+    payment_purpose: Option<String>,
 }
 
 /// Paysafe payment method details for account_id configuration.
@@ -566,6 +567,10 @@ pub enum ConnectorSpecificConfig {
         issuer_id: Option<Secret<String>>,
         organizational_unit_id: Option<Secret<String>>,
         jwt_mac_key: Option<Secret<String>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        funding_transaction_type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        payment_purpose: Option<String>,
     },
     /// Datatrans connector configuration
     Datatrans {
@@ -1582,6 +1587,12 @@ impl ForeignTryFrom<(Connector, &ConnectorAuthType, Option<&serde_json::Value>)>
                             .as_ref()
                             .and_then(|m| m.organizational_unit_id.clone()),
                         jwt_mac_key: worldpayxml_meta.as_ref().and_then(|m| m.jwt_mac_key.clone()),
+                        funding_transaction_type: worldpayxml_meta
+                            .as_ref()
+                            .and_then(|m| m.funding_transaction_type.clone()),
+                        payment_purpose: worldpayxml_meta
+                            .as_ref()
+                            .and_then(|m| m.payment_purpose.clone()),
                     })
                 }
                 _ => Err(err("Worldpayxml requires SignatureKey auth type")),


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Populates `funding_transaction_type` and `payment_purpose` on the UCS worldpay connector config from the merchant connector account metadata, so the UCS connector can emit `instruction.fundsTransfer` for account funding transactions (AFT). Values use the Worldpay REST API vocabulary (e.g. `walletLoad`, `crypto`).
- Pins the UCS deps to the connector-service PR head (juspay/hyperswitch-prism#2209) until a release tag is cut; to be switched to the tag before merge.

Stacked on #13866 — retarget to `main` once that merges.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

AFT support for the worldpay (Worldpay REST API) connector was added in UCS (juspay/hyperswitch-prism#2209). The funds transfer type and purpose are per-merchant configuration and must be sent by hyperswitch in the connector config; without this wiring every AFT authorize through UCS worldpay fails with a missing `funding_transaction_type` error.

Reference for the equivalent worldpayxml (WPG) support: #13889.

## How did you test it?

Can't test as we do not have the creds yet. Verified with `cargo check`, `cargo +nightly fmt --all`, `just clippy` and `just clippy_v2`.
