### PR TITLE
refactor(core): let connectors decide 3DS leg continuation

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nuvei.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nuvei.rs
@@ -1815,6 +1815,15 @@ impl ConnectorSpecifications for Nuvei {
         }
     }
 
+    /// Gate after the `PreAuthenticate` leg of the Authorize flow: Nuvei always continues
+    /// on to Authorize, whatever the PreAuthenticate leg returned.
+    fn should_continue_after_pre_authentication(
+        &self,
+        _ctx: api::AuthenticationLegContext,
+    ) -> bool {
+        true
+    }
+
     fn get_supported_payment_methods(&self) -> Option<&'static SupportedPaymentMethods> {
         Some(&*NUVEI_SUPPORTED_PAYMENT_METHODS)
     }

--- a/crates/hyperswitch_connectors/src/connectors/paysafe.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paysafe.rs
@@ -1392,6 +1392,17 @@ impl ConnectorSpecifications for Paysafe {
         }
     }
 
+    /// Paysafe card + 3DS: PreAuthenticate mints the handle. When Paysafe returns no ACS
+    /// redirect (frictionless / no challenge), continue straight to the settle Authorize
+    /// in this flow; when it returns a redirect, break so the shopper completes the
+    /// challenge and the settle runs from CompleteAuthorize.
+    fn should_continue_after_pre_authentication(&self, ctx: api::AuthenticationLegContext) -> bool {
+        match ctx.transaction_response {
+            Some(transaction_response) => !transaction_response.has_redirection_data,
+            None => false,
+        }
+    }
+
     fn get_supported_payment_methods(&self) -> Option<&'static SupportedPaymentMethods> {
         Some(&*PAYSAFE_SUPPORTED_PAYMENT_METHODS)
     }

--- a/crates/hyperswitch_connectors/src/connectors/redsys.rs
+++ b/crates/hyperswitch_connectors/src/connectors/redsys.rs
@@ -1159,6 +1159,49 @@ impl ConnectorSpecifications for Redsys {
         }
     }
 
+    /// Gate after the `PreAuthenticate` leg of the Authorize flow.
+    fn should_continue_after_pre_authentication(&self, ctx: api::AuthenticationLegContext) -> bool {
+        match ctx.transaction_response {
+            Some(transaction_response) => {
+                let has_ucs_redirection = transaction_response.has_redirection_data;
+
+                let has_hyperswitch_three_ds_invoke_data =
+                    transaction_response.has_three_ds_invoke_data;
+
+                // Continue only if neither UCS nor hyperswitch indicates a redirect is needed
+                !has_ucs_redirection && !has_hyperswitch_three_ds_invoke_data
+            }
+            None => false,
+        }
+    }
+
+    /// Gate after the `Authenticate` leg of the Authorize flow.
+    fn should_continue_after_authentication(&self, ctx: api::AuthenticationLegContext) -> bool {
+        match ctx.transaction_response {
+            Some(transaction_response) => {
+                // For UCS Redsys: if redirection_data is present (3DS challenge), don't continue
+                // For hyperswitch native: check connector_metadata for PaymentsConnectorThreeDsInvokeData
+                let has_ucs_redirection = transaction_response.has_redirection_data;
+
+                let has_hyperswitch_three_ds_invoke_data =
+                    transaction_response.has_three_ds_invoke_data;
+
+                let payment_status = !matches!(
+                    ctx.attempt_status,
+                    common_enums::AttemptStatus::AuthenticationFailed
+                        | common_enums::AttemptStatus::Failure
+                        | common_enums::AttemptStatus::Charged
+                        | common_enums::AttemptStatus::PartialCharged
+                        | common_enums::AttemptStatus::Authorized
+                );
+
+                // Continue only if neither UCS nor hyperswitch indicates a redirect is needed
+                !has_ucs_redirection && !has_hyperswitch_three_ds_invoke_data && payment_status
+            }
+            None => false,
+        }
+    }
+
     fn get_connector_about(&self) -> Option<&'static ConnectorInfo> {
         Some(&REDSYS_CONNECTOR_INFO)
     }

