### PR TITLE
fix(offers): fail open on eligibility list failure and relax config 

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1567,8 +1567,8 @@ backup_file_path = "./config/superposition_seed.toml" # Path to a local file for
 
 [offer_engine]
 base_url = "https://offer-engine.example.com/" # Base URL of the Offer Engine service
-api_key = ""                                  # API key for API-key authenticated Offer Engine calls
-merchant_id = ""                              # Offer Engine merchant id sent in request bodies
+api_key = ""                                  # API key for the `application` credential source; omit when credentials are at the merchant level
+merchant_id = ""                              # Offer Engine merchant id for the `application` credential source; omit when credentials are at the merchant level
 
 # Credentials and call settings for the Account Updater flow; omit the section entirely to keep it off
 [account_updater.juspay]

--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -376,9 +376,10 @@ impl SecretsHandler for settings::OfferEngineConfig {
         secret_management_client: &dyn SecretManagementInterface,
     ) -> CustomResult<SecretStateContainer<Self, RawSecret>, SecretsManagementError> {
         let offer_engine = value.get_inner();
-        let api_key = secret_management_client
-            .get_secret(offer_engine.api_key.clone())
-            .await?;
+        let api_key = match offer_engine.api_key.clone() {
+            Some(api_key) => Some(secret_management_client.get_secret(api_key).await?),
+            None => None,
+        };
 
         Ok(value.transition_state(|offer_engine| Self {
             api_key,

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -709,8 +709,8 @@ pub struct ForexApi {
 #[derive(Debug, Deserialize, Clone)]
 pub struct OfferEngineConfig {
     pub base_url: url::Url,
-    pub api_key: Secret<String>,
-    pub merchant_id: String,
+    pub api_key: Option<Secret<String>>,
+    pub merchant_id: Option<String>,
 }
 
 impl OfferEngineConfig {
@@ -720,18 +720,28 @@ impl OfferEngineConfig {
                 "offer_engine.base_url must end with a trailing slash".into(),
             ))
         })?;
-        common_utils::fp_utils::when(self.api_key.peek().is_empty(), || {
-            Err(ApplicationError::InvalidConfigurationValueError(
-                "offer_engine.api_key must not be empty".into(),
-            ))
-        })?;
-        common_utils::fp_utils::when(self.merchant_id.is_empty(), || {
-            Err(error_stack::Report::from(
-                ApplicationError::InvalidConfigurationValueError(
-                    "offer_engine.merchant_id must not be empty".into(),
-                ),
-            ))
-        })
+        common_utils::fp_utils::when(
+            self.api_key
+                .as_ref()
+                .is_some_and(|api_key| api_key.peek().is_empty()),
+            || {
+                Err(ApplicationError::InvalidConfigurationValueError(
+                    "offer_engine.api_key must not be empty".into(),
+                ))
+            },
+        )?;
+        common_utils::fp_utils::when(
+            self.merchant_id
+                .as_ref()
+                .is_some_and(|merchant_id| merchant_id.is_empty()),
+            || {
+                Err(error_stack::Report::from(
+                    ApplicationError::InvalidConfigurationValueError(
+                        "offer_engine.merchant_id must not be empty".into(),
+                    ),
+                ))
+            },
+        )
     }
 }
 

--- a/crates/router/src/core/offer_engine.rs
+++ b/crates/router/src/core/offer_engine.rs
@@ -12,6 +12,18 @@ pub mod velocity;
 
 pub use client::OfferEngineClient;
 pub use config::resolve_offer_engine_credential_source;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub enum SupportedPaymentMethodType {
+    Card,
+}
+
+pub fn is_supported_payment_method_type(payment_method_type: &str) -> bool {
+    payment_method_type
+        .parse::<SupportedPaymentMethodType>()
+        .is_ok()
+}
 #[cfg(feature = "v1")]
 pub use notify::{schedule_payment_notification_for_attempt, schedule_refund_notification};
 pub use types::{OfferEngineCredentialSource, OfferEngineError, ResolvedOfferEngineConfig};

--- a/crates/router/src/core/offer_engine/config.rs
+++ b/crates/router/src/core/offer_engine/config.rs
@@ -86,10 +86,24 @@ impl OfferEngineCredentialSource {
             })?
             .get_inner();
 
