### PR TITLE
feat(offers): add merchant-level Offer Engine credential source

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -26823,6 +26823,14 @@
               }
             ],
             "nullable": true
+          },
+          "offer_engine_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OfferEngineMerchantConfig"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -28840,6 +28848,24 @@
           },
           "number": {
             "$ref": "#/components/schemas/MinorUnit"
+          }
+        }
+      },
+      "OfferEngineMerchantConfig": {
+        "type": "object",
+        "description": "Merchant-level Offer Engine credentials (Offer Engine issues one account per merchant)",
+        "required": [
+          "api_key",
+          "merchant_id"
+        ],
+        "properties": {
+          "api_key": {
+            "type": "string",
+            "description": "API key issued by Offer Engine for this merchant"
+          },
+          "merchant_id": {
+            "type": "string",
+            "description": "The Offer Engine merchant id sent in Offer Engine request bodies"
           }
         }
       },

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -6570,6 +6570,55 @@
         ]
       }
     },
+    "/offer_engine/offers/list": {
+      "post": {
+        "tags": [
+          "Offers"
+        ],
+        "summary": "Offers - Browse",
+        "description": "Lists the offers currently available to the merchant. Offers that are not eligible are\nexcluded, so the response contains only offers that can be used.",
+        "operationId": "Browse offers",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BrowseOffersRequest"
+              },
+              "examples": {
+                "Browse offers for a currency": {
+                  "value": {
+                    "offer_payment_info": {
+                      "currency": "USD"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Offers available to the merchant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowseOffersResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Offer Engine is not enabled for this merchant"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
     "/blocklist": {
       "delete": {
         "tags": [
@@ -15840,6 +15889,82 @@
           "merchant_config_currency": {
             "type": "string",
             "description": "Information about the merchant_config_currency that merchant wants to specify at connector level."
+          }
+        }
+      },
+      "BrowseOffer": {
+        "type": "object",
+        "description": "A single offer available to the merchant.",
+        "required": [
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Offer code, as configured in Offer Engine.",
+            "example": "TESTHS"
+          },
+          "title": {
+            "type": "string",
+            "description": "Full offer title.",
+            "example": "Test offer HS",
+            "nullable": true
+          },
+          "display_title": {
+            "type": "string",
+            "description": "Shortened title, for constrained layouts.",
+            "example": "TSH",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Offer description.",
+            "example": "Testing offers",
+            "nullable": true
+          },
+          "currency": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Currency"
+              }
+            ],
+            "nullable": true
+          },
+          "valid_till": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the offer stops being valid.",
+            "example": "2026-08-31T18:29:59.000Z",
+            "nullable": true
+          }
+        }
+      },
+      "BrowseOffersRequest": {
+        "type": "object",
+        "description": "Request to browse the offers available to a merchant.",
+        "properties": {
+          "offer_payment_info": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OfferPaymentInfo"
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "BrowseOffersResponse": {
+        "type": "object",
+        "description": "The offers a merchant can currently use.",
+        "required": [
+          "offers"
+        ],
+        "properties": {
+          "offers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BrowseOffer"
+            }
           }
         }
       },
@@ -28866,6 +28991,18 @@
           "merchant_id": {
             "type": "string",
             "description": "The Offer Engine merchant id sent in Offer Engine request bodies"
+          }
+        }
+      },
+      "OfferPaymentInfo": {
+        "type": "object",
+        "description": "Order context supplied when browsing offers.",
+        "required": [
+          "currency"
+        ],
+        "properties": {
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
           }
         }
       },

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1564,8 +1564,8 @@ backup_file_path = "./config/superposition_seed.toml" # Path to a local file for
 
 [offer_engine]
 base_url = "https://offer-engine.example.com/" # Base URL of the Offer Engine service
-api_key = ""                                  # API key for API-key authenticated Offer Engine calls
-merchant_id = ""                              # Offer Engine merchant id sent in request bodies
+api_key = ""                                  # API key for the `application` credential source; omit when credentials are at the merchant level
+merchant_id = ""                              # Offer Engine merchant id for the `application` credential source; omit when credentials are at the merchant level
 
 # Credentials and call settings for the Account Updater flow; omit the section entirely to keep it off
 [account_updater.juspay]

--- a/config/superposition_seed.toml
+++ b/config/superposition_seed.toml
@@ -15,11 +15,12 @@
 
 [default-configs]
 deja_record = { value = false, schema = { type = "boolean" }, description = "Deja per-request recording decision — default SKIP (false). The deja_dimension cohort override (seeded by scripts/seed_superposition.sh) sets this true for the recordable endpoint bucket; /health and other probe traffic fall through to false.", change_reason = "Deja recording sampler" }
-offer_engine_enabled = { value = false, schema = { type = "boolean" }, description = "Master gate for the Offer Engine integration. When false (default) Offer Engine is never called, regardless of offer_engine_credential_source. Set true (per tenant/env override) to allow Offer Engine calls.", change_reason = "Offer Engine disabled by default; enable via Superposition override" }
-offer_engine_credential_source = { value = "none", schema = { type = "string", enum = [
+"offer_engine.enabled" = { value = false, schema = { type = "boolean" }, description = "Master gate for the Offer Engine integration. When false (default) Offer Engine is never called, regardless of offer_engine.credential_source. Set true (per tenant/env override) to allow Offer Engine calls.", change_reason = "Offer Engine disabled by default; enable via Superposition override" }
+"offer_engine.credential_source" = { value = "none", schema = { type = "string", enum = [
     "none",
     "application",
-] }, description = "Source of Offer Engine credentials once offer_engine_enabled is true: 'none' skips Offer Engine; 'application' uses the static offer_engine application config. Future org/merchant/profile sources will extend the enum alongside their credential storage.", change_reason = "Offer Engine credential source is a string enum: 'none' disables, 'application' enables; extensible to org/merchant/profile sources" }
+    "merchant",
+] }, description = "Source of Offer Engine credentials once offer_engine.enabled is true: 'none' skips Offer Engine; 'application' uses the static offer_engine application config; 'merchant' uses the per-merchant credentials stored on the merchant account. Future org/profile sources will extend the enum alongside their credential storage.", change_reason = "Offer Engine credential source is a string enum: 'none' disables, 'application' uses app config, 'merchant' uses merchant-account credentials; extensible to org/profile sources" }
 "account_updater.enabled" = { value = false, schema = { type = "boolean" }, description = "Master gate for the Account Updater integration. When false (default) Account Updater is never called, regardless of account_updater.credential_source. Set true (per tenant/env override) to allow Account Updater calls.", change_reason = "Account Updater disabled by default; enable via Superposition override" }
 "account_updater.credential_source" = { value = "none", schema = { type = "string", enum = [
     "none",

--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -421,6 +421,17 @@ pub struct MerchantAccountMetadata {
     pub data: Option<pii::SecretSerdeValue>,
 }
 
+/// Merchant-level Offer Engine credentials (Offer Engine issues one account per merchant)
+#[derive(Clone, Debug, Deserialize, ToSchema, Serialize)]
+pub struct OfferEngineMerchantConfig {
+    /// API key issued by Offer Engine for this merchant
+    #[schema(value_type = String)]
+    pub api_key: Secret<String>,
+
+    /// The Offer Engine merchant id sent in Offer Engine request bodies
+    pub merchant_id: String,
+}
+
 #[cfg(feature = "v1")]
 #[derive(Clone, Debug, Deserialize, ToSchema, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -502,6 +513,10 @@ pub struct MerchantAccountUpdate {
     /// Network tokenization credentials for this merchant account
     #[schema(value_type = Option<NetworkTokeizationProviderCredentials>)]
     pub network_tokenization_credentials: Option<NetworkTokeizationProviderCredentials>,
+
+    /// Merchant-level Offer Engine credentials, used when the resolved credential source is `merchant`
+    #[schema(value_type = Option<OfferEngineMerchantConfig>)]
+    pub offer_engine_config: Option<OfferEngineMerchantConfig>,
 }
 
 #[cfg(feature = "v1")]

--- a/crates/api_models/src/events.rs
+++ b/crates/api_models/src/events.rs
@@ -5,6 +5,7 @@ pub mod customer;
 pub mod dispute;
 pub mod external_service_auth;
 pub mod gsm;
+pub mod offer_engine;
 pub mod payment;
 #[cfg(feature = "payouts")]
 pub mod payouts;

--- a/crates/api_models/src/events/offer_engine.rs
+++ b/crates/api_models/src/events/offer_engine.rs
@@ -1,0 +1,7 @@
+use common_utils::events::ApiEventMetric;
+
+use crate::offer_engine::{BrowseOffersRequest, BrowseOffersResponse};
+
+impl ApiEventMetric for BrowseOffersRequest {}
+
+impl ApiEventMetric for BrowseOffersResponse {}

--- a/crates/api_models/src/lib.rs
+++ b/crates/api_models/src/lib.rs
@@ -27,6 +27,7 @@ pub mod health_check;
 pub mod launch_sage;
 pub mod mandates;
 pub mod merchant_connector_webhook_management;
+pub mod offer_engine;
 pub mod oidc;
 pub mod open_router;
 pub mod organization;

--- a/crates/api_models/src/offer_engine.rs
+++ b/crates/api_models/src/offer_engine.rs
@@ -1,0 +1,47 @@
+use utoipa::ToSchema;
+
+/// Request to browse the offers available to a merchant.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct BrowseOffersRequest {
+    /// Order context. Omit to browse without one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offer_payment_info: Option<OfferPaymentInfo>,
+}
+
+/// Order context supplied when browsing offers.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct OfferPaymentInfo {
+    /// Order currency.
+    #[schema(value_type = Currency, example = "USD")]
+    pub currency: common_enums::Currency,
+}
+
+/// The offers a merchant can currently use.
+#[derive(Debug, Clone, serde::Serialize, ToSchema)]
+pub struct BrowseOffersResponse {
+    pub offers: Vec<BrowseOffer>,
+}
+
+/// A single offer available to the merchant.
+#[derive(Debug, Clone, serde::Serialize, ToSchema)]
+pub struct BrowseOffer {
+    /// Offer code, as configured in Offer Engine.
+    #[schema(example = "TESTHS")]
+    pub code: String,
+    /// Full offer title.
+    #[schema(example = "Test offer HS")]
+    pub title: Option<String>,
+    /// Shortened title, for constrained layouts.
+    #[schema(example = "TSH")]
+    pub display_title: Option<String>,
+    /// Offer description.
+    #[schema(example = "Testing offers")]
+    pub description: Option<String>,
+    /// Currency the offer applies to.
+    #[schema(value_type = Option<Currency>, example = "USD")]
+    pub currency: Option<common_enums::Currency>,
+    /// When the offer stops being valid.
+    #[serde(with = "common_utils::custom_serde::iso8601::option")]
+    #[schema(value_type = Option<PrimitiveDateTime>, example = "2026-08-31T18:29:59.000Z")]
+    pub valid_till: Option<time::PrimitiveDateTime>,
+}

