### PR TITLE
fix(common_utils): prevent `MaskedEmail` from panicking on short local parts

### DIFF
--- a/crates/common_utils/src/new_type.rs
+++ b/crates/common_utils/src/new_type.rs
@@ -285,12 +285,17 @@ impl From<String> for MaskedEmail {
     fn from(src: String) -> Self {
         let unmasked_char_count = 2;
         let masked_value = if let Some((user_identifier, domain)) = src.split_once('@') {
+            // Count characters rather than bytes so that a short or non-ASCII local part
+            // neither underflows the subtraction nor produces a mask of the wrong length.
+            let masked_char_count = user_identifier
+                .chars()
+                .count()
+                .saturating_sub(unmasked_char_count);
             let masked_user_identifier = user_identifier
-                .to_string()
                 .chars()
                 .take(unmasked_char_count)
                 .collect::<String>()
-                + &"*".repeat(user_identifier.len() - unmasked_char_count);
+                + &"*".repeat(masked_char_count);
             format!("{masked_user_identifier}@{domain}")
         } else {
             let masked_value = apply_mask(src.as_ref(), unmasked_char_count, 8);
@@ -356,9 +361,39 @@ mod apply_mask_fn_test {
     use hyperswitch_masking::PeekInterface;
 
     use crate::new_type::{
-        apply_mask, MaskedBankAccount, MaskedIban, MaskedRoutingNumber, MaskedSortCode,
-        MaskedUpiVpaId,
+        apply_mask, MaskedBankAccount, MaskedEmail, MaskedIban, MaskedRoutingNumber,
+        MaskedSortCode, MaskedUpiVpaId,
     };
+
+    #[test]
+    fn test_masked_email() {
+        let email = MaskedEmail::from("username@example.com".to_string());
+        assert_eq!(
+            email.0.peek().to_owned(),
+            "us******@example.com".to_string()
+        );
+
+        // Local parts shorter than the unmasked prefix used to underflow the mask length
+        // computation and panic (or, in release builds, attempt a huge allocation).
+        let email = MaskedEmail::from("ab@example.com".to_string());
+        assert_eq!(email.0.peek().to_owned(), "ab@example.com".to_string());
+        let email = MaskedEmail::from("a@example.com".to_string());
+        assert_eq!(email.0.peek().to_owned(), "a@example.com".to_string());
+        let email = MaskedEmail::from("@example.com".to_string());
+        assert_eq!(email.0.peek().to_owned(), "@example.com".to_string());
+
+        // The mask length follows the number of characters, not bytes.
+        let email = MaskedEmail::from("j\u{00e9}r\u{00f4}me@example.com".to_string());
+        assert_eq!(
+            email.0.peek().to_owned(),
+            "j\u{00e9}****@example.com".to_string()
+        );
+
+        // Values without an `@` fall back to the generic mask.
+        let email = MaskedEmail::from("not-an-email".to_string());
+        assert_eq!(email.0.peek().to_owned(), "no*-**-***il".to_string());
+    }
+
     #[test]
     fn test_masked_types() {
         let sort_code = MaskedSortCode::from("110011".to_string());


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
`MaskedEmail::from` keeps the first two characters of the local part and masks the rest with
`"*".repeat(user_identifier.len() - 2)`. When the local part is shorter than two characters
(`a@example.com`, or `@example.com`) that subtraction underflows: debug builds panic with
`attempt to subtract with overflow`, and release builds wrap to `usize::MAX` and panic inside
`str::repeat` with `capacity overflow`. Either way the request handling the payout / recipient
data crashes for a perfectly valid email address.

This PR:
- computes the mask length with `saturating_sub`, so a local part shorter than the unmasked
  prefix is returned as-is (consistent with the existing behaviour for exactly two characters);
- counts characters instead of bytes, so a non-ASCII local part gets a mask of the right length
  (`jérôme@example.com` previously produced six asterisks for four masked characters);
- adds unit tests covering the regular case, the short / empty local part, the non-ASCII local
  part and the fallback for values without an `@`.

`MaskedEmail` is used by `payout_method_utils` (PayPal / Venmo payout method data) and by
`api_models::payments::recipient`.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
Found while running a small property-style harness over the pure helpers in `common_utils`
with edge-case inputs. Minimal reproduction on `main`:

```rust
let _ = common_utils::new_type::MaskedEmail::from("a@example.com".to_string());
// debug: thread panicked at 'attempt to subtract with overflow', crates/common_utils/src/new_type.rs:293
// release: thread panicked at 'capacity overflow' (alloc::str::repeat)
```

## How did you test it?
- `cargo test -p common_utils --lib new_type` — the new `test_masked_email` fails on `main` (panics)
  and passes with this change; existing `apply_mask` tests unchanged.
- `cargo +nightly fmt --all` and `cargo clippy -p common_utils --lib --tests` are clean.

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

Closes #14198