### PR TITLE
build(observability): add dedicated Dockerfile

### DIFF
--- a/docker/observability-plane.Dockerfile
+++ b/docker/observability-plane.Dockerfile
@@ -1,0 +1,59 @@
+FROM public.ecr.aws/docker/library/rust:trixie AS builder
+
+ARG VERSION_FEATURE_SET="v1"
+
+# Which cargo profile compiles the binary: `release` (default, production),
+# `release-fast` (optimized, no LTO, for development cycles) or `dev`
+# (unoptimized). Features are untouched by this choice.
+ARG CARGO_BUILD_PROFILE=release
+
+RUN apt-get update \
+    && apt-get install -y libpq-dev libssl-dev pkg-config protobuf-compiler
+
+WORKDIR /router
+
+# Incremental compilation adds overhead in ephemeral CI build environments.
+ENV CARGO_INCREMENTAL=0 \
+    CARGO_NET_RETRY=10 \
+    RUSTUP_MAX_RETRIES=10 \
+    RUST_BACKTRACE="short"
+
+COPY . .
+RUN cargo build \
+    --package observability \
+    --profile ${CARGO_BUILD_PROFILE} \
+    --no-default-features \
+    --features release \
+    --features ${VERSION_FEATURE_SET}
+
+# Cargo places the `dev` profile under `target/debug`.
+RUN mkdir -p /router/out \
+    && cp "/router/target/$([ "${CARGO_BUILD_PROFILE}" = "dev" ] && echo debug || echo "${CARGO_BUILD_PROFILE}")/observability" /router/out/observability
+
+
+FROM public.ecr.aws/docker/library/debian:trixie
+
+ARG CONFIG_DIR=/local/config
+ARG BIN_DIR=/local/bin
+ARG RUN_ENV=sandbox
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates tzdata libpq-dev curl procps
+
+EXPOSE 8080
+
+ENV TZ=Etc/UTC \
+    RUN_ENV=${RUN_ENV} \
+    CONFIG_DIR=${CONFIG_DIR} \
+    RUST_MIN_STACK=6291456
+
+RUN mkdir -p ${BIN_DIR}
+
+COPY --from=builder /router/out/observability ${BIN_DIR}/observability
+
+RUN useradd --user-group --system --no-create-home --no-log-init app
+USER app:app
+
+WORKDIR ${BIN_DIR}
+
+CMD ["./observability"]


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Adds `docker/observability-plane.Dockerfile` for the independently released observability plane.

The dedicated multi-stage image:

- builds only the `observability` workspace package with its `release` and selected version features;
- supports the existing `release`, `release-fast`, and `dev` Cargo profiles;
- copies only the observability binary into the runtime image;
- runs as an unprivileged system user; and
- preserves the deployment's `RUN_ENV` and `CONFIG_DIR` configuration contract.

The shared router Dockerfile remains untouched, preserving its workspace-wide build cache for router, producer, consumer, and drainer images.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Related to [hyperswitch-cloud#23228](https://github.com/juspay/hyperswitch-cloud/issues/23228).

The observability image needs one binary and has an independent release pipeline. A service-specific Dockerfile avoids compiling unrelated workspace binaries without adding observability-specific behavior to the shared application image.

This PR is stacked on #14039 because that PR introduces the renamed `observability` package.

## How did you test it?

- Ran `git diff --check`.
- Built the complete image against the package from #14039:
  ```shell
  podman build --isolation chroot \
    --file docker/observability-plane.Dockerfile \
    --tag hyperswitch-observability-plane:validation \
    .
  ```
- Confirmed the release build compiled only `--package observability` and successfully assembled the non-root runtime image.

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all` (not applicable; Dockerfile-only change)
- [ ] I addressed lints thrown by `cargo clippy` (not applicable; Dockerfile-only change)
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible (validated with a complete container build)
