### PR TITLE
feat(payments): return the card BIN for Google Pay and Apple Pay payments

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -11001,6 +11001,12 @@
             "example": "003925",
             "nullable": true
           },
+          "token_isin": {
+            "type": "string",
+            "description": "The BIN of the device token. Apple Pay always decrypts to a device PAN rather than\nthe funding PAN, so the BIN is reported here and never as `card_isin`.",
+            "example": "513331",
+            "nullable": true
+          },
           "auth_code": {
             "type": "string",
             "description": "Unique authorisation code generated for the payment",
@@ -47653,6 +47659,26 @@
             "type": "string",
             "description": "The card's expiry year",
             "example": "25",
+            "nullable": true
+          },
+          "card_isin": {
+            "type": "string",
+            "description": "The BIN of the underlying funding card, present when the decrypted wallet token\ncarries the funding PAN (Google Pay `PAN_ONLY`)",
+            "example": "424242",
+            "nullable": true
+          },
+          "token_isin": {
+            "type": "string",
+            "description": "The BIN of the device token, present when the decrypted wallet token carries a\ndevice PAN rather than the funding PAN (Apple Pay, and Google Pay `CRYPTOGRAM_3DS`)",
+            "example": "513331",
+            "nullable": true
+          },
+          "auth_method": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GooglePayAuthMethod"
+              }
+            ],
             "nullable": true
           },
           "auth_code": {

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -6653,6 +6653,12 @@
             "example": "003925",
             "nullable": true
           },
+          "token_isin": {
+            "type": "string",
+            "description": "The BIN of the device token. Apple Pay always decrypts to a device PAN rather than\nthe funding PAN, so the BIN is reported here and never as `card_isin`.",
+            "example": "513331",
+            "nullable": true
+          },
           "auth_code": {
             "type": "string",
             "description": "Unique authorisation code generated for the payment",
@@ -34849,6 +34855,26 @@
             "type": "string",
             "description": "The card's expiry year",
             "example": "25",
+            "nullable": true
+          },
+          "card_isin": {
+            "type": "string",
+            "description": "The BIN of the underlying funding card, present when the decrypted wallet token\ncarries the funding PAN (Google Pay `PAN_ONLY`)",
+            "example": "424242",
+            "nullable": true
+          },
+          "token_isin": {
+            "type": "string",
+            "description": "The BIN of the device token, present when the decrypted wallet token carries a\ndevice PAN rather than the funding PAN (Apple Pay, and Google Pay `CRYPTOGRAM_3DS`)",
+            "example": "513331",
+            "nullable": true
+          },
+          "auth_method": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GooglePayAuthMethod"
+              }
+            ],
             "nullable": true
           },
           "auth_code": {

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -1852,6 +1852,11 @@ impl From<PaymentMethodDataWalletInfo> for payments::additional_info::WalletAddi
             card_type: item.card_type,
             card_exp_month: item.card_exp_month,
             card_exp_year: item.card_exp_year,
+            // Derived from the decrypted wallet token at payment time, so these are not
+            // available on a stored payment method.
+            card_isin: None,
+            token_isin: None,
+            auth_method: None,
             auth_code: item.auth_code,
             email: item.email,
         }
@@ -1890,6 +1895,7 @@ impl TryFrom<PaymentMethodDataWalletInfo> for Box<payments::ApplepayPaymentMetho
             pm_type: item.card_type.get_required_value("card_type")?,
             card_exp_month: item.card_exp_month,
             card_exp_year: item.card_exp_year,
+            token_isin: None,
             auth_code: item.auth_code,
         }))
     }

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -5877,6 +5877,11 @@ pub struct ApplepayPaymentMethod {
     /// The card's expiry year
     #[schema(value_type = Option<String>, example = "003925")]
     pub card_exp_year: Option<Secret<String>>,
+    /// The BIN of the device token. Apple Pay always decrypts to a device PAN rather than
+    /// the funding PAN, so the BIN is reported here and never as `card_isin`.
+    #[schema(value_type = Option<String>, example = "513331")]
+    #[smithy(value_type = "Option<String>")]
+    pub token_isin: Option<String>,
     /// Unique authorisation code generated for the payment
     pub auth_code: Option<String>,
 }
@@ -9552,6 +9557,9 @@ impl From<AdditionalPaymentData> for PaymentMethodDataResponse {
                             card_type: Some(apple_pay_pm.pm_type.clone()),
                             card_exp_month: apple_pay_pm.card_exp_month,
                             card_exp_year: apple_pay_pm.card_exp_year,
+                            card_isin: None,
+                            token_isin: apple_pay_pm.token_isin,
+                            auth_method: None,
                             auth_code: apple_pay_pm.auth_code,
                             email: None,
                         },