--- a/crates/diesel_models/src/merchant_account.rs
+++ b/crates/diesel_models/src/merchant_account.rs
@@ -58,6 +58,7 @@ pub struct MerchantAccount {
     pub merchant_account_type: Option<common_enums::MerchantAccountType>,
     pub network_tokenization_credentials: Option<Encryption>,
     pub fingerprint_secret: Option<Secret<String>>,
+    pub offer_engine_config: Option<Encryption>,
 }
 
 #[cfg(feature = "v1")]
@@ -95,6 +96,7 @@ pub struct MerchantAccountSetter {
     pub merchant_account_type: common_enums::MerchantAccountType,
     pub network_tokenization_credentials: Option<Encryption>,
     pub fingerprint_secret: Option<Secret<String>>,
+    pub offer_engine_config: Option<Encryption>,
 }
 
 #[cfg(feature = "v1")]
@@ -135,6 +137,7 @@ impl From<MerchantAccountSetter> for MerchantAccount {
             merchant_account_type: Some(item.merchant_account_type),
             network_tokenization_credentials: item.network_tokenization_credentials,
             fingerprint_secret: item.fingerprint_secret,
+            offer_engine_config: item.offer_engine_config,
         }
     }
 }
@@ -171,6 +174,7 @@ pub struct MerchantAccount {
     pub merchant_account_type: Option<common_enums::MerchantAccountType>,
     pub network_tokenization_credentials: Option<Encryption>,
     pub fingerprint_secret: Option<Secret<String>>,
+    pub offer_engine_config: Option<Encryption>,
 }
 
 #[cfg(feature = "v2")]
@@ -193,6 +197,7 @@ impl From<MerchantAccountSetter> for MerchantAccount {
             merchant_account_type: Some(item.merchant_account_type),
             network_tokenization_credentials: None, // need to check if we can have this column in v2
             fingerprint_secret: item.fingerprint_secret,
+            offer_engine_config: None,
         }
     }
 }
@@ -267,6 +272,7 @@ pub struct MerchantAccountNew {
     pub merchant_account_type: common_enums::MerchantAccountType,
     pub network_tokenization_credentials: Option<Encryption>,
     pub fingerprint_secret: Option<Secret<String>>,
+    pub offer_engine_config: Option<Encryption>,
 }
 
 #[cfg(feature = "v2")]
@@ -340,4 +346,5 @@ pub struct MerchantAccountUpdateInternal {
     pub is_platform_account: Option<bool>,
     pub product_type: Option<common_enums::MerchantProductType>,
     pub network_tokenization_credentials: Option<Encryption>,
+    pub offer_engine_config: Option<Encryption>,
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -1039,6 +1039,7 @@ diesel::table! {
         network_tokenization_credentials -> Nullable<Bytea>,
         #[max_length = 128]
         fingerprint_secret -> Nullable<Varchar>,
+        offer_engine_config -> Nullable<Bytea>,
     }
 }
 

--- a/crates/diesel_models/src/schema_v2.rs
+++ b/crates/diesel_models/src/schema_v2.rs
@@ -1005,6 +1005,7 @@ diesel::table! {
         network_tokenization_credentials -> Nullable<Bytea>,
         #[max_length = 128]
         fingerprint_secret -> Nullable<Varchar>,
+        offer_engine_config -> Nullable<Bytea>,
     }
 }
 

--- a/crates/hyperswitch_domain_models/src/merchant_account.rs
+++ b/crates/hyperswitch_domain_models/src/merchant_account.rs
@@ -56,6 +56,7 @@ pub struct MerchantAccount {
     pub merchant_account_type: common_enums::MerchantAccountType,
     pub network_tokenization_credentials: OptionalEncryptableValue,
     pub fingerprint_secret: Option<Secret<String>>,
+    pub offer_engine_config: OptionalEncryptableValue,
 }
 
 #[cfg(feature = "v1")]
@@ -95,6 +96,7 @@ pub struct MerchantAccountSetter {
     pub merchant_account_type: common_enums::MerchantAccountType,
     pub network_tokenization_credentials: OptionalEncryptableValue,
     pub fingerprint_secret: Option<Secret<String>>,
+    pub offer_engine_config: OptionalEncryptableValue,
 }
 
 #[cfg(feature = "v1")]
@@ -134,6 +136,7 @@ impl From<MerchantAccountSetter> for MerchantAccount {
             merchant_account_type: item.merchant_account_type,
             network_tokenization_credentials: item.network_tokenization_credentials,
             fingerprint_secret: item.fingerprint_secret,
+            offer_engine_config: item.offer_engine_config,
         }
     }
 }
@@ -232,6 +235,14 @@ impl MerchantAccount {
         &self.default_profile
     }
 
+    #[cfg(feature = "v1")]
+    /// Get the decrypted merchant-level Offer Engine config JSON, if configured
+    pub fn get_offer_engine_config(&self) -> Option<&pii::SecretSerdeValue> {
+        self.offer_engine_config
+            .as_ref()
+            .map(|config| config.get_inner())
+    }
+
     #[cfg(feature = "v2")]
     /// Get the unique identifier of MerchantAccount
     pub fn get_id(&self) -> &common_utils::id_type::MerchantId {
@@ -294,6 +305,7 @@ pub enum MerchantAccountUpdate {
         payment_link_config: Option<serde_json::Value>,
         pm_collect_link_config: Option<serde_json::Value>,
         network_tokenization_credentials: OptionalEncryptableValue,
+        offer_engine_config: OptionalEncryptableValue,
     },
     StorageSchemeUpdate {
         storage_scheme: MerchantStorageScheme,
@@ -351,6 +363,7 @@ impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {
                 payment_link_config,
                 pm_collect_link_config,
                 network_tokenization_credentials,
+                offer_engine_config,
             } => Self {
                 merchant_name: merchant_name.map(Encryption::from),
                 merchant_details: merchant_details.map(Encryption::from),
@@ -381,6 +394,7 @@ impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {
                 product_type: None,
                 network_tokenization_credentials: network_tokenization_credentials
                     .map(Encryption::from),
+                offer_engine_config: offer_engine_config.map(Encryption::from),
             },
             MerchantAccountUpdate::StorageSchemeUpdate { storage_scheme } => Self {
                 storage_scheme: Some(storage_scheme),
@@ -411,6 +425,7 @@ impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {
                 is_platform_account: None,
                 product_type: None,
                 network_tokenization_credentials: None,
+                offer_engine_config: None,
             },
             MerchantAccountUpdate::ReconUpdate { recon_status } => Self {
                 recon_status: Some(recon_status),
@@ -441,6 +456,7 @@ impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {
                 is_platform_account: None,
                 product_type: None,
                 network_tokenization_credentials: None,
+                offer_engine_config: None,
             },
             MerchantAccountUpdate::UnsetDefaultProfile => Self {
                 default_profile: Some(None),
@@ -471,6 +487,7 @@ impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {
                 is_platform_account: None,
                 product_type: None,
                 network_tokenization_credentials: None,
+                offer_engine_config: None,
             },
             MerchantAccountUpdate::ModifiedAtUpdate => Self {
                 modified_at: now,
@@ -501,6 +518,7 @@ impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {
                 is_platform_account: None,
                 product_type: None,
                 network_tokenization_credentials: None,
+                offer_engine_config: None,
             },
         }
     }
@@ -731,6 +749,7 @@ impl Conversion for MerchantAccount {
                 .network_tokenization_credentials
                 .map(|credentials| credentials.into()),
             fingerprint_secret: self.fingerprint_secret,
+            offer_engine_config: self.offer_engine_config.map(|config| config.into()),
         };
 
         Ok(diesel_models::MerchantAccount::from(setter))
@@ -826,6 +845,20 @@ impl Conversion for MerchantAccount {
                     })
                     .await?,
                 fingerprint_secret: item.fingerprint_secret,
+                offer_engine_config: item
+                    .offer_engine_config
+                    .async_lift(|inner| async {
+                        crypto_operation(
+                            state,
+                            type_name!(Self::DstType),
+                            CryptoOperation::DecryptOptional(inner),
+                            key_manager_identifier.clone(),
+                            key.peek(),
+                        )
+                        .await
+                        .and_then(|val| val.try_into_optionaloperation())
+                    })
+                    .await?,
             })
         }
         .await
@@ -875,6 +908,7 @@ impl Conversion for MerchantAccount {
                 .network_tokenization_credentials
                 .map(|credentials| credentials.into()),
             fingerprint_secret: self.fingerprint_secret,
+            offer_engine_config: self.offer_engine_config.map(|config| config.into()),
         })
     }
 }

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -198,6 +198,8 @@ Never share your secret api keys. Keep them guarded and secure.
         routes::routing::call_update_gateway_score_open_router,
         routes::routing::evaluate_routing_rule,
 
+        // Routes for offers
+        routes::offer_engine::offer_engine_browse_offers,
         // Routes for blocklist
         routes::blocklist::remove_entry_from_blocklist,
         routes::blocklist::list_blocked_payment_methods,
@@ -1015,6 +1017,10 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::routing::ast::NumberComparison,
         api_models::payment_methods::RequestPaymentMethodTypes,
         api_models::payments::PaymentLinkStatus,
+        api_models::offer_engine::BrowseOffersRequest,
+        api_models::offer_engine::OfferPaymentInfo,
+        api_models::offer_engine::BrowseOffersResponse,
+        api_models::offer_engine::BrowseOffer,
         api_models::blocklist::BlocklistRequest,
         api_models::blocklist::BlocklistResponse,
         api_models::blocklist::ToggleBlocklistResponse,

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -392,6 +392,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::admin::CardTestingGuardConfig,
         api_models::admin::CardTestingGuardStatus,
         api_models::admin::NetworkTokeizationProviderCredentials,
+        api_models::admin::OfferEngineMerchantConfig,
         api_models::admin::InternalNetworkTokenizationCredentials,
         api_models::admin::PaymentMethodBlockingConfig,
         api_models::admin::CardBlockingConfig,

--- a/crates/openapi/src/routes.rs
+++ b/crates/openapi/src/routes.rs
@@ -10,6 +10,7 @@ pub mod gsm;
 pub mod mandates;
 pub mod merchant_account;
 pub mod merchant_connector_account;
+pub mod offer_engine;
 pub mod organization;
 pub mod payment_link;
 pub mod payment_method;

--- a/crates/openapi/src/routes/offer_engine.rs
+++ b/crates/openapi/src/routes/offer_engine.rs
@@ -1,0 +1,24 @@
+/// Offers - Browse
+///
+/// Lists the offers currently available to the merchant. Offers that are not eligible are
+/// excluded, so the response contains only offers that can be used.
+#[utoipa::path(
+    post,
+    path = "/offer_engine/offers/list",
+    request_body (
+        content = BrowseOffersRequest,
+        examples ((
+            "Browse offers for a currency" = (
+                value = json!({"offer_payment_info": {"currency": "USD"}})
+            )
+        ))
+    ),
+    responses(
+        (status = 200, description = "Offers available to the merchant", body = BrowseOffersResponse),
+        (status = 403, description = "Offer Engine is not enabled for this merchant")
+    ),
+    tag = "Offers",
+    operation_id = "Browse offers",
+    security(("api_key" = []))
+)]
+pub async fn offer_engine_browse_offers() {}

--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -376,9 +376,10 @@ impl SecretsHandler for settings::OfferEngineConfig {
         secret_management_client: &dyn SecretManagementInterface,
     ) -> CustomResult<SecretStateContainer<Self, RawSecret>, SecretsManagementError> {
         let offer_engine = value.get_inner();
-        let api_key = secret_management_client
-            .get_secret(offer_engine.api_key.clone())
-            .await?;
+        let api_key = match offer_engine.api_key.clone() {
+            Some(api_key) => Some(secret_management_client.get_secret(api_key).await?),
+            None => None,
+        };
 
         Ok(value.transition_state(|offer_engine| Self {
             api_key,

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -708,8 +708,8 @@ pub struct ForexApi {
 #[derive(Debug, Deserialize, Clone)]
 pub struct OfferEngineConfig {
     pub base_url: url::Url,
-    pub api_key: Secret<String>,
-    pub merchant_id: String,
+    pub api_key: Option<Secret<String>>,
+    pub merchant_id: Option<String>,
 }
 
 impl OfferEngineConfig {
@@ -719,18 +719,28 @@ impl OfferEngineConfig {
                 "offer_engine.base_url must end with a trailing slash".into(),
             ))
         })?;
-        common_utils::fp_utils::when(self.api_key.peek().is_empty(), || {
-            Err(ApplicationError::InvalidConfigurationValueError(
-                "offer_engine.api_key must not be empty".into(),
-            ))
-        })?;
-        common_utils::fp_utils::when(self.merchant_id.is_empty(), || {
-            Err(error_stack::Report::from(
-                ApplicationError::InvalidConfigurationValueError(
-                    "offer_engine.merchant_id must not be empty".into(),
-                ),
-            ))
-        })
+        common_utils::fp_utils::when(
+            self.api_key
+                .as_ref()
+                .is_some_and(|api_key| api_key.peek().is_empty()),
+            || {
+                Err(ApplicationError::InvalidConfigurationValueError(
+                    "offer_engine.api_key must not be empty".into(),
+                ))
+            },
+        )?;
+        common_utils::fp_utils::when(
+            self.merchant_id
+                .as_ref()
+                .is_some_and(|merchant_id| merchant_id.is_empty()),
+            || {
+                Err(error_stack::Report::from(
+                    ApplicationError::InvalidConfigurationValueError(
+                        "offer_engine.merchant_id must not be empty".into(),
+                    ),
+                ))
+            },
+        )
     }
 }
 

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -406,9 +406,9 @@ pub const UCS_DDC_METHOD_URL_KEY: &str = "threeDsMethodUrl";
 /// Superposition configuration keys
 pub mod superposition {
     /// Offer Engine master gate key: boolean, `false` (default) disables all Offer Engine calls.
-    pub const OFFER_ENGINE_ENABLED: &str = "offer_engine_enabled";
-    /// Offer Engine credential source key: `"none"` skips Offer Engine, `"application"` uses the static app config.
-    pub const OFFER_ENGINE_CREDENTIAL_SOURCE: &str = "offer_engine_credential_source";
+    pub const OFFER_ENGINE_ENABLED: &str = "offer_engine.enabled";
+    /// Offer Engine credential source key: `"none"` skips Offer Engine, `"application"` uses the static app config, `"merchant"` uses per-merchant credentials.
+    pub const OFFER_ENGINE_CREDENTIAL_SOURCE: &str = "offer_engine.credential_source";
     /// Account Updater master gate key: `false` (default) disables all Account Updater calls.
     pub const ACCOUNT_UPDATER_ENABLED: &str = "account_updater.enabled";
     /// Account Updater credential source key: `"none"` skips Account Updater, `"application"` uses the static application config.

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -643,6 +643,7 @@ impl MerchantAccountCreateBridge for api::MerchantAccountCreate {
                         consts::FINGERPRINT_SECRET_LENGTH,
                         "fs",
                     ))),