--- a/crates/hyperswitch_connectors/src/connectors/shift4.rs
+++ b/crates/hyperswitch_connectors/src/connectors/shift4.rs
@@ -1114,6 +1114,15 @@ impl ConnectorSpecifications for Shift4 {
         }
     }
 
+    /// Gate after the `PreAuthenticate` leg of the Authorize flow: Shift4 always continues
+    /// on to Authorize, whatever the PreAuthenticate leg returned.
+    fn should_continue_after_pre_authentication(
+        &self,
+        _ctx: api::AuthenticationLegContext,
+    ) -> bool {
+        true
+    }
+
     fn get_connector_about(&self) -> Option<&'static ConnectorInfo> {
         Some(&SHIFT4_CONNECTOR_INFO)
     }

--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -89,6 +89,35 @@ impl CurrentFlowInfo {
     }
 }
 
+/// Facts the router read off an authentication leg's response, handed to the connector so
+/// it can decide whether the 3DS chain continues to the next leg.
+///
+/// The router does the parsing — presence of redirection data, and whether
+/// `connector_metadata` parses as `api_models::payments::PaymentsConnectorThreeDsInvokeData`
+/// — so that connectors never have to re-parse `connector_metadata` themselves.
+#[derive(Clone, Copy, Debug)]
+pub struct AuthenticationLegContext {
+    /// Facts from the leg's response, populated only when it was a successful
+    /// `PaymentsResponseData::TransactionResponse`. `None` for an error response or for
+    /// any other `PaymentsResponseData` variant.
+    pub transaction_response: Option<AuthenticationLegTransactionResponse>,
+    /// The attempt status after the leg completed.
+    pub attempt_status: common_enums::AttemptStatus,
+}
+
+/// Facts read off a successful `PaymentsResponseData::TransactionResponse` returned by an
+/// authentication leg.
+#[derive(Clone, Copy, Debug)]
+pub struct AuthenticationLegTransactionResponse {
+    /// Whether the response carried redirection data, i.e. the shopper has to be sent to
+    /// the connector/ACS before the payment can be settled.
+    pub has_redirection_data: bool,
+    /// Whether `connector_metadata` parsed as
+    /// `api_models::payments::PaymentsConnectorThreeDsInvokeData`, i.e. hyperswitch itself
+    /// has to invoke the 3DS method before the payment can be settled.
+    pub has_three_ds_invoke_data: bool,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct PaymentsAuthorizeData {
     pub payment_method_data: PaymentMethodData,

--- a/crates/hyperswitch_interfaces/src/api.rs
+++ b/crates/hyperswitch_interfaces/src/api.rs
@@ -45,7 +45,9 @@ use common_utils::{
     request::{Method, Request, RequestContent},
 };
 use error_stack::ResultExt;
-pub use hyperswitch_domain_models::router_request_types::CurrentFlowInfo;
+pub use hyperswitch_domain_models::router_request_types::{
+    AuthenticationLegContext, AuthenticationLegTransactionResponse, CurrentFlowInfo,
+};
 use hyperswitch_domain_models::{
     connector_endpoints::Connectors,
     errors::api_error_response::ApiErrorResponse,
@@ -469,6 +471,28 @@ pub trait ConnectorSpecifications {
     }
     /// Check if post-authentication flow is required
     fn is_post_authentication_flow_required(&self, _current_flow: CurrentFlowInfo) -> bool {
+        false
+    }
+    /// Decide whether the payment chain continues on to `Authorize` after the
+    /// `PreAuthenticate` leg has run.
+    ///
+    /// Only consulted for connectors that declare
+    /// [`Self::is_pre_authentication_flow_required`]. Returning `false` — the default —
+    /// stops the chain after the `PreAuthenticate` leg, which is what a connector wants
+    /// when the leg produced a redirect the shopper still has to complete; the settle then
+    /// runs from `CompleteAuthorize` once the shopper is back.
+    fn should_continue_after_pre_authentication(&self, _ctx: AuthenticationLegContext) -> bool {
+        false
+    }
+
+    /// Decide whether the payment chain continues on to `Authorize` after the
+    /// `Authenticate` leg has run.
+    ///
+    /// Only consulted for connectors that declare
+    /// [`Self::is_authentication_flow_required`]. Returning `false` — the default — stops
+    /// the chain after the `Authenticate` leg, so the shopper can complete the 3DS
+    /// challenge and the settle runs from `CompleteAuthorize`.
+    fn should_continue_after_authentication(&self, _ctx: AuthenticationLegContext) -> bool {
         false
     }
     /// Check if pre-authenticate cancel flow is supported

--- a/crates/hyperswitch_interfaces/src/connector_integration_interface.rs
+++ b/crates/hyperswitch_interfaces/src/connector_integration_interface.rs
@@ -597,6 +597,18 @@ impl ConnectorSpecifications for ConnectorEnum {
             Self::New(connector) => connector.is_post_authentication_flow_required(current_flow),
         }
     }
+    fn should_continue_after_pre_authentication(&self, ctx: api::AuthenticationLegContext) -> bool {
+        match self {
+            Self::Old(connector) => connector.should_continue_after_pre_authentication(ctx),
+            Self::New(connector) => connector.should_continue_after_pre_authentication(ctx),
+        }
+    }
+    fn should_continue_after_authentication(&self, ctx: api::AuthenticationLegContext) -> bool {
+        match self {
+            Self::Old(connector) => connector.should_continue_after_authentication(ctx),
+            Self::New(connector) => connector.should_continue_after_authentication(ctx),
+        }
+    }
     fn is_settlement_split_call_required(&self, current_flow: CurrentFlowInfo) -> bool {
         match self {
             Self::Old(connector) => connector.is_settlement_split_call_required(current_flow),

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -206,6 +206,44 @@ impl
     }
 }
 
+/// Read off an authentication leg's response the facts a connector needs to decide whether
+/// the 3DS chain continues on to `Authorize`.
+///
+/// The parsing lives here, in the router, so that connectors implementing
+/// [`ConnectorSpecifications::should_continue_after_pre_authentication`] and
+/// [`ConnectorSpecifications::should_continue_after_authentication`] never have to re-parse
+/// `connector_metadata` themselves.
+fn build_authentication_leg_context(
+    response: &Result<types::PaymentsResponseData, types::ErrorResponse>,
+    attempt_status: enums::AttemptStatus,
+) -> api_interface::AuthenticationLegContext {
+    let transaction_response = match response {
+        Ok(types::PaymentsResponseData::TransactionResponse {
+            connector_metadata,
+            redirection_data,
+            ..
+        }) => Some(api_interface::AuthenticationLegTransactionResponse {
+            has_redirection_data: redirection_data.is_some(),
+            has_three_ds_invoke_data: connector_metadata
+                .clone()
+                .and_then(|metadata| {
+                    metadata
+                        .parse_value::<api_models::payments::PaymentsConnectorThreeDsInvokeData>(
+                            "PaymentsConnectorThreeDsInvokeData",
+                        )
+                        .ok()
+                })
+                .is_some(),
+        }),
+        Ok(_) | Err(_) => None,
+    };
+
+    api_interface::AuthenticationLegContext {
+        transaction_response,
+        attempt_status,
+    }
+}
+
 #[async_trait]
 impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAuthorizeRouterData {
     fn current_flow_info(&self) -> Option<api_interface::CurrentFlowInfo> {
@@ -553,44 +591,16 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
                 authorize_router_data.request.related_transaction_id = related_transaction_id;
             }
 
-            let should_continue_after_preauthenticate = match connector.connector_name {
-                // connector specific handling to decide whether to continue with authorize or not should not be done here
-                // this is just a temporary fix for Redsys and Shift4 connectors
-                api_models::enums::Connector::Redsys => match &authorize_router_data.response {
-                    Ok(types::PaymentsResponseData::TransactionResponse {
-                        connector_metadata,
-                        redirection_data,
-                        ..
-                    }) => {
-                        let has_ucs_redirection = redirection_data.is_some();
-
-                        let has_hyperswitch_three_ds_invoke_data: bool =
-                            connector_metadata.clone().and_then(|metadata| {
-                                metadata
-                                    .parse_value::<api_models::payments::PaymentsConnectorThreeDsInvokeData>("PaymentsConnectorThreeDsInvokeData")
-                                    .ok()
-                            }).is_some();
-
-                        // Continue only if neither UCS nor hyperswitch indicates a redirect is needed
-                        !has_ucs_redirection && !has_hyperswitch_three_ds_invoke_data
-                    }
-                    _ => false,
-                },
-                api_models::enums::Connector::Shift4 => true,
-                api_models::enums::Connector::Nuvei => true,
-                // Paysafe card + 3DS: PreAuthenticate mints the handle. When Paysafe returns no ACS
-                // redirect (frictionless / no challenge), continue straight to the settle Authorize
-                // in this flow; when it returns a redirect, break so the shopper completes the
-                // challenge and the settle runs from CompleteAuthorize.
-                api_models::enums::Connector::Paysafe => match &authorize_router_data.response {
-                    Ok(types::PaymentsResponseData::TransactionResponse {
-                        redirection_data,
-                        ..
-                    }) => redirection_data.is_none(),
-                    _ => false,
-                },
-                _ => false,
-            };
+            // Whether the chain continues on to Authorize is the connector's decision, not
+            // the router's: the router only reads the facts off the PreAuthenticate response
+            // and hands them over. Connectors that do not implement the hook default to
+            // stopping here.
+            let should_continue_after_preauthenticate = connector
+                .connector
+                .should_continue_after_pre_authentication(build_authentication_leg_context(
+                    &authorize_router_data.response,
+                    authorize_router_data.status,
+                ));
             Ok((authorize_router_data, should_continue_after_preauthenticate))
         } else {
             Ok((self, true))
@@ -694,42 +704,14 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
                 }
             }
 
-            let should_continue_after_authenticate = match &authorize_router_data.response {
-                Ok(types::PaymentsResponseData::TransactionResponse {
-                    connector_metadata,
-                    redirection_data,
-                    ..
-                }) => match connector.connector_name {
-                    api_models::enums::Connector::Redsys => {
-                        // For UCS Redsys: if redirection_data is present (3DS challenge), don't continue
-                        // For hyperswitch native: check connector_metadata for PaymentsConnectorThreeDsInvokeData
-                        let has_ucs_redirection = redirection_data.is_some();
-
-                        let has_hyperswitch_three_ds_invoke_data: bool =
-                            connector_metadata.clone().and_then(|metadata| {
-                                metadata
-                                    .parse_value::<api_models::payments::PaymentsConnectorThreeDsInvokeData>("PaymentsConnectorThreeDsInvokeData")
-                                    .ok()
-                            }).is_some();
-
-                        let payment_status = !matches!(
-                            authorize_router_data.status,
-                            common_enums::AttemptStatus::AuthenticationFailed
-                                | common_enums::AttemptStatus::Failure
-                                | common_enums::AttemptStatus::Charged
-                                | common_enums::AttemptStatus::PartialCharged
-                                | common_enums::AttemptStatus::Authorized
-                        );
-
-                        // Continue only if neither UCS nor hyperswitch indicates a redirect is needed
-                        !has_ucs_redirection
-                            && !has_hyperswitch_three_ds_invoke_data
-                            && payment_status
-                    }
-                    _ => false,
-                },
-                _ => false,
-            };
+            // Same as after PreAuthenticate: the connector owns the decision, the router
+            // only supplies the facts read off the Authenticate response.
+            let should_continue_after_authenticate = connector
+                .connector
+                .should_continue_after_authentication(build_authentication_leg_context(
+                    &authorize_router_data.response,
+                    authorize_router_data.status,
+                ));
             Ok((authorize_router_data, should_continue_after_authenticate))
         } else {
             Ok((self, true))

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -876,6 +876,12 @@ impl
             return_url: router_data.request.router_return_url.clone(),
             address: Some(address),
             auth_type: auth_type.into(),
+            // NOTE: hardcoded, not forwarded. The sibling builders that send
+            // `Some(router_data.request.enrolled_for_3ds)` are built from `PaymentsAuthorizeData`
+            // and `ExternalVaultProxyPaymentsData`, both of which carry that field.
+            // `CompleteAuthorizeData` does not carry it at all, so there is no real value to
+            // forward here. Synthesising one (from `auth_type`, say) would change what is sent
+            // to UCS on every CompleteAuthorize and is a product decision, not a refactor.
             enrolled_for_3ds: Some(true),
             request_incremental_authorization: Some(
                 router_data.request.request_incremental_authorization,
@@ -2036,6 +2042,21 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
     }
 }
 
