### PR TITLE
feat(scheduler): generate payment reports through the process tracker

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1323,6 +1323,17 @@ file_storage_backend = "aws_s3" # File storage backend to be used
 region = "us-east-1"    # The AWS region used by the AWS S3 for file storage
 bucket_name = "bucket1" # The AWS S3 bucket name for file storage
 
+# Configuration for analytics report generation
+[report_download_config]
+payment_function = ""                          # Name of the lambda function used to generate payment reports
+refund_function = ""                           # Name of the lambda function used to generate refund reports
+dispute_function = ""                          # Name of the lambda function used to generate dispute reports
+authentication_function = ""                   # Name of the lambda function used to generate authentication reports
+payout_function = ""                           # Name of the lambda function used to generate payout reports
+relay_function = ""                            # Name of the lambda function used to generate relay reports
+region = ""                                    # AWS region of the report lambda functions
+generate_payment_reports_via_scheduler = false # Generate payment reports through the process tracker instead of the payment report lambda
+
 [secrets_management]
 secrets_manager = "aws_kms" # Secrets manager client to be used (no_encryption | aws_kms | hashicorp_vault | gcp_kms)
 

--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -299,6 +299,7 @@ refund_function = "report_download_config_refund_function"   # Config to downloa
 payout_function = "report_download_config_payout_function"   # Config to download payout report
 relay_function = "report_download_config_relay_function"     # Config to download relay report
 region = "report_download_config_region"                     # Region of the bucket
+generate_payment_reports_via_scheduler = false               # Generate payment reports through the process tracker instead of the payment report lambda
 
 [opensearch]
 host = "https://localhost:9200"

--- a/config/development.toml
+++ b/config/development.toml
@@ -1485,6 +1485,9 @@ enabled = true
 [file_storage]
 file_storage_backend = "file_system"
 
+[report_download_config]
+generate_payment_reports_via_scheduler = true
+
 [unmasked_headers]
 keys = "accept-language,user-agent,x-profile-id"
 

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -1318,6 +1318,9 @@ emit_external_service_call_events = false
 [file_storage]
 file_storage_backend = "file_system"
 
+[report_download_config]
+generate_payment_reports_via_scheduler = true
+
 [unmasked_headers]
 keys = "accept-language,user-agent,x-profile-id"
 

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -1133,6 +1133,7 @@ impl Default for AnalyticsConfig {
 }
 
 #[derive(Clone, Debug, serde::Deserialize, Default, serde::Serialize)]
+#[serde(default)]
 pub struct ReportConfig {
     pub payment_function: String,
     pub refund_function: String,
@@ -1141,6 +1142,8 @@ pub struct ReportConfig {
     pub payout_function: String,
     pub relay_function: String,
     pub region: String,
+    #[serde(default)]
+    pub generate_payment_reports_via_scheduler: bool,
 }
 
 /// Analytics Flow routes Enums

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -11336,6 +11336,7 @@ pub enum ProcessTrackerRunner {
     BatchBlocklistUpload,
     NetworkTokenizationWorkflow,
     OfferEngineNotifyWorkflow,
+    GenerateReportWorkflow,
 }
 
 #[derive(

--- a/crates/diesel_models/src/query/payment_attempt.rs
+++ b/crates/diesel_models/src/query/payment_attempt.rs
@@ -2,16 +2,16 @@
 use std::collections::HashSet;
 
 use async_bb8_diesel::AsyncRunQueryDsl;
-#[cfg(feature = "v1")]
-use diesel::Table;
 use diesel::{
     associations::HasTable, debug_query, pg::Pg, BoolExpressionMethods, ExpressionMethods, QueryDsl,
 };
+#[cfg(feature = "v1")]
+use diesel::{JoinOnDsl, Table};
 use error_stack::{report, ResultExt};
 
 use super::generics;
 #[cfg(feature = "v1")]
-use crate::schema::payment_attempt::dsl;
+use crate::schema::{payment_attempt::dsl, payment_intent::dsl as payment_intent_dsl};
 #[cfg(feature = "v2")]
 use crate::schema_v2::payment_attempt::dsl;
 use crate::{
@@ -610,5 +610,50 @@ impl PaymentAttemptUpdateInternal {
         )
         .await
         .attach_printable("Failed to generate update query for payment attempt")
+    }
+}
+
+#[cfg(feature = "v1")]
+impl PaymentAttempt {
+    pub async fn find_for_payment_report(
+        conn: &DatabaseConnectionWithContext<'_>,
+        organization_id: &common_utils::id_type::OrganizationId,
+        merchant_ids: Option<Vec<common_utils::id_type::MerchantId>>,
+        profile_ids: Option<Vec<common_utils::id_type::ProfileId>>,
+        time_lower_limit: time::PrimitiveDateTime,
+        time_upper_limit: time::PrimitiveDateTime,
+        limit: i64,
+    ) -> StorageResult<Vec<(Self, Option<PaymentIntent>)>> {
+        let mut query = crate::list::into_boxed_list(
+            <Self as HasTable>::table()
+                .left_join(
+                    payment_intent_dsl::payment_intent
+                        .on(payment_intent_dsl::active_attempt_id.eq(dsl::attempt_id)),
+                )
+                .filter(dsl::organization_id.eq(organization_id.to_owned()))
+                .filter(dsl::created_at.between(time_lower_limit, time_upper_limit))
+                .order(dsl::created_at.asc())
+                .limit(limit),
+        );
+
+        if let Some(merchant_ids) = merchant_ids {
+            query = query.filter(dsl::merchant_id.eq_any(merchant_ids));
+        }
+
+        if let Some(profile_ids) = profile_ids {
+            query = query.filter(dsl::profile_id.eq_any(profile_ids));
+        }
+
+        router_env::logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
+
+        db_metrics::track_database_call::<<Self as HasTable>::Table, _, _>(
+            conn.request_id(),
+            conn.event_emitter(),
+            db_metrics::DatabaseOperation::Filter,
+            query.get_results_async::<(Self, Option<PaymentIntent>)>(conn.raw_connection()),
+        )
+        .await
+        .change_context(DatabaseError::Others)
+        .attach_printable("Error fetching payment attempts with intents for payment report")
     }
 }

--- a/crates/external_services/src/file_storage.rs
+++ b/crates/external_services/src/file_storage.rs
@@ -64,6 +64,14 @@ pub trait FileStorageInterface: dyn_clone::DynClone + Sync + Send {
 
     /// Retrieves a file from the selected storage scheme.
     async fn retrieve_file(&self, file_key: &str) -> CustomResult<Vec<u8>, FileStorageError>;
+
+    /// Generates a time-limited signed URL from which the file can be downloaded without
+    /// further authentication.
+    async fn get_signed_url(
+        &self,
+        file_key: &str,
+        expires_in: std::time::Duration,
+    ) -> CustomResult<String, FileStorageError>;
 }
 
 dyn_clone::clone_trait_object!(FileStorageInterface);
@@ -94,4 +102,8 @@ pub enum FileStorageError {
     /// Indicates that the file deletion operation failed.
     #[error("Failed to delete file")]
     DeleteFailed,
+
+    /// Indicates that the signed URL generation operation failed.
+    #[error("Failed to generate signed URL for file")]
+    SignedUrlGenerationFailed,
 }

