### PR TITLE
tmp(router): add a throwaway /chat_probe endpoint for the chat service

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -278,6 +278,9 @@ pub fn mk_app(
             .service(routes::Relay::server(state.clone()))
             .service(routes::ThreeDsDecisionRule::server(state.clone()));
 
+        // THROWAWAY — dropped before the PR. See `routes::chat_probe`.
+        server_app = server_app.service(routes::ChatProbe::server(state.clone()));
+
         #[cfg(feature = "oltp")]
         {
             server_app = server_app.service(routes::PaymentMethods::server(state.clone()));

--- a/crates/router/src/routes.rs
+++ b/crates/router/src/routes.rs
@@ -9,6 +9,8 @@ pub mod blocklist;
 pub mod cache;
 pub mod card_issuer;
 pub mod cards_info;
+// THROWAWAY — dropped before the PR. See the module docs.
+pub mod chat_probe;
 pub mod configs;
 #[cfg(feature = "olap")]
 pub mod connector_onboarding;
@@ -95,7 +97,7 @@ pub use self::app::PaymentMethodSession;
 pub use self::app::Proxy;
 pub use self::app::{
     ApiKeys, AppState, ApplePayCertificatesMigration, Authentication, Cache, CardIssuers, Cards,
-    Chat, Configs, ConnectorOnboarding, Customers, Disputes, Embedded, EphemeralKey,
+    Chat, ChatProbe, Configs, ConnectorOnboarding, Customers, Disputes, Embedded, EphemeralKey,
     ExternalService, FeatureMatrix, Files, Forex, Gsm, Health, Hypersense, Mandates,
     MerchantAccount, MerchantConnectorAccount, OfferEngine, Oidc, PaymentLink, PaymentMethods,
     Payments, Poll, ProcessTracker, ProcessTrackerDeprecated, Profile, ProfileAcquirer, ProfileNew,

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -69,7 +69,7 @@ use super::verification::{apple_pay_merchant_registration, retrieve_apple_pay_ve
 #[cfg(feature = "oltp")]
 use super::webhooks::*;
 use super::{
-    admin, api_keys, cache::*, card_issuer, chat, connector_onboarding, disputes,
+    admin, api_keys, cache::*, card_issuer, chat, chat_probe, connector_onboarding, disputes,
     external_service_auth as external_service_auth_routes, files, gsm, health::*, offer_engine,
     oidc, profiles, relay, user, user_role,
 };
@@ -2745,6 +2745,17 @@ impl Gsm {
             .service(web::resource("/get").route(web::post().to(gsm::get_gsm_rule)))
             .service(web::resource("/update").route(web::post().to(gsm::update_gsm_rule)))
             .service(web::resource("/delete").route(web::post().to(gsm::delete_gsm_rule)))
+    }
+}
+pub struct ChatProbe;
+
+/// THROWAWAY — dropped before the PR. See `routes::chat_probe`.
+impl ChatProbe {
+    pub fn server(state: AppState) -> Scope {
+        web::scope("/chat_probe")
+            .app_data(web::Data::new(state))
+            .service(web::resource("/xyne").route(web::post().to(chat_probe::probe_xyne)))
+            .service(web::resource("/slack").route(web::post().to(chat_probe::probe_slack)))
     }
 }
 pub struct Chat;

--- a/crates/router/src/routes/chat_probe.rs
+++ b/crates/router/src/routes/chat_probe.rs
@@ -1,0 +1,112 @@
+//! **THROWAWAY — DO NOT MERGE.**
+//!
+//! A hand-poke endpoint for `external_services::chat_service`, so a real Xyne or Slack channel can
+//! be hit from `curl` before anything is wired up for real. It exists on the `chatservice` branch
+//! only and is dropped before the pull request: the Notifier owns this surface
+//! (juspay/hyperswitch-cloud#23128, #23129), not the router.
+//!
+//! It is **unauthenticated and takes an arbitrary base URL**, which makes it a server-side request
+//! forgery primitive. That is tolerable for a branch that never merges and for nothing else.
+//!
+//! The whole destination travels in the request body, so nothing is read from settings but the
+//! egress proxy, and no `AppState` field is added:
+//!
+//! ```sh
+//! curl -X POST localhost:8080/chat_probe/xyne -H 'content-type: application/json' -d '{
+//!   "app_jwt": "...", "channel": "C0123456789", "text": "*hello* from `chat_service`"
+//! }'
+//! ```
+
+use actix_web::{web, HttpResponse};
+use external_services::chat_service::{
+    slack::{SlackClient, SlackConfig},
+    xyne::{XyneClient, XyneConfig},
+    ChatClient, ChatMessage, MessageId,
+};
+use router_env::logger;
+
+use super::app;
+
+/// A Xyne destination plus what to say to it. `base_url`, `timeout_seconds` and
+/// `max_message_chars` fall back to [`XyneConfig`]'s own defaults when omitted.
+#[derive(Debug, serde::Deserialize)]
+pub struct XyneProbeRequest {
+    #[serde(flatten)]
+    config: XyneConfig,
+    text: String,
+    /// Reply into an existing thread, using the `ts` a previous probe returned.
+    thread_ts: Option<String>,
+}
+
+/// A Slack destination plus what to say to it.
+#[derive(Debug, serde::Deserialize)]
+pub struct SlackProbeRequest {
+    #[serde(flatten)]
+    config: SlackConfig,
+    text: String,
+    thread_ts: Option<String>,
+}
+
+/// `POST /chat_probe/xyne`
+pub async fn probe_xyne(
+    state: web::Data<app::AppState>,
+    payload: web::Json<XyneProbeRequest>,
+) -> HttpResponse {
+    let XyneProbeRequest {
+        config,
+        text,
+        thread_ts,
+    } = payload.into_inner();
+
+    match XyneClient::new(config, state.conf.proxy.clone()) {
+        Ok(client) => post(&client, text, thread_ts).await,
+        Err(error) => rejected(&error),
+    }
+}
+
+/// `POST /chat_probe/slack`
+pub async fn probe_slack(
+    state: web::Data<app::AppState>,
+    payload: web::Json<SlackProbeRequest>,
+) -> HttpResponse {
+    let SlackProbeRequest {
+        config,
+        text,
+        thread_ts,
+    } = payload.into_inner();
+
+    match SlackClient::new(config, state.conf.proxy.clone()) {
+        Ok(client) => post(&client, text, thread_ts).await,
+        Err(error) => rejected(&error),
+    }
+}
+
+async fn post(client: &dyn ChatClient, text: String, thread_ts: Option<String>) -> HttpResponse {
+    let message = match thread_ts {
+        Some(thread_ts) => ChatMessage::new(text).reply_to(MessageId::ts(thread_ts)),
+        None => ChatMessage::new(text),
+    };
+
+    match client.post_message(message).await {
+        Ok(message_id) => HttpResponse::Ok().json(serde_json::json!({
+            "ok": true,
+            "ts": message_id.as_ts(),
+        })),
+        Err(error) => {
+            logger::error!(?error, "chat probe failed");
+            HttpResponse::BadGateway().json(serde_json::json!({
+                "ok": false,
+                // The debug rendering carries the whole `error_stack` report, attachments and all,
+                // which is the entire point of poking this by hand.
+                "error": format!("{error:?}"),
+            }))
+        }
+    }
+}
+
+fn rejected<E: std::fmt::Debug>(error: &E) -> HttpResponse {
+    HttpResponse::BadRequest().json(serde_json::json!({
+        "ok": false,
+        "error": format!("{error:?}"),
+    }))
+}


### PR DESCRIPTION
## What

Adds `POST /chat_probe/{xyne,slack}` to the router so `external_services::chat_service` can be
exercised against a real channel by hand.

**This targets `observability-plane-testable` and must never reach `observability-plane-i` or
`main`.** That is the whole reason the branch exists: things that are useful while building and
unacceptable to ship.

## Why it is not on the mergeable branch

It is **unauthenticated and takes an arbitrary base URL**, so it is a server-side request forgery
primitive. Tolerable on a branch nobody deploys to production, and nowhere else.

It also does not belong to the router even in principle — the Notifier owns this surface
([#23128](https://github.com/juspay/hyperswitch-cloud/issues/23128),
[#23129](https://github.com/juspay/hyperswitch-cloud/issues/23129)). It lives here only because
`AppState` has no chat client yet, so there is nowhere else to hang it.

## How it is kept droppable

The whole destination travels in the request body, so nothing is read from settings but the egress
proxy and **no `AppState` field is added**. That is what keeps this one self-contained commit
rather than an untangling: it touches `routes.rs`, `routes/app.rs` and `lib.rs` by three lines each
for registration, plus its own module.

```sh
curl -X POST localhost:8080/chat_probe/xyne -H 'content-type: application/json' -d '{
  "app_jwt": "...",
  "channel": "C0123456789",
  "text": "*hello* from `chat_service`"
}'
```

`base_url`, `timeout_seconds` and `max_message_chars` fall back to `XyneConfig`'s defaults when
omitted, so the minimum body is a credential, a channel and some text. `/chat_probe/slack` takes
`bot_token` instead of `app_jwt`. A `thread_ts` from a previous response threads the next message
under it.

On success it returns `{"ok": true, "ts": "..."}`. On failure it returns the `error_stack` report
rendered in full — attachments, the provider's own error code, the lot — which is the entire point
of poking it by hand rather than reading a log.

## Testing

`cargo check -p router --features v1,olap,oltp` passes. There are no automated tests here on
purpose: the code under test already has 28 of them against a mock server, and what this adds is
the one thing they cannot cover — a real credential against a real channel, which needs
[#23117](https://github.com/juspay/hyperswitch-cloud/issues/23117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JesWVUgg7SX72gvxjP1Mfi