+// NOTE: this impl is unreferenced — nothing in the tree calls it.
+//
+// Every `payments_grpc::PaymentServiceAuthorizeRequest` built in this crate is built by one of
+// the other impls in this file: `authorize_gateway.rs:208` and `complete_authorize_gateway.rs:79`
+// pass a `(&RouterData<..>, CallConnectorAction)` tuple, and `external_proxy_flow.rs:419,532`
+// pass an `&RouterData<ExternalVaultProxy, ..>`. There is no other call site — the type name
+// appears nowhere else in the crate, no `foreign_try_into()` here resolves to it, and no crate
+// depends on `router` as a library — so this single-argument `CompleteAuthorize` impl is
+// reachable from nothing. Confirmed by commenting it out and running `cargo check -p router`,
+// which still built the crate.
+//
+// It is also NOT a description of what CompleteAuthorize actually sends to UCS: the live impl
+// above forwards the router data's own `auth_type` and sends `enrolled_for_3ds: Some(true)`,
+// while this one forces `AuthenticationType::NoThreeDs` and `enrolled_for_3ds: Some(false)`.
+// Kept rather than deleted, but do not read it as the CompleteAuthorize contract.
 impl
     transformers::ForeignTryFrom<
         &RouterData<


### PR DESCRIPTION
## Why

