### PR TITLE
test(cypress): add coverage for blocklist card_bin widening, customer_acceptance_support and payment_account_reference

### DIFF
--- a/cypress-tests/.gitignore
+++ b/cypress-tests/.gitignore
@@ -10,6 +10,7 @@ creds.json
 cypress.env.json
 run_all.sh
 run-givepayments-ucs.sh
+run_stripe_ucs.sh
 
 # Cypress Dashboard build
 **/dist

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -612,6 +612,7 @@ export const CONNECTOR_LISTS = {
       "fiservcommercehub",
       "givepayments",
       "ilixium",
+      "stripe",
     ],
     OVERCAPTURE: ["adyen"],
     IFRAME_REDIRECTION: [

--- a/cypress-tests/cypress/e2e/configs/PaymentMethodList/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/PaymentMethodList/Commons.js
@@ -58,6 +58,73 @@ export const cardCreditEnabledInUs = [
   },
 ];
 
+export const cardCreditAndAchEnabledInUs = [
+  {
+    payment_method: "card",
+    payment_method_types: [
+      {
+        payment_method_type: "credit",
+        card_networks: ["Visa"],
+        minimum_amount: 0,
+        accepted_countries: {
+          type: "enable_only",
+          list: ["US"],
+        },
+        maximum_amount: 68607706,
+        recurring_enabled: false,
+        installment_payment_enabled: true,
+      },
+    ],
+  },
+  {
+    payment_method: "bank_debit",
+    payment_method_types: [
+      {
+        payment_method_type: "ach",
+        payment_experience: null,
+        card_networks: null,
+        accepted_currencies: {
+          type: "enable_only",
+          list: ["USD"],
+        },
+        accepted_countries: {
+          type: "enable_only",
+          list: ["US"],
+        },
+        minimum_amount: 1,
+        maximum_amount: 68607706,
+        recurring_enabled: true,
+        installment_payment_enabled: true,
+      },
+    ],
+  },
+];
+
+export const openBankingEnabledInGb = [
+  {
+    payment_method: "bank_redirect",
+    payment_method_types: [
+      {
+        payment_method_type: "open_banking",
+        payment_experience: null,
+        card_networks: null,
+        accepted_currencies: {
+          type: "enable_only",
+          list: ["GBP"],
+        },
+        accepted_countries: {
+          type: "enable_only",
+          list: ["GB"],
+        },
+        minimum_amount: 1,
+        maximum_amount: 68607706,
+        recurring_enabled: true,
+        installment_payment_enabled: true,
+      },
+    ],
+  },
+];
+
 export const cardCreditEnabledInEur = [
   {
     payment_method: "card",

--- a/cypress-tests/cypress/e2e/spec/Payment/04-NoThreeDSAutoCapture.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/04-NoThreeDSAutoCapture.cy.js
@@ -76,6 +76,22 @@ describe("Card - NoThreeDS payment flow test", () => {
         ]["No3DSAutoCapture"];
 
         cy.retrievePaymentCallTest({ globalState, data: confirmData });
+
+        if (globalState.get("ucsEnabled")) {
+          cy.getPaymentDetails(globalState, "force_sync=true").then(
+            (response) => {
+              const cardNetwork =
+                response.body.payment_method_data?.card?.card_network;
+              if (cardNetwork === "Visa" || cardNetwork === "Mastercard") {
+                expect(response.body.payment_account_reference).to.be.a(
+                  "string"
+                ).and.not.be.empty;
+              } else if (cardNetwork === "AmericanExpress") {
+                expect(response.body.payment_account_reference).to.be.null;
+              }
+            }
+          );
+        }
       });
     });
   });

