### PR TITLE
fix(revenue_recovery): fix the invoice_billing__start_at_time which is getting overridden by multiple attempts

### DIFF
--- a/crates/hyperswitch_domain_models/src/payments.rs
+++ b/crates/hyperswitch_domain_models/src/payments.rs
@@ -1701,9 +1701,7 @@ where
                 invoice_billing_started_at_time: revenue_recovery
                     .as_ref()
                     .and_then(|data| data.invoice_billing_started_at_time)
-                    .or(self
-                        .revenue_recovery_data
-                        .invoice_billing_started_at_time),
+                    .or(self.revenue_recovery_data.invoice_billing_started_at_time),
                 billing_connector_payment_method_details,
                 first_payment_attempt_network_advice_code: first_network_advice_code,
                 first_payment_attempt_network_decline_code: first_network_decline_code,

--- a/crates/hyperswitch_domain_models/src/payments.rs
+++ b/crates/hyperswitch_domain_models/src/payments.rs
@@ -1582,6 +1582,7 @@ pub struct RevenueRecoveryData {
     pub connector_customer_id: String,
     pub retry_count: Option<u16>,
     pub invoice_next_billing_time: Option<PrimitiveDateTime>,
+    pub invoice_billing_started_at_time: Option<PrimitiveDateTime>,
     pub triggered_by: storage_enums::enums::TriggeredBy,
     pub card_network: Option<common_enums::CardNetwork>,
     pub card_issuer: Option<String>,
@@ -1690,10 +1691,19 @@ where
                     router_env::logger::error!(?err, "Failed to parse connector string to enum");
                     errors::api_error_response::ApiErrorResponse::InternalServerError
                 })?,
-                invoice_next_billing_time: self.revenue_recovery_data.invoice_next_billing_time,
-                invoice_billing_started_at_time: self
-                    .revenue_recovery_data
-                    .invoice_next_billing_time,
+                // Both billing times belong to the invoice rather than to an individual attempt,
+                // so the value recorded first is retained and later webhooks only seed it when it
+                // is still unset.
+                invoice_next_billing_time: revenue_recovery
+                    .as_ref()
+                    .and_then(|data| data.invoice_next_billing_time)
+                    .or(self.revenue_recovery_data.invoice_next_billing_time),
+                invoice_billing_started_at_time: revenue_recovery
+                    .as_ref()
+                    .and_then(|data| data.invoice_billing_started_at_time)
+                    .or(self
+                        .revenue_recovery_data
+                        .invoice_billing_started_at_time),
                 billing_connector_payment_method_details,
                 first_payment_attempt_network_advice_code: first_network_advice_code,
                 first_payment_attempt_network_decline_code: first_network_decline_code,

--- a/crates/router/src/core/payments/operations/payment_attempt_record.rs
+++ b/crates/router/src/core/payments/operations/payment_attempt_record.rs
@@ -202,6 +202,7 @@ impl<F: Send + Clone + Sync>
             connector_customer_id: request.connector_customer_id.clone(),
             retry_count: request.retry_count,
             invoice_next_billing_time: request.invoice_next_billing_time,
+            invoice_billing_started_at_time: request.invoice_billing_started_at_time,
             triggered_by: request.triggered_by,
             card_network: request.card_network.clone(),
             card_issuer: request.card_issuer.clone(),


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

`invoice_billing_started_at_time` was being populated from `invoice_next_billing_time`,
so it stored the next billing date instead of the invoice's billing start date. The field
was also never plumbed from the record request into `RevenueRecoveryData`, so there was no
correct value available to read in the first place.

Separately, both invoice billing times were rebuilt on every recorded attempt. Later
webhooks and internal retries (which send `None`) overwrote whatever was already stored.

Changes:
1. Add `invoice_billing_started_at_time` to `RevenueRecoveryData`.
2. Populate it from `PaymentsAttemptRecordRequest` in the record-attempt operation.
3. In `get_updated_feature_metadata`, keep the value already stored on the intent for both
   `invoice_billing_started_at_time` and `invoice_next_billing_time`, falling back to the
   incoming webhook only when unset.

Both timestamps belong to the invoice, not to an individual attempt, so the first recorded
value is now retained for the life of the intent. A new billing term creates a new invoice
and therefore a new intent, so the values cannot go stale.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

These fields feed the Kafka revenue recovery event (`invoice_date`) and the retry decider
(`invoice_due_date`). With the wrong source, `invoice_date` reported the next billing time
and drifted on every attempt — for a monthly plan that is a full month off.

## How did you test it?

Tested it locally by setting up revenue recovery locally and triggerring webhooks from chargebee


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