--- a/crates/external_services/src/file_storage/aws_s3.rs
+++ b/crates/external_services/src/file_storage/aws_s3.rs
@@ -3,6 +3,7 @@ use aws_sdk_s3::{
     operation::{
         delete_object::DeleteObjectError, get_object::GetObjectError, put_object::PutObjectError,
     },
+    presigning::{PresigningConfig, PresigningConfigError},
     Client,
 };
 use aws_sdk_sts::config::Region;
@@ -53,8 +54,13 @@ impl AwsFileStorageClient {
     pub(super) async fn new(config: &AwsFileStorageConfig) -> Self {
         let region_provider = RegionProviderChain::first_try(Region::new(config.region.clone()));
         let sdk_config = aws_config::from_env().region(region_provider).load().await;
+        // Custom endpoints (e.g. a local AWS emulator) do not resolve virtual hosted
+        // bucket DNS, so path style addressing is required there
+        let s3_config = aws_sdk_s3::config::Builder::from(&sdk_config)
+            .force_path_style(sdk_config.endpoint_url().is_some())
+            .build();
         Self {
-            inner_client: Client::new(&sdk_config),
+            inner_client: Client::from_conf(s3_config),
             bucket_name: config.bucket_name.clone(),
         }
     }
@@ -104,6 +110,26 @@ impl AwsFileStorageClient {
             .map_err(AwsS3StorageError::UnknownError)?
             .to_vec())
     }
+
+    /// Generates a presigned URL for downloading a file from AWS S3.
+    async fn get_signed_url(
+        &self,
+        file_key: &str,
+        expires_in: std::time::Duration,
+    ) -> CustomResult<String, AwsS3StorageError> {
+        let presigning_config = PresigningConfig::expires_in(expires_in)
+            .map_err(AwsS3StorageError::PresigningConfigFailure)?;
+        Ok(self
+            .inner_client
+            .get_object()
+            .bucket(&self.bucket_name)
+            .key(file_key)
+            .presigned(presigning_config)
+            .await
+            .map_err(AwsS3StorageError::PresigningFailure)?
+            .uri()
+            .to_string())
+    }
 }
 
 #[async_trait::async_trait]
@@ -135,6 +161,18 @@ impl FileStorageInterface for AwsFileStorageClient {
             .await
             .change_context(FileStorageError::RetrieveFailed)?)
     }
+
+    /// Generates a presigned URL for downloading a file from AWS S3.
+    async fn get_signed_url(
+        &self,
+        file_key: &str,
+        expires_in: std::time::Duration,
+    ) -> CustomResult<String, FileStorageError> {
+        Ok(self
+            .get_signed_url(file_key, expires_in)
+            .await
+            .change_context(FileStorageError::SignedUrlGenerationFailed)?)
+    }
 }
 
 /// Enum representing errors that can occur during AWS S3 file storage operations.
@@ -151,6 +189,14 @@ enum AwsS3StorageError {
     /// Error indicating that file deletion from S3 failed.
     #[error("File delete from S3 failed: {0:?}")]
     DeleteFailure(aws_sdk_s3::error::SdkError<DeleteObjectError>),
+
+    /// Error indicating that the presigning configuration could not be built.
+    #[error("Failed to build S3 presigning configuration: {0:?}")]
+    PresigningConfigFailure(PresigningConfigError),
+
+    /// Error indicating that presigned URL generation failed.
+    #[error("Presigned URL generation for S3 failed: {0:?}")]
+    PresigningFailure(aws_sdk_s3::error::SdkError<GetObjectError>),
 
     /// Unknown error occurred.
     #[error("Unknown error occurred: {0:?}")]

--- a/crates/external_services/src/file_storage/file_system.rs
+++ b/crates/external_services/src/file_storage/file_system.rs
@@ -100,6 +100,24 @@ impl FileStorageInterface for FileSystem {
             .await
             .change_context(FileStorageError::RetrieveFailed)?)
     }
+
+    /// Returns a `file://` URL pointing to the file on the local file system. The URL does
+    /// not expire; the expiry parameter only applies to storage backends that support
+    /// time-limited access.
+    async fn get_signed_url(
+        &self,
+        file_key: &str,
+        _expires_in: std::time::Duration,
+    ) -> CustomResult<String, FileStorageError> {
+        let file_path = get_file_path(file_key);
+        url::Url::from_file_path(&file_path)
+            .map(String::from)
+            .map_err(|()| {
+                error_stack::report!(FileStorageError::SignedUrlGenerationFailed).attach_printable(
+                    format!("Failed to construct file URL from path: {file_path:?}"),
+                )
+            })
+    }
 }
 
 /// Represents an error that can occur during local file system storage operations.

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -3080,15 +3080,9 @@ pub mod routes {
                     payment_response_hash_key: hash_key,
                 };
 
-                let json_bytes =
-                    serde_json::to_vec(&lambda_req).map_err(|_| AnalyticsError::UnknownError)?;
-                invoke_lambda(
-                    &state.conf.report_download_config.payment_function,
-                    &state.conf.report_download_config.region,
-                    &json_bytes,
-                )
-                .await
-                .map(ApplicationResponse::Json)
+                crate::core::generate_report::trigger_payment_report_generation(&state, lambda_req)
+                    .await
+                    .map(ApplicationResponse::Json)
             },
             auth::auth_type::<auth::AuthenticationDataWithUserId, _>(
                 &auth::ApiKeyAuth {
@@ -3171,15 +3165,9 @@ pub mod routes {
                     payment_response_hash_key: None,
                 };
 
-                let json_bytes =
-                    serde_json::to_vec(&lambda_req).map_err(|_| AnalyticsError::UnknownError)?;
-                invoke_lambda(
-                    &state.conf.report_download_config.payment_function,
-                    &state.conf.report_download_config.region,
-                    &json_bytes,
-                )
-                .await
-                .map(ApplicationResponse::Json)
+                crate::core::generate_report::trigger_payment_report_generation(&state, lambda_req)
+                    .await
+                    .map(ApplicationResponse::Json)
             },
             &auth::JWTAuth {
                 permission: Permission::OrganizationReportRead,
@@ -3280,15 +3268,9 @@ pub mod routes {
                     payment_response_hash_key: hash_key,
                 };
 
-                let json_bytes =
-                    serde_json::to_vec(&lambda_req).map_err(|_| AnalyticsError::UnknownError)?;
-                invoke_lambda(
-                    &state.conf.report_download_config.payment_function,
-                    &state.conf.report_download_config.region,
-                    &json_bytes,
-                )
-                .await
-                .map(ApplicationResponse::Json)
+                crate::core::generate_report::trigger_payment_report_generation(&state, lambda_req)
+                    .await
+                    .map(ApplicationResponse::Json)
             },
             auth::auth_type::<auth::AuthenticationDataWithUserId, _>(
                 &auth::ApiKeyAuth {

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -411,6 +411,19 @@ impl ProcessTrackerWorkflows<routes::SessionState> for WorkflowRunner {
                             )
                     }
                 }
+                storage::ProcessTrackerRunner::GenerateReportWorkflow => {
+                    #[cfg(all(feature = "olap", feature = "v1"))]
+                    {
+                        Ok(Box::new(workflows::generate_report::GenerateReportWorkflow))
+                    }
+                    #[cfg(not(all(feature = "olap", feature = "v1")))]
+                    {
+                        Err(error_stack::report!(ProcessTrackerError::UnexpectedFlow))
+                            .attach_printable(
+                                "Cannot run report generation workflow when the olap and v1 features are disabled",
+                            )
+                    }
+                }
             }
         };
 