--- a/cypress-tests/cypress/e2e/spec/Payment/59-BlocklistCardBinBoundaries.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/59-BlocklistCardBinBoundaries.cy.js
@@ -1,0 +1,226 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import { connectorDetails } from "../../../e2e/configs/Payment/Commons";
+
+let globalState;
+
+describe("Blocklist card_bin / extended_card_bin / generic_card_bin boundaries", () => {
+  before("seed global state", () => {
+    cy.task("getGlobalState").then((state) => {
+      globalState = new State(state);
+    });
+  });
+
+  after("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("Setup Phase", () => {
+    it("payment intent create call", () => {
+      cy.createPaymentIntentTest(
+        fixtures.createPaymentBody,
+        connectorDetails.eligibility_api.PaymentIntentForBlocklist,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+  });
+
+  context("card_bin - unchanged 6-digit-exact validation", () => {
+    it("should accept a 6 digit card_bin (regression)", () => {
+      cy.blocklistCreateRuleRaw("card_bin", "424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+          expect(response.body).to.have.property("data_kind", "card_bin");
+          expect(response.body).to.have.property(
+            "fingerprint_id",
+            "424242"
+          );
+        }
+      );
+    });
+
+    it("cleanup: delete the 6 digit card_bin entry", () => {
+      cy.blocklistDeleteRuleRaw("card_bin", "424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+        }
+      );
+    });
+
+    it("should reject a 5 digit card_bin", () => {
+      cy.blocklistCreateRuleRaw("card_bin", "42424", globalState).then(
+        (response) => {
+          expect(response.status).to.not.equal(200);
+        }
+      );
+    });
+
+    it("should reject a 7 digit card_bin (still not widened)", () => {
+      cy.blocklistCreateRuleRaw("card_bin", "4242424", globalState).then(
+        (response) => {
+          expect(response.status).to.not.equal(200);
+        }
+      );
+    });
+  });
+
+  context("extended_card_bin - unchanged 8-digit-exact validation (deprecated, kept for backward compat)", () => {
+    it("should still accept an 8 digit extended_card_bin", () => {
+      cy.blocklistCreateRuleRaw("extended_card_bin", "42424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+          expect(response.body).to.have.property(
+            "data_kind",
+            "extended_card_bin"
+          );
+        }
+      );
+    });
+
+    it("cleanup: delete the extended_card_bin entry", () => {
+      cy.blocklistDeleteRuleRaw("extended_card_bin", "42424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+        }
+      );
+    });
+
+    it("should reject a 6 digit extended_card_bin", () => {
+      cy.blocklistCreateRuleRaw("extended_card_bin", "424242", globalState).then(
+        (response) => {
+          expect(response.status).to.not.equal(200);
+        }
+      );
+    });
+  });
+
+  context("generic_card_bin - new 6 to 10 digit range", () => {
+    it("should accept a 6 digit generic_card_bin", () => {
+      cy.blocklistCreateRuleRaw("generic_card_bin", "424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+          expect(response.body).to.have.property(
+            "data_kind",
+            "generic_card_bin"
+          );
+        }
+      );
+    });
+
+    it("cleanup: delete the 6 digit generic_card_bin entry", () => {
+      cy.blocklistDeleteRuleRaw("generic_card_bin", "424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+        }
+      );
+    });
+
+    it("should accept an 8 digit generic_card_bin (previously only valid as extended_card_bin)", () => {
+      cy.blocklistCreateRuleRaw("generic_card_bin", "42424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+          expect(response.body).to.have.property(
+            "data_kind",
+            "generic_card_bin"
+          );
+        }
+      );
+    });
+
+    it("cleanup: delete the 8 digit generic_card_bin entry", () => {
+      cy.blocklistDeleteRuleRaw("generic_card_bin", "42424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+        }
+      );
+    });
+
+    it("should accept a 10 digit generic_card_bin (new upper bound)", () => {
+      cy.blocklistCreateRuleRaw(
+        "generic_card_bin",
+        "4242424242",
+        globalState
+      ).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body).to.have.property(
+          "data_kind",
+          "generic_card_bin"
+        );
+      });
+    });
+
+    it("cleanup: delete the 10 digit generic_card_bin entry", () => {
+      cy.blocklistDeleteRuleRaw("generic_card_bin", "4242424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+        }
+      );
+    });
+
+    it("should reject a 5 digit generic_card_bin (below minimum)", () => {
+      cy.blocklistCreateRuleRaw("generic_card_bin", "42424", globalState).then(
+        (response) => {
+          expect(response.status).to.not.equal(200);
+        }
+      );
+    });
+
+    it("should reject an 11 digit generic_card_bin (above maximum)", () => {
+      cy.blocklistCreateRuleRaw(
+        "generic_card_bin",
+        "42424242424",
+        globalState
+      ).then((response) => {
+        expect(response.status).to.not.equal(200);
+      });
+    });
+  });
+
+  context("Eligibility check with an 8 digit generic_card_bin block", () => {
+    it("should create a generic_card_bin blocklist rule for 42424242", () => {
+      cy.blocklistCreateRuleRaw("generic_card_bin", "42424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+        }
+      );
+    });
+
+    it("should enable blocklist functionality using configs API", () => {
+      const merchantId = globalState.get("merchantId");
+      const key = `guard_blocklist_for_${merchantId}`;
+      cy.setConfigs(globalState, key, "true", "CREATE");
+    });
+
+    it("should deny payment for a card matching the blocked 8 digit generic_card_bin", () => {
+      cy.paymentsEligibilityCheck(
+        fixtures.eligibilityCheckBody,
+        connectorDetails.eligibility_api.BlocklistedCardDenied,
+        globalState
+      );
+    });
+
+    it("should allow payment for a non-blocklisted card", () => {
+      cy.paymentsEligibilityCheck(
+        fixtures.eligibilityCheckBody,
+        connectorDetails.eligibility_api.NonBlocklistedCardAllowed,
+        globalState
+      );
+    });
+
+    it("cleanup: delete the generic_card_bin rule", () => {
+      cy.blocklistDeleteRuleRaw("generic_card_bin", "42424242", globalState).then(
+        (response) => {
+          expect(response.status).to.equal(200);
+        }
+      );
+    });
+
+    it("should disable blocklist functionality using configs API", () => {
+      const merchantId = globalState.get("merchantId");
+      const key = `guard_blocklist_for_${merchantId}`;
+      cy.setConfigs(globalState, key, "true", "DELETE");
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/spec/PaymentMethodList/00001-CustomerAcceptanceSupport.cy.js
+++ b/cypress-tests/cypress/e2e/spec/PaymentMethodList/00001-CustomerAcceptanceSupport.cy.js
@@ -1,0 +1,248 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import {
+  cardCreditAndAchEnabledInUs,
+  openBankingEnabledInGb,
+  createPaymentBodyWithCurrency,
+  createPaymentBodyWithCurrencyCountry,
+} from "../../configs/PaymentMethodList/Commons";
+import getConnectorDetails from "../../configs/PaymentMethodList/Utils";
+
+let globalState;
+
+describe("Payment Method List - customer_acceptance_support field", () => {
+  context(
+    `
+    MCA1 -> Stripe configured with credit = { country = "US" } and bank_debit.ach = { country = "US" }\n
+    Payment is done with country as US and currency as USD\n
+    card.credit should report "supported" (configured in customer_acceptance_support.card.credit)\n
+    bank_debit.ach should report "unsupported" (bank_debit has no entry in customer_acceptance_support)\n
+    `,
+    () => {
+      before("seed global state", () => {
+        cy.task("getGlobalState").then((state) => {
+          globalState = new State(state);
+        });
+      });
+
+      after("flush global state", () => {
+        cy.task("setGlobalState", globalState.data);
+      });
+
+      it("merchant-create-call-test", () => {
+        cy.merchantCreateCallTest(fixtures.merchantCreateBody, globalState);
+      });
+
+      it("api-key-create-call-test", () => {
+        cy.apiKeyCreateTest(fixtures.apiKeyCreateBody, globalState);
+      });
+
+      it("customer-create-call-test", () => {
+        cy.createCustomerCallTest(fixtures.customerCreateBody, globalState);
+      });
+
+      it("connector-create-call-test", () => {
+        cy.createNamedConnectorCallTest(
+          "payment_processor",
+          fixtures.createConnectorBody,
+          cardCreditAndAchEnabledInUs,
+          globalState,
+          "stripe",
+          "stripe_US_default"
+        );
+      });
+
+      it("create-payment-call-test", () => {
+        const data =
+          getConnectorDetails("connector")["pm_list"]["PaymentIntent"];
+
+        const newData = {
+          ...data,
+          Request: data.RequestCurrencyUSD,
+          RequestCurrencyUSD: undefined,
+        };
+
+        cy.createPaymentIntentTest(
+          createPaymentBodyWithCurrency("USD"),
+          newData,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+      });
+
+      it("payment-method-list-call-test: card.credit is supported, bank_debit.ach is unsupported", () => {
+        const validValues = [
+          "supported",
+          "partially_supported",
+          "unsupported",
+        ];
+
+        cy.getPaymentMethodsList(globalState).then((response) => {
+          expect(response.headers["content-type"]).to.include(
+            "application/json"
+          );
+
+          if (response.status === 200) {
+            const paymentMethods = response.body["payment_methods"];
+            expect(paymentMethods).to.be.an("array");
+            expect(paymentMethods.length).to.be.greaterThan(0);
+
+            let sawCardCredit = false;
+            let sawBankDebitAch = false;
+
+            paymentMethods.forEach((paymentMethod) => {
+              expect(paymentMethod["payment_method_types"]).to.be.an(
+                "array"
+              );
+              paymentMethod["payment_method_types"].forEach(
+                (paymentMethodType) => {
+                  expect(paymentMethodType).to.have.property(
+                    "customer_acceptance_support"
+                  );
+                  expect(validValues).to.include(
+                    paymentMethodType["customer_acceptance_support"]
+                  );
+
+                  if (
+                    paymentMethod["payment_method"] === "card" &&
+                    paymentMethodType["payment_method_type"] === "credit"
+                  ) {
+                    sawCardCredit = true;
+                    expect(
+                      paymentMethodType["customer_acceptance_support"]
+                    ).to.equal("supported");
+                  }
+
+                  if (
+                    paymentMethod["payment_method"] === "bank_debit" &&
+                    paymentMethodType["payment_method_type"] === "ach"
+                  ) {
+                    sawBankDebitAch = true;
+                    expect(
+                      paymentMethodType["customer_acceptance_support"]
+                    ).to.equal("unsupported");
+                  }
+                }
+              );
+            });
+
+            expect(sawCardCredit, "card.credit entry present").to.be.true;
+            expect(sawBankDebitAch, "bank_debit.ach entry present").to.be
+              .true;
+          } else {
+            throw new Error(
+              `List payment methods failed with status code "${response.status}"`
+            );
+          }
+        });
+      });
+    }
+  );
+
+  context(
+    `
+    MCA2 -> Volt configured with bank_redirect.open_banking = { country = "GB", currency = "GBP" }\n
+    Payment is done with country as GB and currency as GBP\n
+    bank_redirect.open_banking should report "partially_supported" (configured in customer_acceptance_support.bank_redirect.open_banking)\n
+    `,
+    () => {
+      before("seed global state", () => {
+        cy.task("getGlobalState").then((state) => {
+          globalState = new State(state);
+        });
+      });
+
+      after("flush global state", () => {
+        cy.task("setGlobalState", globalState.data);
+      });
+
+      it("merchant-create-call-test", () => {
+        cy.merchantCreateCallTest(fixtures.merchantCreateBody, globalState);
+      });
+
+      it("api-key-create-call-test", () => {
+        cy.apiKeyCreateTest(fixtures.apiKeyCreateBody, globalState);
+      });
+
+      it("customer-create-call-test", () => {
+        cy.createCustomerCallTest(fixtures.customerCreateBody, globalState);
+      });
+
+      it("connector-create-call-test", () => {
+        cy.createNamedConnectorCallTest(
+          "payment_processor",
+          fixtures.createConnectorBody,
+          openBankingEnabledInGb,
+          globalState,
+          "volt",
+          "volt_GB_default"
+        );
+      });
+
+      it("create-payment-call-test", () => {
+        const data =
+          getConnectorDetails("connector")["pm_list"]["PaymentIntent"];
+
+        const newData = {
+          ...data,
+          Request: {
+            currency: "GBP",
+            customer_acceptance: null,
+            setup_future_usage: "off_session",
+            authentication_type: "no_three_ds",
+          },
+        };
+
+        cy.createPaymentIntentTest(
+          createPaymentBodyWithCurrencyCountry("GBP", "GB", "GB"),
+          newData,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+      });
+
+      it("payment-method-list-call-test: bank_redirect.open_banking is partially_supported", () => {
+        cy.getPaymentMethodsList(globalState).then((response) => {
+          expect(response.headers["content-type"]).to.include(
+            "application/json"
+          );
+
+          if (response.status === 200) {
+            const paymentMethods = response.body["payment_methods"];
+            expect(paymentMethods).to.be.an("array");
+
+            let sawOpenBanking = false;
+
+            paymentMethods.forEach((paymentMethod) => {
+              if (paymentMethod["payment_method"] !== "bank_redirect") {
+                return;
+              }
+              (paymentMethod["payment_method_types"] || []).forEach(
+                (paymentMethodType) => {
+                  if (
+                    paymentMethodType["payment_method_type"] ===
+                    "open_banking"
+                  ) {
+                    sawOpenBanking = true;
+                    expect(
+                      paymentMethodType["customer_acceptance_support"]
+                    ).to.equal("partially_supported");
+                  }
+                }
+              );
+            });
+
+            expect(sawOpenBanking, "bank_redirect.open_banking entry present")
+              .to.be.true;
+          } else {
+            throw new Error(
+              `List payment methods failed with status code "${response.status}"`
+            );
+          }
+        });
+      });
+    }
+  );
+});

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -7961,7 +7961,7 @@ Cypress.Commands.add(
 // Blocklist and Eligibility API Commands
 Cypress.Commands.add(
   "blocklistCreateRule",
-  (requestBody, cardBin, globalState) => {
+  (requestBody, cardBin, globalState, type = "card_bin") => {
     const apiKey = globalState.get("apiKey");
     const baseUrl = globalState.get("baseUrl");
     const profileId = globalState.get("profileId");
@@ -7969,7 +7969,7 @@ Cypress.Commands.add(
 
     const body = {
       ...requestBody,
-      type: "card_bin",
+      type: type,
       data: cardBin,
     };
 
@@ -7993,7 +7993,7 @@ Cypress.Commands.add(
             .to.equal(cardBin);
           expect(response.body)
             .to.have.property("data_kind")
-            .to.equal("card_bin");
+            .to.equal(type);
           expect(response.body).to.have.property("created_at").to.not.be.null;
           globalState.set("blocklistRuleId", response.body.fingerprint_id);
         } else {
@@ -8039,6 +8039,75 @@ Cypress.Commands.add("blocklistDeleteRule", (type, data, globalState) => {
         );
       }
     });
+  });
+});
+
+Cypress.Commands.add(
+  "getPaymentDetails",
+  (globalState, queryParams = "force_sync=true&expand_attempts=true") => {
+    const paymentId = globalState.get("paymentID");
+    return cy.request({
+      method: "GET",
+      url: `${globalState.get("baseUrl")}/payments/${paymentId}?${queryParams}`,
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": globalState.get("apiKey"),
+      },
+      failOnStatusCode: false,
+    });
+  }
+);
+
+Cypress.Commands.add("getPaymentMethodsList", (globalState) => {
+  const clientSecret = globalState.get("clientSecret");
+  return cy.request({
+    method: "GET",
+    url: `${globalState.get("baseUrl")}/account/payment_methods?client_secret=${clientSecret}`,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "api-key": globalState.get("publishableKey"),
+    },
+    failOnStatusCode: false,
+  });
+});
+
+// Unlike blocklistCreateRule/blocklistDeleteRule, these don't assert or
+// throw on non-200 - they just return the raw response, for callers that
+// need to assert both success and expected-rejection paths.
+Cypress.Commands.add("blocklistCreateRuleRaw", (type, data, globalState) => {
+  const apiKey = globalState.get("apiKey");
+  const baseUrl = globalState.get("baseUrl");
+  const profileId = globalState.get("profileId");
+
+  return cy.request({
+    method: "POST",
+    url: `${baseUrl}/blocklist`,
+    headers: {
+      "Content-Type": "application/json",
+      "api-key": apiKey,
+      "X-Profile-Id": profileId,
+    },
+    body: { type, data },
+    failOnStatusCode: false,
+  });
+});
+
+Cypress.Commands.add("blocklistDeleteRuleRaw", (type, data, globalState) => {
+  const apiKey = globalState.get("apiKey");
+  const baseUrl = globalState.get("baseUrl");
+  const profileId = globalState.get("profileId");
+
+  return cy.request({
+    method: "DELETE",
+    url: `${baseUrl}/blocklist`,
+    headers: {
+      "Content-Type": "application/json",
+      "api-key": apiKey,
+      "X-Profile-Id": profileId,
+    },
+    body: { type, data },
+    failOnStatusCode: false,
   });
 });
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds Cypress E2E coverage for several recently merged features that had none yet:

- `59-BlocklistCardBinBoundaries.cy.js`: `card_bin`/`extended_card_bin` boundaries stay unchanged and are still accepted for backward compatibility; the new `generic_card_bin` type accepts a 6-10 digit range; verified end-to-end against the live blocking/eligibility path (#13861).
- `PaymentMethodList/00001-CustomerAcceptanceSupport.cy.js`: all three `customer_acceptance_support` states (`supported`, `partially_supported`, `unsupported`) are exercised against real config-driven values - `card.credit`, `bank_debit.ach` (defaults to unsupported, no config entry), and `bank_redirect.open_banking` on Volt (#13854).
- `04-NoThreeDSAutoCapture.cy.js`: `payment_account_reference` is populated for Visa/Mastercard and null for Amex under UCS routing (#13883). Live-verified against stripe with `execution_mode: primary` - the assertion is gated on `ucsEnabled` so it specifically exercises the UCS/Prism-side mapping code, not the pre-existing classic-connector mapping.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

Closes #14087

## How did you test it?
<!-- Did you write an integration/unit/API test to verify the code changes? -->

Ran each spec interactively against a live merchant on `integ.hyperswitch.io`:
- `59-BlocklistCardBinBoundaries.cy.js`: 22/22 passed, covering all `card_bin`/`extended_card_bin`/`generic_card_bin` boundary cases plus a live eligibility-block/allow check.
- `PaymentMethodList/00001-CustomerAcceptanceSupport.cy.js`: 12/12 passed across two contexts, covering all three `customer_acceptance_support` states with real assertions per state.
- `04-NoThreeDSAutoCapture.cy.js`: passed with `payment_account_reference` correctly null for the spec's default Amex card under UCS routing.

Each of these was audited against the actual new code the underlying PR introduces (not just "does the assertion pass") - i.e. checked that the test would have failed before the fix existed, not only that it passes now. That audit is what surfaced the #13849 and #13607 gaps called out above and moved them out of this PR.

Known gap: #13633 (browser_info forwarded to Stripe's tokenization request) is not covered here - it can't be verified from Cypress, since there's no way to inspect the outbound router-to-connector request body. See #14087 for details and the suggested alternative (a Rust unit test on the `TokenRequest` `TryFrom` impl).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible