### PR TITLE
ci(deja): auto-apply deja-art label and re-trigger replay on S-test-ready

### DIFF
--- a/.github/workflows/deja-art-labeler.yml
+++ b/.github/workflows/deja-art-labeler.yml
@@ -7,7 +7,7 @@ on:
   # pull request whenever this trigger is used.
   # Since we do not have a checkout step in this workflow, this is an
   # acceptable use of this trigger.
-  pull_request:  # TEMP: smoke test only, revert to pull_request_target before merge
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/deja-art-labeler.yml
+++ b/.github/workflows/deja-art-labeler.yml
@@ -1,0 +1,98 @@
+name: Deja ART Labeler
+
+on:
+  # This is a dangerous event trigger as it causes the workflow to run in the
+  # context of the target repository.
+  # Avoid checking out the head of the pull request or building code from the
+  # pull request whenever this trigger is used.
+  # Since we do not have a checkout step in this workflow, this is an
+  # acceptable use of this trigger.
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - labeled
+
+permissions:
+  contents: read
+
+jobs:
+  add_deja_art_label:
+    name: Add 'deja-art' label when a PR is opened or marked ready for review
+    # Draft PRs are skipped; they get labeled once marked ready for review.
+    # Only label PRs raised from branches within this repository. The
+    # 'deja-art' label triggers a Jenkins pipeline that builds and replays
+    # traffic against the PR's code, which we do not want to do for forks.
+    if: >-
+      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+      && !github.event.pull_request.draft
+      && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+
+    steps:
+      # The GitHub App token is required (instead of `GITHUB_TOKEN`) so that the
+      # `labeled` event emitted by adding the label triggers other workflows.
+      - name: Generate GitHub app token
+        id: generate_app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
+          private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.event.repository.owner.login }}
+
+      - name: Add 'deja-art' label
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.generate_app_token.outputs.token }}
+          REPOSITORY: ${{ github.event.repository.full_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Adding 'deja-art' label to PR #${PR_NUMBER}..."
+          gh --repo "${REPOSITORY}" pr edit --add-label 'deja-art' "${PR_NUMBER}"
+
+  retrigger_deja_art_on_test_ready:
+    name: Re-trigger Deja ART when 'S-test-ready' is added
+    if: >-
+      github.event.action == 'labeled'
+      && github.event.label.name == 'S-test-ready'
+      && !github.event.pull_request.draft
+      && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate GitHub app token
+        id: generate_app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
+          private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.event.repository.owner.login }}
+
+      - name: Remove and re-add 'deja-art' label
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.generate_app_token.outputs.token }}
+          REPOSITORY: ${{ github.event.repository.full_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          labels="$(
+            gh --repo "${REPOSITORY}" pr view "${PR_NUMBER}" \
+              --json labels \
+              --jq '.labels[].name'
+          )"
+
+          if echo "${labels}" | grep --quiet --line-regexp --fixed-strings 'deja-art'; then
+            echo "Removing 'deja-art' label from PR #${PR_NUMBER}..."
+            gh --repo "${REPOSITORY}" pr edit --remove-label 'deja-art' "${PR_NUMBER}"
+
+            # Give webhook consumers a moment to observe the 'unlabeled' event
+            # before the label is added back, so the re-add is seen as a fresh
+            # trigger rather than being coalesced with the removal.
+            sleep 10
+          else
+            echo "'deja-art' label is not present on PR #${PR_NUMBER}."
+          fi
+
+          echo "Adding 'deja-art' label to PR #${PR_NUMBER} to re-trigger the replay..."
+          gh --repo "${REPOSITORY}" pr edit --add-label 'deja-art' "${PR_NUMBER}"

--- a/.github/workflows/deja-art-labeler.yml
+++ b/.github/workflows/deja-art-labeler.yml
@@ -7,7 +7,7 @@ on:
   # pull request whenever this trigger is used.
   # Since we do not have a checkout step in this workflow, this is an
   # acceptable use of this trigger.
-  pull_request_target:
+  pull_request:  # TEMP: smoke test only, revert to pull_request_target before merge
     types:
       - opened
       - reopened


### PR DESCRIPTION
Adds `.github/workflows/deja-art-labeler.yml`, which automates the `deja-art` label so every eligible PR gets a Deja ART replay without anyone having to remember to add the label.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Two jobs, both driven by `pull_request_target` (no checkout, so the trigger is safe):

- **Add `deja-art` on PR creation.** When a PR is opened, reopened, or marked ready for review, the `deja-art` label is applied. Draft PRs are skipped and get the label once they are marked ready for review. Adding a label that is already present is a no-op, so reopen does not re-trigger anything.
- **Re-trigger the replay when `S-test-ready` is added.** When the `S-test-ready` label lands, the workflow removes `deja-art` (if present), waits 10 seconds so webhook consumers see a clean `unlabeled` → `labeled` transition, and re-adds it. This re-runs the Deja ART replay against the test-ready code.

Notes:

- Labels are applied with the hyperswitch-bot GitHub App token rather than `GITHUB_TOKEN`. This is required so the resulting `labeled` events trigger other Actions workflows (for example the gate in #13614); label changes made with `GITHUB_TOKEN` never do.
- Both jobs are restricted to same-repo branches. The `deja-art` label kicks off a Jenkins pipeline that builds and replays the PR's code, which we do not want to run for forks. This mirrors how `S-test-ready` is handled in `cypress-tests-runner.yml`.
- This lives in its own workflow file rather than in `pr-convention-checks.yml`, so the convention checks are not re-run on every label change.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

We want Deja ART replays to be mandatory for PRs rather than opt-in. Auto-applying the label on creation removes the manual step, and re-triggering on `S-test-ready` ensures the replay reflects the code that is actually going through the cypress test gate.

## How did you test it?

- YAML parsed and validated with `actionlint` (including shellcheck) with no findings.
- Job conditions and token usage follow the existing `pr_labeler` job in `pr-convention-checks.yml`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es6Dybc1fsYKRzgpi8F6Km