+                    offer_engine_config: None,
                 },
             )
         }
@@ -1217,6 +1218,21 @@ impl MerchantAccountUpdateBridge for api::MerchantAccountUpdate {
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Unable to encrypt network_tokenization_credentials")?;
 
+        let offer_engine_config = self
+            .offer_engine_config
+            .async_map(|value| {
+                core_utils::create_encrypted_data(
+                    key_manager_state,
+                    key_store,
+                    value,
+                    type_name!(storage::MerchantAccount),
+                )
+            })
+            .await
+            .transpose()
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Unable to encrypt offer_engine_config")?;
+
         let identifier = km_types::Identifier::Merchant(key_store.merchant_id.clone());
         Ok(storage::MerchantAccountUpdate::Update {
             merchant_name: self
@@ -1273,6 +1289,7 @@ impl MerchantAccountUpdateBridge for api::MerchantAccountUpdate {
             pm_collect_link_config,
             routing_algorithm: self.routing_algorithm,
             network_tokenization_credentials,
+            offer_engine_config,
         })
     }
 }

--- a/crates/router/src/core/configs/dimension_config.rs
+++ b/crates/router/src/core/configs/dimension_config.rs
@@ -872,7 +872,7 @@ config! {
 }
 
 impl DatabaseBackedConfig for OfferEngineEnabled {
-    const KEY: &'static str = "offer_engine_enabled";
+    const KEY: &'static str = "offer_engine.enabled";
 }
 
 config! {
@@ -897,7 +897,7 @@ config! {
 }
 
 impl DatabaseBackedConfig for OfferEngineCredentialSource {
-    const KEY: &'static str = "offer_engine_credential_source";
+    const KEY: &'static str = "offer_engine.credential_source";
 }
 
 #[cfg(feature = "v2")]

--- a/crates/router/src/core/external_service_auth.rs
+++ b/crates/router/src/core/external_service_auth.rs
@@ -147,19 +147,42 @@ async fn resolve_offer_engine_merchant_id(
         .with_organization_id(payload.org_id.clone())
         .with_profile_id(payload.profile_id.clone());
 
-    offer_engine::resolve_offer_engine_config(state, &dimensions)
-        .await
-        .inspect_err(|error| {
-            router_env::logger::warn!(?error, "failed to resolve Offer Engine config");
-        })
-        .ok()
-        .flatten()
-        .map(|config| config.merchant_id)
-        .ok_or_else(|| {
-            error_stack::report!(errors::ApiErrorResponse::AccessForbidden {
-                resource: "offer_engine".to_string(),
-            })
-        })
+    let config =
+        match offer_engine::resolve_offer_engine_credential_source(state, &dimensions).await {
+            offer_engine::OfferEngineCredentialSource::None => {
+                return Err(error_stack::report!(
+                    errors::ApiErrorResponse::AccessForbidden {
+                        resource: "offer_engine".to_string(),
+                    }
+                ));
+            }
+            offer_engine::OfferEngineCredentialSource::Application => {
+                offer_engine::OfferEngineCredentialSource::resolve_application_offer_config(state)
+            }
+            offer_engine::OfferEngineCredentialSource::Merchant => {
+                let db = &*state.store;
+                let key_store = db
+                    .get_merchant_key_store_by_merchant_id(
+                        &payload.merchant_id,
+                        &db.get_master_key().to_vec().into(),
+                    )
+                    .await
+                    .change_context(errors::ApiErrorResponse::InternalServerError)?;
+                let merchant_account = db
+                    .find_merchant_account_by_merchant_id(&payload.merchant_id, &key_store)
+                    .await
+                    .change_context(errors::ApiErrorResponse::InternalServerError)?;
+                offer_engine::OfferEngineCredentialSource::resolve_merchant_offer_config(
+                    state,
+                    &merchant_account,
+                )
+            }
+        }
+        .change_context(errors::ApiErrorResponse::AccessForbidden {
+            resource: "offer_engine".to_string(),
+        })?;
+
+    Ok(config.merchant_id)
 }
 
 /// Offer permissions held by the role. Empty means no offer access.

--- a/crates/router/src/core/offer_engine.rs
+++ b/crates/router/src/core/offer_engine.rs
@@ -11,7 +11,7 @@ pub mod types;
 pub mod velocity;
 
 pub use client::OfferEngineClient;
-pub use config::resolve_offer_engine_config;
+pub use config::resolve_offer_engine_credential_source;
 #[cfg(feature = "v1")]
 pub use notify::{schedule_payment_notification_for_attempt, schedule_refund_notification};
 pub use types::{OfferEngineCredentialSource, OfferEngineError, ResolvedOfferEngineConfig};

--- a/crates/router/src/core/offer_engine.rs
+++ b/crates/router/src/core/offer_engine.rs
@@ -12,6 +12,18 @@ pub mod velocity;
 
 pub use client::OfferEngineClient;
 pub use config::resolve_offer_engine_credential_source;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub enum SupportedPaymentMethodType {
+    Card,
+}
+
+pub fn is_supported_payment_method_type(payment_method_type: &str) -> bool {
+    payment_method_type
+        .parse::<SupportedPaymentMethodType>()
+        .is_ok()
+}
 #[cfg(feature = "v1")]
 pub use notify::{schedule_payment_notification_for_attempt, schedule_refund_notification};
 pub use types::{OfferEngineCredentialSource, OfferEngineError, ResolvedOfferEngineConfig};

--- a/crates/router/src/core/offer_engine.rs
+++ b/crates/router/src/core/offer_engine.rs
@@ -1,5 +1,6 @@
 pub mod amount;
 pub mod apply;
+pub mod browse;
 pub mod client;
 pub mod config;
 pub mod connectivity;

--- a/crates/router/src/core/offer_engine/browse.rs
+++ b/crates/router/src/core/offer_engine/browse.rs
@@ -1,0 +1,87 @@
+use api_models::offer_engine::{BrowseOffer, BrowseOffersRequest, BrowseOffersResponse};
+use common_utils::id_type;
+use error_stack::ResultExt;
+
+use super::{
+    client::OfferEngineClient,
+    config::resolve_offer_engine_credential_source,
+    types::{BrowseOfferListRequest, OfferEngineCredentialSource, OfferStatus},
+};
+use crate::{
+    core::{
+        configs::dimension_state::Dimensions,
+        errors::{self, RouterResponse},
+    },
+    routes::SessionState,
+    services::api as service_api,
+    types::domain,
+};
+
+/// Lists the offers a merchant can currently use. Ineligible offers are dropped, so the caller
+/// sees only what is usable.
+pub async fn browse_offers(
+    state: SessionState,
+    platform: domain::Platform,
+    profile_id: Option<id_type::ProfileId>,
+    request: BrowseOffersRequest,
+) -> RouterResponse<BrowseOffersResponse> {
+    let processor = platform.get_processor();
+
+    // Each `with_*` yields a distinct type, so the profile-scoped and merchant-scoped lookups
+    // cannot share one binding.
+    let dimensions = Dimensions::new()
+        .with_processor_merchant_id(processor.get_processor_merchant_id())
+        .with_organization_id(processor.get_account().get_org_id().clone());
+
+    let credential_source = match profile_id {
+        Some(profile_id) => {
+            resolve_offer_engine_credential_source(&state, &dimensions.with_profile_id(profile_id))
+                .await
+        }
+        None => resolve_offer_engine_credential_source(&state, &dimensions).await,
+    };
+
+    let config = match credential_source {
+        OfferEngineCredentialSource::None => {
+            return Err(error_stack::report!(
+                errors::ApiErrorResponse::AccessForbidden {
+                    resource: "offer_engine".to_string(),
+                }
+            ));
+        }
+        OfferEngineCredentialSource::Application => {
+            OfferEngineCredentialSource::resolve_application_offer_config(&state)
+        }
+        OfferEngineCredentialSource::Merchant => {
+            OfferEngineCredentialSource::resolve_merchant_offer_config(
+                &state,
+                processor.get_account(),
+            )
+        }
+    }
+    .change_context(errors::ApiErrorResponse::AccessForbidden {
+        resource: "offer_engine".to_string(),
+    })?;
+
+    let list_request = BrowseOfferListRequest {
+        currency: request.offer_payment_info.map(|info| info.currency),
+    };
+
+    let client = OfferEngineClient::new(config, &state.conf.trace_header.header_name);
+    let response = client
+        .browse_offers(&state, list_request)
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Offer Engine /list failed")?;
+
+    Ok(service_api::ApplicationResponse::Json(
+        BrowseOffersResponse {
+            offers: response
+                .offers
+                .into_iter()
+                .filter(|entry| entry.status == OfferStatus::Eligible)
+                .map(BrowseOffer::from)
+                .collect(),
+        },
+    ))
+}

--- a/crates/router/src/core/offer_engine/client.rs
+++ b/crates/router/src/core/offer_engine/client.rs
@@ -10,8 +10,9 @@ use hyperswitch_masking::{Mask, PeekInterface};
 use router_env::{IdReuse, RequestIdentifier};
 
 use super::types::{
-    OfferApplyRequest, OfferApplyResponse, OfferEngineError, OfferListRequest, OfferListResponse,
-    OfferNotifyRequest, ResolvedOfferEngineConfig,
+    BrowseOfferListRequest, BrowseOfferListResponse, OfferApplyRequest, OfferApplyResponse,
+    OfferEngineError, OfferListRequest, OfferListResponse, OfferNotifyRequest,
+    ResolvedOfferEngineConfig,
 };
 use crate::{consts::BASE64_ENGINE, routes::SessionState};
 
@@ -56,6 +57,17 @@ impl OfferEngineClient {
         request: OfferListRequest,
     ) -> CustomResult<OfferListResponse, OfferEngineError> {
         OfferList::call(state, self, OfferListV1Request(request))
+            .await
+            .map(|response| response.0)
+            .map_err(map_offer_engine_error)
+    }
+
+    pub async fn browse_offers(
+        &self,
+        state: &SessionState,
+        request: BrowseOfferListRequest,
+    ) -> CustomResult<BrowseOfferListResponse, OfferEngineError> {
+        OfferBrowseList::call(state, self, OfferBrowseListV1Request(request))
             .await
             .map(|response| response.0)
             .map_err(map_offer_engine_error)
@@ -284,6 +296,42 @@ hyperswitch_interfaces::impl_microservice_flow!(
     v1_response = OfferNotifyV1Response,
     client = OfferEngineClient,
     body = OfferNotify::build_body
+);
+
+pub struct OfferBrowseList;
+pub struct OfferBrowseListV1Request(pub BrowseOfferListRequest);
+pub struct OfferBrowseListV1Response(pub BrowseOfferListResponse);
+
+impl TryFrom<&OfferBrowseListV1Request> for BrowseOfferListRequest {
+    type Error = MicroserviceClientError;
+    fn try_from(value: &OfferBrowseListV1Request) -> Result<Self, Self::Error> {
+        Ok(value.0.clone())
+    }
+}
+
+impl TryFrom<BrowseOfferListResponse> for OfferBrowseListV1Response {
+    type Error = MicroserviceClientError;
+    fn try_from(value: BrowseOfferListResponse) -> Result<Self, Self::Error> {
+        Ok(Self(value))
+    }
+}
+
+impl OfferBrowseList {
+    fn build_body(&self, request: BrowseOfferListRequest) -> Option<RequestContent> {
+        Some(RequestContent::Json(Box::new(request)))
+    }
+}
+
+hyperswitch_interfaces::impl_microservice_flow!(
+    OfferBrowseList,
+    method = Method::Post,
+    path = OFFERS_LIST_PATH,
+    v1_request = OfferBrowseListV1Request,
+    v2_request = BrowseOfferListRequest,
+    v2_response = BrowseOfferListResponse,
+    v1_response = OfferBrowseListV1Response,
+    client = OfferEngineClient,
+    body = OfferBrowseList::build_body
 );
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/router/src/core/offer_engine/config.rs
+++ b/crates/router/src/core/offer_engine/config.rs
@@ -86,10 +86,24 @@ impl OfferEngineCredentialSource {
             })?
             .get_inner();
 
+        let api_key = app_config.api_key.clone().ok_or_else(|| {
+            error_stack::report!(OfferEngineError::MissingApplicationConfig(
+                "offer_engine.api_key is required when credential source is application"
+                    .to_string()
+            ))
+        })?;
+
+        let merchant_id = app_config.merchant_id.clone().ok_or_else(|| {
+            error_stack::report!(OfferEngineError::MissingApplicationConfig(
+                "offer_engine.merchant_id is required when credential source is application"
+                    .to_string()
+            ))
+        })?;
+
         Ok(ResolvedOfferEngineConfig {
             base_url: app_config.base_url.clone(),
-            api_key: app_config.api_key.clone(),
-            merchant_id: app_config.merchant_id.clone(),
+            api_key,
+            merchant_id,
         })
     }
 