--- a/crates/router/src/core.rs
+++ b/crates/router/src/core.rs
@@ -32,6 +32,8 @@ pub mod external_service_auth;
 pub mod files;
 #[cfg(feature = "frm")]
 pub mod fraud_check;
+#[cfg(feature = "olap")]
+pub mod generate_report;
 pub mod gsm;
 pub mod health_check;
 pub mod mandate;

--- a/crates/router/src/core/generate_report.rs
+++ b/crates/router/src/core/generate_report.rs
@@ -1,0 +1,79 @@
+use analytics::{errors::AnalyticsError, lambda_utils::invoke_lambda};
+use api_models::analytics::GenerateReportRequest;
+use common_utils::errors::CustomResult;
+#[cfg(feature = "v1")]
+use router_env::logger;
+
+#[cfg(feature = "v1")]
+use crate::routes::metrics;
+use crate::routes::SessionState;
+#[cfg(feature = "v1")]
+use crate::types::storage;
+
+pub const PAYMENT_REPORT_TASK: &str = "PAYMENT_REPORT";
+
+pub async fn trigger_payment_report_generation(
+    state: &SessionState,
+    report_request: GenerateReportRequest,
+) -> CustomResult<(), AnalyticsError> {
+    #[cfg(feature = "v1")]
+    if state
+        .conf
+        .report_download_config
+        .generate_payment_reports_via_scheduler
+    {
+        return schedule_payment_report_task(state, report_request).await;
+    }
+
+    let json_bytes =
+        serde_json::to_vec(&report_request).map_err(|_| AnalyticsError::UnknownError)?;
+    invoke_lambda(
+        &state.conf.report_download_config.payment_function,
+        &state.conf.report_download_config.region,
+        &json_bytes,
+    )
+    .await
+}
+
+#[cfg(feature = "v1")]
+async fn schedule_payment_report_task(
+    state: &SessionState,
+    report_request: GenerateReportRequest,
+) -> CustomResult<(), AnalyticsError> {
+    let runner = storage::ProcessTrackerRunner::GenerateReportWorkflow;
+    // Reports for the same scope and time range may legitimately be requested multiple
+    // times, so the task id is unique per request instead of deterministic.
+    let process_tracker_id = format!(
+        "{runner}_{PAYMENT_REPORT_TASK}_{}",
+        uuid::Uuid::new_v4().simple()
+    );
+
+    let process_tracker_entry = storage::ProcessTrackerNew::new(
+        process_tracker_id,
+        PAYMENT_REPORT_TASK,
+        runner,
+        ["REPORT", "PAYMENT"],
+        report_request,
+        None,
+        common_utils::date_time::now(),
+        common_types::consts::API_VERSION,
+        state.conf.application_source,
+    )
+    .map_err(|error| {
+        logger::error!(?error, "Failed to construct payment report task");
+        AnalyticsError::UnknownError
+    })?;
+
+    state
+        .store
+        .insert_process(process_tracker_entry)
+        .await
+        .map_err(|error| {
+            logger::error!(?error, "Failed to insert payment report task");
+            AnalyticsError::UnknownError
+        })?;
+
+    metrics::TASKS_ADDED_COUNT.add(1, router_env::metric_attributes!(("flow", "PaymentReport")));
+
+    Ok(())
+}

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -19,6 +19,7 @@ pub mod ephemeral_key;
 pub mod events;
 pub mod file;
 pub mod fraud_check;
+pub mod generate_report;
 pub mod generic_link;
 pub mod gsm;
 pub mod health_check;
@@ -113,6 +114,7 @@ pub trait StorageInterface:
     + events::EventInterface
     + file::FileMetadataInterface
     + FraudCheckInterface
+    + generate_report::PaymentReportInterface
     + locker_mock_up::LockerMockUpInterface
     + mandate::MandateInterface
     + merchant_account::MerchantAccountInterface<Error = StorageError>