Whether a gateway-3DS payment continues past the `PreAuthenticate` and `Authenticate` legs is currently decided by a hardcoded `match connector.connector_name` in `authorize_flow.rs`, defaulting to `_ => false`. The code carries its own apology:

```rust
// connector specific handling to decide whether to continue with authorize or not should not be done here
// this is just a temporary fix for Redsys and Shift4 connectors
```

**Twelve** connectors declare `is_pre_authentication_flow_required`; only **four** have an arm in that match. So barclaycard, cybersource, ilixium, moneris, nmi, nexixpay and worldpayxml all run PreAuthenticate and then fall through to `false`.

The practical cost: adding a connector with gateway 3DS requires editing the router, and forgetting to means the chain silently stops after leg 1 — no error, no log, the payment just never authorizes.

## What

Two hooks on `ConnectorSpecifications`, alongside the existing `is_*_flow_required` family they sit next to:

```rust
fn should_continue_after_pre_authentication(&self, _ctx: AuthenticationLegContext) -> bool { false }
fn should_continue_after_authentication(&self, _ctx: AuthenticationLegContext) -> bool { false }
```

The **router keeps the parsing**. A new private helper reads redirection-data presence and the `PaymentsConnectorThreeDsInvokeData` metadata off the response — the single `parse_value` call, moved verbatim out of both matches — and hands the connector plain facts. Connectors never touch `connector_metadata`.

### Why the context nests instead of flattening

Every original arm was shaped `match &response { Ok(TransactionResponse{..}) => <logic>, _ => false }`. That outer match is load-bearing and the arms disagree about it: Shift4 and Nuvei returned `true` unconditionally, *including on `Err`*, while Redsys and Paysafe returned `false` for anything that was not `Ok(TransactionResponse)`.

So the context carries it explicitly:

```rust
pub struct AuthenticationLegContext {
    pub transaction_response: Option<AuthenticationLegTransactionResponse>,
    pub attempt_status: common_enums::AttemptStatus,
}
```

Each connector impl is then a literal transcription of its old arm (`Some(tr) => …, None => false`), and it is impossible to write `!ctx.has_redirection_data` and accidentally return `true` on an error response — which a flat `has_redirection_data: false` would have invited for Paysafe.

## Behaviour is unchanged

| Connector | Before | After |
|---|---|---|
| redsys | preauth + authenticate arms | same logic, same status list, moved to `redsys.rs` |
| shift4 | `true` unconditionally | `true` unconditionally |
| nuvei | `true` unconditionally | `true` unconditionally |
| paysafe | continue iff no redirection data | identical, comment carried over |
| barclaycard, cybersource, ilixium, moneris, nmi, nexixpay, worldpayxml | `_ => false` | trait default `false` |
| every other connector | `_ => false` | trait default `false` |

