### PR TITLE
fix(common_utils): return an error instead of panicking when a major-unit amount overflows `Decimal`

### DIFF
--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -642,19 +642,27 @@ impl FloatMajorUnit {
         let amount_decimal =
             Decimal::from_f64(self.0).ok_or(ParsingError::FloatToDecimalConversionFailure)?;
 
-        let amount = if currency.is_zero_decimal_currency() {
-            amount_decimal
-        } else if currency.is_three_decimal_currency() {
-            amount_decimal * Decimal::from(1000)
-        } else {
-            amount_decimal * Decimal::from(100)
-        };
-
-        let amount_i64 = amount
-            .to_i64()
+        let amount_i64 = scale_major_to_minor(amount_decimal, currency)
             .ok_or(ParsingError::DecimalToI64ConversionFailure)?;
         Ok(MinorUnit::new(amount_i64))
     }
+}
+
+/// Scales a major-unit decimal amount to minor units for the given currency and narrows it to
+/// `i64`, returning `None` when the scaled amount does not fit in either `Decimal` or `i64`.
+///
+/// `Decimal`'s `Mul` implementation panics on overflow, so the multiplication has to be checked:
+/// a connector response amount close to `Decimal::MAX` would otherwise take the process down
+/// instead of surfacing as a conversion error.
+fn scale_major_to_minor(amount_decimal: Decimal, currency: enums::Currency) -> Option<i64> {
+    let amount = if currency.is_zero_decimal_currency() {
+        amount_decimal
+    } else if currency.is_three_decimal_currency() {
+        amount_decimal.checked_mul(Decimal::from(1000))?
+    } else {
+        amount_decimal.checked_mul(Decimal::from(100))?
+    };
+    amount.to_i64()
 }
 
 /// Connector specific types to send
@@ -678,15 +686,7 @@ impl StringMajorUnit {
             }
         })?;
 
-        let amount = if currency.is_zero_decimal_currency() {
-            amount_decimal
-        } else if currency.is_three_decimal_currency() {
-            amount_decimal * Decimal::from(1000)
-        } else {
-            amount_decimal * Decimal::from(100)
-        };
-        let amount_i64 = amount
-            .to_i64()
+        let amount_i64 = scale_major_to_minor(amount_decimal, currency)
             .ok_or(ParsingError::DecimalToI64ConversionFailure)?;
         Ok(MinorUnit::new(amount_i64))
     }
@@ -888,6 +888,44 @@ mod amount_conversion_tests {
             .convert_back(converted_amount, currency)
             .unwrap();
         assert_eq!(converted_back_amount, request_amount);
+    }
+
+    #[test]
+    fn amount_conversion_back_from_major_unit_overflow_is_an_error() {
+        // `Decimal::MAX` is ~7.9e28. Scaling anything above `Decimal::MAX / 1000` to minor
+        // units overflows `Decimal` itself, which must surface as a conversion error rather
+        // than a panic from `Decimal`'s `Mul`.
+        let float_amount = FloatMajorUnit::new(1e27);
+        for currency in [TWO_DECIMAL_CURRENCY, THREE_DECIMAL_CURRENCY] {
+            let error = FloatMajorUnitForConnector
+                .convert_back(float_amount, currency)
+                .unwrap_err();
+            assert!(matches!(
+                error.current_context(),
+                ParsingError::DecimalToI64ConversionFailure
+            ));
+        }
+
+        let string_amount = StringMajorUnit::new("792281625142643375935439503.36".to_string());
+        for currency in [TWO_DECIMAL_CURRENCY, THREE_DECIMAL_CURRENCY] {
+            let error = StringMajorUnitForConnector
+                .convert_back(string_amount.clone(), currency)
+                .unwrap_err();
+            assert!(matches!(
+                error.current_context(),
+                ParsingError::DecimalToI64ConversionFailure
+            ));
+        }
+
+        // Amounts that fit in `Decimal` but not in `i64` keep reporting the same error.
+        let string_amount = StringMajorUnit::new("92233720368547758.08".to_string());
+        let error = StringMajorUnitForConnector
+            .convert_back(string_amount, TWO_DECIMAL_CURRENCY)
+            .unwrap_err();
+        assert!(matches!(
+            error.current_context(),
+            ParsingError::DecimalToI64ConversionFailure
+        ));
     }
 }
 


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
`FloatMajorUnit::to_minor_unit_as_i64` and `StringMajorUnit::to_minor_unit_as_i64` scale the
parsed amount with `amount_decimal * Decimal::from(100)` (or `1000` for three-decimal
currencies). `rust_decimal`'s `Mul` implementation panics on overflow
(`Multiplication overflowed`), so any amount in the range `Decimal::MAX / 1000 .. Decimal::MAX`
(roughly `7.9e25 .. 7.9e28`) — which `Decimal::from_f64` / `Decimal::from_str` happily accept —
takes the handler down instead of surfacing as a conversion error. The `i64` overflow right
after it is already handled through `ParsingError::DecimalToI64ConversionFailure`, so the two
overflow paths were inconsistent.

These conversions run through `AmountConvertor::convert_back` on connector *responses*
(`convert_back_amount_to_minor_units` in `hyperswitch_connectors`, used for the
authorize / sync / capture integrity objects), so a malformed or absurd amount coming back from a
connector should produce `ConnectorError::AmountConversionFailed`, not a panic.

This PR moves the scaling into a small `scale_major_to_minor` helper that uses `checked_mul` and
maps the overflow to the existing `DecimalToI64ConversionFailure` (the result would not fit in an
`i64` either), and adds a unit test for both the `Decimal` overflow and the `i64` overflow.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
Found while running a small property-style harness over the pure helpers in `common_utils`
with extreme inputs. Reproduction on `main`:

```rust
use common_utils::types::{AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector};
let amount: FloatMajorUnit = serde_json::from_str("1e27").unwrap();
let _ = FloatMajorUnitForConnector.convert_back(amount, common_enums::Currency::USD);
// thread panicked at 'Multiplication overflowed', rust_decimal/src/arithmetic_impls.rs
```

The same happens for `StringMajorUnit` with `"792281625142643375935439503.36"`.

## How did you test it?
- `cargo test -p common_utils --lib types::amount_conversion_tests` — the new
  `amount_conversion_back_from_major_unit_overflow_is_an_error` panics on `main` and passes with
  this change; the existing round-trip tests are unchanged.
- `cargo +nightly fmt --all` and `cargo clippy -p common_utils --lib --tests` are clean.

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

Closes #14199