--- a/crates/router/src/db/generate_report.rs
+++ b/crates/router/src/db/generate_report.rs
@@ -1,0 +1,79 @@
+#[cfg(feature = "v1")]
+use common_utils::id_type;
+#[cfg(feature = "v1")]
+use diesel_models::{PaymentAttempt, PaymentIntent};
+#[cfg(feature = "v1")]
+use error_stack::report;
+#[cfg(feature = "v1")]
+use router_env::{instrument, tracing};
+#[cfg(feature = "v1")]
+use time::PrimitiveDateTime;
+
+use super::MockDb;
+#[cfg(feature = "v1")]
+use crate::connection;
+use crate::{core::errors, services::Store};
+
+/// Storage access for building analytics reports through the process tracker.
+#[async_trait::async_trait]
+pub trait PaymentReportInterface {
+    /// Fetches payment attempts created within the given time range along with the payment
+    /// intent they are the active attempt of, scoped to the given organization and the
+    /// optional merchant and profile filters.
+    #[cfg(feature = "v1")]
+    async fn find_payment_report_rows(
+        &self,
+        organization_id: &id_type::OrganizationId,
+        merchant_ids: Option<Vec<id_type::MerchantId>>,
+        profile_ids: Option<Vec<id_type::ProfileId>>,
+        time_lower_limit: PrimitiveDateTime,
+        time_upper_limit: PrimitiveDateTime,
+        limit: i64,
+    ) -> errors::CustomResult<Vec<(PaymentAttempt, Option<PaymentIntent>)>, errors::StorageError>;
+}
+
+#[async_trait::async_trait]
+impl PaymentReportInterface for Store {
+    #[cfg(feature = "v1")]
+    #[instrument(skip_all)]
+    async fn find_payment_report_rows(
+        &self,
+        organization_id: &id_type::OrganizationId,
+        merchant_ids: Option<Vec<id_type::MerchantId>>,
+        profile_ids: Option<Vec<id_type::ProfileId>>,
+        time_lower_limit: PrimitiveDateTime,
+        time_upper_limit: PrimitiveDateTime,
+        limit: i64,
+    ) -> errors::CustomResult<Vec<(PaymentAttempt, Option<PaymentIntent>)>, errors::StorageError>
+    {
+        let conn = connection::pg_connection_read(self).await?;
+        PaymentAttempt::find_for_payment_report(
+            &conn,
+            organization_id,
+            merchant_ids,
+            profile_ids,
+            time_lower_limit,
+            time_upper_limit,
+            limit,
+        )
+        .await
+        .map_err(|error| report!(errors::StorageError::from(error)))
+    }
+}
+
+#[async_trait::async_trait]
+impl PaymentReportInterface for MockDb {
+    #[cfg(feature = "v1")]
+    async fn find_payment_report_rows(
+        &self,
+        _organization_id: &id_type::OrganizationId,
+        _merchant_ids: Option<Vec<id_type::MerchantId>>,
+        _profile_ids: Option<Vec<id_type::ProfileId>>,
+        _time_lower_limit: PrimitiveDateTime,
+        _time_upper_limit: PrimitiveDateTime,
+        _limit: i64,
+    ) -> errors::CustomResult<Vec<(PaymentAttempt, Option<PaymentIntent>)>, errors::StorageError>
+    {
+        Err(errors::StorageError::MockDbError)?
+    }
+}

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -79,6 +79,7 @@ use crate::{
         ephemeral_key::EphemeralKeyInterface,
         events::EventInterface,
         file::FileMetadataInterface,
+        generate_report::PaymentReportInterface,
         generic_link::GenericLinkInterface,
         gsm::GsmInterface,
         health_check::HealthCheckDbInterface,
@@ -596,6 +597,37 @@ impl CustomerInterface for KafkaStore {
     ) -> CustomResult<domain::Customer, errors::StorageError> {
         self.diesel_store
             .insert_customer(customer_data, key_store, storage_scheme)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl PaymentReportInterface for KafkaStore {
+    #[cfg(feature = "v1")]
+    async fn find_payment_report_rows(
+        &self,
+        organization_id: &id_type::OrganizationId,
+        merchant_ids: Option<Vec<id_type::MerchantId>>,
+        profile_ids: Option<Vec<id_type::ProfileId>>,
+        time_lower_limit: PrimitiveDateTime,
+        time_upper_limit: PrimitiveDateTime,
+        limit: i64,
+    ) -> CustomResult<
+        Vec<(
+            diesel_models::PaymentAttempt,
+            Option<diesel_models::PaymentIntent>,
+        )>,
+        errors::StorageError,
+    > {
+        self.diesel_store
+            .find_payment_report_rows(
+                organization_id,
+                merchant_ids,
+                profile_ids,
+                time_lower_limit,
+                time_upper_limit,
+                limit,
+            )
             .await
     }
 }

--- a/crates/router/src/services/email/assets/payment_report_ready.html
+++ b/crates/router/src/services/email/assets/payment_report_ready.html
@@ -1,0 +1,7 @@
+<p>Please find the payment report for the period of {start_date} UTC to {end_date} UTC.<br>
+This file provides a comprehensive overview of payments made by your customers via Hyperswitch during this time frame.
+<br><br>Access your report here: <a href="{report_link}">Download Payment Report</a>.
+<br>(The link expires in {expires_in_days} days)
+<br>If you have any questions or require further assistance, please reach out to your Hyperswitch support contact.
+<br><br>Best regards,<br>
+Hyperswitch Team</p>

--- a/crates/router/src/services/email/types.rs
+++ b/crates/router/src/services/email/types.rs
@@ -82,6 +82,12 @@ pub enum EmailBody {
         prefix: String,
     },
     WelcomeToCommunity,
+    PaymentReportReady {
+        report_link: String,
+        start_date: String,
+        end_date: String,
+        expires_in_days: u32,
+    },
     RoleDeleted {
         user_name: String,
         role_name: String,
@@ -253,6 +259,18 @@ Email         : {user_email}
             EmailBody::WelcomeToCommunity => {
                 include_str!("assets/welcome_to_community.html").to_string()
             }
+            EmailBody::PaymentReportReady {
+                report_link,
+                start_date,
+                end_date,
+                expires_in_days,
+            } => format!(
+                include_str!("assets/payment_report_ready.html"),
+                report_link = report_link,
+                start_date = start_date,
+                end_date = end_date,
+                expires_in_days = expires_in_days,
+            ),
             EmailBody::RoleDeleted {
                 user_name,
                 role_name,
@@ -703,6 +721,33 @@ impl EmailData for ApiKeyExpiryReminder {
             subject: self.subject.to_string(),
             body: external_services::email::IntermediateString::new(body),
             recipient,
+        })
+    }
+}
+
+pub struct PaymentReportReady {
+    pub recipient_email: domain::UserEmail,
+    pub subject: String,
+    pub report_link: String,
+    pub start_date: String,
+    pub end_date: String,
+    pub expires_in_days: u32,
+}
+
+#[async_trait::async_trait]
+impl EmailData for PaymentReportReady {
+    async fn get_email_data(&self, _base_url: &str) -> CustomResult<EmailContents, EmailError> {
+        let body = html::get_html_body(EmailBody::PaymentReportReady {
+            report_link: self.report_link.clone(),
+            start_date: self.start_date.clone(),
+            end_date: self.end_date.clone(),
+            expires_in_days: self.expires_in_days,
+        });
+
+        Ok(EmailContents {
+            subject: self.subject.clone(),
+            body: external_services::email::IntermediateString::new(body),
+            recipient: self.recipient_email.clone().into_inner(),
         })
     }
 }

--- a/crates/router/src/workflows.rs
+++ b/crates/router/src/workflows.rs
@@ -27,6 +27,9 @@ pub mod payout_sync;
 #[cfg(feature = "v1")]
 pub mod batch_blocklist_upload;
 
+#[cfg(all(feature = "olap", feature = "v1"))]
+pub mod generate_report;
+
 pub mod network_tokenization;
 
 #[cfg(feature = "v1")]

--- a/crates/router/src/workflows/generate_report.rs
+++ b/crates/router/src/workflows/generate_report.rs
@@ -1,0 +1,801 @@
+use api_models::analytics::{payments::PaymentReportColumn, GenerateReportRequest};
+use common_utils::{
+    crypto::{HmacSha512, SignMessage},
+    date_time,
+    ext_traits::ValueExt,
+    id_type,
+    request::{Method, RequestContent},
+    types::{authentication::AuthInfo, MinorUnit},
+};
+use diesel_models::{process_tracker::business_status, PaymentAttempt, PaymentIntent};
+use error_stack::ResultExt;
+use hyperswitch_masking::Mask;
+use router_env::logger;
+use scheduler::{
+    utils as scheduler_utils, workflows::ProcessTrackerWorkflow, SchedulerSessionState,
+};
+use strum::IntoEnumIterator;
+use time::PrimitiveDateTime;
+
+#[cfg(feature = "email")]
+use crate::services::email::types::PaymentReportReady;
+#[cfg(feature = "email")]
+use crate::types::domain::UserEmail;
+#[cfg(feature = "email")]
+use crate::utils::user as user_utils;
+use crate::{
+    core::generate_report::PAYMENT_REPORT_TASK, errors, headers, routes::SessionState, services,
+    types::storage,
+};
+
+// (retry frequency in seconds, count)
+const REPORT_RETRY_FREQUENCIES: [(i32, i32); 1] = [(300, 3)];
+
+const PAYMENT_REPORT_TYPE: &str = "payment_report";
+const REPORT_GENERATION_COMPLETED_EVENT: &str = "report_generation.completed";
+const REPORT_GENERATION_FAILED_EVENT: &str = "report_generation.failed";
+
+const REPORT_FILE_PATH_PREFIX: &str = "reports";
+// 7 days, the maximum validity supported by S3 presigned URLs
+const REPORT_URL_EXPIRY_SECS: u32 = 604800;
+const PAYMENT_REPORT_ROW_LIMIT: i64 = 50000;
+
+const REPORT_TIMESTAMP_FORMAT: &[time::format_description::BorrowedFormatItem<'static>] =
+    time::macros::format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+
+pub struct GenerateReportWorkflow;
+
+#[async_trait::async_trait]
+impl ProcessTrackerWorkflow<SessionState> for GenerateReportWorkflow {
+    async fn execute_workflow<'a>(
+        &'a self,
+        state: &'a SessionState,
+        process: storage::ProcessTracker,
+    ) -> Result<(), errors::ProcessTrackerError> {
+        match process.name.as_deref() {
+            Some(PAYMENT_REPORT_TASK) => {
+                Box::pin(generate_and_deliver_payment_report(state, process)).await
+            }
+            _ => Err(errors::ProcessTrackerError::JobNotFound),
+        }
+    }
+
+    async fn error_handler<'a>(
+        &'a self,
+        state: &'a SessionState,
+        process: storage::ProcessTracker,
+        error: errors::ProcessTrackerError,
+    ) -> errors::CustomResult<(), errors::ProcessTrackerError> {
+        logger::error!(?error, process_id = %process.id, "Report generation workflow failed");
+
+        let db = state.get_db();
+        let next_schedule_time = scheduler_utils::get_time_from_delta(scheduler_utils::get_delay(
+            process.retry_count + 1,
+            &REPORT_RETRY_FREQUENCIES,
+        ));
+
+        match next_schedule_time {
+            Some(schedule_time) => db
+                .as_scheduler()
+                .retry_process(process, schedule_time)
+                .await
+                .change_context(errors::ProcessTrackerError::ProcessUpdateFailed),
+            None => {
+                notify_payment_report_failure(state, &process).await;
+                db.as_scheduler()
+                    .finish_process_with_business_status(process, business_status::RETRIES_EXCEEDED)
+                    .await
+                    .change_context(errors::ProcessTrackerError::ProcessUpdateFailed)
+            }
+        }
+    }
+}
+
+struct ReportScope {
+    organization_id: id_type::OrganizationId,
+    merchant_ids: Option<Vec<id_type::MerchantId>>,
+    profile_ids: Option<Vec<id_type::ProfileId>>,
+}
+
+impl ReportScope {
+    fn from_auth_info(auth: &AuthInfo) -> Self {
+        match auth {
+            AuthInfo::OrgLevel { org_id } => Self {
+                organization_id: org_id.clone(),
+                merchant_ids: None,
+                profile_ids: None,
+            },
+            AuthInfo::MerchantLevel {
+                org_id,
+                merchant_ids,
+                ..
+            } => Self {
+                organization_id: org_id.clone(),
+                merchant_ids: Some(merchant_ids.clone()),
+                profile_ids: None,
+            },
+            AuthInfo::ProfileLevel {
+                org_id,
+                merchant_id,
+                profile_ids,
+                ..
+            } => Self {
+                organization_id: org_id.clone(),
+                merchant_ids: Some(vec![merchant_id.clone()]),
+                profile_ids: Some(profile_ids.clone()),
+            },
+        }
+    }
+}
+
+async fn generate_and_deliver_payment_report(
+    state: &SessionState,
+    process: storage::ProcessTracker,
+) -> Result<(), errors::ProcessTrackerError> {
+    let tracking_data: GenerateReportRequest = process
+        .tracking_data
+        .clone()
+        .parse_value("GenerateReportRequest")?;
+
+    let scope = ReportScope::from_auth_info(&tracking_data.auth);
+    let start_time = tracking_data.request.time_range.start_time;
+    let end_time = tracking_data
+        .request
+        .time_range
+        .end_time
+        .unwrap_or_else(date_time::now);
+
+    let rows = state
+        .store
+        .find_payment_report_rows(
+            &scope.organization_id,
+            scope.merchant_ids.clone(),
+            scope.profile_ids.clone(),
+            start_time,
+            end_time,
+            PAYMENT_REPORT_ROW_LIMIT,
+        )
+        .await?;
+
+    logger::info!(
+        row_count = rows.len(),
+        organization_id = %scope.organization_id.get_string_repr(),
+        "Fetched rows for payment report"
+    );
+
+    let report_bytes = build_payment_report_csv(&rows)?;
+
+    let file_key = build_report_file_key(&scope, start_time, end_time)?;
+    state
+        .file_storage_client
+        .upload_file(&file_key, report_bytes)
+        .await
+        .map_err(|error| {
+            logger::error!(?error, file_key, "Failed to upload payment report");
+            errors::ProcessTrackerError::FlowExecutionError {
+                flow: "PaymentReportUpload",
+            }
+        })?;
+
+    let download_url = state
+        .file_storage_client
+        .get_signed_url(
+            &file_key,
+            std::time::Duration::from_secs(u64::from(REPORT_URL_EXPIRY_SECS)),
+        )
+        .await
+        .map_err(|error| {
+            logger::error!(?error, file_key, "Failed to generate payment report URL");
+            errors::ProcessTrackerError::FlowExecutionError {
+                flow: "PaymentReportSignedUrl",
+            }
+        })?;
+
+    deliver_payment_report(
+        state,
+        &tracking_data,
+        &scope,
+        &download_url,
+        start_time,
+        end_time,
+    )
+    .await?;
+
+    state
+        .get_db()
+        .as_scheduler()
+        .finish_process_with_business_status(process, business_status::COMPLETED_BY_PT)
+        .await?;
+
+    Ok(())
+}
+
+fn build_report_file_key(
+    scope: &ReportScope,
+    start_time: PrimitiveDateTime,
+    end_time: PrimitiveDateTime,
+) -> Result<String, errors::ProcessTrackerError> {
+    let format_for_key = |date: PrimitiveDateTime| {
+        date_time::format_date(date, date_time::DateFormat::YYYYMMDDHHmmss)
+            .map_err(|_| errors::ProcessTrackerError::TypeConversionError)
+    };
+    let start = format_for_key(start_time)?;
+    let end = format_for_key(end_time)?;
+
+    let mut segments = vec![
+        REPORT_FILE_PATH_PREFIX.to_owned(),
+        scope.organization_id.get_string_repr().to_owned(),
+    ];
+    if let Some(merchant_id) = scope
+        .merchant_ids
+        .as_ref()
+        .and_then(|merchant_ids| merchant_ids.first())
+    {
+        segments.push(merchant_id.get_string_repr().to_owned());
+    }
+    if let Some(profile_id) = scope
+        .profile_ids
+        .as_ref()
+        .and_then(|profile_ids| profile_ids.first())
+    {
+        segments.push(profile_id.get_string_repr().to_owned());
+    }
+    segments.push(String::from("payments"));
+    segments.push(format!("payments_report_{start}_{end}.csv"));
+
+    Ok(segments.join("/"))
+}
+
+fn build_payment_report_csv(
+    rows: &[(PaymentAttempt, Option<PaymentIntent>)],
+) -> Result<Vec<u8>, errors::ProcessTrackerError> {
+    let columns: Vec<PaymentReportColumn> = PaymentReportColumn::iter().collect();
+    let mut writer = csv::WriterBuilder::new()
+        .quote_style(csv::QuoteStyle::Always)
+        .from_writer(Vec::new());
+
+    let csv_error = |error: csv::Error| {
+        logger::error!(?error, "Failed to write payment report record");
+        errors::ProcessTrackerError::FlowExecutionError {
+            flow: "PaymentReportCsv",
+        }
+    };
+
+    writer
+        .write_record(columns.iter().map(AsRef::as_ref))
+        .map_err(csv_error)?;
+
+    for (attempt, intent) in rows {
+        writer
+            .write_record(
+                columns
+                    .iter()
+                    .map(|column| payment_report_column_value(*column, attempt, intent.as_ref())),
+            )
+            .map_err(csv_error)?;
+    }
+
+    writer.into_inner().map_err(|error| {
+        logger::error!(?error, "Failed to finalize payment report");
+        errors::ProcessTrackerError::FlowExecutionError {
+            flow: "PaymentReportCsv",
+        }
+    })
+}
+
+fn payment_report_column_value(
+    column: PaymentReportColumn,
+    attempt: &PaymentAttempt,
+    intent: Option<&PaymentIntent>,
+) -> String {
+    match column {
+        PaymentReportColumn::PaymentId => {
+            display_optional(intent.map(|intent| intent.payment_id.get_string_repr().to_owned()))
+        }
+        PaymentReportColumn::AttemptId => attempt.attempt_id.clone(),
+        PaymentReportColumn::Status => attempt.status.to_string(),
+        PaymentReportColumn::Amount => format_amount_in_base_unit(
+            intent.map(|intent| intent.amount),
+            intent.and_then(|intent| intent.currency),
+        ),
+        PaymentReportColumn::Currency => {
+            display_optional(intent.and_then(|intent| intent.currency))
+        }
+        PaymentReportColumn::Connector => attempt.connector.clone().unwrap_or_default(),
+        PaymentReportColumn::ConnectorTransactionId => display_optional(
+            attempt
+                .connector_transaction_id
+                .as_ref()
+                .map(|transaction_id| transaction_id.get_id().clone()),
+        ),
+        PaymentReportColumn::AmountToCapture => format_amount_in_base_unit(
+            attempt.amount_to_capture,
+            intent.and_then(|intent| intent.currency),
+        ),
+        PaymentReportColumn::CustomerId => display_optional(
+            intent
+                .and_then(|intent| intent.customer_id.as_ref())
+                .map(|customer_id| customer_id.get_string_repr().to_owned()),
+        ),
+        PaymentReportColumn::CreatedAt => format_timestamp(attempt.created_at),
+        PaymentReportColumn::OrderDetails => intent
+            .and_then(|intent| intent.order_details.as_ref())
+            .and_then(|order_details| serde_json::to_string(order_details).ok())
+            .unwrap_or_default(),
+        PaymentReportColumn::ErrorMessage => attempt.error_message.clone().unwrap_or_default(),
+        PaymentReportColumn::CaptureMethod => display_optional(attempt.capture_method),
+        PaymentReportColumn::AuthenticationType => display_optional(attempt.authentication_type),
+        PaymentReportColumn::MandateId => attempt.mandate_id.clone().unwrap_or_default(),
+        PaymentReportColumn::PaymentMethod => display_optional(attempt.payment_method),
+        PaymentReportColumn::PaymentMethodType => display_optional(attempt.payment_method_type),
+        PaymentReportColumn::Metadata => {
+            display_optional(intent.and_then(|intent| intent.metadata.as_ref()))
+        }
+        PaymentReportColumn::SetupFutureUsage => {
+            display_optional(intent.and_then(|intent| intent.setup_future_usage))
+        }
+        PaymentReportColumn::StatementDescriptorName => intent
+            .and_then(|intent| intent.statement_descriptor_name.clone())
+            .unwrap_or_default(),
+        PaymentReportColumn::Description => intent
+            .and_then(|intent| intent.description.clone())
+            .unwrap_or_default(),
+        PaymentReportColumn::OffSession => {
+            display_optional(intent.and_then(|intent| intent.off_session))
+        }
+        PaymentReportColumn::BusinessCountry => {
+            display_optional(intent.and_then(|intent| intent.business_country))
+        }
+        PaymentReportColumn::BusinessLabel => intent
+            .and_then(|intent| intent.business_label.clone())
+            .unwrap_or_default(),
+        PaymentReportColumn::BusinessSubLabel => {
+            attempt.business_sub_label.clone().unwrap_or_default()
+        }
+        PaymentReportColumn::AllowedPaymentMethodTypes => {
+            display_optional(intent.and_then(|intent| intent.allowed_payment_method_types.as_ref()))
+        }
+        PaymentReportColumn::PaymentMethodData => {
+            display_optional(attempt.payment_method_data.as_ref())
+        }
+        PaymentReportColumn::CardNetwork => {
+            get_card_field(attempt.payment_method_data.as_ref(), "card_network")
+        }
+        PaymentReportColumn::FingerprintId => intent
+            .and_then(|intent| intent.fingerprint_id.clone())
+            .unwrap_or_default(),
+        PaymentReportColumn::ModifiedAt => format_timestamp(attempt.modified_at),
+        PaymentReportColumn::ErrorCode => attempt.error_code.clone().unwrap_or_default(),
+        PaymentReportColumn::PaymentMethodId => {
+            attempt.payment_method_id.clone().unwrap_or_default()
+        }
+        PaymentReportColumn::CardHolderName => {
+            get_card_field(attempt.payment_method_data.as_ref(), "card_holder_name")
+        }
+        PaymentReportColumn::MerchantOrderReferenceId => intent
+            .and_then(|intent| intent.merchant_order_reference_id.clone())
+            .unwrap_or_default(),
+        PaymentReportColumn::ProfileId => display_optional(
+            intent
+                .and_then(|intent| intent.profile_id.as_ref())
+                .map(|profile_id| profile_id.get_string_repr().to_owned()),
+        ),
+    }
+}
+
+fn display_optional(value: Option<impl ToString>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
+}
+
+fn format_timestamp(date: PrimitiveDateTime) -> String {
+    date.format(&REPORT_TIMESTAMP_FORMAT)
+        .unwrap_or_else(|_| date.to_string())
+}
+
+fn format_amount_in_base_unit(
+    amount: Option<MinorUnit>,
+    currency: Option<common_enums::Currency>,
+) -> String {
+    let Some(amount) = amount else {
+        return String::new();
+    };
+    let amount = amount.get_amount_as_i64();
+    // Unknown currencies are treated as two decimal, in line with the lambda based flow
+    let currency = currency.unwrap_or(common_enums::Currency::USD);
+
+    let sign = if amount < 0 { "-" } else { "" };
+    let amount_abs = amount.unsigned_abs();
+    if currency.is_zero_decimal_currency() {
+        format!("{sign}{amount_abs}")
+    } else if currency.is_three_decimal_currency() {
+        format!("{sign}{}.{:03}", amount_abs / 1000, amount_abs % 1000)
+    } else {
+        format!("{sign}{}.{:02}", amount_abs / 100, amount_abs % 100)
+    }
+}
+
+fn get_card_field(payment_method_data: Option<&serde_json::Value>, field: &str) -> String {
+    payment_method_data
+        .and_then(|payment_method_data| payment_method_data.get("card"))
+        .and_then(|card| card.get(field))
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_default()
+}
+
+#[derive(serde::Serialize)]
+struct ReportWebhookPayload<'a> {
+    org_id: &'a id_type::OrganizationId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    merchant_id: Option<&'a id_type::MerchantId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    profile_id: Option<&'a id_type::ProfileId>,
+    event: &'static str,
+    data: ReportWebhookData<'a>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+enum ReportWebhookData<'a> {
+    Completed {
+        report_type: &'static str,
+        start_date_utc: String,
+        end_date_utc: String,
+        download_url: &'a str,
+        expires_in_hours: u32,
+    },
+    Failed {
+        code: &'static str,
+        message: &'static str,
+    },
+}
+
+async fn deliver_payment_report(
+    state: &SessionState,
+    tracking_data: &GenerateReportRequest,
+    scope: &ReportScope,
+    download_url: &str,
+    start_time: PrimitiveDateTime,
+    end_time: PrimitiveDateTime,
+) -> Result<(), errors::ProcessTrackerError> {
+    match tracking_data.request.return_url.as_ref() {
+        Some(return_url) => {
+            let payload = ReportWebhookPayload {
+                org_id: &scope.organization_id,
+                merchant_id: scope
+                    .merchant_ids
+                    .as_ref()
+                    .and_then(|merchant_ids| merchant_ids.first()),
+                profile_id: scope
+                    .profile_ids
+                    .as_ref()
+                    .and_then(|profile_ids| profile_ids.first()),
+                event: REPORT_GENERATION_COMPLETED_EVENT,
+                data: ReportWebhookData::Completed {
+                    report_type: PAYMENT_REPORT_TYPE,
+                    start_date_utc: format_timestamp(start_time),
+                    end_date_utc: format_timestamp(end_time),
+                    download_url,
+                    expires_in_hours: REPORT_URL_EXPIRY_SECS / 3600,
+                },
+            };
+            send_report_webhook(
+                state,
+                return_url.get_string_repr(),
+                tracking_data.payment_response_hash_key.as_deref(),
+                &payload,
+            )
+            .await
+        }
+        None => send_report_emails(state, tracking_data, download_url, start_time, end_time).await,
+    }
+}
+
+async fn send_report_webhook(
+    state: &SessionState,
+    return_url: &str,
+    payment_response_hash_key: Option<&str>,
+    payload: &ReportWebhookPayload<'_>,
+) -> Result<(), errors::ProcessTrackerError> {
+    let body = serde_json::to_vec(payload)
+        .map_err(|_| errors::ProcessTrackerError::SerializationFailed)?;
+
+    let mut request_headers = vec![(
+        headers::CONTENT_TYPE.to_string(),
+        "application/json".to_string().into_masked(),
+    )];
+    if let Some(hash_key) = payment_response_hash_key {
+        let signature = HmacSha512
+            .sign_message(hash_key.as_bytes(), &body)
+            .map(hex::encode)
+            .map_err(|error| {
+                logger::error!(?error, "Failed to sign report webhook payload");
+                errors::ProcessTrackerError::FlowExecutionError {
+                    flow: "PaymentReportWebhookSignature",
+                }
+            })?;
+        request_headers.push((
+            headers::X_WEBHOOK_SIGNATURE.to_string(),
+            signature.into_masked(),
+        ));
+    }
+
+    let request = services::RequestBuilder::new()
+        .method(Method::Post)
+        .url(return_url)
+        .attach_default_headers()
+        .headers(request_headers)
+        .set_body(RequestContent::RawBytes(body))
+        .build();
+
+    let response = state
+        .api_client
+        .send_request(state, request, None, false)
+        .await
+        .map_err(|error| {
+            logger::error!(?error, "Failed to deliver payment report webhook");
+            errors::ProcessTrackerError::FlowExecutionError {
+                flow: "PaymentReportWebhook",
+            }
+        })?;
+
+    if !response.status().is_success() {
+        logger::error!(
+            status = %response.status(),
+            "Payment report webhook was not accepted by the merchant endpoint"
+        );
+        return Err(errors::ProcessTrackerError::FlowExecutionError {
+            flow: "PaymentReportWebhook",
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "email")]
+async fn send_report_emails(
+    state: &SessionState,
+    tracking_data: &GenerateReportRequest,
+    download_url: &str,
+    start_time: PrimitiveDateTime,
+    end_time: PrimitiveDateTime,
+) -> Result<(), errors::ProcessTrackerError> {
+    let mut recipients = vec![tracking_data.email.clone()];
+    if let Some(emails) = tracking_data.request.emails.as_ref() {
+        recipients.extend(emails.iter().cloned());
+    }
+
+    let start_date = format_timestamp(start_time);
+    let end_date = format_timestamp(end_time);
+    let expires_in_days = REPORT_URL_EXPIRY_SECS / 86400;
+
+    for recipient in recipients {
+        let email_contents = PaymentReportReady {
+            recipient_email: UserEmail::from_pii_email(recipient).map_err(|error| {
+                logger::error!(?error, "Failed to parse report recipient email");
+                errors::ProcessTrackerError::FlowExecutionError {
+                    flow: "PaymentReportEmail",
+                }
+            })?,
+            subject: format!("Your Payments Report: {start_date} - {end_date}"),
+            report_link: download_url.to_owned(),
+            start_date: start_date.clone(),
+            end_date: end_date.clone(),
+            expires_in_days,
+        };
+
+        state
+            .email_client
+            .clone()
+            .compose_and_send_email(
+                user_utils::get_base_url(state),
+                Box::new(email_contents),
+                state.conf.proxy.https_url.as_ref(),
+            )
+            .await
+            .map_err(errors::ProcessTrackerError::EEmailError)?;
+    }
+
+    Ok(())
+}
+
+/// Without the email feature there is no way to deliver the report link, so it is only
+/// logged. Production builds are expected to enable the email feature.
+#[cfg(not(feature = "email"))]
+async fn send_report_emails(
+    _state: &SessionState,
+    _tracking_data: &GenerateReportRequest,
+    download_url: &str,
+    _start_time: PrimitiveDateTime,
+    _end_time: PrimitiveDateTime,
+) -> Result<(), errors::ProcessTrackerError> {
+    logger::warn!(
+        download_url,
+        "Email feature is disabled; payment report generated but not delivered over email"
+    );
+    Ok(())
+}
+
+/// Notifies the merchant's webhook endpoint that report generation has permanently
+/// failed, mirroring the failure notification of the lambda based flow. Failures here are
+/// logged and swallowed since the task is already being finished.
+async fn notify_payment_report_failure(state: &SessionState, process: &storage::ProcessTracker) {
+    let tracking_data: GenerateReportRequest = match process
+        .tracking_data
+        .clone()
+        .parse_value("GenerateReportRequest")
+    {
+        Ok(tracking_data) => tracking_data,
+        Err(error) => {
+            logger::error!(?error, "Failed to parse tracking data for failure webhook");
+            return;
+        }
+    };
+
+    let Some(return_url) = tracking_data.request.return_url.as_ref() else {
+        return;
+    };
+
+    let scope = ReportScope::from_auth_info(&tracking_data.auth);
+    let payload = ReportWebhookPayload {
+        org_id: &scope.organization_id,
+        merchant_id: scope
+            .merchant_ids
+            .as_ref()
+            .and_then(|merchant_ids| merchant_ids.first()),
+        profile_id: scope
+            .profile_ids
+            .as_ref()
+            .and_then(|profile_ids| profile_ids.first()),
+        event: REPORT_GENERATION_FAILED_EVENT,
+        data: ReportWebhookData::Failed {
+            code: "internal_server_error",
+            message: "We could not generate the report due to an internal server error. Please request the report again.",
+        },
+    };
+
+    if let Err(error) = send_report_webhook(
+        state,
+        return_url.get_string_repr(),
+        tracking_data.payment_response_hash_key.as_deref(),
+        &payload,
+    )
+    .await
+    {
+        logger::error!(?error, "Failed to deliver payment report failure webhook");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use time::macros::datetime;
+
+    use super::*;
+
+    fn test_scope(with_merchant: bool, with_profile: bool) -> ReportScope {
+        ReportScope {
+            organization_id: id_type::OrganizationId::try_from_string(String::from("org_test"))
+                .unwrap(),
+            merchant_ids: with_merchant.then(|| {
+                vec![
+                    id_type::MerchantId::try_from(std::borrow::Cow::from("merchant_test")).unwrap(),
+                ]
+            }),
+            profile_ids: with_profile.then(|| {
+                vec![id_type::ProfileId::try_from(std::borrow::Cow::from("pro_test")).unwrap()]
+            }),
+        }
+    }
+
+    #[test]
+    fn report_file_key_includes_scope_segments() {
+        let start_time = datetime!(2026-07-01 00:00:00);
+        let end_time = datetime!(2026-08-01 00:00:00);
+
+        assert_eq!(
+            build_report_file_key(&test_scope(false, false), start_time, end_time).unwrap(),
+            "reports/org_test/payments/payments_report_20260701000000_20260801000000.csv"
+        );
+        assert_eq!(
+            build_report_file_key(&test_scope(true, false), start_time, end_time).unwrap(),
+            "reports/org_test/merchant_test/payments/payments_report_20260701000000_20260801000000.csv"
+        );
+        assert_eq!(
+            build_report_file_key(&test_scope(true, true), start_time, end_time).unwrap(),
+            "reports/org_test/merchant_test/pro_test/payments/payments_report_20260701000000_20260801000000.csv"
+        );
+    }
+
+    #[test]
+    fn amounts_are_converted_to_currency_base_units() {
+        let amount = Some(MinorUnit::new(12345));
+        assert_eq!(
+            format_amount_in_base_unit(amount, Some(common_enums::Currency::USD)),
+            "123.45"
+        );
+        assert_eq!(
+            format_amount_in_base_unit(amount, Some(common_enums::Currency::JPY)),
+            "12345"
+        );
+        assert_eq!(
+            format_amount_in_base_unit(amount, Some(common_enums::Currency::BHD)),
+            "12.345"
+        );
+        assert_eq!(
+            format_amount_in_base_unit(Some(MinorUnit::new(5)), Some(common_enums::Currency::USD)),
+            "0.05"
+        );
+        // Amounts that overflow u32 minor units must not be dropped
+        assert_eq!(
+            format_amount_in_base_unit(
+                Some(MinorUnit::new(10_000_000_000)),
+                Some(common_enums::Currency::USD)
+            ),
+            "100000000.00"
+        );
+        assert_eq!(format_amount_in_base_unit(amount, None), "123.45");
+        assert_eq!(
+            format_amount_in_base_unit(None, Some(common_enums::Currency::USD)),
+            ""
+        );
+    }
+
+    #[test]
+    fn card_fields_are_read_from_payment_method_data() {
+        let payment_method_data = serde_json::json!({
+            "card": {
+                "card_network": "Visa",
+                "card_exp_year": 2030
+            }
+        });
+        assert_eq!(
+            get_card_field(Some(&payment_method_data), "card_network"),
+            "Visa"
+        );
+        // Non-string and missing values are rendered as empty
+        assert_eq!(
+            get_card_field(Some(&payment_method_data), "card_exp_year"),
+            ""
+        );
+        assert_eq!(
+            get_card_field(Some(&payment_method_data), "card_holder_name"),
+            ""
+        );
+        assert_eq!(get_card_field(None, "card_network"), "");
+    }
+
+    #[test]
+    fn tracking_data_parses_into_generate_report_request() {
+        let tracking_data = serde_json::json!({
+            "request": {
+                "timeRange": {
+                    "start_time": "2026-07-01T00:00:00.000Z",
+                    "end_time": "2026-08-01T00:00:00.000Z"
+                },
+                "emails": null,
+                "returnUrl": null,
+                "columns": null
+            },
+            "merchantId": "merchant_test",
+            "auth": {
+                "MerchantLevel": {
+                    "org_id": "org_test",
+                    "merchant_ids": ["merchant_test"],
+                    "processor_merchant_ids": null
+                }
+            },
+            "email": "user@example.com",
+            "paymentResponseHashKey": null
+        });
+
+        let request: GenerateReportRequest = serde_json::from_value(tracking_data).unwrap();
+        let scope = ReportScope::from_auth_info(&request.auth);
+        assert_eq!(scope.organization_id.get_string_repr(), "org_test");
+        assert_eq!(
+            scope.merchant_ids.unwrap()[0].get_string_repr(),
+            "merchant_test"
+        );
+        assert!(scope.profile_ids.is_none());
+    }
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds a `GenerateReportWorkflow` process tracker runner so payment report generation can run inside the scheduler instead of invoking the payment report lambda. The lambda remains the default path; the new flow is enabled per environment with `report_download_config.generate_payment_reports_via_scheduler` (v2 always uses the lambda).

Flow: the payment report handlers insert a `PAYMENT_REPORT` process tracker task (tracking data = the existing `GenerateReportRequest`); the consumer workflow fetches `payment_attempt` rows left joined with their active `payment_intent` via a type safe diesel query scoped by org/merchant/profile and time range, builds the CSV (columns driven by an exhaustive match on `PaymentReportColumn`, amounts converted to currency base units with exact integer math), uploads it through `FileStorageInterface`, generates a signed download URL (new `get_signed_url` trait method, S3 presigned URL), and delivers it over the merchant `return_url` webhook (HMAC-SHA512 signed, same payload contract as the lambda) or a report-ready email. Failures retry 3 times at 5 minute intervals, then finish with `RETRIES_EXCEEDED` and a best effort failure webhook, mirroring the lambda flow.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

New optional config field (defaults to `false`, existing configs keep working): `report_download_config.generate_payment_reports_via_scheduler` in [config/config.example.toml](https://github.com/juspay/hyperswitch/blob/feat/report-generation-process-tracker/config/config.example.toml), [config/deployments/env_specific.toml](https://github.com/juspay/hyperswitch/blob/feat/report-generation-process-tracker/config/deployments/env_specific.toml), [config/development.toml](https://github.com/juspay/hyperswitch/blob/feat/report-generation-process-tracker/config/development.toml), [config/docker_compose.toml](https://github.com/juspay/hyperswitch/blob/feat/report-generation-process-tracker/config/docker_compose.toml).

## Motivation and Context

Report generation currently depends on per-region AWS lambda deployments (a separate deploy surface, Python code with no type safety over column names or query construction, and only the 2 automatic retries that lambda async invocation provides). Running it through the process tracker gives durable retries with backoff, a queryable audit row per report (`business_status`), compile time safety over the report query and columns, and removes the lambda deploy surface once all report types are ported. Payment reports are ported first; refund/dispute/payout/relay reports keep using the lambda and can follow the same pattern.

## How did you test it?

- Unit tests in `crates/router/src/workflows/generate_report.rs` (file key scoping, currency base unit conversion incl. zero/three decimal and > u32 amounts, card field extraction, tracking data serde round trip) — 4/4 passing.
- Live end to end run with the real producer + consumer binaries (`SCHEDULER_FLOW=producer|consumer`) against Postgres + Redis, with an S3 emulator (localstack) as the file storage backend:
  - Task inserted -> producer picked it up -> consumer executed the workflow -> CSV uploaded to S3 -> task finished with `COMPLETED_BY_PT`. CSV headers and values match the lambda output (verified against real `payment_attempt`/`payment_intent` rows, minor units converted correctly).
  - Webhook delivery: local listener received the `report_generation.completed` payload with a **valid** `X-Webhook-Signature-512` HMAC-SHA512 signature; the presigned URL from the payload downloaded the exact CSV via `curl`.
  - Failure path: a task pointing at a dead webhook endpoint retried 3 times at 5 minute intervals and finished with `RETRIES_EXCEEDED`; a transient DB failure on another task retried automatically and succeeded.
- `cargo check -p router` clean, `cargo clippy -p router` (with and without `external_services/aws_s3`) clean, `cargo +nightly fmt` applied.

Not covered: real AWS S3/SES (emulator only) and the email delivery path at runtime (compiles; requires an `email` feature build — same pattern as `ApiKeyExpiryWorkflow`).

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)