**The default is `false`.** That is the constraint the whole design hangs on — a "smarter" default such as `redirection_data.is_none()` would have silently changed behaviour for seven connectors that currently stop.

The dispatch is wired in `ConnectorEnum` in `connector_integration_interface.rs`, byte-for-byte like `is_pre_authentication_flow_required` directly above it. `ConnectorEnum` is the only non-connector implementor of the trait in the workspace.

One dispatch-key change: the old code matched `connector.connector_name`, the new code calls through `connector.connector`. Every `ConnectorData` constructor derives both from the same `name` string and the single struct-literal construction copies both fields, so they cannot disagree — and this is already how `is_pre_authentication_flow_required` is dispatched two lines earlier in the same function.

## `enrolled_for_3ds` — documented, not changed

`enrolled_for_3ds: Some(true)` on the CompleteAuthorize → UCS path reads as a hardcode next to siblings that forward `router_data.request.enrolled_for_3ds`. It is not fixable as written: that impl's request type is `CompleteAuthorizeData`, which **has no `enrolled_for_3ds` field**. There is no value to forward.

Synthesising one (from `auth_type`, say) would change what is sent to UCS on every CompleteAuthorize — a product decision, not a refactor. Added a comment recording why the literal is there so the next reader does not "fix" it into a behaviour change.

## Testing

- `cargo check -p hyperswitch_interfaces --features v1` — clean
- `cargo check -p router` — clean, 5m31s, on this branch built from `main`
- `rustfmt --edition 2021 --check` on all nine changed files — clean
- Behaviour equivalence re-derived connector by connector against `git show HEAD:…/authorize_flow.rs` by a separate review pass, which went looking for a regression and found none

Note: bare `cargo check -p hyperswitch_connectors` and `-p hyperswitch_interfaces` fail on this repo with pre-existing missing-feature errors (`diesel_models` needs `v1`/`v2`); the feature-flagged invocations above are what actually build, matching CI.

## Follow-up, not in this PR

`moneris.rs` has a latent arm-ordering defect in its `next_authentication_step`: arm 3 shadows arm 4 for both redirect states and the `PostAuthenticate` arm has no break, so after PostAuthenticate completes in a redirect state the loop re-dispatches it. Rust emits no unreachable-pattern warning because arm 4 stays reachable for `InitialRequest`. Out of scope here; flagging so it is not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbxcmzikBQKdpworp9YSrB