### PR TITLE
fix(openapi): add missing value_type for funding_source in AdditionalCardInfo

### DIFF
--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -5589,6 +5589,27 @@
             "description": "Card type, can be either `credit` or `debit`",
             "nullable": true
           },
+          "card_subtype": {
+            "type": "string",
+            "description": "The product the card is issued under, e.g. `CLASSIC` or `ELECTRON`.\nFree form, as the value comes straight from the BIN record.",
+            "nullable": true
+          },
+          "card_segment_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardSegmentType"
+              }
+            ],
+            "nullable": true
+          },
+          "funding_source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FundingSource"
+              }
+            ],
+            "nullable": true
+          },
           "card_issuing_country": {
             "type": "string",
             "nullable": true

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4213,6 +4213,7 @@ pub struct AdditionalCardInfo {
 
     /// How the card is funded, as recorded against its BIN. More granular than
     /// `card_type`, which collapses deferred debit and charge cards.
+    #[schema(value_type = Option<FundingSource>, example = "CREDIT")]
     pub funding_source: Option<api_enums::FundingSource>,
 
     pub card_issuing_country: Option<String>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

`AdditionalCardInfo::funding_source` was added in #13985 without a `#[schema(value_type = ...)]` annotation. Without it, utoipa derives the schema reference from the written type path, so the generated v2 spec emits `#/components/schemas/api_enums.FundingSource`, while the component itself is registered as `FundingSource` in `crates/openapi/src/openapi_v2.rs`.

That dangling reference makes the `Validate Generated OpenAPI Spec File` workflow fail at the v2 step:

```
Token "api_enums.FundingSource" does not exist.
```

Since the workflow runs on every PR and on the merge queue, this blocks all merges, not just changes touching payments.

`AdditionalCardInfo` is only present in the v2 spec, which is why the v1 validation step is unaffected.

The fix adds the annotation, matching the `card_network` and `card_segment_type` fields directly above it:

```rust
#[schema(value_type = Option<FundingSource>, example = "CREDIT")]
pub funding_source: Option<api_enums::FundingSource>,
```

The checked-in `api-reference/v2/openapi_spec_v2.json` is also stale — its `AdditionalCardInfo` is missing `card_subtype`, `card_segment_type` and `funding_source` entirely. The workflow regenerates and commits the spec for same-repo PRs, so it will be brought up to date on this branch.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

The request/response shape is unchanged — `funding_source` already exists on `AdditionalCardInfo`. Only the generated OpenAPI reference for that field is corrected.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The OpenAPI validation check is red on `main`, so no PR can clear the merge queue until the dangling reference is removed.

## Linked Issues
<!-- Cloud issues are cross-repo + private, so `Fixes #` does NOT auto-close them. Use full URLs. -->
- Issue: https://github.com/juspay/hyperswitch-cloud/issues/23315

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

The `Validate Generated OpenAPI Spec File` workflow on this PR is the test: `cargo run -p openapi --features v2` followed by `swagger-cli validate ./api-reference/v2/openapi_spec_v2.json`, which is the exact command that currently fails on `main`.

Confirmed against the failing run on the merge queue ([run 33865500807](https://github.com/juspay/hyperswitch/actions/runs/33865500807)), and by checking the committed v2 spec for dangling references — `FundingSource` is registered under that name, so referencing it as `api_enums.FundingSource` cannot resolve.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
