### PR TITLE
ci: add consolidated result check for stable toolchain matrix

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -226,6 +226,42 @@ jobs:
         shell: bash
         run: cargo check --features "release"
 
+  test-result:
+    name: Run tests on stable toolchain — Consolidated Result
+    needs: [test]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      # The matrix legs run identical commands, so a genuine lint failure fails
+      # both. Only infrastructure faults hit one leg alone, so one green leg is
+      # sufficient signal.
+      - name: Evaluate matrix results
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          legs="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" --paginate \
+            --jq '.jobs[] | select(.name | startswith("Run tests on stable toolchain (")) | "\(.conclusion)\t\(.name)"')"
+
+          if [ -z "${legs}" ]; then
+            echo "::error::found no 'Run tests on stable toolchain' legs to evaluate"
+            exit 1
+          fi
+
+          echo "${legs}"
+          passed="$(printf '%s\n' "${legs}" | grep -c '^success' || true)"
+
+          if [ "${passed}" -ge 1 ]; then
+            echo "::notice::${passed} runner(s) passed"
+          else
+            echo "::error::every runner failed"
+            exit 1
+          fi
+
   typos:
     name: Spell check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds a `test-result` job to `CI-pr.yml`, surfaced as **`Run tests on stable toolchain — Consolidated Result`**, which passes when **at least one** leg of the `test` matrix (`ubuntu-latest` or `hyperswitch-runners`) succeeds.

The job is guarded with `if: ${{ !cancelled() }}` so it evaluates when a leg fails but stays skipped on a cancelled run, and is scoped to `permissions: actions: read`. It relies on `fail-fast: false`, which the `test` job already sets.

> **Follow-up required for this to take effect:** the required status check in the Default Branch ruleset must be **swapped** from `Run tests on stable toolchain (ubuntu-latest)` to `Run tests on stable toolchain — Consolidated Result`. Adding the new context without removing the old one changes nothing, since the ubuntu leg would still block. This needs repo-admin access and is not part of this PR.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

`Run tests on stable toolchain (ubuntu-latest)` fails on most pull requests and blocks merges. Across the last 40 `CI-pr` runs, **all 8** failures on that leg die in the first step, `Run clippy (redis-rs backend)`, with:

```
error: recipe `clippy` was terminated by signal 15
##[error]Process completed with exit code 143.
```

The signature is identical every time. It is **not** a timeout — the job dies at ~16 minutes against the 360-minute default, and no `timeout-minutes` is set anywhere in `.github/workflows/`. It is **not** a cancellation — there is no `The operation was canceled.`, the job conclusion is `failure`, and `fail-fast: false` rules out a sibling leg cancelling it.

Every failure stalls at the same point: immediately after `Checking hsdev`, which is where `Compiling router v0.2.0` begins, then produces no output for 2m41s–6m34s before the kill. `--all-targets` expands `router` alone into 19 compilation units (1 lib, 2 bins, 16 integration test targets), each test target linking the full router rlib; with `CARGO_BUILD_JOBS: 3` on a 4-vCPU/16 GB runner, several land concurrently and exhaust the machine.

Meanwhile the `hyperswitch-runners` leg runs the identical command and passes, but it is **not** a required check — only `(ubuntu-latest)` is. So the flakier of the two legs gates merges on its own while the one that passes does not count.

This PR stops the false negatives. Reducing the peak memory itself (aligning `CARGO_BUILD_JOBS` with the `2` that `CI-push.yml` already uses for the same workload) is tracked as a follow-up.

## Linked Issues

- Issue: https://github.com/juspay/hyperswitch-cloud/issues/23291

Fixes juspay/hyperswitch-cloud#23291

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
-->

This PR tests itself: the `Run tests on stable toolchain — Consolidated Result` check appears on this PR, and should report green as long as either matrix leg passes. Its step log prints each leg's conclusion, e.g.:

```
success	Run tests on stable toolchain (hyperswitch-runners)
failure	Run tests on stable toolchain (ubuntu-latest)
::notice::1 runner(s) passed
```

Verified locally before pushing:
- The workflow YAML parses and the job graph resolves — `test-result` has `needs=test` and `if=${{ !cancelled() }}`.
- The name filter `startswith("Run tests on stable toolchain (")` matches both matrix legs and excludes the gate itself, whose name has ` — ` rather than ` (` at that position.
- Failure path: with both legs red the gate exits 1; with no legs found it exits 1 rather than passing vacuously.

No Rust code is changed by this diff, so `cargo +nightly fmt` and `cargo clippy` are not applicable here.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

