### PR TITLE
feat(router): generate Apple Pay PPC keypair internally, keep merchant out of PCI scope

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -32863,6 +32863,10 @@
           },
           "payment_processing_certificate_key": {
             "type": "string"
+          },
+          "system_generated_payment_processing_certificate_key": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -24647,6 +24647,10 @@
           },
           "payment_processing_certificate_key": {
             "type": "string"
+          },
+          "system_generated_payment_processing_certificate_key": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -10509,6 +10509,10 @@ pub struct PaymentProcessingDetails {
     #[schema(value_type = String)]
     #[smithy(value_type = "String")]
     pub payment_processing_certificate_key: Secret<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    #[smithy(value_type = "Option<String>")]
+    pub system_generated_payment_processing_certificate_key: Option<Secret<String>>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -3169,15 +3169,12 @@ pub async fn generate_apple_pay_certificate(
             &key_store,
         )
         .await
-        .to_not_found_response(
-            errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
-                id: merchant_connector_id.get_string_repr().to_string(),
-            },
-        )?;
+        .to_not_found_response(errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
+            id: merchant_connector_id.get_string_repr().to_string(),
+        })?;
 
-    let (private_key_pem, csr) = helpers::generate_apple_pay_keypair_and_csr(
-        mca.get_id().get_string_repr(),
-    )?;
+    let (private_key_pem, csr) =
+        helpers::generate_apple_pay_keypair_and_csr(mca.get_id().get_string_repr())?;
 
     let updated_metadata =
         helpers::set_apple_pay_system_generated_key(mca.metadata.clone(), private_key_pem);

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -2163,12 +2163,16 @@ impl MerchantConnectorAccountUpdateBridge for api_models::admin::MerchantConnect
     }
 
     async fn create_domain_model_from_request(
-        self,
+        mut self,
         state: &SessionState,
         mca: &domain::MerchantConnectorAccount,
         key_manager_state: &KeyManagerState,
         platform: &domain::Platform,
     ) -> RouterResult<domain::MerchantConnectorAccountUpdate> {
+        self.metadata = helpers::carry_forward_apple_pay_system_generated_key(
+            mca.metadata.as_ref(),
+            self.metadata,
+        );
         let payment_methods_enabled = self.payment_methods_enabled.map(|pm_enabled| {
             pm_enabled
                 .iter()
@@ -3144,6 +3148,67 @@ pub async fn update_connector(
     let response = updated_mca.foreign_try_into()?;
 
     Ok(service_api::ApplicationResponse::Json(response))
+}
+
+#[cfg(feature = "v1")]
+pub async fn generate_apple_pay_certificate(
+    state: SessionState,
+    merchant_id: id_type::MerchantId,
+    merchant_connector_id: id_type::MerchantConnectorAccountId,
+) -> RouterResponse<serde_json::Value> {
+    let db = state.store.as_ref();
+    let key_store = db
+        .get_merchant_key_store_by_merchant_id(&merchant_id, &db.get_master_key().to_vec().into())
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
+
+    let mca = db
+        .find_by_merchant_connector_account_merchant_id_merchant_connector_id(
+            &merchant_id,
+            &merchant_connector_id,
+            &key_store,
+        )
+        .await
+        .to_not_found_response(
+            errors::ApiErrorResponse::MerchantConnectorAccountNotFound {
+                id: merchant_connector_id.get_string_repr().to_string(),
+            },
+        )?;
+
+    let (private_key_pem, csr) = helpers::generate_apple_pay_keypair_and_csr(
+        mca.get_id().get_string_repr(),
+    )?;
+
+    let updated_metadata =
+        helpers::set_apple_pay_system_generated_key(mca.metadata.clone(), private_key_pem);
+
+    db.update_merchant_connector_account(
+        mca.clone(),
+        storage::MerchantConnectorAccountUpdate::ConnectorWebhookRegisterationUpdate {
+            connector_webhook_registration_details: None,
+            connector_webhook_details: None,
+            metadata: Some(updated_metadata),
+        }
+        .into(),
+        &key_store,
+    )
+    .await
+    .change_context(errors::ApiErrorResponse::InternalServerError)
+    .attach_printable_lazy(|| {
+        format!(
+            "Failed while persisting generated Apple Pay certificate key for MCA: {merchant_connector_id:?}",
+        )
+    })?;
+
+    let content_type = "application/pkcs10"
+        .parse::<mime::Mime>()
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to parse CSR content type")?;
+
+    Ok(service_api::ApplicationResponse::FileData((
+        csr.into_bytes(),
+        content_type,
+    )))
 }
 
 #[cfg(feature = "v1")]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -7840,7 +7840,10 @@ async fn decrypt_apple_pay_wallet_data(
             .attach_printable("failed to parse apple pay token to json")?
             .decrypt(
                 &payment_processing_details.payment_processing_certificate,
-                &payment_processing_details.payment_processing_certificate_key,
+                payment_processing_details
+                    .system_generated_payment_processing_certificate_key
+                    .as_ref()
+                    .unwrap_or(&payment_processing_details.payment_processing_certificate_key),
             )
             .await
             .change_context(errors::ApiErrorResponse::InternalServerError)
@@ -9229,6 +9232,7 @@ fn check_apple_pay_metadata(
                                     .get_inner()
                                     .apple_pay_ppc_key
                                     .clone(),
+                                system_generated_payment_processing_certificate_key: None,
                             },
                         ))
                     }

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -7062,8 +7062,7 @@ fn mask_apple_pay_certificate_key(
     let masked = match (header, footer) {
         (Some(header), Some(footer)) => {
             let body: String = body_lines.concat();
-            let masked_body =
-                mask_middle(&body, UNMASKED_PREFIX_LEN, UNMASKED_SUFFIX_LEN);
+            let masked_body = mask_middle(&body, UNMASKED_PREFIX_LEN, UNMASKED_SUFFIX_LEN);
             format!("{header}\n{masked_body}\n{footer}\n")
         }
         // Not a two-armor-line PEM block (shouldn't happen for a key we generated ourselves);
@@ -7086,7 +7085,10 @@ fn mask_middle(value: &str, prefix_len: usize, suffix_len: usize) -> String {
 
     let prefix: String = chars[..prefix_len].iter().collect();
     let suffix: String = chars[len - suffix_len..].iter().collect();
-    format!("{prefix}{}{suffix}", "*".repeat(len - prefix_len - suffix_len))
+    format!(
+        "{prefix}{}{suffix}",
+        "*".repeat(len - prefix_len - suffix_len)
+    )
 }
 
 /// Stores Hyperswitch's internally generated Apple Pay private key into the MCA `metadata`
@@ -7121,7 +7123,8 @@ pub fn carry_forward_apple_pay_system_generated_key(
     existing_metadata: Option<&pii::SecretSerdeValue>,
     new_metadata: Option<pii::SecretSerdeValue>,
 ) -> Option<pii::SecretSerdeValue> {
-    let existing_key = apple_pay_metadata::Metadata::parse(existing_metadata).get_system_generated_key();
+    let existing_key =
+        apple_pay_metadata::Metadata::parse(existing_metadata).get_system_generated_key();
 
     let existing_key = match existing_key {
         Some(key) => key,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -6904,6 +6904,262 @@ async fn get_and_merge_apple_pay_metadata(
     Ok(connector_wallets_details_optional)
 }
 
+/// Partial, lenient views of the Apple Pay portion of MCA `metadata`, used only to read/write
+/// the internally-generated-key fields without disturbing anything else stored there.
+///
+/// Every named field is optional and each level carries a `#[serde(flatten)]` catch-all map,
+/// so parsing an arbitrary (possibly unrelated, possibly partially-filled) metadata blob can
+/// never fail structurally and never drops unmodeled data on reserialization — there is no
+/// `unwrap`/`expect`/panic possible in this parse-modify-reserialize path.
+mod apple_pay_metadata {
+    use hyperswitch_masking::{PeekInterface, Secret};
+    use serde::{Deserialize, Serialize};
+
+    use super::pii;
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    pub struct Metadata {
+        pub apple_pay_combined: Option<ApplePayCombined>,
+        #[serde(flatten)]
+        pub other: serde_json::Map<String, serde_json::Value>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    pub struct ApplePayCombined {
+        pub manual: Option<Manual>,
+        #[serde(flatten)]
+        pub other: serde_json::Map<String, serde_json::Value>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    pub struct Manual {
+        pub session_token_data: Option<SessionTokenData>,
+        #[serde(flatten)]
+        pub other: serde_json::Map<String, serde_json::Value>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    pub struct SessionTokenData {
+        pub payment_processing_certificate_key: Option<Secret<String>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub system_generated_payment_processing_certificate_key: Option<Secret<String>>,
+        #[serde(flatten)]
+        pub other: serde_json::Map<String, serde_json::Value>,
+    }
+
+    impl Metadata {
+        pub fn parse(metadata: Option<&pii::SecretSerdeValue>) -> Self {
+            metadata
+                .map(|value| value.peek().clone())
+                .map(|value| serde_json::from_value(value).unwrap_or_default())
+                .unwrap_or_default()
+        }
+
+        pub fn into_secret_value(self) -> pii::SecretSerdeValue {
+            let value = serde_json::to_value(self)
+                .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
+            Secret::new(value)
+        }
+
+        pub fn get_system_generated_key(&self) -> Option<Secret<String>> {
+            self.apple_pay_combined
+                .as_ref()
+                .and_then(|combined| combined.manual.as_ref())
+                .and_then(|manual| manual.session_token_data.as_ref())
+                .and_then(|session_token_data| {
+                    session_token_data
+                        .system_generated_payment_processing_certificate_key
+                        .clone()
+                })
+        }
+
+        /// Clears the system-generated key if `session_token_data` already exists; never
+        /// fabricates any of the intermediate structure when it doesn't.
+        pub fn strip_system_generated_key(mut self) -> Self {
+            if let Some(session_token_data) = self
+                .apple_pay_combined
+                .as_mut()
+                .and_then(|combined| combined.manual.as_mut())
+                .and_then(|manual| manual.session_token_data.as_mut())
+            {
+                session_token_data.system_generated_payment_processing_certificate_key = None;
+            }
+            self
+        }
+
+        /// Runs `apply` on the (possibly newly-created) `session_token_data` level, preserving
+        /// every other field already present at every level above and below it.
+        pub fn update_session_token_data(
+            mut self,
+            apply: impl FnOnce(&mut SessionTokenData),
+        ) -> Self {
+            let mut combined = self.apple_pay_combined.unwrap_or_default();
+            let mut manual = combined.manual.unwrap_or_default();
+            let mut session_token_data = manual.session_token_data.unwrap_or_default();
+
+            apply(&mut session_token_data);
+
+            manual.session_token_data = Some(session_token_data);
+            combined.manual = Some(manual);
+            self.apple_pay_combined = Some(combined);
+            self
+        }
+    }
+}
+
+/// Generates a fresh EC-256 (prime256v1) keypair and a CSR signed by it. Returns
+/// `(private_key_pem, csr_pem)`. Callers must never return `private_key_pem` in any API
+/// response — it is only meant to be persisted directly into MCA metadata.
+pub fn generate_apple_pay_keypair_and_csr(
+    common_name: &str,
+) -> CustomResult<(hyperswitch_masking::Secret<String>, String), errors::ApiErrorResponse> {
+    generate_apple_pay_keypair_and_csr_impl(common_name)
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to generate Apple Pay keypair and CSR")
+}
+
+fn generate_apple_pay_keypair_and_csr_impl(
+    common_name: &str,
+) -> Result<(hyperswitch_masking::Secret<String>, String), openssl::error::ErrorStack> {
+    let group = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1)?;
+    let ec_key = openssl::ec::EcKey::generate(&group)?;
+    let pkey = PKey::from_ec_key(ec_key)?;
+
+    let mut name_builder = openssl::x509::X509NameBuilder::new()?;
+    name_builder.append_entry_by_text("CN", common_name)?;
+    let name = name_builder.build();
+
+    let mut req_builder = openssl::x509::X509Req::builder()?;
+    req_builder.set_subject_name(&name)?;
+    req_builder.set_pubkey(&pkey)?;
+    req_builder.sign(&pkey, openssl::hash::MessageDigest::sha256())?;
+    let csr = req_builder.build();
+
+    let private_key_pem = String::from_utf8_lossy(&pkey.private_key_to_pem_pkcs8()?).into_owned();
+    let csr_pem = String::from_utf8_lossy(&csr.to_pem()?).into_owned();
+
+    Ok((hyperswitch_masking::Secret::new(private_key_pem), csr_pem))
+}
+
+/// Masks a PEM-encoded private key for display: keeps the armor lines (the "BEGIN"/"END"
+/// header and footer lines) intact and readable on their own lines, and replaces only the
+/// base64 body with asterisks, leaving a few characters visible at each end so the value still
+/// reads as "a key" in the dashboard rather than as noise. Falls back to masking the entire
+/// value verbatim (no panic) if the input isn't shaped like a PEM block with both armor lines
+/// present.
+fn mask_apple_pay_certificate_key(
+    key: &hyperswitch_masking::Secret<String>,
+) -> hyperswitch_masking::Secret<String> {
+    const UNMASKED_PREFIX_LEN: usize = 4;
+    const UNMASKED_SUFFIX_LEN: usize = 4;
+
+    let pem = key.clone().expose();
+    let mut lines = pem.lines();
+    let header = lines.next();
+    let mut body_lines: Vec<&str> = lines.collect();
+    let footer = body_lines.pop();
+
+    let masked = match (header, footer) {
+        (Some(header), Some(footer)) => {
+            let body: String = body_lines.concat();
+            let masked_body =
+                mask_middle(&body, UNMASKED_PREFIX_LEN, UNMASKED_SUFFIX_LEN);
+            format!("{header}\n{masked_body}\n{footer}\n")
+        }
+        // Not a two-armor-line PEM block (shouldn't happen for a key we generated ourselves);
+        // fall back to masking the whole thing rather than risk showing it unmasked.
+        _ => mask_middle(&pem, UNMASKED_PREFIX_LEN, UNMASKED_SUFFIX_LEN),
+    };
+
+    hyperswitch_masking::Secret::new(masked)
+}
+
+/// Replaces every character of `value` between the first `prefix_len` and last `suffix_len`
+/// characters with `*`. Masks the whole value if it's too short to leave both ends unmasked.
+fn mask_middle(value: &str, prefix_len: usize, suffix_len: usize) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    let len = chars.len();
+
+    if len <= prefix_len + suffix_len {
+        return "*".repeat(len);
+    }
+
+    let prefix: String = chars[..prefix_len].iter().collect();
+    let suffix: String = chars[len - suffix_len..].iter().collect();
+    format!("{prefix}{}{suffix}", "*".repeat(len - prefix_len - suffix_len))
+}
+
+/// Stores Hyperswitch's internally generated Apple Pay private key into the MCA `metadata`
+/// under `apple_pay_combined.manual.session_token_data`, creating that scaffold if it doesn't
+/// exist yet (the merchant may not have filled in the Apple Pay form at this point). The
+/// masked placeholder is written into `payment_processing_certificate_key` once, here, at
+/// generation time — every subsequent read of this MCA returns that masked value as-is; the
+/// real key is never re-derived or re-exposed on any read path.
+pub fn set_apple_pay_system_generated_key(
+    existing_metadata: Option<pii::SecretSerdeValue>,
+    private_key_pem: hyperswitch_masking::Secret<String>,
+) -> pii::SecretSerdeValue {
+    let masked_key = mask_apple_pay_certificate_key(&private_key_pem);
+
+    apple_pay_metadata::Metadata::parse(existing_metadata.as_ref())
+        .update_session_token_data(|session_token_data| {
+            session_token_data.system_generated_payment_processing_certificate_key =
+                Some(private_key_pem);
+            session_token_data.payment_processing_certificate_key = Some(masked_key);
+        })
+        .into_secret_value()
+}
+
+/// Hyperswitch's internally generated Apple Pay private key is never part of a merchant's
+/// update request payload (the dashboard form doesn't know about it), so it must be carried
+/// forward from the currently stored metadata into the metadata being persisted. No-op when
+/// the existing metadata doesn't carry such a key, and — importantly — a no-op (returns `None`,
+/// meaning "leave the metadata column untouched") when the merchant's request didn't include
+/// metadata at all, rather than persisting a metadata blob that contains only the Apple Pay
+/// key and silently drops every other stored metadata field.
+pub fn carry_forward_apple_pay_system_generated_key(
+    existing_metadata: Option<&pii::SecretSerdeValue>,
+    new_metadata: Option<pii::SecretSerdeValue>,
+) -> Option<pii::SecretSerdeValue> {
+    let existing_key = apple_pay_metadata::Metadata::parse(existing_metadata).get_system_generated_key();
+
+    let existing_key = match existing_key {
+        Some(key) => key,
+        None => return new_metadata,
+    };
+
+    let new_metadata = match new_metadata {
+        Some(metadata) => metadata,
+        None => return None,
+    };
+
+    Some(
+        apple_pay_metadata::Metadata::parse(Some(&new_metadata))
+            .update_session_token_data(|session_token_data| {
+                session_token_data.system_generated_payment_processing_certificate_key =
+                    Some(existing_key);
+            })
+            .into_secret_value(),
+    )
+}
+
+/// Strips Hyperswitch's internally generated Apple Pay private key out of `metadata` before it
+/// is returned in any API response. The masked `payment_processing_certificate_key` (written
+/// once, permanently, at generation time by [`set_apple_pay_system_generated_key`]) is left
+/// untouched and is what the client sees instead. A no-op — `metadata` is returned completely
+/// unchanged, not merely re-serialized — whenever the key isn't present at all, which keeps
+/// every merchant who never used this feature entirely unaffected.
+pub fn strip_apple_pay_system_generated_key(
+    metadata: Option<pii::SecretSerdeValue>,
+) -> Option<pii::SecretSerdeValue> {
+    let parsed = apple_pay_metadata::Metadata::parse(metadata.as_ref());
+    if parsed.get_system_generated_key().is_none() {
+        return metadata;
+    }
+
+    Some(parsed.strip_system_generated_key().into_secret_value())
+}
+
 pub fn is_googlepay_predecrypted_flow_supported(
     connector_metadata: Option<pii::SecretSerdeValue>,
 ) -> bool {

--- a/crates/router/src/routes/admin.rs
+++ b/crates/router/src/routes/admin.rs
@@ -931,6 +931,53 @@ pub async fn connector_update(
     ))
     .await
 }
+/// Merchant Connector - Generate Apple Pay Certificate
+///
+/// Generates an EC keypair and a Certificate Signing Request (CSR) for Apple Pay's payment
+/// processing certificate flow. Hyperswitch retains the private key internally and returns
+/// only the CSR — the merchant submits the CSR to Apple, then uploads the resulting signed
+/// certificate back onto this merchant connector account via the regular update API. The
+/// private key never leaves Hyperswitch, so the merchant does not need to handle it.
+#[cfg(feature = "v1")]
+#[instrument(skip_all, fields(flow = ?Flow::ApplePayCertificateGenerate))]
+pub async fn apple_pay_certificate_generate(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    path: web::Path<(
+        common_utils::id_type::MerchantId,
+        common_utils::id_type::MerchantConnectorAccountId,
+    )>,
+) -> HttpResponse {
+    let flow = Flow::ApplePayCertificateGenerate;
+    let (merchant_id, merchant_connector_id) = path.into_inner();
+
+    Box::pin(api::server_wrap(
+        flow,
+        state,
+        &req,
+        (),
+        |state, auth, _, _| {
+            generate_apple_pay_certificate(
+                state,
+                auth.platform.get_processor().get_account().get_id().clone(),
+                merchant_connector_id.clone(),
+            )
+        },
+        auth::auth_type(
+            &auth::ApiKeyAuthWithMerchantIdFromRouteAllowPlatform(merchant_id.clone()),
+            &auth::JWTAndEmbeddedAuth {
+                merchant_id_from_route: Some(merchant_id.clone()),
+                permission: Some(Permission::ProfileConnectorWrite),
+                allow_connected: true,
+                allow_platform: true,
+            },
+            req.headers(),
+        ),
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
 /// Merchant Connector - Delete
 ///
 /// Delete or Detach a Merchant Connector from Merchant Account

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -2159,6 +2159,12 @@ impl MerchantConnectorAccount {
                     web::resource("/{merchant_id}/connectors/webhooks/{merchant_connector_id}")
                         .route(web::post().to(connector_webhook_register))
                         .route(web::get().to(retrieve_connector_webhook)),
+                )
+                .service(
+                    web::resource(
+                        "/{merchant_id}/connectors/{merchant_connector_id}/applepay/certificate/generate",
+                    )
+                    .route(web::post().to(apple_pay_certificate_generate)),
                 );
         }
         #[cfg(feature = "oltp")]

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -117,7 +117,8 @@ impl From<Flow> for ApiIdentifier {
             | Flow::MerchantConnectorsRetrieve
             | Flow::MerchantConnectorsUpdate
             | Flow::MerchantConnectorsDelete
-            | Flow::MerchantConnectorsList => Self::MerchantConnector,
+            | Flow::MerchantConnectorsList
+            | Flow::ApplePayCertificateGenerate => Self::MerchantConnector,
             Flow::ConfigKeyCreate
             | Flow::ConfigKeyFetch
             | Flow::ConfigKeyUpdate

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -23,7 +23,7 @@ use super::domain;
 #[cfg(feature = "v2")]
 use crate::db::storage::revenue_recovery_redis_operation;
 use crate::{
-    core::errors,
+    core::{errors, payments::helpers as payments_helpers},
     headers::{
         ACCEPT_LANGUAGE, BROWSER_NAME, X_APP_ID, X_CLIENT_PLATFORM, X_CLIENT_SOURCE,
         X_CLIENT_VERSION, X_MERCHANT_DOMAIN, X_PAYMENT_CONFIRM_SOURCE, X_REDIRECT_URI,
@@ -1157,6 +1157,9 @@ impl ForeignTryFrom<domain::MerchantConnectorAccount>
                 .attach_printable("Failed to encode ConnectorAuthType")?,
         );
 
+        let metadata =
+            payments_helpers::strip_apple_pay_system_generated_key(item.metadata.clone());
+
         #[cfg(feature = "v2")]
         let response = Self {
             id: item.get_id(),
@@ -1166,7 +1169,7 @@ impl ForeignTryFrom<domain::MerchantConnectorAccount>
             connector_account_details: masked_connector_account_details,
             disabled: item.disabled,
             payment_methods_enabled,
-            metadata: item.metadata,
+            metadata,
             frm_configs,
             connector_webhook_details: item
                 .connector_webhook_details
@@ -1220,7 +1223,7 @@ impl ForeignTryFrom<domain::MerchantConnectorAccount>
             test_mode: item.test_mode,
             disabled: item.disabled,
             payment_methods_enabled,
-            metadata: item.metadata,
+            metadata,
             business_country: item.business_country,
             business_label: item.business_label,
             business_sub_label: item.business_sub_label,

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -90,6 +90,8 @@ pub enum Flow {
     MerchantConnectorsUpdate,
     /// Merchant Connectors delete flow.
     MerchantConnectorsDelete,
+    /// Apple Pay certificate signing request generation flow.
+    ApplePayCertificateGenerate,
     /// Merchant Connectors list flow.
     MerchantConnectorsList,
     /// Merchant Transfer Keys


### PR DESCRIPTION
## Summary
- Adds `POST /account/{merchant_id}/connectors/{merchant_connector_id}/applepay/certificate/generate`, which generates the Apple Pay payment-processing-certificate (PPC) EC keypair server-side and returns only the CSR (as a raw downloadable file) for the merchant to submit to Apple — the private key never leaves Hyperswitch.
- The generated key is stored in a new sibling field, `system_generated_payment_processing_certificate_key`, on `PaymentProcessingDetails`. A masked placeholder is written into the existing `payment_processing_certificate_key` field once, at generation time, so the dashboard form still shows a non-empty value — the raw key is never returned by any API response.
- `decrypt_apple_pay_wallet_data` prefers the internally-generated key when present, falling back to the merchant-supplied key otherwise.
- Merchant connector account update no longer silently drops the internally-generated key when a merchant updates other fields without resending `metadata` (fixed during testing).
- Fully additive: merchants who never call the new endpoint see zero change in stored data, API responses, or decrypt behavior.

## Why
Today, using Hyperswitch-side Apple Pay decryption requires the merchant to generate their own EC private key and paste it into the dashboard — putting the merchant in PCI scope for that key. This lets Hyperswitch generate and retain the key internally instead, while the merchant only ever handles a CSR and the certificate Apple issues back.

## Test plan
- [x] `cargo check` clean on v1 (default), v2/olap, and full workspace — no new warnings.
- [x] Manually verified end-to-end against a local stack: `generate` returns a valid CSR (`openssl req -text -noout` parses it cleanly); the CSR was submitted through Apple's real PPC issuance flow and the signed certificate was uploaded back onto the MCA.
- [x] Confirmed via direct DB query that the raw private key is stored (required for decryption) and confirmed via the live API that it never appears in any `GET`/update response — only the masked placeholder does.
- [x] Confirmed updating the MCA without resending `metadata` leaves the internally-generated key and all other metadata fields intact (regression check for a bug found during testing).
- [x] Confirmed a full real-world round trip: generated a keypair, got Apple's certificate issued and uploaded, and successfully decrypted a freshly-generated Apple Pay token end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCMh1qVfR2NNMBbrGpUqi5