--- a/crates/api_models/src/payments/additional_info.rs
+++ b/crates/api_models/src/payments/additional_info.rs
@@ -458,6 +458,20 @@ pub struct WalletAdditionalDataForCard {
     /// The card's expiry year
     #[schema(value_type = Option<String>, example = "25")]
     pub card_exp_year: Option<Secret<String>>,
+    /// The BIN of the underlying funding card, present when the decrypted wallet token
+    /// carries the funding PAN (Google Pay `PAN_ONLY`)
+    #[schema(value_type = Option<String>, example = "424242")]
+    #[smithy(value_type = "Option<String>")]
+    pub card_isin: Option<String>,
+    /// The BIN of the device token, present when the decrypted wallet token carries a
+    /// device PAN rather than the funding PAN (Apple Pay, and Google Pay `CRYPTOGRAM_3DS`)
+    #[schema(value_type = Option<String>, example = "513331")]
+    #[smithy(value_type = "Option<String>")]
+    pub token_isin: Option<String>,
+    /// Whether Google Pay supplied a funding PAN or a tokenized device PAN
+    #[schema(value_type = Option<GooglePayAuthMethod>, example = "PAN_ONLY")]
+    #[smithy(value_type = "Option<GooglePayAuthMethod>")]
+    pub auth_method: Option<common_enums::GooglePayAuthMethod>,
     /// Unique authorisation code generated for the payment
     #[schema(value_type = Option<String>, example = "009825")]
     pub auth_code: Option<String>,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -6342,13 +6342,16 @@ pub async fn get_additional_payment_data(
         },
         domain::PaymentMethodData::Wallet(wallet) => match wallet {
             domain::WalletData::ApplePay(apple_pay_wallet_data) => {
-                let (card_exp_month, card_exp_year) = match payment_method_token {
+                // Apple Pay always decrypts to a device PAN rather than the funding PAN,
+                // so its BIN is reported as `token_isin`.
+                let (card_exp_month, card_exp_year, token_isin) = match payment_method_token {
                     Some(PaymentMethodToken::ApplePayDecrypt(token)) => (
                         Some(token.application_expiration_month.clone()),
                         Some(token.application_expiration_year.clone()),
+                        Some(token.application_primary_account_number.get_card_isin()),
                     ),
 
-                    _ => (None, None),
+                    _ => (None, None, None),
                 };
 
                 Ok(Some(api_models::payments::AdditionalPaymentData::Wallet {
@@ -6358,6 +6361,7 @@ pub async fn get_additional_payment_data(
                         pm_type: apple_pay_wallet_data.payment_method.pm_type.clone(),
                         card_exp_month,
                         card_exp_year,
+                        token_isin,
                         // These are filled after calling the processor / connector
                         auth_code: None,
                     })),
@@ -6366,13 +6370,33 @@ pub async fn get_additional_payment_data(
                 }))
             }
             domain::WalletData::GooglePay(google_pay_pm_data) => {
-                let (card_exp_month, card_exp_year) = match payment_method_token {
-                    Some(PaymentMethodToken::GooglePayDecrypt(token)) => (
-                        Some(token.card_exp_month.clone()),
-                        Some(token.card_exp_year.clone()),
-                    ),
-                    _ => (None, None),
-                };
+                // `PAN_ONLY` decrypts to the funding PAN and `CRYPTOGRAM_3DS` to a device
+                // PAN, so the BIN is reported under a different field for each. When the
+                // auth method is absent the origin of the PAN is unknown, so neither field
+                // is set rather than risk reporting a device PAN as a funding PAN.
+                let (card_exp_month, card_exp_year, card_isin, token_isin, auth_method) =
+                    match payment_method_token {
+                        Some(PaymentMethodToken::GooglePayDecrypt(token)) => {
+                            let isin = token.application_primary_account_number.get_card_isin();
+                            let (card_isin, token_isin) = match token.auth_method {
+                                Some(common_enums::GooglePayAuthMethod::PanOnly) => {
+                                    (Some(isin), None)
+                                }
+                                Some(common_enums::GooglePayAuthMethod::Cryptogram) => {
+                                    (None, Some(isin))
+                                }
+                                None => (None, None),
+                            };
+                            (
+                                Some(token.card_exp_month.clone()),
+                                Some(token.card_exp_year.clone()),
+                                card_isin,
+                                token_isin,
+                                token.auth_method,
+                            )
+                        }
+                        _ => (None, None, None, None, None),
+                    };
 
                 Ok(Some(api_models::payments::AdditionalPaymentData::Wallet {
                     apple_pay: None,
@@ -6383,6 +6407,9 @@ pub async fn get_additional_payment_data(
                             card_type: Some(google_pay_pm_data.pm_type.clone()),
                             card_exp_month,
                             card_exp_year,
+                            card_isin,
+                            token_isin,
+                            auth_method,
                             // These are filled after calling the processor / connector
                             auth_code: None,
                             email: None,
@@ -6412,6 +6439,9 @@ pub async fn get_additional_payment_data(
                             card_type: None,
                             card_exp_month: None,
                             card_exp_year: None,
+                            card_isin: None,
+                            token_isin: None,
+                            auth_method: None,
                             // These are filled after calling the processor / connector
                             auth_code: None,
                             email: None,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Wallet payments returned no card BIN. `WalletAdditionalDataForCard` had no BIN field, and
the wallet arm of `get_additional_payment_data` received `payment_method_token` but used it
only for the expiry month and year — even though the decrypted wallet token carries the PAN.

This PR adds three fields to `WalletAdditionalDataForCard` and populates them from the
decrypted token:

- `card_isin` — the BIN of the funding card, set only for Google Pay `PAN_ONLY`, where the
  decrypted PAN is the FPAN.
- `token_isin` — the BIN of the device token, set for Apple Pay and for Google Pay
  `CRYPTOGRAM_3DS`, where the decrypted PAN is a DPAN.
- `auth_method` (`GooglePayAuthMethod`) — which of the two Google Pay supplied. It was not
  previously surfaced in any response model, and without it a consumer cannot tell how to
  read the BIN.

Both names reuse existing public API fields for the same concepts rather than inventing new
ones: `card_isin` on `CardResponse`, and `token_isin` on `NetworkTokenResponse` and
`AdditionalNetworkTokenInfo`, which already means "BIN derived from a token rather than a
funding PAN".

### A note on Apple Pay

The issue proposes putting `token_isin` on `WalletAdditionalDataForCard` for Apple Pay, but
`get_additional_payment_data` builds Apple Pay as `ApplepayPaymentMethod`, a different
struct. That struct is converted into `WalletAdditionalDataForCard` in
`From<AdditionalPaymentData> for PaymentMethodDataResponse`, which is why the response shape
looks the same.

So `token_isin` is added to **both** structs: populated on `ApplepayPaymentMethod` at the
point of decryption, then carried across that conversion. Without the field on
`ApplepayPaymentMethod` there is nowhere for the Apple Pay value to live between the two.

### When the auth method is unknown

If Google Pay does not state an auth method, neither BIN field is populated. The origin of
the PAN is unknowable in that case, and reporting a device PAN as a funding PAN would be
worse than reporting nothing — `card_isin` is used for BIN lookups and routing decisions
where an FPAN and a DPAN are not interchangeable.

`PaymentMethodDataWalletInfo` (the stored-payment-method path) is deliberately left alone:
these values come from a token decrypted at payment time and are not available for a saved
payment method, so the conversion sets them to `None`.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

The change is additive only — three new optional fields on a response object and one on
`ApplepayPaymentMethod`. No existing field changes type, name or meaning, so no consumer
breaks. Regenerated `api-reference/v1/openapi_spec_v1.json` and
`api-reference/v2/openapi_spec_v2.json` are included (26 added lines each, no other churn).

## Motivation and Context

Closes #13944.

Card payments already expose `card_isin`; wallet payments did not, so merchants doing BIN
based routing, surcharging, or issuer identification had no equivalent for Google Pay or
Apple Pay despite the data being present in the decrypted token.

## How did you test it?

Locally verified with:

```
cargo run -p openapi --features v1
cargo run -p openapi --features v2
cargo check -p router
cargo +nightly fmt --all --check
```

The two OpenAPI runs both compile `api_models` and then regenerate the spec, and the
resulting diff is exactly the four new fields — `auth_method` resolves against the existing
`GooglePayAuthMethod` schema, which was already registered in both `openapi.rs` and
`openapi_v2.rs`.

No live Google Pay or Apple Pay credentials were available, so the population logic was
verified by compilation and code inspection rather than against a real decrypted token.
Reviewers may want to confirm the `PAN_ONLY` / `CRYPTOGRAM_3DS` split against a sandbox
transaction before merging.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
