### PR TITLE
fix(connector): [worldpayvantiv] forward the authorization code from the connector response

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/worldpayvantiv/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpayvantiv/transformers.rs
@@ -2115,7 +2115,7 @@ impl<F>
                     };
                     let connector_metadata =   Some(report_group.encode_to_value()
                     .change_context(errors::ConnectorError::ResponseHandlingFailed)?);
-                    let additional_payment_method_connector_response = sale_response.fraud_result.as_ref().map(get_additional_payment_method_connector_response);
+                    let additional_payment_method_connector_response = get_additional_payment_method_connector_response(sale_response.fraud_result.as_ref(), sale_response.auth_code.clone());
                     let connector_response = Some(ConnectorResponseData::new(
                         additional_payment_method_connector_response,
                         None,
@@ -2218,7 +2218,7 @@ impl<F>
                                 auth_response.network_transaction_id.clone(),
                             )
                         });
-                    let connector_response = auth_response.fraud_result.as_ref().map(get_connector_response);
+                    let connector_response = get_additional_payment_method_connector_response(auth_response.fraud_result.as_ref(), auth_response.auth_code.clone()).map(ConnectorResponseData::with_additional_payment_method_data);
 
                     Ok(Self {
                         status,
@@ -2363,10 +2363,11 @@ impl<F>
                                     auth_response.network_transaction_id.clone(),
                                 )
                             });
-                    let connector_response = auth_response
-                        .fraud_result
-                        .as_ref()
-                        .map(get_connector_response);
+                    let connector_response = get_additional_payment_method_connector_response(
+                        auth_response.fraud_result.as_ref(),
+                        auth_response.auth_code.clone(),
+                    )
+                    .map(ConnectorResponseData::with_additional_payment_method_data);
 
                     Ok(Self {
                         status,
@@ -4772,42 +4773,35 @@ fn get_vantiv_card_data(
     }
 }
 
-fn get_connector_response(payment_response: &FraudResult) -> ConnectorResponseData {
-    let payment_checks = Some(serde_json::json!({
-        "avs_result": payment_response.avs_result,
-        "card_validation_result": payment_response.card_validation_result,
-        "authentication_result": payment_response.authentication_result,
-        "advanced_a_v_s_result": payment_response.advanced_a_v_s_result,
-    }));
-
-    ConnectorResponseData::with_additional_payment_method_data(
-        AdditionalPaymentMethodConnectorResponse::Card {
-            authentication_data: None,
-            payment_checks,
-            card_network: None,
-            domestic_network: None,
-            auth_code: None,
-        },
-    )
-}
-
+/// Vantiv returns `fraudResult` only when fraud checks actually ran, but it returns
+/// `authCode` on every approval. Keying the connector response off `fraudResult` alone
+/// therefore dropped the auth code on the ordinary approval path, so both inputs are
+/// optional here and a response is produced whenever either one is present.
 fn get_additional_payment_method_connector_response(
-    payment_response: &FraudResult,
-) -> AdditionalPaymentMethodConnectorResponse {
-    let payment_checks = Some(serde_json::json!({
-        "avs_result": payment_response.avs_result,
-        "card_validation_result": payment_response.card_validation_result,
-        "authentication_result": payment_response.authentication_result,
-        "advanced_a_v_s_result": payment_response.advanced_a_v_s_result,
-    }));
+    fraud_result: Option<&FraudResult>,
+    auth_code: Option<Secret<String>>,
+) -> Option<AdditionalPaymentMethodConnectorResponse> {
+    let payment_checks = fraud_result.map(|fraud_result| {
+        serde_json::json!({
+            "avs_result": fraud_result.avs_result,
+            "card_validation_result": fraud_result.card_validation_result,
+            "authentication_result": fraud_result.authentication_result,
+            "advanced_a_v_s_result": fraud_result.advanced_a_v_s_result,
+        })
+    });
+    let auth_code = auth_code.map(|auth_code| auth_code.expose());
 
-    AdditionalPaymentMethodConnectorResponse::Card {
+    if payment_checks.is_none() && auth_code.is_none() {
+        return None;
+    }
+
+    Some(AdditionalPaymentMethodConnectorResponse::Card {
         authentication_data: None,
         payment_checks,
         card_network: None,
         domestic_network: None,
-        auth_code: None,
-    }
+        auth_code,
+    })
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -5346,4 +5340,76 @@ fn get_last_non_auxiliary_activity_type(activities: Vec<Activity>) -> Option<Str
         }
     }
     last_non_auxiliary_activity
+}
+
+#[cfg(test)]
+mod auth_code_tests {
+    use hyperswitch_domain_models::router_data::AdditionalPaymentMethodConnectorResponse;
+    use hyperswitch_masking::Secret;
+
+    use super::{get_additional_payment_method_connector_response, FraudResult};
+
+    fn fraud_result() -> FraudResult {
+        FraudResult {
+            avs_result: Some("01".to_string()),
+            card_validation_result: Some("M".to_string()),
+            authentication_result: None,
+            advanced_a_v_s_result: None,
+            advanced_fraud_results: None,
+        }
+    }
+
+    /// Reduce a response down to just the two fields these tests assert on.
+    fn card_fields(
+        response: Option<AdditionalPaymentMethodConnectorResponse>,
+    ) -> Option<(Option<String>, Option<serde_json::Value>)> {
+        match response {
+            Some(AdditionalPaymentMethodConnectorResponse::Card {
+                auth_code,
+                payment_checks,
+                ..
+            }) => Some((auth_code, payment_checks)),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn auth_code_is_reported_when_vantiv_omits_the_fraud_result() {
+        let card = card_fields(get_additional_payment_method_connector_response(
+            None,
+            Some(Secret::new("123456".to_string())),
+        ));
+
+        // The regression: previously this whole branch collapsed to `None`, so an
+        // approval without fraud checks reported no auth code at all.
+        assert_eq!(
+            card,
+            Some((Some("123456".to_string()), None)),
+            "the auth code must survive when no fraud result is returned"
+        );
+    }
+
+    #[test]
+    fn fraud_checks_and_auth_code_are_reported_together() {
+        let card = card_fields(get_additional_payment_method_connector_response(
+            Some(&fraud_result()),
+            Some(Secret::new("654321".to_string())),
+        ));
+
+        assert_eq!(
+            card.clone().and_then(|(auth_code, _)| auth_code),
+            Some("654321".to_string()),
+            "the auth code must not be dropped when fraud checks are present"
+        );
+        assert!(
+            card.and_then(|(_, payment_checks)| payment_checks)
+                .is_some(),
+            "existing fraud check reporting must be preserved"
+        );
+    }
+
+    #[test]
+    fn nothing_is_reported_when_both_inputs_are_absent() {
+        assert!(get_additional_payment_method_connector_response(None, None).is_none());
+    }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

`worldpayvantiv` parses Vantiv's `authCode` into `PaymentResponse.auth_code` but never
forwards it — every construction of the connector response hardcoded `auth_code: None`,
so the value had no readers and `payment_method_data.card.auth_code` was always null.

There was a second, compounding problem. Both response helpers took `&FraudResult`, so
the connector response was produced by mapping over `fraud_result`:

```rust
let connector_response = auth_response.fraud_result.as_ref().map(get_connector_response);
```

Vantiv returns `fraudResult` only when fraud checks actually ran, but returns `authCode`
on every approval. Wiring `auth_code` into the struct alone would therefore still have
dropped it on any approval without a fraud result — the ordinary path for merchants
without Vantiv fraud filtering. On the two authorize call sites the entire
`connector_response` collapsed to `None` in that case.

This PR:

1. Collapses the two near-identical helpers into one that takes
   `Option<&FraudResult>` and `Option<Secret<String>>` and returns
   `Option<AdditionalPaymentMethodConnectorResponse>`, producing a response whenever
   either input is present.
2. Threads `auth_code` from `PaymentResponse` through all three call sites (sale and
   both authorize paths).

`AdditionalPaymentMethodConnectorResponse::Card` already carries `auth_code` and it
already surfaces as `payment_method_data.card.auth_code`, so no schema, migration or API
contract change is needed — this is connector-side wiring only.

Deliberately out of scope: Vantiv also supports Apple Pay and Google Pay, and
`ConnectorResponseData::with_auth_code` would dispatch those to the wallet variants.
This connector emits the `Card` variant for every payment method today, and switching
that would drop the `payment_checks` wallets currently receive. Keeping the existing
variant selection keeps this change to the reported defect; the wallet split is better
raised on its own.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes #13974.

Merchants use the auth code for reconciliation and for card-network dispute
representment, so silently discarding a value Vantiv did return loses data they need.

The same gap was noted in passing in #13941 for `worldpayxml` and fixed there by #13954.
`worldpayvantiv` was left untouched, and its `fraudResult` coupling makes this a distinct
fix rather than a copy of that one.

## How did you test it?

Unit tests added in `crates/hyperswitch_connectors/src/connectors/worldpayvantiv/transformers.rs`:

- `auth_code_is_reported_when_vantiv_omits_the_fraud_result` — pins the actual
  regression: no fraud result, auth code still reported.
- `fraud_checks_and_auth_code_are_reported_together` — the auth code is added without
  losing the existing `payment_checks` reporting.
- `nothing_is_reported_when_both_inputs_are_absent` — no empty response is fabricated.

Locally verified with:

```
cargo +nightly fmt --all --check
cargo clippy -p hyperswitch_connectors --all-targets --features v1,payouts,frm,revenue_recovery
```

No Vantiv sandbox credentials were available, so this was verified at the transformer
level rather than against a live authorization.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
