### PR TITLE
fix(user): make community welcome email generic and skip it in production

### DIFF
--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -397,7 +397,9 @@ pub async fn connect_account(
 
         logger::info!(?magic_link_result);
 
-        if state.tenant.tenant_id.get_string_repr() == common_utils::consts::DEFAULT_TENANT {
+        if state.tenant.tenant_id.get_string_repr() == common_utils::consts::DEFAULT_TENANT
+            && !matches!(env::which(), env::Env::Production)
+        {
             let welcome_to_community_email = email_types::WelcomeToCommunity {
                 recipient_email: domain::UserEmail::from_pii_email(user_from_db.get_email())?,
             };

--- a/crates/router/src/services/email/assets/welcome_to_community.html
+++ b/crates/router/src/services/email/assets/welcome_to_community.html
@@ -33,9 +33,9 @@
     <div>
       <p>Hello there,</p>
       <p>
-        I'm Neeraj from the Community Growth team at Hyperswitch. We're building
-        the world's first open-source payments orchestration platform to
-        simplify payment diversity and accelerate innovation.
+        We're the Community Growth team at Hyperswitch. We're building the
+        world's first open-source payments orchestration platform to simplify
+        payment diversity and accelerate innovation.
       </p>
       <p>
         Learn more about our journey in this blog:
@@ -63,7 +63,7 @@
         >.
       </p>
       <p>Let’s build the future of payments, together.</p>
-      <p>Thank you,<br />Neeraj | Hyperswitch.io</p>
+      <p>Thank you,<br />Team Hyperswitch | Hyperswitch.io</p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Two changes to the community welcome email:

1. **`crates/router/src/services/email/assets/welcome_to_community.html`** — the copy was written in the first person and signed off with an individual team member's name. It is now attributed to the team:
   - `I'm <name> from the Community Growth team at Hyperswitch. We're building…` → `We're the Community Growth team at Hyperswitch. We're building…`
   - `Thank you,<br /><name> | Hyperswitch.io` → `Thank you,<br />Team Hyperswitch | Hyperswitch.io`

2. **`crates/router/src/core/user.rs`** — the send is now explicitly gated on the environment, so the email goes out in `development`, `integ` and `sandbox` but never in `production`:

```rust
if state.tenant.tenant_id.get_string_repr() == common_utils::consts::DEFAULT_TENANT
    && !matches!(env::which(), env::Env::Production)
{
```

The enclosing new-user branch of `connect_account` already returns `InvalidCredentials` in production (`core/user.rs:355`), so production was previously unreachable by side effect. This makes it a stated, local invariant instead of one that silently depends on that outer guard staying in place. Note that `env::which()` defaults to `Env::Production` for release builds when `RUN_ENV` is unset, so the unset case fails closed.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

No config files are modified. The gate reads the existing `RUN_ENV` variable via `router_env::env::which()`, which is already used elsewhere in this file.

## Motivation and Context

Closes #14102.

The team member who signed this email has left the organisation, so new signups were receiving an email attributed to someone who cannot reply. Making the sign-off generic means the template does not need editing whenever the team changes.

## How did you test it?

No new tests — the change is email copy plus a boolean condition on an existing environment helper, and there is no existing test coverage for this send path to extend.

Verified by inspection and by the toolchain:

- `cargo check -p router --features email` — passes, no new warnings.
- `cargo clippy -p router --features email` — exits 0; the only warnings in the touched files are pre-existing `type_name!` trailing-semicolon warnings unrelated to this change.
- `cargo +nightly fmt --check -p router` — clean.

Blast radius checked:

- `WelcomeToCommunity` has exactly one call site, so this single gate covers the whole flow.
- The gated block only composes/sends the email and logs the result; `welcome_email_result` is local to it. `ConnectAccountResponse.is_email_sent` is derived from `magic_link_result`, so the API response is unchanged in every environment.
- Invite emails are unaffected: they use a different email type (`InviteUser`, `assets/invite.html`) from different functions (`handle_existing_user_invitation`, `handle_new_or_inactive_user_invitation`, `resend_invite`), and there is no environment gating anywhere on that path — they continue to send in all environments.
- The template is consumed via `include_str!(...).to_string()` rather than `format!`, so the copy edit carries no format-placeholder risk.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njbxy1PHJFXU5JnLcVigWu
