### PR TITLE
fix(cypress): reset globalState.customerId and session fixtures across tests

### DIFF
--- a/cypress-tests-v2/cypress.config.js
+++ b/cypress-tests-v2/cypress.config.js
@@ -19,6 +19,12 @@ module.exports = defineConfig({
         getGlobalState: () => {
           return globalState || {};
         },
+        resetCustomerId: () => {
+          if (globalState && "customerId" in globalState) {
+            delete globalState.customerId;
+          }
+          return null;
+        },
         cli_log: (message) => {
           console.log("Logging console message from task");
           console.log(message);

--- a/cypress-tests-v2/cypress/support/e2e.js
+++ b/cypress-tests-v2/cypress/support/e2e.js
@@ -17,5 +17,10 @@
 import "cypress-mochawesome-reporter/register";
 import "./commands";
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
+beforeEach(() => {
+  cy.task("resetCustomerId");
+});
+
+afterEach(() => {
+  cy.task("resetCustomerId");
+});

--- a/cypress-tests/cypress.config.js
+++ b/cypress-tests/cypress.config.js
@@ -48,6 +48,12 @@ export default defineConfig({
         getGlobalState: () => {
           return globalState || {};
         },
+        resetCustomerId: () => {
+          if (globalState && "customerId" in globalState) {
+            delete globalState.customerId;
+          }
+          return null;
+        },
         readFileOrNull: (filePath) => {
           if (!fs.existsSync(filePath)) return null;
           try {

--- a/cypress-tests/cypress/e2e/spec/Misc/99-StateIsolation.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Misc/99-StateIsolation.cy.js
@@ -1,0 +1,28 @@
+import * as fixtures from "../../../fixtures/imports";
+
+describe("State and Fixture Isolation", () => {
+  it("sets customerId and mutates session fixture in test 1", () => {
+    cy.task("setGlobalState", { customerId: "test_customer_123" });
+    cy.then(() => {
+      fixtures.sessionTokenBody.payment_id = "test_payment_id";
+      fixtures.sessionTokenBody.wallets = ["apple_pay"];
+    });
+
+    cy.task("getGlobalState").then((state) => {
+      expect(state.customerId).to.equal("test_customer_123");
+    });
+    cy.then(() => {
+      expect(fixtures.sessionTokenBody.payment_id).to.equal("test_payment_id");
+    });
+  });
+
+  it("verifies customerId and session fixtures are cleanly reset in test 2", () => {
+    cy.task("getGlobalState").then((state) => {
+      expect(state.customerId).to.be.undefined;
+    });
+    cy.then(() => {
+      expect(fixtures.sessionTokenBody.payment_id).to.equal("{{payment_id}}");
+      expect(fixtures.sessionTokenBody.wallets).to.deep.equal([]);
+    });
+  });
+});

--- a/cypress-tests/cypress/fixtures/imports.js
+++ b/cypress-tests/cypress/fixtures/imports.js
@@ -90,3 +90,45 @@ export {
   modularPmServicePaymentsCall,
   pmCollectLinkBody,
 };
+
+if (!globalThis.__CYPRESS_FIXTURES_LIST__) {
+  globalThis.__CYPRESS_FIXTURES_LIST__ = [];
+}
+
+const currentSnapshot = {
+  sessionTokenBody: JSON.parse(JSON.stringify(sessionTokenBody || {})),
+  paymentMethodSessionCreate: JSON.parse(
+    JSON.stringify(paymentMethodSessionCreate || {})
+  ),
+  paymentMethodSessionUpdate: JSON.parse(
+    JSON.stringify(paymentMethodSessionUpdate || {})
+  ),
+  paymentMethodSessionConfirm: JSON.parse(
+    JSON.stringify(paymentMethodSessionConfirm || {})
+  ),
+};
+
+const currentInstance = {
+  sessionTokenBody,
+  paymentMethodSessionCreate,
+  paymentMethodSessionUpdate,
+  paymentMethodSessionConfirm,
+  snapshots: currentSnapshot,
+};
+
+globalThis.__CYPRESS_FIXTURES_LIST__.push(currentInstance);
+
+export function resetSessionFixtures() {
+  const list = globalThis.__CYPRESS_FIXTURES_LIST__ || [];
+  for (const item of list) {
+    for (const [key, initial] of Object.entries(item.snapshots)) {
+      const target = item[key];
+      if (target && initial) {
+        for (const prop of Object.keys(target)) {
+          delete target[prop];
+        }
+        Object.assign(target, JSON.parse(JSON.stringify(initial)));
+      }
+    }
+  }
+}

--- a/cypress-tests/cypress/support/e2e.js
+++ b/cypress-tests/cypress/support/e2e.js
@@ -1,6 +1,7 @@
 import "cypress-mochawesome-reporter/register";
 import "./commands";
 import "./redirectionHandler";
+import { resetSessionFixtures } from "../fixtures/imports";
 
 Cypress.on("window:before:load", (win) => {
   win.headers = {
@@ -119,11 +120,13 @@ function notifyProxyTestEnded() {
   });
 }
 
-if (IS_PROXY_ENABLED) {
-  Cypress._getStepCounter = () => stepCounter;
-  Cypress._buildRequestId = buildRequestId;
+beforeEach(() => {
+  cy.task("resetCustomerId");
+  cy.then(() => {
+    resetSessionFixtures();
+  });
 
-  beforeEach(() => {
+  if (IS_PROXY_ENABLED) {
     const { titlePath } = Cypress.currentTest;
     const title = titlePath.join(" > ");
     const connector = Cypress.env("CONNECTOR") || "";
@@ -147,13 +150,25 @@ if (IS_PROXY_ENABLED) {
         timeout: PROXY_ADMIN_TIMEOUT_MS,
       });
     }
+  }
+});
+
+afterEach(() => {
+  cy.task("resetCustomerId");
+  cy.then(() => {
+    resetSessionFixtures();
   });
 
-  afterEach(() => {
+  if (IS_PROXY_ENABLED) {
     if (PROXY_ADMIN_URL) {
       notifyProxyTestEnded();
     }
-  });
+  }
+});
+
+if (IS_PROXY_ENABLED) {
+  Cypress._getStepCounter = () => stepCounter;
+  Cypress._buildRequestId = buildRequestId;
 
   // Tag every cy.request with a deterministic X-Request-ID for cassette matching.
   Cypress.Commands.overwrite("request", (originalFn, ...args) => {


### PR DESCRIPTION
## Description
Fixes #13934

### Changes
- Added task `resetCustomerId` in `cypress.config.js` (both v1 and v2) to clear `globalState.customerId` from Cypress node state.
- Added fixture snapshotting and `resetSessionFixtures()` in `cypress/fixtures/imports.js` to cleanly restore session fixtures across tests.
- Configured `beforeEach` and `afterEach` hooks in `cypress/support/e2e.js` to reset `globalState.customerId` and restore session fixtures.
- Added Cypress test spec `cypress/e2e/spec/Misc/99-StateIsolation.cy.js` validating test isolation.