### PR TITLE
fix(common_utils): fix `PhoneNumberStrategy` masking underflow and missing asterisks

### DIFF
--- a/crates/common_utils/src/pii.rs
+++ b/crates/common_utils/src/pii.rs
@@ -44,9 +44,13 @@ where
     fn fmt(val: &T, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let val_str: &str = val.as_ref();
 
-        if let Some(val_str) = val_str.get(val_str.len() - 4..) {
+        if let Some(last_four) = val_str
+            .len()
+            .checked_sub(4)
+            .and_then(|index| val_str.get(index..))
+        {
             // masks everything but the last 4 digits
-            write!(f, "{}{}", "*".repeat(val_str.len() - 4), val_str)
+            write!(f, "{}{}", "*".repeat(val_str.len() - 4), last_four)
         } else {
             #[cfg(feature = "logs")]
             logger::error!("Invalid phone number: {val_str}");
@@ -433,6 +437,23 @@ mod pii_masking_strategy_tests {
     fn test_invalid_newtype_email() {
         let email_check = Email::from_str("example@abc@com");
         assert!(email_check.is_err());
+    }
+
+    #[test]
+    fn test_phone_number_strategy_masking() {
+        use crate::pii::PhoneNumberStrategy;
+
+        let secret: Secret<String, PhoneNumberStrategy> = Secret::new("+15555555555".to_string());
+        assert_eq!("********5555", format!("{secret:?}"));
+
+        let secret: Secret<String, PhoneNumberStrategy> = Secret::new("5555".to_string());
+        assert_eq!("5555", format!("{secret:?}"));
+
+        // Values shorter than the unmasked suffix used to underflow and panic.
+        let secret: Secret<String, PhoneNumberStrategy> = Secret::new("555".to_string());
+        assert_eq!("*** alloc::string::String ***", format!("{secret:?}"));
+        let secret: Secret<String, PhoneNumberStrategy> = Secret::new(String::new());
+        assert_eq!("*** alloc::string::String ***", format!("{secret:?}"));
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
`PhoneNumberStrategy::fmt` (the `Debug`/`Display` masking used for `Secret<_, PhoneNumberStrategy>`)
has two problems:

1. `val_str.get(val_str.len() - 4..)` underflows for values shorter than four bytes. Debug builds
   panic with `attempt to subtract with overflow` while formatting; release builds silently fall
   through to the generic `WithType` output. `Secret<String, PhoneNumberStrategy>` is also used for
   `payment_processor_token` in the revenue-recovery backfill models and in the revenue-recovery
   workflow, where a short token is plausible.
2. The `if let Some(val_str) = ...` binding shadows the full value, so `"*".repeat(val_str.len() - 4)`
   is computed on the four-character suffix and always yields zero asterisks: `+15555555555` was
   rendered as `5555` instead of `********5555` as the comment (and the `EmailStrategy` next to it)
   intend.

This PR uses `checked_sub` for the suffix index, binds the suffix under a separate name so the
asterisk count is computed on the full value, and adds a unit test for the regular, exact-length,
too-short and empty cases.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
Found while running a small property-style harness over the pure helpers in `common_utils`.
Reproduction on `main` (debug build):

```rust
use common_utils::pii::PhoneNumberStrategy;
let secret = hyperswitch_masking::Secret::<String, PhoneNumberStrategy>::new("12".to_string());
let _ = format!("{secret:?}");
// thread panicked at 'attempt to subtract with overflow', crates/common_utils/src/pii.rs:47
```

## How did you test it?
- `cargo test -p common_utils --lib pii` — the new `test_phone_number_strategy_masking` fails on
  `main` (`5555` instead of `********5555`, and a panic for the short value) and passes with this
  change.
- `cargo +nightly fmt --all` and `cargo clippy -p common_utils --lib --tests` are clean.

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

Closes #14200