### PR TITLE
feat(ucs): PaymentMethodType bridge gaps + sender_payment_instrument_id on authorize

### DIFF
--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -279,6 +279,9 @@ where
                     router_data.minor_amount_captured = payment_authorize_response
                         .captured_amount
                         .map(MinorUnit::new);
+                    router_data.sender_payment_instrument_id = payment_authorize_response
+                        .sender_payment_instrument_id
+                        .clone();
                     router_data.minor_amount_capturable = payment_authorize_response
                         .capturable_amount
                         .map(MinorUnit::new);

--- a/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/complete_authorize_gateway.rs
@@ -158,6 +158,9 @@ where
                 router_data.minor_amount_captured = payment_authorize_response
                     .captured_amount
                     .map(MinorUnit::new);
+                router_data.sender_payment_instrument_id = payment_authorize_response
+                    .sender_payment_instrument_id
+                    .clone();
                 if return_raw_connector_response.unwrap_or(false) {
                     router_data.raw_connector_response = payment_authorize_response
                         .raw_connector_response

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -4187,11 +4187,38 @@ impl transformers::ForeignTryFrom<common_enums::PaymentMethodType>
             common_enums::PaymentMethodType::OpenBankingPIS => Ok(Self::OpenBankingPis),
             common_enums::PaymentMethodType::DirectCarrierBilling => Ok(Self::DirectCarrierBilling),
             common_enums::PaymentMethodType::InstantBankTransfer => Ok(Self::InstantBankTransfer),
+            common_enums::PaymentMethodType::InstantBankTransferFinland => {
+                Ok(Self::InstantBankTransferFinland)
+            }
+            common_enums::PaymentMethodType::InstantBankTransferPoland => {
+                Ok(Self::InstantBankTransferPoland)
+            }
             common_enums::PaymentMethodType::Paypal => Ok(Self::PayPal),
             common_enums::PaymentMethodType::RevolutPay => Ok(Self::RevolutPay),
             common_enums::PaymentMethodType::NetworkToken => Ok(Self::NetworkToken),
             common_enums::PaymentMethodType::OpenBanking => Ok(Self::OpenBanking),
             common_enums::PaymentMethodType::Skrill => Ok(Self::Skrill),
+            common_enums::PaymentMethodType::Klarna => Ok(Self::Klarna),
+            common_enums::PaymentMethodType::BhnCardNetwork => Ok(Self::BhnCardNetwork),
+            common_enums::PaymentMethodType::Bluecode => Ok(Self::Bluecode),
+            common_enums::PaymentMethodType::Breadpay => Ok(Self::Breadpay),
+            common_enums::PaymentMethodType::EftDebitOrder => Ok(Self::EftDebitOrder),
+            common_enums::PaymentMethodType::Flexiti => Ok(Self::Flexiti),
+            common_enums::PaymentMethodType::IndonesianBankTransfer => {
+                Ok(Self::IndonesianBankTransfer)
+            }
+            common_enums::PaymentMethodType::Mifinity => Ok(Self::Mifinity),
+            common_enums::PaymentMethodType::Payjustnow => Ok(Self::Payjustnow),
+            common_enums::PaymentMethodType::Paysera => Ok(Self::Paysera),
+            common_enums::PaymentMethodType::Payshap => Ok(Self::Payshap),
+            common_enums::PaymentMethodType::PayshapProxy => Ok(Self::PayshapProxy),
+            common_enums::PaymentMethodType::PixAutomaticoPush => Ok(Self::PixAutomaticoPush),
+            common_enums::PaymentMethodType::PixAutomaticoQr => Ok(Self::PixAutomaticoQr),
+            common_enums::PaymentMethodType::PixEmv => Ok(Self::PixEmv),
+            common_enums::PaymentMethodType::PixKey => Ok(Self::PixKey),
+            common_enums::PaymentMethodType::PixQr => Ok(Self::PixQr),
+            common_enums::PaymentMethodType::Qris => Ok(Self::Qris),
+            common_enums::PaymentMethodType::SepaGuarenteedDebit => Ok(Self::SepaGuarenteedDebit),
             _ => Err(
                 UnifiedConnectorServiceError::RequestEncodingFailedWithReason(
                     "Payment Method Type not yet supported".to_string(),

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -4198,7 +4198,7 @@ impl transformers::ForeignTryFrom<common_enums::PaymentMethodType>
             common_enums::PaymentMethodType::NetworkToken => Ok(Self::NetworkToken),
             common_enums::PaymentMethodType::OpenBanking => Ok(Self::OpenBanking),
             common_enums::PaymentMethodType::Skrill => Ok(Self::Skrill),
-            common_enums::PaymentMethodType::Klarna => Ok(Self::KlarnaPm),
+            common_enums::PaymentMethodType::Klarna => Ok(Self::Klarna),
             common_enums::PaymentMethodType::BhnCardNetwork => Ok(Self::BhnCardNetwork),
             common_enums::PaymentMethodType::Bluecode => Ok(Self::Bluecode),
             common_enums::PaymentMethodType::Breadpay => Ok(Self::Breadpay),
@@ -4207,7 +4207,7 @@ impl transformers::ForeignTryFrom<common_enums::PaymentMethodType>
             common_enums::PaymentMethodType::IndonesianBankTransfer => {
                 Ok(Self::IndonesianBankTransfer)
             }
-            common_enums::PaymentMethodType::Mifinity => Ok(Self::MifinityPm),
+            common_enums::PaymentMethodType::Mifinity => Ok(Self::Mifinity),
             common_enums::PaymentMethodType::Payjustnow => Ok(Self::Payjustnow),
             common_enums::PaymentMethodType::Paysera => Ok(Self::Paysera),
             common_enums::PaymentMethodType::Payshap => Ok(Self::Payshap),

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -4198,7 +4198,7 @@ impl transformers::ForeignTryFrom<common_enums::PaymentMethodType>
             common_enums::PaymentMethodType::NetworkToken => Ok(Self::NetworkToken),
             common_enums::PaymentMethodType::OpenBanking => Ok(Self::OpenBanking),
             common_enums::PaymentMethodType::Skrill => Ok(Self::Skrill),
-            common_enums::PaymentMethodType::Klarna => Ok(Self::Klarna),
+            common_enums::PaymentMethodType::Klarna => Ok(Self::KlarnaPm),
             common_enums::PaymentMethodType::BhnCardNetwork => Ok(Self::BhnCardNetwork),
             common_enums::PaymentMethodType::Bluecode => Ok(Self::Bluecode),
             common_enums::PaymentMethodType::Breadpay => Ok(Self::Breadpay),
@@ -4207,7 +4207,7 @@ impl transformers::ForeignTryFrom<common_enums::PaymentMethodType>
             common_enums::PaymentMethodType::IndonesianBankTransfer => {
                 Ok(Self::IndonesianBankTransfer)
             }
-            common_enums::PaymentMethodType::Mifinity => Ok(Self::Mifinity),
+            common_enums::PaymentMethodType::Mifinity => Ok(Self::MifinityPm),
             common_enums::PaymentMethodType::Payjustnow => Ok(Self::Payjustnow),
             common_enums::PaymentMethodType::Paysera => Ok(Self::Paysera),
             common_enums::PaymentMethodType::Payshap => Ok(Self::Payshap),
@@ -4218,7 +4218,7 @@ impl transformers::ForeignTryFrom<common_enums::PaymentMethodType>
             common_enums::PaymentMethodType::PixKey => Ok(Self::PixKey),
             common_enums::PaymentMethodType::PixQr => Ok(Self::PixQr),
             common_enums::PaymentMethodType::Qris => Ok(Self::Qris),
-            common_enums::PaymentMethodType::SepaGuarenteedDebit => Ok(Self::SepaGuarenteedDebit),
+            common_enums::PaymentMethodType::SepaGuarenteedDebit => Ok(Self::SepaGuaranteedDebit),
             _ => Err(
                 UnifiedConnectorServiceError::RequestEncodingFailedWithReason(
                     "Payment Method Type not yet supported".to_string(),


### PR DESCRIPTION
Two UCS-bridge fixes surfaced by the shadow migration-diff comparison. Companion to [juspay/hyperswitch-prism#2244](https://github.com/juspay/hyperswitch-prism/pull/2244) (proto).

---

## 1. Missing `PaymentMethodType` bridge match arms

HS's bridge conversion (`ForeignTryFrom<common_enums::PaymentMethodType> for payments_grpc::PaymentMethodType`, `crates/router/src/core/unified_connector_service/transformers.rs`) is an exhaustive match with a catch-all `_ => Err(...)` arm. Several of HS's own `common_enums::PaymentMethodType` variants were missing arms and fell through to that catch-all, hard-erroring with "Payment Method Type not yet supported" - before a UCS gRPC request is even attempted.

Confirmed via production log evidence (stripe klarna/pay_later PSync): request encoding failed at exactly this match, on HS's own request-encoding side, with no corresponding UCS-side log entry at all for the reqid - i.e. shadow execution silently fails before reaching UCS; primary/direct payment flow is unaffected.

Adds the missing match arms:
- `InstantBankTransferFinland`, `InstantBankTransferPoland` - proto values already existed, only this bridge match was missing them.
- `Klarna`, `BhnCardNetwork`, `Bluecode`, `Breadpay`, `EftDebitOrder`, `Flexiti`, `IndonesianBankTransfer`, `Mifinity`, `Payjustnow`, `Paysera`, `Payshap`, `PayshapProxy`, `PixAutomaticoPush`, `PixAutomaticoQr`, `PixEmv`, `PixKey`, `PixQr`, `Qris`, `SepaGuarenteedDebit` - require the new proto enum values in #2244.

---

## 2. `sender_payment_instrument_id` from the authorize UCS response

The direct connector path sets `router_data.sender_payment_instrument_id` on authorize (e.g. PayPal `payer_id`), but the UCS path left it unset: the gRPC `PaymentServiceAuthorizeResponse` had no such field (added in #2244), and the authorize / complete-authorize gateways never copied it. PSync already handled this via `payment_get_response.sender_payment_instrument_id` (`psync_gateway.rs`).

Adds `router_data.sender_payment_instrument_id = payment_authorize_response.sender_payment_instrument_id.clone()` in the authorize and complete-authorize gateways, mirroring the existing `captured_amount` / `minor_amount_captured` handling. From there `payment_response.rs` already persists it onto the payment attempt.

---

## Sequencing

**This PR will not compile until #2244 merges and a new `hyperswitch-prism` tag is cut.** A small follow-up commit bumping the `unified-connector-service-client` git tag pin in `crates/router/Cargo.toml` (currently `2026.08.31.1`) will be added once that tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)