--- a/crates/router/src/core/offer_engine/config.rs
+++ b/crates/router/src/core/offer_engine/config.rs
@@ -1,18 +1,18 @@
 use common_utils::errors::CustomResult;
+use error_stack::ResultExt;
+use hyperswitch_masking::PeekInterface;
 
 use super::types::{OfferEngineCredentialSource, OfferEngineError, ResolvedOfferEngineConfig};
 use crate::{
     core::configs::{self, dimension_config, dimension_state},
     routes::SessionState,
+    types::domain,
 };
 
-/// Resolve the Offer Engine config for the given dimensions. Generic over the
-/// dimension so callers can target at any level (connectivity uses the global
-/// dimension; payments pass merchant/org/profile for superposition targeting).
-pub async fn resolve_offer_engine_config<D>(
+pub async fn resolve_offer_engine_credential_source<D>(
     state: &SessionState,
     dimensions: &D,
-) -> CustomResult<Option<ResolvedOfferEngineConfig>, OfferEngineError>
+) -> OfferEngineCredentialSource
 where
     D: dimension_state::DimensionsBase,
 {
@@ -25,23 +25,35 @@ where
     .await;
 
     if enabled {
-        resolve_offer_engine_credentials(state, dimensions).await
+        configs::fetch_db_config_for_string_enum::<
+            dimension_config::OfferEngineCredentialSource,
+            OfferEngineCredentialSource,
+        >(
+            state.store.as_ref(),
+            state.superposition_service.as_ref(),
+            dimensions,
+            None,
+        )
+        .await
+        .unwrap_or_else(|| {
+            router_env::logger::warn!(
+                "Offer Engine credential source config could not be parsed; defaulting to none"
+            );
+            OfferEngineCredentialSource::None
+        })
     } else {
-        Ok(None)
+        OfferEngineCredentialSource::None
     }
 }
 
-/// Resolve the Offer Engine credentials for the given dimensions by credential
-/// source, independent of the `enabled` toggle. The notification path uses this:
-/// an applied offer's outcome must be reported even after the feature is disabled.
-pub async fn resolve_offer_engine_credentials<D>(
+pub async fn fetch_offer_engine_credential_source_for_notify<D>(
     state: &SessionState,
     dimensions: &D,
-) -> CustomResult<Option<ResolvedOfferEngineConfig>, OfferEngineError>
+) -> OfferEngineCredentialSource
 where
     D: dimension_state::DimensionsBase,
 {
-    let source = configs::fetch_db_config_for_string_enum::<
+    configs::fetch_db_config_for_string_enum::<
         dimension_config::OfferEngineCredentialSource,
         OfferEngineCredentialSource,
     >(
@@ -51,31 +63,84 @@ where
         None,
     )
     .await
-    .unwrap_or(OfferEngineCredentialSource::None);
-
-    match source {
-        OfferEngineCredentialSource::None => Ok(None),
-        OfferEngineCredentialSource::Application => resolve_application_config(state).map(Some),
-    }
+    .unwrap_or_else(|| {
+        router_env::logger::warn!(
+            "Offer Engine credential source config could not be parsed; defaulting to none"
+        );
+        OfferEngineCredentialSource::None
+    })
 }
 
