### PR TITLE
feat(monitoring): add PostgreSQL, ClickHouse and Redis datasources to local Grafana setup

### DIFF
--- a/config/grafana-datasource.yaml
+++ b/config/grafana-datasource.yaml
@@ -18,14 +18,29 @@ datasources:
     access: proxy
     url: http://prometheus:9090/
     editable: true
-    datasources:
-  # - name: ClickHouse
-  #   type: grafana-clickhouse-datasource
-  #   jsonData:
-  #     defaultDatabase: default
-  #     port: 9000
-  #     server: clickhouse-server
-  #     username: default
-  #     tlsSkipVerify: true
-  #     protocol: native
-  #   editable: true
+  - name: ClickHouse
+    type: grafana-clickhouse-datasource
+    jsonData:
+      defaultDatabase: default
+      port: 9000
+      server: clickhouse-server
+      username: default
+      tlsSkipVerify: true
+      protocol: native
+    editable: true
+  - name: PostgreSQL
+    type: postgres
+    access: proxy
+    url: pg:5432
+    database: hyperswitch_db
+    user: db_user
+    secureJsonData:
+      password: db_pass
+    jsonData:
+      sslmode: disable
+    editable: true
+  - name: Redis
+    type: redis-datasource
+    access: proxy
+    url: redis://redis-standalone:6379
+    editable: true

--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -59,16 +59,14 @@ services:
 
   tempo:
     image: grafana/tempo:latest
-    command: -config.file=/etc/tempo.yaml
-    volumes:
-      - ../config/tempo.yaml:/etc/tempo.yaml
-      - ./tempo.tmp:/tmp/tempo
+    command: [ "-config.file=/etc/tempo.yaml" ]
     networks:
       - loki
+    volumes:
+      - ../config/tempo.yaml:/etc/tempo.yaml
     ports:
-      - "3200" # tempo
-      - "4317" # otlp grpc
-      - "4318" # otlp http
+      - "3200:3200"
+      - "4318:4318"
     restart: unless-stopped
 
   grafana:
@@ -78,6 +76,8 @@ services:
     networks:
       - loki
     restart: unless-stopped
+    environment:
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource,redis-datasource
     volumes:
       - ../config:/etc/grafana
 


### PR DESCRIPTION
Part of #5029.

## What this does

Extends the local Grafana monitoring setup with three additional datasources so that Clickhouse, Postgres, and Redis data can be explored directly from the Grafana UI during local development.

### `config/grafana-datasource.yaml`
- **PostgreSQL** — built-in Grafana datasource, connects to the `pg` service already present in `docker-compose.yml` (port 5432).
- **ClickHouse** — uses the `grafana-clickhouse-datasource` community plugin, connects to `clickhouse-server:9000`.
- **Redis** — uses the `redis-datasource` community plugin, connects to `redis-standalone:6379`.

Also removes a stray `datasources:` key that appeared inline between the Metrics and ClickHouse entries in the original file; it was treated by the YAML parser as a property on the Metrics datasource object rather than a top-level list continuation.

### `monitoring/docker-compose.yaml`
- Adds `GF_INSTALL_PLUGINS=grafana-clickhouse-datasource,redis-datasource` to the `grafana` service environment so both community plugins are downloaded and installed when the container starts.

## Testing
Start the monitoring stack (`docker compose -f monitoring/docker-compose.yaml up -d`) and open Grafana at `http://localhost:3000`. All five datasources (Traces, Logs, Metrics, ClickHouse, PostgreSQL, Redis) should appear under **Configuration → Data Sources** once the plugins finish installing.