+        let api_key = app_config.api_key.clone().ok_or_else(|| {
+            error_stack::report!(OfferEngineError::MissingApplicationConfig(
+                "offer_engine.api_key is required when credential source is application"
+                    .to_string()
+            ))
+        })?;
+
+        let merchant_id = app_config.merchant_id.clone().ok_or_else(|| {
+            error_stack::report!(OfferEngineError::MissingApplicationConfig(
+                "offer_engine.merchant_id is required when credential source is application"
+                    .to_string()
+            ))
+        })?;
+
         Ok(ResolvedOfferEngineConfig {
             base_url: app_config.base_url.clone(),
-            api_key: app_config.api_key.clone(),
-            merchant_id: app_config.merchant_id.clone(),
+            api_key,
+            merchant_id,
         })
     }
 

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -14951,11 +14951,10 @@ pub async fn payments_submit_eligibility(
 /// Resolve Offer Engine eligibility into `(amount_details, offer_details)` for the
 /// eligibility response.
 ///
-/// Both are `None` when eligibility is denied or Offer Engine is not available
-/// (config resolution failures are treated as "offers not available"). A `/list`
-/// failure while Offer Engine is enabled fails eligibility. When enabled but no
-/// offer is selected, the payable amount is returned unchanged with an empty
-/// offer list.
+/// Both are `None` when eligibility is denied, the payment method is not one Offer
+/// Engine serves, or Offer Engine is not available. A `/list` failure is failed
+/// **open** (logged + metered, payable amount unchanged); `/apply` at confirm stays
+/// fail-closed.
 #[cfg(all(feature = "oltp", feature = "v1"))]
 #[allow(clippy::too_many_arguments)]
 async fn resolve_offer_eligibility_details(
@@ -14978,12 +14977,11 @@ async fn resolve_offer_eligibility_details(
     Option<api_models::payments::EligibilityAmountDetails>,
     Option<api_models::payments::EligibilityOfferDetails>,
 )> {
-    // Offers apply only when eligibility is not denied, an Offer Engine config
-    // resolves, and the currency is known (config-resolution failures are treated
-    // as "offers not available").
     let offer_context = if matches!(
         next_action,
         api_models::payments::NextActionCall::Deny { .. }
+    ) || !offer_engine::is_supported_payment_method_type(
+        &payment_method_type,
     ) {
         None
     } else {
@@ -15064,12 +15062,17 @@ async fn resolve_offer_eligibility_details(
                 card_alias,
             };
 
-            // A `/list` failure while Offer Engine is enabled fails eligibility.
             let selected =
                 offer_engine::eligibility::run_offer_eligibility(state, offer_config, ctx)
                     .await
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Offer Engine /list failed")?;
+                    .unwrap_or_else(|error| {
+                        logger::warn!(
+                            ?error,
+                            "Offer Engine /list failed; proceeding without offers (fail-open)"
+                        );
+                        metrics::OFFER_ENGINE_LIST_FAILURES.add(1, &[]);
+                        None
+                    });
 
             match selected {
                 // Enabled but no eligible offer: payable amount unchanged.
@@ -15082,7 +15085,7 @@ async fn resolve_offer_eligibility_details(
                     Some(api_models::payments::EligibilityOfferDetails::default()),
                 )),
                 // Eligible offer: store the quote for confirm to validate `/apply`
-                // against (keyed by offer id, the first-launch quote id; TTL kept).
+                // against (keyed by a generated offer_quote_id; TTL kept).
                 Some(selected) => {
                     let processor_merchant_id = processor.get_account().get_id().clone();
                     // Issue a unique quote id; confirm echoes it back to apply this offer.

--- a/crates/router/src/routes/metrics.rs
+++ b/crates/router/src/routes/metrics.rs
@@ -234,6 +234,8 @@ counter_metric!(TASKS_ADDED_COUNT, GLOBAL_METER); // Tasks added to process trac
 counter_metric!(TASK_ADDITION_FAILURES_COUNT, GLOBAL_METER); // Failures in task addition to process tracker
 counter_metric!(TASKS_RESET_COUNT, GLOBAL_METER); // Tasks reset in process tracker for requeue flow
 
+counter_metric!(OFFER_ENGINE_LIST_FAILURES, GLOBAL_METER);
+
 // Offer Engine notification (Process Tracker) metrics
 counter_metric!(OFFER_ENGINE_NOTIFY_TASKS_SCHEDULED, GLOBAL_METER);
 counter_metric!(OFFER_ENGINE_NOTIFY_SCHEDULE_FAILURES, GLOBAL_METER);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Hardens the Offer Engine eligibility flow and fixes a configuration gap that blocked the **merchant** credential source. Three related changes:

1. **Fail open on eligibility `/list` failure.** Previously a transient Offer Engine `/list` failure during eligibility propagated as `InternalServerError` and failed the whole eligibility call, blocking checkout — even though offers are a non-critical enhancement. Now a `/list` failure maps to "no offer" (logged + metered via a new `OFFER_ENGINE_LIST_FAILURES` counter) and checkout proceeds with the payable amount unchanged. `/apply` at confirm stays **fail-closed**.

2. **Gate Offer Engine by payment method type.** `is_supported_payment_method_type` (currently `Card`) short-circuits the offer flow for unsupported payment methods instead of calling Offer Engine unconditionally.

3. **Relax application config for the merchant credential source.** `OfferEngineConfig.api_key` / `merchant_id` are now `Option` (`base_url` stays required). When `credential_source = merchant`, credentials come from the `merchant_account` and only `base_url` is used from app config, so a merchant-source deployment no longer needs those keys. Validation checks format only when present; presence is enforced **at resolve time** for the `application` source (a clear `MissingApplicationConfig` error) rather than at startup. Fully backward compatible — configs specifying all three keep working for both sources.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

Config-related files:
- `crates/router/src/configs/settings.rs` (`OfferEngineConfig`: `api_key`/`merchant_id` now optional)
- `crates/router/src/configs/secrets_transformers.rs` (optional `api_key` secret resolution)
- `config/config.example.toml` (documents the now-optional keys)

## Motivation and Context

Offers are a non-critical enhancement to checkout; a transient Offer Engine outage should not block payments. Additionally, the merchant credential source (sources credentials from the merchant account) should not require application-level `api_key`/`merchant_id`.

Fixes: juspay/hyperswitch-cloud#23159 (sub-issue of the Offer Engine Milestone 4 parent, juspay/hyperswitch-cloud#22763)

## How did you test it?

Manually verified end-to-end against a local router (Postgres + Redis + card locker) with Offer Engine pointed at the sandbox, exercising every branch this PR touches. Superposition was driven via the local file data source with `offer_engine.enabled = true` and `offer_engine.credential_source` set per scenario.

Common setup (create a payment intent, then submit eligibility):

```bash
# Create a payment intent (merchant API key)
PID=$(curl -s -X POST http://localhost:8080/payments \
  -H "api-key: $MERCHANT_API_KEY" -H 'Content-Type: application/json' \
  -d '{"amount":10000,"currency":"USD","confirm":false}' | jq -r .payment_id)
CS=$(curl -s "http://localhost:8080/payments/$PID" -H "api-key: $MERCHANT_API_KEY" | jq -r .client_secret)

# Submit eligibility with a card (publishable key + client secret)
curl -s -X POST "http://localhost:8080/payments/$PID/eligibility" \
  -H "api-key: $PUBLISHABLE_KEY" -H 'Content-Type: application/json' \
  -d "{\"client_secret\":\"$CS\",\"payment_method_type\":\"card\",
       \"payment_method_data\":{\"card\":{\"card_number\":\"4242424242424242\",
       \"card_exp_month\":\"12\",\"card_exp_year\":\"2030\",\"card_cvc\":\"123\"}}}"
```

### 1. Merchant credential source — app config has `base_url` only (no `api_key`/`merchant_id`)

Merchant credentials were set on the merchant account via the update API:

```bash
curl -s -X POST "http://localhost:8080/accounts/$MID" \
  -H "api-key: $ADMIN_API_KEY" -H 'Content-Type: application/json' \
  -d "{\"merchant_id\":\"$MID\",
       \"offer_engine_config\":{\"api_key\":\"<offer-engine-api-key>\",\"merchant_id\":\"<offer-engine-merchant-id>\"}}"
```

`[offer_engine]` app config carried **only** `base_url`. Result — offer returned, credentials sourced from the merchant account:

```json
{"amount_details":{"total_amount":10000,"net_amount":9800,"currency":"USD"},
 "offer_details":{"eligible_offers":[{"offer_amount":200,"code":"HSVELO1", ...}]}}
```
Router log: `POST /v1/offers/list -> 200` with `x-jp-merchant-id` = the merchant-account merchant id, and no `MissingApplicationConfig` error. ✅ (Also confirms the router now boots with `api_key`/`merchant_id` absent from app config.)

### 2. Application credential source — `api_key`/`merchant_id` missing

App config had `base_url` only while `credential_source = application`. Result — graceful **HTTP 200**, no offer, and a clear warning (checkout proceeds):

```
WARN offer engine: unable to resolve offer config; offers unavailable,
     error: ... offer_engine.api_key is required when credential source is application
```
No crash, no startup failure. ✅

### 3. Application credential source — credentials present

App config had `base_url` + `api_key` + `merchant_id`. Result — offer returned (`net_amount` 10000 → 9800, `HSVELO1`); router log shows fingerprint → locker `200`, then `POST /v1/offers/list -> 200`. ✅

### 4. Fail-open on `/list` failure

`base_url` pointed at an unreachable host so `/list` errors. Result — eligibility still returns **HTTP 200** with the amount **unchanged** and no offer:

```json
{"amount_details":{"total_amount":10000,"net_amount":10000,"currency":"USD"},
 "offer_details":{"uplifted_offer_quote_ids":[],"eligible_offers":[]}}
```
Router log:
```
ERROR ... OfferList ... tcp connect error: Connection refused
WARN  Offer Engine /list failed; proceeding without offers (fail-open), error: Offer Engine request failed
```
The `OFFER_ENGINE_LIST_FAILURES` counter increments alongside that warning. Checkout is not blocked. ✅

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