-fn resolve_application_config(
-    state: &SessionState,
-) -> CustomResult<ResolvedOfferEngineConfig, OfferEngineError> {
-    let app_config = state
-        .conf
-        .offer_engine
-        .as_ref()
-        .ok_or_else(|| {
-            error_stack::report!(OfferEngineError::MissingApplicationConfig(
-                "offer_engine application config is not set".to_string()
-            ))
-        })?
-        .get_inner();
+impl OfferEngineCredentialSource {
+    pub fn resolve_application_offer_config(
+        state: &SessionState,
+    ) -> CustomResult<ResolvedOfferEngineConfig, OfferEngineError> {
+        let app_config = state
+            .conf
+            .offer_engine
+            .as_ref()
+            .ok_or_else(|| {
+                error_stack::report!(OfferEngineError::MissingApplicationConfig(
+                    "offer_engine application config is not set".to_string()
+                ))
+            })?
+            .get_inner();
 
-    Ok(ResolvedOfferEngineConfig {
-        base_url: app_config.base_url.clone(),
-        api_key: app_config.api_key.clone(),
-        merchant_id: app_config.merchant_id.clone(),
-    })
+        Ok(ResolvedOfferEngineConfig {
+            base_url: app_config.base_url.clone(),
+            api_key: app_config.api_key.clone(),
+            merchant_id: app_config.merchant_id.clone(),
+        })
+    }
+
+    #[cfg(feature = "v1")]
+    pub fn resolve_merchant_offer_config(
+        state: &SessionState,
+        merchant_account: &domain::MerchantAccount,
+    ) -> CustomResult<ResolvedOfferEngineConfig, OfferEngineError> {
+        let base_url = state
+            .conf
+            .offer_engine
+            .as_ref()
+            .ok_or_else(|| {
+                error_stack::report!(OfferEngineError::MissingApplicationConfig(
+                    "offer_engine base_url is not set in application config".to_string()
+                ))
+            })?
+            .get_inner()
+            .base_url
+            .clone();
+
+        let merchant_offer_config =
+            merchant_account.get_offer_engine_config().ok_or_else(|| {
+                error_stack::report!(OfferEngineError::MissingMerchantConfig(
+                    "merchant Offer Engine config is not set on the merchant account".to_string()
+                ))
+            })?;
+
+        let merchant_config: api_models::admin::OfferEngineMerchantConfig = serde_json::from_value(
+            merchant_offer_config.peek().clone(),
+        )
+        .change_context(OfferEngineError::MissingMerchantConfig(
+            "merchant Offer Engine config is invalid".to_string(),
+        ))?;
+
+        Ok(ResolvedOfferEngineConfig {
+            base_url,
+            api_key: merchant_config.api_key,
+            merchant_id: merchant_config.merchant_id,
+        })
+    }
+
+    #[cfg(feature = "v2")]
+    pub fn resolve_merchant_offer_config(
+        _state: &SessionState,
+        _merchant_account: &domain::MerchantAccount,
+    ) -> CustomResult<ResolvedOfferEngineConfig, OfferEngineError> {
+        Err(error_stack::report!(
+            OfferEngineError::MissingMerchantConfig(
+                "merchant-level Offer Engine credentials are only supported in v1".to_string()
+            )
+        ))
+    }
 }

--- a/crates/router/src/core/offer_engine/connectivity.rs
+++ b/crates/router/src/core/offer_engine/connectivity.rs
@@ -1,4 +1,7 @@
-use super::{client::OfferEngineClient, config::resolve_offer_engine_config};
+use super::{
+    client::OfferEngineClient, config::resolve_offer_engine_credential_source,
+    types::OfferEngineCredentialSource,
+};
 use crate::{
     core::{configs::dimension_state, errors::RouterResponse},
     routes::SessionState,
@@ -24,22 +27,35 @@ pub async fn check_offer_engine_connectivity(
     state: SessionState,
 ) -> RouterResponse<OfferEngineConnectivityResponse> {
     let dimensions: dimension_state::DimensionsGlobal = dimension_state::Dimensions::new();
-    let response = match resolve_offer_engine_config(&state, &dimensions).await {
-        Err(err) => OfferEngineConnectivityResponse {
+    let resolved_config = match resolve_offer_engine_credential_source(&state, &dimensions).await {
+        OfferEngineCredentialSource::None => None,
+        OfferEngineCredentialSource::Application => {
+            Some(OfferEngineCredentialSource::resolve_application_offer_config(&state))
+        }
+        OfferEngineCredentialSource::Merchant => Some(Err(error_stack::report!(
+            super::types::OfferEngineError::MissingMerchantConfig(
+                "credential source is 'merchant' but no merchant context is available in a \
+                 global connectivity check"
+                    .to_string()
+            )
+        ))),
+    };
+    let response = match resolved_config {
+        Some(Err(err)) => OfferEngineConnectivityResponse {
             enabled: false,
             reachable: None,
             status_code: None,
             detail: format!("Offer Engine config could not be resolved: {err:?}"),
         },
-        Ok(None) => OfferEngineConnectivityResponse {
+        None => OfferEngineConnectivityResponse {
             enabled: false,
             reachable: None,
             status_code: None,
             detail: "Offer Engine is not enabled in global config \
-                (offer_engine_enabled is false or credential source is none)"
+                (offer_engine.enabled is false or credential source is none)"
                 .to_string(),
         },
-        Ok(Some(config)) => {
+        Some(Ok(config)) => {
             let result = OfferEngineClient::new(config, &state.conf.trace_header.header_name)
                 .check_connectivity(&state)
                 .await;

--- a/crates/router/src/core/offer_engine/notify.rs
+++ b/crates/router/src/core/offer_engine/notify.rs
@@ -5,8 +5,11 @@ use scheduler::{consumer::types::process_data, utils as pt_utils};
 
 use super::{
     client::OfferEngineClient,
-    config::resolve_offer_engine_credentials,
-    types::{OfferNotifyOffer, OfferNotifyRequest, OfferNotifyStatus, OfferTxnStatus},
+    config::fetch_offer_engine_credential_source_for_notify,
+    types::{
+        OfferEngineCredentialSource, OfferNotifyOffer, OfferNotifyRequest, OfferNotifyStatus,
+        OfferTxnStatus,
+    },
 };
 use crate::{
     core::{configs::dimension_state, errors},
@@ -210,8 +213,21 @@ pub async fn execute_notification(
                 ))
                 .with_organization_id(payment_attempt.organization_id.clone())
                 .with_profile_id(payment_attempt.profile_id.clone());
-            match resolve_offer_engine_credentials(state, &dimensions).await {
-                Ok(Some(config)) => {
+            let config =
+                match fetch_offer_engine_credential_source_for_notify(state, &dimensions).await {
+                    OfferEngineCredentialSource::None => None,
+                    OfferEngineCredentialSource::Application => {
+                        Some(OfferEngineCredentialSource::resolve_application_offer_config(state))
+                    }
+                    OfferEngineCredentialSource::Merchant => {
+                        Some(OfferEngineCredentialSource::resolve_merchant_offer_config(
+                            state,
+                            &merchant_account,
+                        ))
+                    }
+                };
+            match config {
+                Some(Ok(config)) => {
                     let applied = applied.inner();
                     let request = OfferNotifyRequest {
                         order_id: tracking_data.payment_id.get_string_repr().to_string(),

--- a/crates/router/src/core/offer_engine/types.rs
+++ b/crates/router/src/core/offer_engine/types.rs
@@ -19,6 +19,7 @@ use super::amount;
 pub enum OfferEngineCredentialSource {
     None,
     Application,
+    Merchant,
 }
 
 #[derive(Debug, Clone)]
@@ -32,6 +33,8 @@ pub struct ResolvedOfferEngineConfig {
 pub enum OfferEngineError {
     #[error("Offer Engine application config is missing or invalid: {0}")]
     MissingApplicationConfig(String),
+    #[error("Offer Engine merchant config is missing or invalid: {0}")]
+    MissingMerchantConfig(String),
     #[error("Offer Engine request failed")]
     RequestFailed,
     #[error("Failed to parse Offer Engine response")]

--- a/crates/router/src/core/offer_engine/types.rs
+++ b/crates/router/src/core/offer_engine/types.rs
@@ -327,3 +327,47 @@ pub struct OfferNotifyRequest {
 
 /// Response marker for `/offers/notify`; a 2xx is treated as delivered.
 pub struct OfferNotifyResponse;
+
+/// Browse request to Offer Engine. Carries no `order`: Offer Engine requires an amount inside
+/// an `order` once one is present, and browse has no order. The merchant comes from the API key.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BrowseOfferListRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<common_enums::Currency>,
+}
+
+/// Browse response from Offer Engine
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct BrowseOfferListResponse {
+    #[serde(default)]
+    pub offers: Vec<BrowseOfferListEntry>,
+}
+
+/// A per-offer entry in a browse response.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct BrowseOfferListEntry {
+    pub status: OfferStatus,
+    pub offer_code: String,
+    pub offer_description: Option<OfferDescription>,
+    pub display_title: Option<String>,
+    pub currency: Option<common_enums::Currency>,
+    #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
+    pub valid_till: Option<time::PrimitiveDateTime>,
+}
+
+impl From<BrowseOfferListEntry> for api_models::offer_engine::BrowseOffer {
+    fn from(entry: BrowseOfferListEntry) -> Self {
+        let (title, description) = entry.offer_description.map_or((None, None), |description| {
+            (description.title, description.description)
+        });
+
+        Self {
+            code: entry.offer_code,
+            title,
+            display_title: entry.display_title,
+            description,
+            currency: entry.currency,
+            valid_till: entry.valid_till,
+        }
+    }
+}

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -4954,10 +4954,21 @@ pub async fn build_merchant_enabled_pms_context(
         None => false,
     };
 
-    let offers_enabled = matches!(
-        offer_engine::resolve_offer_engine_config(state, &dimensions).await,
-        Ok(Some(_))
-    );
+    let offers_enabled =
+        match offer_engine::resolve_offer_engine_credential_source(state, &dimensions).await {
+            offer_engine::OfferEngineCredentialSource::None => false,
+            offer_engine::OfferEngineCredentialSource::Application => {
+                offer_engine::OfferEngineCredentialSource::resolve_application_offer_config(state)
+                    .is_ok()
+            }
+            offer_engine::OfferEngineCredentialSource::Merchant => {
+                offer_engine::OfferEngineCredentialSource::resolve_merchant_offer_config(
+                    state,
+                    platform.get_processor().get_account(),
+                )
+                .is_ok()
+            }
+        };
 
     let sdk_next_action = payment_method_utils::get_sdk_next_action_for_payment_method_list(
         state,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -14993,11 +14993,38 @@ async fn resolve_offer_eligibility_details(
             .with_processor_merchant_id(processor.get_processor_merchant_id())
             .with_organization_id(processor.get_account().get_org_id().clone())
             .with_profile_id(profile_id.clone());
-        offer_engine::resolve_offer_engine_config(state, &offer_dimensions)
-            .await
-            .ok()
-            .flatten()
-            .zip(currency)
+        let resolved_config =
+            match offer_engine::resolve_offer_engine_credential_source(state, &offer_dimensions)
+                .await
+            {
+                offer_engine::OfferEngineCredentialSource::None => None,
+                offer_engine::OfferEngineCredentialSource::Application => {
+                    offer_engine::OfferEngineCredentialSource::resolve_application_offer_config(
+                        state,
+                    )
+                    .inspect_err(|error| {
+                        logger::warn!(
+                            ?error,
+                            "offer engine: unable to resolve offer config; offers unavailable"
+                        )
+                    })
+                    .ok()
+                }
+                offer_engine::OfferEngineCredentialSource::Merchant => {
+                    offer_engine::OfferEngineCredentialSource::resolve_merchant_offer_config(
+                        state,
+                        processor.get_account(),
+                    )
+                    .inspect_err(|error| {
+                        logger::warn!(
+                            ?error,
+                            "offer engine: unable to resolve offer config; offers unavailable"
+                        )
+                    })
+                    .ok()
+                }
+            };
+        resolved_config.zip(currency)
     };
 
     match offer_context {

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -14951,11 +14951,10 @@ pub async fn payments_submit_eligibility(
 /// Resolve Offer Engine eligibility into `(amount_details, offer_details)` for the
 /// eligibility response.
 ///
-/// Both are `None` when eligibility is denied or Offer Engine is not available
-/// (config resolution failures are treated as "offers not available"). A `/list`
-/// failure while Offer Engine is enabled fails eligibility. When enabled but no
-/// offer is selected, the payable amount is returned unchanged with an empty
-/// offer list.
+/// Both are `None` when eligibility is denied, the payment method is not one Offer
+/// Engine serves, or Offer Engine is not available. A `/list` failure is failed
+/// **open** (logged + metered, payable amount unchanged); `/apply` at confirm stays
+/// fail-closed.
 #[cfg(all(feature = "oltp", feature = "v1"))]
 #[allow(clippy::too_many_arguments)]
 async fn resolve_offer_eligibility_details(
@@ -14978,12 +14977,11 @@ async fn resolve_offer_eligibility_details(
     Option<api_models::payments::EligibilityAmountDetails>,
     Option<api_models::payments::EligibilityOfferDetails>,
 )> {
-    // Offers apply only when eligibility is not denied, an Offer Engine config
-    // resolves, and the currency is known (config-resolution failures are treated
-    // as "offers not available").
     let offer_context = if matches!(
         next_action,
         api_models::payments::NextActionCall::Deny { .. }
+    ) || !offer_engine::is_supported_payment_method_type(
+        &payment_method_type,
     ) {
         None
     } else {
@@ -15064,12 +15062,17 @@ async fn resolve_offer_eligibility_details(
                 card_alias,
             };
 
-            // A `/list` failure while Offer Engine is enabled fails eligibility.
             let selected =
                 offer_engine::eligibility::run_offer_eligibility(state, offer_config, ctx)
                     .await
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Offer Engine /list failed")?;
+                    .unwrap_or_else(|error| {
+                        logger::warn!(
+                            ?error,
+                            "Offer Engine /list failed; proceeding without offers (fail-open)"
+                        );
+                        metrics::OFFER_ENGINE_LIST_FAILURES.add(1, &[]);
+                        None
+                    });
 
             match selected {
                 // Enabled but no eligible offer: payable amount unchanged.
@@ -15082,7 +15085,7 @@ async fn resolve_offer_eligibility_details(
                     Some(api_models::payments::EligibilityOfferDetails::default()),
                 )),
                 // Eligible offer: store the quote for confirm to validate `/apply`
-                // against (keyed by offer id, the first-launch quote id; TTL kept).
+                // against (keyed by a generated offer_quote_id; TTL kept).
                 Some(selected) => {
                     let processor_merchant_id = processor.get_account().get_id().clone();
                     // Issue a unique quote id; confirm echoes it back to apply this offer.

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -3238,13 +3238,30 @@ async fn apply_selected_offer<F: Clone + Send + Sync>(
         .with_processor_merchant_id(processor.get_processor_merchant_id())
         .with_organization_id(processor.get_account().get_org_id().clone())
         .with_profile_id(profile_id.clone());
-    let offer_config = offer_engine::resolve_offer_engine_config(state, &offer_dimensions)
-        .await
-        .ok()
-        .flatten()
-        .ok_or(report!(errors::ApiErrorResponse::PreconditionFailed {
-            message: "Offer Engine is not available for this offer selection".to_string(),
-        }))?;
+    let offer_config = match offer_engine::resolve_offer_engine_credential_source(
+        state,
+        &offer_dimensions,
+    )
+    .await
+    {
+        offer_engine::OfferEngineCredentialSource::None => {
+            return Err(report!(errors::ApiErrorResponse::PreconditionFailed {
+                message: "Offer Engine is not available for this offer selection".to_string(),
+            }));
+        }
+        offer_engine::OfferEngineCredentialSource::Application => {
+            offer_engine::OfferEngineCredentialSource::resolve_application_offer_config(state)
+        }
+        offer_engine::OfferEngineCredentialSource::Merchant => {
+            offer_engine::OfferEngineCredentialSource::resolve_merchant_offer_config(
+                state,
+                processor.get_account(),
+            )
+        }
+    }
+    .change_context(errors::ApiErrorResponse::PreconditionFailed {
+        message: "Offer Engine is not available for this offer selection".to_string(),
+    })?;
 
     let processor_merchant_id = processor.get_account().get_id().clone();
     let payment_id = payment_data.payment_attempt.payment_id.clone();

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -206,6 +206,7 @@ pub async fn update_merchant_active_algorithm_ref(
         payment_link_config: None,
         pm_collect_link_config: None,
         network_tokenization_credentials: None,
+        offer_engine_config: None,
     };
 
     let db = &*state.store;

--- a/crates/router/src/db/events.rs
+++ b/crates/router/src/db/events.rs
@@ -1997,6 +1997,7 @@ mod tests {
             version: common_enums::ApiVersion::V1,
             network_tokenization_credentials: None,
             fingerprint_secret: None,
+            offer_engine_config: None,
         });
         let merchant_account = state
             .store

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -300,7 +300,8 @@ pub fn mk_app(
                 .service(routes::Mandates::server(state.clone()))
                 .service(routes::Authentication::server(state.clone()))
                 .service(routes::SdkConfig::server(state.clone()))
-                .service(routes::SuperpositionProxy::server(state.clone()));
+                .service(routes::SuperpositionProxy::server(state.clone()))
+                .service(routes::OfferEngine::server(state.clone()));
         }
     }
 
@@ -380,7 +381,6 @@ pub fn mk_app(
 
     server_app = server_app.service(routes::Cache::server(state.clone()));
     server_app = server_app.service(routes::Health::server(state.clone()));
-    server_app = server_app.service(routes::OfferEngine::server(state.clone()));
     // Registered at the end because this entry has an empty scope
     #[cfg(feature = "olap")]
     {

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -747,6 +747,8 @@ impl Health {
 
 pub struct OfferEngine;
 
+/// Offers are only supported on v1.
+#[cfg(feature = "v1")]
 impl OfferEngine {
     pub fn server(state: AppState) -> Scope {
         web::scope("/offer_engine")
@@ -754,6 +756,10 @@ impl OfferEngine {
             .service(
                 web::resource("/connectivity")
                     .route(web::post().to(offer_engine::offer_engine_connectivity_check)),
+            )
+            .service(
+                web::resource("/offers/list")
+                    .route(web::post().to(offer_engine::offer_engine_browse_offers)),
             )
     }
 }

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -44,6 +44,7 @@ pub enum ApiIdentifier {
     CardNetworkTokenization,
     Hypersense,
     ExternalServiceAuth,
+    OfferEngine,
     PaymentMethodSession,
     ProcessTracker,
     Authentication,
@@ -136,6 +137,7 @@ impl From<Flow> for ApiIdentifier {
             Flow::EphemeralKeyCreate | Flow::EphemeralKeyDelete => Self::Ephemeral,
             Flow::DeepHealthCheck | Flow::HealthCheck => Self::Health,
             Flow::OfferEngineConnectivityCheck => Self::Health,
+            Flow::OfferEngineBrowseOffers => Self::OfferEngine,
             Flow::MandatesRetrieve | Flow::MandatesRevoke | Flow::MandatesList => Self::Mandates,
             Flow::PaymentMethodsCreate
             | Flow::PaymentMethodsMigrate

--- a/crates/router/src/routes/metrics.rs
+++ b/crates/router/src/routes/metrics.rs
@@ -234,6 +234,8 @@ counter_metric!(TASKS_ADDED_COUNT, GLOBAL_METER); // Tasks added to process trac
 counter_metric!(TASK_ADDITION_FAILURES_COUNT, GLOBAL_METER); // Failures in task addition to process tracker
 counter_metric!(TASKS_RESET_COUNT, GLOBAL_METER); // Tasks reset in process tracker for requeue flow
 
+counter_metric!(OFFER_ENGINE_LIST_FAILURES, GLOBAL_METER);
+
 // Offer Engine notification (Process Tracker) metrics
 counter_metric!(OFFER_ENGINE_NOTIFY_TASKS_SCHEDULED, GLOBAL_METER);
 counter_metric!(OFFER_ENGINE_NOTIFY_SCHEDULE_FAILURES, GLOBAL_METER);

--- a/crates/router/src/routes/offer_engine.rs
+++ b/crates/router/src/routes/offer_engine.rs
@@ -1,4 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
+use api_models::offer_engine as offer_engine_api;
 use router_env::{instrument, tracing, Flow};
 
 use super::app;
@@ -20,6 +21,32 @@ pub async fn offer_engine_connectivity_check(
         (),
         |state, _, _, _| offer_engine::connectivity::check_offer_engine_connectivity(state),
         &auth::AdminApiAuth,
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
+#[cfg(feature = "v1")]
+#[instrument(skip_all, fields(flow = ?Flow::OfferEngineBrowseOffers))]
+pub async fn offer_engine_browse_offers(
+    state: web::Data<app::AppState>,
+    req: HttpRequest,
+    json_payload: web::Json<offer_engine_api::BrowseOffersRequest>,
+) -> HttpResponse {
+    let flow = Flow::OfferEngineBrowseOffers;
+    Box::pin(api::server_wrap(
+        flow,
+        state,
+        &req,
+        json_payload.into_inner(),
+        |state, auth: auth::AuthenticationData, payload, _| {
+            let profile_id = auth.profile.map(|profile| profile.get_id().clone());
+            offer_engine::browse::browse_offers(state, auth.platform, profile_id, payload)
+        },
+        &auth::HeaderAuth(auth::ApiKeyAuth {
+            allow_connected_scope_operation: true,
+            allow_platform_self_operation: false,
+        }),
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -58,6 +58,8 @@ pub enum Flow {
     DeepHealthCheck,
     /// Offer Engine connectivity check (dev/admin only)
     OfferEngineConnectivityCheck,
+    /// Browse the offers available to a merchant
+    OfferEngineBrowseOffers,
     /// OIDC Discovery endpoint
     OidcDiscovery,
     /// OIDC JWKS endpoint

--- a/migrations/2026-08-24-100000_add_offer_engine_config_to_merchant_account/down.sql
+++ b/migrations/2026-08-24-100000_add_offer_engine_config_to_merchant_account/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE merchant_account
+DROP COLUMN IF EXISTS offer_engine_config;

--- a/migrations/2026-08-24-100000_add_offer_engine_config_to_merchant_account/up.sql
+++ b/migrations/2026-08-24-100000_add_offer_engine_config_to_merchant_account/up.sql
@@ -1,0 +1,4 @@
+-- Merchant-level Offer Engine credentials (encrypted), used when the resolved
+-- credential source is `merchant`.
+ALTER TABLE merchant_account
+ADD COLUMN IF NOT EXISTS offer_engine_config BYTEA;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Hotfix for #13831 and #14008 #13999 against `hotfix-2026.09.02.0`.

Both commits are cherry-picked from `main` with no modifications (verified identical to the originals via `git range-diff`). They are dependent and must ship together, in this order:

1. **#13831 — `feat(offers): add merchant-level Offer Engine credential source`**
   Adds the `merchant` credential source for the Offer Engine: a new encrypted `offer_engine_config` column on `merchant_account` (Offer Engine `api_key` + `merchant_id`, encrypted via the merchant key store like `network_tokenization_credentials`), settable through `POST /accounts/{id}`. `base_url` continues to come from application config. Superposition keys are namespaced to `offer_engine.enabled` / `offer_engine.credential_source`. The `application` path is unchanged and both levels coexist.

2. **#14008 — `fix(offers): fail open on eligibility list failure and relax config`**
   Hardens the eligibility flow and closes a config gap left by the above:
   - **Fail open on `/list` failure** — a transient Offer Engine `/list` error during eligibility no longer surfaces as `InternalServerError` and no longer blocks checkout; it maps to "no offer" (logged, metered via the new `OFFER_ENGINE_LIST_FAILURES` counter) with the payable amount unchanged. `/apply` at confirm remains **fail-closed**.
   - **Gate by payment method type** — `is_supported_payment_method_type` (currently `Card`) short-circuits the offer flow instead of calling Offer Engine unconditionally.
   - **Relax application config** — `OfferEngineConfig.api_key` / `merchant_id` become `Option` (`base_url` stays required), so a `credential_source = merchant` deployment no longer needs application-level credentials. Presence is enforced at resolve time for the `application` source rather than at startup. Fully backward compatible.

**#14008 cannot be applied without #13831** — it relaxes configuration introduced by it.

### Additional Changes

- [x] This PR modifies the API contract
- [x] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

**Database schema — this hotfix requires a migration to be run on deploy:**
- `migrations/2026-08-24-100000_add_offer_engine_config_to_merchant_account/` — adds `offer_engine_config BYTEA` to `merchant_account` (additive, nullable; `down.sql` drops the column)
- `crates/diesel_models/src/schema.rs`, `crates/diesel_models/src/schema_v2.rs`

API contract:
- `crates/api_models/src/admin.rs` — optional `offer_engine_config` on `MerchantAccountUpdate` (+ `OfferEngineMerchantConfig` registered in `crates/openapi`)
- `api-reference/v1/openapi_spec_v1.json`

Config-related files:
- `crates/router/src/configs/settings.rs` — `OfferEngineConfig`: `api_key` / `merchant_id` now optional
- `crates/router/src/configs/secrets_transformers.rs` — optional `api_key` secret resolution
- `config/config.example.toml`, `config/superposition_seed.toml`

## Motivation and Context

Offer Engine Milestone 4 — merchant-level offer configuration — needs to reach the `2026.09.02.0` release so merchants can be onboarded onto their own Offer Engine accounts. The accompanying fix is required alongside it: offers are a non-critical enhancement to checkout, so a transient Offer Engine outage must not block payments, and a `merchant`-source deployment must not require application-level `api_key` / `merchant_id`.

Fixes: juspay/hyperswitch-cloud#23159

Related to: juspay/hyperswitch-cloud#22766 — the Offer Engine Milestone 4 parent tracking issue, already closed by #13831 on `main`. Referenced here rather than linked as closing, so this hotfix does not re-close the parent.

## How did you test it?

Both changes were tested end-to-end on `main` as part of the original PRs (#13831, #14008) — merchant-sourced credentials resolving against the Offer Engine sandbox, ciphertext-at-rest verification for the new column, fail-open behaviour on an unreachable `/list`, and the `application` source remaining unchanged.

For this hotfix, the cherry-picks were verified to be byte-identical to the merged commits on `main`:

```
$ git range-diff 959002988d..HEAD 33b91704ca^..fb4c2c8b5f
1:  e5852167ff9 =  1:  33b91704cac feat(offers): add merchant-level Offer Engine credential source (#13831)
2:  9c9dc224870 = 10:  fb4c2c8b5fa fix(offers): fail open on eligibility list failure and relax config  (#14008)
```

The branch point is `959002988d` (`chore(version): 2026.09.02.0`), which is the exact tip of `hotfix-2026.09.02.0` — the cherry-picks applied cleanly with no conflict resolution.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
