### PR TITLE
feat(router): add bin and issuer details for apple pay and google pay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "nutype",
  "reqwest 0.11.27",
  "router_derive",
+ "router_env",
  "rust_decimal",
  "serde",
  "serde_json",

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -11148,9 +11148,61 @@
             "example": "003925",
             "nullable": true
           },
+          "device_pan_bin": {
+            "type": "string",
+            "description": "Bin of the DPAN (device PAN) obtained from decrypting the Apple Pay payment data",
+            "nullable": true
+          },
+          "card_bin": {
+            "type": "string",
+            "description": "Bin of the underlying card, provided by the connector when it resolves the DPAN",
+            "nullable": true
+          },
+          "card_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardType"
+              }
+            ],
+            "nullable": true
+          },
           "auth_code": {
             "type": "string",
             "description": "Unique authorisation code generated for the payment",
+            "nullable": true
+          },
+          "card_subtype": {
+            "type": "string",
+            "description": "The card's product/subtype, as returned by the connector",
+            "nullable": true
+          },
+          "card_segment_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardSegmentType"
+              }
+            ],
+            "nullable": true
+          },
+          "funding_source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FundingSource"
+              }
+            ],
+            "nullable": true
+          },
+          "issuer_name": {
+            "type": "string",
+            "description": "The name of the card issuer, as returned by the connector",
+            "nullable": true
+          },
+          "issuer_country": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CountryAlpha2"
+              }
+            ],
             "nullable": true
           }
         }
@@ -48220,9 +48272,9 @@
       "WalletAdditionalDataForCard": {
         "type": "object",
         "properties": {
-          "last4": {
+          "type": {
             "type": "string",
-            "description": "Last 4 digits of the card number",
+            "description": "The type of payment method",
             "nullable": true
           },
           "card_network": {
@@ -48230,9 +48282,50 @@
             "description": "The information of the payment method",
             "nullable": true
           },
-          "type": {
+          "card_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardType"
+              }
+            ],
+            "nullable": true
+          },
+          "card_subtype": {
             "type": "string",
-            "description": "The type of payment method",
+            "description": "The card's product/subtype, as returned by the connector",
+            "nullable": true
+          },
+          "card_segment_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardSegmentType"
+              }
+            ],
+            "nullable": true
+          },
+          "funding_source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FundingSource"
+              }
+            ],
+            "nullable": true
+          },
+          "last4": {
+            "type": "string",
+            "description": "Last 4 digits of the card number",
+            "nullable": true
+          },
+          "card_bin": {
+            "type": "string",
+            "description": "Bin of the underlying card",
+            "example": "411111",
+            "nullable": true
+          },
+          "device_pan_bin": {
+            "type": "string",
+            "description": "Bin of the DPAN (device PAN) obtained from decrypting the wallet payment data.",
+            "example": "411111",
             "nullable": true
           },
           "card_exp_month": {
@@ -48245,6 +48338,19 @@
             "type": "string",
             "description": "The card's expiry year",
             "example": "25",
+            "nullable": true
+          },
+          "issuer_name": {
+            "type": "string",
+            "description": "The name of the card issuer, as returned by the connector",
+            "nullable": true
+          },
+          "issuer_country": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CountryAlpha2"
+              }
+            ],
             "nullable": true
           },
           "auth_code": {

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -6850,9 +6850,61 @@
             "example": "003925",
             "nullable": true
           },
+          "device_pan_bin": {
+            "type": "string",
+            "description": "Bin of the DPAN (device PAN) obtained from decrypting the Apple Pay payment data",
+            "nullable": true
+          },
+          "card_bin": {
+            "type": "string",
+            "description": "Bin of the underlying card, provided by the connector when it resolves the DPAN",
+            "nullable": true
+          },
+          "card_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardType"
+              }
+            ],
+            "nullable": true
+          },
           "auth_code": {
             "type": "string",
             "description": "Unique authorisation code generated for the payment",
+            "nullable": true
+          },
+          "card_subtype": {
+            "type": "string",
+            "description": "The card's product/subtype, as returned by the connector",
+            "nullable": true
+          },
+          "card_segment_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardSegmentType"
+              }
+            ],
+            "nullable": true
+          },
+          "funding_source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FundingSource"
+              }
+            ],
+            "nullable": true
+          },
+          "issuer_name": {
+            "type": "string",
+            "description": "The name of the card issuer, as returned by the connector",
+            "nullable": true
+          },
+          "issuer_country": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CountryAlpha2"
+              }
+            ],
             "nullable": true
           }
         }
@@ -35399,9 +35451,9 @@
       "WalletAdditionalDataForCard": {
         "type": "object",
         "properties": {
-          "last4": {
+          "type": {
             "type": "string",
-            "description": "Last 4 digits of the card number",
+            "description": "The type of payment method",
             "nullable": true
           },
           "card_network": {
@@ -35409,9 +35461,50 @@
             "description": "The information of the payment method",
             "nullable": true
           },
-          "type": {
+          "card_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardType"
+              }
+            ],
+            "nullable": true
+          },
+          "card_subtype": {
             "type": "string",
-            "description": "The type of payment method",
+            "description": "The card's product/subtype, as returned by the connector",
+            "nullable": true
+          },
+          "card_segment_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardSegmentType"
+              }
+            ],
+            "nullable": true
+          },
+          "funding_source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FundingSource"
+              }
+            ],
+            "nullable": true
+          },
+          "last4": {
+            "type": "string",
+            "description": "Last 4 digits of the card number",
+            "nullable": true
+          },
+          "card_bin": {
+            "type": "string",
+            "description": "Bin of the underlying card",
+            "example": "411111",
+            "nullable": true
+          },
+          "device_pan_bin": {
+            "type": "string",
+            "description": "Bin of the DPAN (device PAN) obtained from decrypting the wallet payment data.",
+            "example": "411111",
             "nullable": true
           },
           "card_exp_month": {
@@ -35424,6 +35517,19 @@
             "type": "string",
             "description": "The card's expiry year",
             "example": "25",
+            "nullable": true
+          },
+          "issuer_name": {
+            "type": "string",
+            "description": "The name of the card issuer, as returned by the connector",
+            "nullable": true
+          },
+          "issuer_country": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CountryAlpha2"
+              }
+            ],
             "nullable": true
           },
           "auth_code": {

--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -61,6 +61,7 @@ hyperswitch_masking = { version = "0.0.1", default-features = false, features = 
     "time",
 ] }
 router_derive = { version = "0.1.0", path = "../router_derive" }
+router_env = { version = "0.1.0", path = "../router_env" }
 smithy = { version = "0.1.0", path = "../smithy" }
 smithy-core = { version = "0.1.0", path = "../smithy-core" }
 

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -20,6 +20,7 @@ use common_utils::{
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
+use router_env::logger;
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},
     Decimal,
@@ -1893,7 +1894,7 @@ impl From<payments::additional_info::WalletAdditionalDataForCard> for PaymentMet
         Self {
             last4: item.last4,
             card_network: item.card_network,
-            card_type: item.card_type,
+            card_type: item.payment_method_data_type,
             card_exp_month: item.card_exp_month,
             card_exp_year: item.card_exp_year,
             auth_code: item.auth_code,
@@ -1907,11 +1908,19 @@ impl From<PaymentMethodDataWalletInfo> for payments::additional_info::WalletAddi
         Self {
             last4: item.last4,
             card_network: item.card_network,
-            card_type: item.card_type,
+            payment_method_data_type: item.card_type,
             card_exp_month: item.card_exp_month,
             card_exp_year: item.card_exp_year,
             auth_code: item.auth_code,
             email: item.email,
+            device_pan_bin: None,
+            card_bin: None,
+            card_subtype: None,
+            card_segment_type: None,
+            funding_source: None,
+            card_type: None,
+            issuer_name: None,
+            issuer_country: None,
         }
     }
 }
@@ -1942,13 +1951,34 @@ impl From<payments::ApplepayPaymentMethod> for PaymentMethodDataWalletInfo {
 impl TryFrom<PaymentMethodDataWalletInfo> for Box<payments::ApplepayPaymentMethod> {
     type Error = error_stack::Report<errors::ValidationError>;
     fn try_from(item: PaymentMethodDataWalletInfo) -> Result<Self, Self::Error> {
+        let card_type = item.card_type.clone().get_required_value("card_type")?;
         Ok(Self::new(payments::ApplepayPaymentMethod {
             display_name: item.last4.get_required_value("last4")?,
             network: item.card_network.get_required_value("card_network")?,
-            pm_type: item.card_type.get_required_value("card_type")?,
+            pm_type: card_type.clone(),
+            // If `card_type` doesn't parse into a known `CardType` variant, it is treated as
+            // `None` instead of erroring.
+            card_type: card_type
+                .to_uppercase()
+                .parse::<api_enums::CardType>()
+                .inspect_err(|error| {
+                    logger::error!(
+                        ?error,
+                        unparsed_card_type = %card_type,
+                        "Received an unrecognized card_type value from Apple Pay; defaulting to None"
+                    )
+                })
+                .ok(),
             card_exp_month: item.card_exp_month,
             card_exp_year: item.card_exp_year,
             auth_code: item.auth_code,
+            device_pan_bin: None,
+            card_bin: None,
+            card_subtype: None,
+            card_segment_type: None,
+            funding_source: None,
+            issuer_name: None,
+            issuer_country: None,
         }))
     }
 }

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -5936,8 +5936,28 @@ pub struct ApplepayPaymentMethod {
     /// The card's expiry year
     #[schema(value_type = Option<String>, example = "003925")]
     pub card_exp_year: Option<Secret<String>>,
+    /// Bin of the DPAN (device PAN) obtained from decrypting the Apple Pay payment data
+    pub device_pan_bin: Option<String>,
+    /// Bin of the underlying card, provided by the connector when it resolves the DPAN
+    pub card_bin: Option<String>,
+    // The card's type (eg. Credit, Debit), as returned by the connector
+    #[schema(value_type = Option<CardType>)]
+    pub card_type: Option<api_enums::CardType>,
     /// Unique authorisation code generated for the payment
     pub auth_code: Option<String>,
+    /// The card's product/subtype, as returned by the connector
+    pub card_subtype: Option<String>,
+    /// The card's segment (e.g. consumer, commercial), as returned by the connector
+    #[schema(value_type = Option<CardSegmentType>)]
+    pub card_segment_type: Option<api_enums::CardSegmentType>,
+    /// The card's funding source (e.g. credit, debit), as returned by the connector
+    #[schema(value_type = Option<FundingSource>)]
+    pub funding_source: Option<api_enums::FundingSource>,
+    /// The name of the card issuer, as returned by the connector
+    pub issuer_name: Option<String>,
+    /// The country of the card issuer, as returned by the connector
+    #[schema(value_type = Option<CountryAlpha2>, example = "US")]
+    pub issuer_country: Option<api_enums::CountryAlpha2>,
 }
 
 #[derive(
@@ -9641,11 +9661,19 @@ impl From<AdditionalPaymentData> for PaymentMethodDataResponse {
                                     .collect::<String>(),
                             ),
                             card_network: Some(apple_pay_pm.network.clone()),
-                            card_type: Some(apple_pay_pm.pm_type.clone()),
+                            payment_method_data_type: Some(apple_pay_pm.pm_type.clone()),
                             card_exp_month: apple_pay_pm.card_exp_month,
                             card_exp_year: apple_pay_pm.card_exp_year,
                             auth_code: apple_pay_pm.auth_code,
                             email: None,
+                            device_pan_bin: apple_pay_pm.device_pan_bin,
+                            card_bin: apple_pay_pm.card_bin,
+                            card_subtype: apple_pay_pm.card_subtype,
+                            card_segment_type: apple_pay_pm.card_segment_type,
+                            funding_source: apple_pay_pm.funding_source,
+                            card_type: apple_pay_pm.card_type,
+                            issuer_name: apple_pay_pm.issuer_name,
+                            issuer_country: apple_pay_pm.issuer_country,
                         },
                     ))),
                 })),

--- a/crates/api_models/src/payments/additional_info.rs
+++ b/crates/api_models/src/payments/additional_info.rs
@@ -456,22 +456,44 @@ pub struct UpiCollectAdditionalData {
 )]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct WalletAdditionalDataForCard {
-    /// Last 4 digits of the card number
-    #[smithy(value_type = "Option<String>")]
-    pub last4: Option<String>,
-    /// The information of the payment method
-    #[smithy(value_type = "Option<String>")]
-    pub card_network: Option<String>,
     /// The type of payment method
     #[serde(rename = "type")]
     #[smithy(value_type = "Option<String>")]
-    pub card_type: Option<String>,
+    pub payment_method_data_type: Option<String>,
+    /// The information of the payment method
+    #[smithy(value_type = "Option<String>")]
+    pub card_network: Option<String>,
+    /// The card's type (e.g. credit, debit), as returned by the connector
+    #[schema(value_type = Option<CardType>)]
+    pub card_type: Option<api_enums::CardType>,
+    /// The card's product/subtype, as returned by the connector
+    pub card_subtype: Option<String>,
+    /// The card's segment (e.g. consumer, commercial), as returned by the connector
+    #[schema(value_type = Option<CardSegmentType>)]
+    pub card_segment_type: Option<api_enums::CardSegmentType>,
+    /// The card's funding source (e.g. credit, debit), as returned by the connector
+    #[schema(value_type = Option<FundingSource>)]
+    pub funding_source: Option<api_enums::FundingSource>,
+    /// Last 4 digits of the card number
+    #[smithy(value_type = "Option<String>")]
+    pub last4: Option<String>,
+    /// Bin of the underlying card
+    #[schema(value_type = Option<String>, example = "411111")]
+    pub card_bin: Option<String>,
+    /// Bin of the DPAN (device PAN) obtained from decrypting the wallet payment data.
+    #[schema(value_type = Option<String>, example = "411111")]
+    pub device_pan_bin: Option<String>,
     /// The card's expiry month
     #[schema(value_type = Option<String>, example = "03")]
     pub card_exp_month: Option<Secret<String>>,
     /// The card's expiry year
     #[schema(value_type = Option<String>, example = "25")]
     pub card_exp_year: Option<Secret<String>>,
+    /// The name of the card issuer, as returned by the connector
+    pub issuer_name: Option<String>,
+    /// The country of the card issuer, as returned by the connector
+    #[schema(value_type = Option<CountryAlpha2>, example = "US")]
+    pub issuer_country: Option<api_enums::CountryAlpha2>,
     /// Unique authorisation code generated for the payment
     #[schema(value_type = Option<String>, example = "009825")]
     pub auth_code: Option<String>,

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -3571,6 +3571,9 @@ pub enum CardSegmentType {
 pub enum CardType {
     Credit,
     Debit,
+    Prepaid,
+    Store,
+    ChargeCard,
 }
 
 impl CardType {
@@ -3578,6 +3581,9 @@ impl CardType {
         match self {
             Self::Credit => "Credit",
             Self::Debit => "Debit",
+            Self::Prepaid => "Prepaid",
+            Self::Store => "Store",
+            Self::ChargeCard => "Charge Card",
         }
     }
 }

--- a/crates/common_types/src/payments.rs
+++ b/crates/common_types/src/payments.rs
@@ -733,6 +733,43 @@ impl GpayTokenizationData {
     }
 }
 impl GPayPredecryptData {
+    /// Bin of the decrypted PAN, when it is a tokenized DPAN (`auth_method` is `CRYPTOGRAM_3DS`)
+    pub fn get_device_pan_bin(&self) -> Option<String> {
+        match self.auth_method {
+            Some(enums::GooglePayAuthMethod::Cryptogram) => {
+                Some(self.application_primary_account_number.get_card_isin())
+            }
+            None if self.cryptogram.is_some() => {
+                Some(self.application_primary_account_number.get_card_isin())
+            }
+            Some(enums::GooglePayAuthMethod::PanOnly) | None => None,
+        }
+    }
+
+    /// Bin of the decrypted PAN, when it is the underlying card's real PAN (`auth_method` is
+    /// `PAN_ONLY`)
+    pub fn get_card_bin(&self) -> Option<String> {
+        match self.auth_method {
+            Some(enums::GooglePayAuthMethod::PanOnly) => {
+                Some(self.application_primary_account_number.get_card_isin())
+            }
+            None if self.cryptogram.is_none() => {
+                Some(self.application_primary_account_number.get_card_isin())
+            }
+            Some(enums::GooglePayAuthMethod::Cryptogram) | None => None,
+        }
+    }
+
+    /// The decrypted PAN's card expiry month
+    pub fn get_card_exp_month(&self) -> Secret<String> {
+        self.card_exp_month.clone()
+    }
+
+    /// The decrypted PAN's card expiry year
+    pub fn get_card_exp_year(&self) -> Secret<String> {
+        self.card_exp_year.clone()
+    }
+
     /// Get the four-digit expiration year from the Google Pay pre-decrypt data
     pub fn get_four_digit_expiry_year(&self) -> Result<Secret<String>, errors::ValidationError> {
         let mut year = self.card_exp_year.peek().clone();
@@ -827,6 +864,23 @@ pub struct ApplePayPredecryptData {
     #[schema(value_type = ApplePayCryptogramData)]
     #[smithy(value_type = "ApplePayCryptogramData")]
     pub payment_data: ApplePayCryptogramData,
+}
+
+impl ApplePayPredecryptData {
+    /// The decrypted PAN's card expiry month
+    pub fn get_application_expiration_month(&self) -> Secret<String> {
+        self.application_expiration_month.clone()
+    }
+
+    /// The decrypted PAN's card expiry year
+    pub fn get_application_expiration_year(&self) -> Secret<String> {
+        self.application_expiration_year.clone()
+    }
+
+    /// Bin of the decrypted PAN
+    pub fn get_device_pan_bin(&self) -> String {
+        self.application_primary_account_number.get_card_isin()
+    }
 }
 
 #[derive(

--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -1510,6 +1510,66 @@ pub struct Source {
     avs_check: Option<String>,
     cvv_check: Option<String>,
     payment_account_reference: Option<String>,
+    /// The card's funding type
+    card_type: Option<CheckoutCardType>,
+    /// The card's category
+    card_category: Option<CheckoutCardCategory>,
+    /// The name of the card issuer
+    issuer: Option<String>,
+    /// The country of the card issuer
+    issuer_country: Option<CountryAlpha2>,
+    /// The card's product/subtype, e.g. "Visa Classic"
+    product_type: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum CheckoutCardType {
+    Credit,
+    Debit,
+    Prepaid,
+    Charge,
+    #[serde(rename = "DEFERRED DEBIT")]
+    DeferredDebit,
+}
+
+impl From<CheckoutCardType> for common_enums::FundingSource {
+    fn from(card_type: CheckoutCardType) -> Self {
+        match card_type {
+            CheckoutCardType::Credit => Self::Credit,
+            CheckoutCardType::Debit => Self::Debit,
+            CheckoutCardType::Prepaid => Self::Prepaid,
+            CheckoutCardType::Charge => Self::ChargeCard,
+            CheckoutCardType::DeferredDebit => Self::DeferredDebit,
+        }
+    }
+}
+
+impl From<CheckoutCardType> for common_enums::CardType {
+    fn from(card_type: CheckoutCardType) -> Self {
+        match card_type {
+            CheckoutCardType::Credit => Self::Credit,
+            CheckoutCardType::Debit | CheckoutCardType::DeferredDebit => Self::Debit,
+            CheckoutCardType::Prepaid => Self::Prepaid,
+            CheckoutCardType::Charge => Self::ChargeCard,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum CheckoutCardCategory {
+    Consumer,
+    Commercial,
+}
+
+impl From<CheckoutCardCategory> for common_enums::CardSegmentType {
+    fn from(card_category: CheckoutCardCategory) -> Self {
+        match card_category {
+            CheckoutCardCategory::Consumer => Self::Consumer,
+            CheckoutCardCategory::Commercial => Self::Commercial,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -2596,6 +2656,11 @@ impl TryFrom<&webhooks::IncomingWebhookRequestDetails<'_>> for PaymentsResponse 
                 avs_check: src.avs_check.clone(),
                 cvv_check: src.cvv_check.clone(),
                 payment_account_reference: src.payment_account_reference.clone(),
+                card_type: src.card_type.clone(),
+                card_category: src.card_category.clone(),
+                issuer: src.issuer.clone(),
+                issuer_country: src.issuer_country,
+                product_type: src.product_type.clone(),
             }),
             scheme_id: None,
             processing: None,
@@ -2666,10 +2731,39 @@ fn convert_to_additional_payment_method_connector_response(
 ) -> Option<AdditionalPaymentMethodConnectorResponse> {
     match payment_method_type {
         Some(enums::PaymentMethodType::GooglePay) => {
-            Some(AdditionalPaymentMethodConnectorResponse::GooglePay { auth_code })
+            Some(AdditionalPaymentMethodConnectorResponse::GooglePay {
+                auth_code,
+                device_pan_bin: None,
+                card_bin: None,
+                card_subtype: source.and_then(|source| source.product_type.clone()),
+                card_segment_type: source
+                    .and_then(|source| source.card_category.clone())
+                    .map(common_enums::CardSegmentType::from),
+                funding_source: source
+                    .and_then(|source| source.card_type.clone())
+                    .map(common_enums::FundingSource::from),
+                card_type: source
+                    .and_then(|source| source.card_type.as_ref())
+                    .map(|card_type| common_enums::CardType::from(card_type.clone())),
+                issuer_name: source.and_then(|source| source.issuer.clone()),
+                issuer_country: source.and_then(|source| source.issuer_country),
+            })
         }
         Some(enums::PaymentMethodType::ApplePay) => {
-            Some(AdditionalPaymentMethodConnectorResponse::ApplePay { auth_code })
+            Some(AdditionalPaymentMethodConnectorResponse::ApplePay {
+                auth_code,
+                device_pan_bin: None,
+                card_bin: None,
+                card_subtype: source.and_then(|source| source.product_type.clone()),
+                card_segment_type: source
+                    .and_then(|source| source.card_category.clone())
+                    .map(common_enums::CardSegmentType::from),
+                funding_source: source
+                    .and_then(|source| source.card_type.clone())
+                    .map(common_enums::FundingSource::from),
+                issuer_name: source.and_then(|source| source.issuer.clone()),
+                issuer_country: source.and_then(|source| source.issuer_country),
+            })
         }
         _ => {
             let payment_checks = source.map(|code| {

--- a/crates/hyperswitch_connectors/src/connectors/worldpayxml/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpayxml/transformers.rs
@@ -222,6 +222,26 @@ struct OrderStatus {
 struct Token {
     authenticated_shopper_i_d: Option<String>,
     token_details: TokenDetails,
+    payment_instrument: Option<TokenPaymentInstrument>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenPaymentInstrument {
+    emvco_token_details: Option<EmvcoTokenDetailsResponse>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EmvcoTokenDetailsResponse {
+    derived: Option<EmvcoTokenDetailsDerived>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EmvcoTokenDetailsDerived {
+    card_brand: Option<String>,
+    card_sub_brand: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -608,6 +628,27 @@ struct WorldpayXmlAmount {
     currency_code: api_models::enums::Currency,
     #[serde(rename = "@exponent")]
     exponent: String,
+    #[serde(
+        rename = "@debitCreditIndicator",
+        skip_serializing_if = "Option::is_none"
+    )]
+    debit_credit_indicator: Option<DebitCreditIndicator>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum DebitCreditIndicator {
+    Credit,
+    Debit,
+}
+
+impl DebitCreditIndicator {
+    fn as_card_type(self) -> common_enums::CardType {
+        match self {
+            Self::Credit => common_enums::CardType::Credit,
+            Self::Debit => common_enums::CardType::Debit,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1779,6 +1820,7 @@ impl TryFrom<&WorldpayxmlRouterData<&PaymentsAuthorizeRouterData>> for PaymentSe
             currency_code: item.router_data.request.currency.to_owned(),
             exponent,
             value: item.amount.to_owned(),
+            debit_credit_indicator: None,
         };
         let shopper = get_shopper_details(item.router_data, accept_header, user_agent_header)?;
         let billing_address = item
@@ -1906,6 +1948,7 @@ impl TryFrom<&WorldpayxmlRouterData<&PaymentsCaptureRouterData>> for PaymentServ
                             .number_of_digits_after_decimal_point()
                             .to_string(),
                         value: item.amount.to_owned(),
+                        debit_credit_indicator: None,
                     },
                 }),
                 cancel_refund: None,
@@ -1973,6 +2016,7 @@ impl<F> TryFrom<&WorldpayxmlRouterData<&RefundsRouterData<F>>> for PaymentServic
                             .number_of_digits_after_decimal_point()
                             .to_string(),
                         value: item.amount.to_owned(),
+                        debit_credit_indicator: None,
                     },
                 }),
             },
@@ -2197,6 +2241,7 @@ impl<F>
                         )?;
                         let connector_response = get_connector_response_data(
                             &payment_data,
+                            order_status.token.as_ref(),
                             item.data.request.payment_method_type,
                         );
                         let response = process_payment_response(
@@ -2534,6 +2579,7 @@ impl<F>
 
                 let connector_response = get_connector_response_data(
                     &payment_data,
+                    order_status.token.as_ref(),
                     item.data.request.payment_method_type,
                 );
                 let response = process_payment_response(
@@ -2805,6 +2851,7 @@ impl TryFrom<WorldpayxmlRouterData<&PaymentsCompleteAuthorizeRouterData>> for Pa
                 currency_code: item.router_data.request.currency.to_owned(),
                 exponent,
                 value: item.amount.to_owned(),
+                debit_credit_indicator: None,
             };
             let shopper = get_shopper_details_cauth(
                 item.router_data,
@@ -2932,6 +2979,7 @@ impl<F>
                 )?;
                 let connector_response = get_connector_response_data(
                     &payment_data,
+                    order_status.token.as_ref(),
                     item.data.request.payment_method_type,
                 );
                 let response = process_payment_response(
@@ -3031,6 +3079,7 @@ impl<F>
 
                 let connector_response = get_connector_response_data(
                     &payment_data,
+                    order_status.token.as_ref(),
                     item.data.request.payment_method_type,
                 );
                 let response = process_payment_response(
@@ -3642,6 +3691,7 @@ impl TryFrom<&WorldpayxmlRouterData<&PayoutsRouterData<PoFulfill>>> for PaymentS
             currency_code: item.router_data.request.destination_currency.to_owned(),
             exponent,
             value: item.amount.to_owned(),
+            debit_credit_indicator: None,
         };
 
         let auth = WorldpayxmlAuthType::try_from(&item.router_data.connector_auth_type)
@@ -3992,6 +4042,7 @@ fn get_mandate_reference(
 /// to the auth code exposed in the connector response.
 fn get_connector_response_data(
     payment_data: &Payment,
+    token: Option<&Token>,
     payment_method_type: Option<enums::PaymentMethodType>,
 ) -> Option<ConnectorResponseData> {
     let auth_code = payment_data
@@ -4000,15 +4051,50 @@ fn get_connector_response_data(
         .and_then(|authorisation_id| authorisation_id.id.clone())
         .map(|id| id.expose())?;
 
+    let issuer_name = payment_data.issuer_name.clone();
+    // Worldpay can return "N/A" here instead of an ISO alpha-2 code; parse leniently.
+    let issuer_country = payment_data
+        .issuer_country_code
+        .as_deref()
+        .and_then(|code| code.parse::<common_enums::CountryAlpha2>().ok());
+    let card_subtype = token
+        .and_then(|token| token.payment_instrument.as_ref())
+        .and_then(|payment_instrument| {
+            payment_instrument
+                .emvco_token_details
+                .as_ref()
+                .and_then(|emvco_token_details| emvco_token_details.derived.as_ref())
+                .and_then(|derived| derived.card_sub_brand.clone())
+        });
+
     let additional_payment_method_data = match payment_method_type {
         Some(enums::PaymentMethodType::GooglePay) => {
             AdditionalPaymentMethodConnectorResponse::GooglePay {
                 auth_code: Some(auth_code),
+                device_pan_bin: None,
+                card_bin: None,
+                card_subtype,
+                card_segment_type: None,
+                funding_source: None,
+                card_type: payment_data
+                    .amount
+                    .as_ref()
+                    .and_then(|amount| amount.debit_credit_indicator)
+                    .map(DebitCreditIndicator::as_card_type),
+                issuer_name,
+                issuer_country,
             }
         }
         Some(enums::PaymentMethodType::ApplePay) => {
             AdditionalPaymentMethodConnectorResponse::ApplePay {
                 auth_code: Some(auth_code),
+                device_pan_bin: None,
+                card_bin: None,
+                card_subtype,
+                card_segment_type: None,
+                funding_source: None,
+                issuer_name,
+                issuer_country,
             }
         }
         _ => AdditionalPaymentMethodConnectorResponse::Card {

--- a/crates/hyperswitch_domain_models/src/payment_method_data.rs
+++ b/crates/hyperswitch_domain_models/src/payment_method_data.rs
@@ -3941,13 +3941,14 @@ pub fn get_googlepay_wallet_info(
     item: GooglePayWalletData,
     payment_method_token: Option<PaymentMethodToken>,
 ) -> payment_methods::PaymentMethodDataWalletInfo {
-    let (card_exp_month, card_exp_year) = match payment_method_token {
-        Some(PaymentMethodToken::GooglePayDecrypt(token)) => (
-            Some(token.card_exp_month.clone()),
-            Some(token.card_exp_year.clone()),
-        ),
-        _ => (None, None),
-    };
+    let googlepay_decrypt_data =
+        payment_method_token.and_then(|token| token.get_google_pay_decrypt_data());
+    let card_exp_month = googlepay_decrypt_data
+        .as_ref()
+        .map(|data| data.card_exp_month.clone());
+    let card_exp_year = googlepay_decrypt_data
+        .as_ref()
+        .map(|data| data.card_exp_year.clone());
     payment_methods::PaymentMethodDataWalletInfo {
         last4: Some(item.info.card_details),
         card_network: Some(item.info.card_network),

--- a/crates/hyperswitch_domain_models/src/router_data.rs
+++ b/crates/hyperswitch_domain_models/src/router_data.rs
@@ -530,6 +530,22 @@ impl PaymentMethodToken {
         }
     }
 
+    pub fn get_google_pay_decrypt_data(&self) -> Option<common_payment_types::GPayPredecryptData> {
+        match self {
+            Self::GooglePayDecrypt(data) => Some((**data).clone()),
+            Self::ApplePayDecrypt(_) | Self::PazeDecrypt(_) | Self::Token(_) => None,
+        }
+    }
+
+    pub fn get_apple_pay_decrypt_data(
+        &self,
+    ) -> Option<common_payment_types::ApplePayPredecryptData> {
+        match self {
+            Self::ApplePayDecrypt(data) => Some((**data).clone()),
+            Self::GooglePayDecrypt(_) | Self::PazeDecrypt(_) | Self::Token(_) => None,
+        }
+    }
+
     pub fn is_apple_pay_decrypt(&self) -> bool {
         matches!(self, Self::ApplePayDecrypt(_))
     }
@@ -735,11 +751,26 @@ impl ConnectorResponseData {
             common_enums::PaymentMethodType::GooglePay => {
                 AdditionalPaymentMethodConnectorResponse::GooglePay {
                     auth_code: Some(auth_code),
+                    device_pan_bin: None,
+                    card_bin: None,
+                    card_subtype: None,
+                    card_segment_type: None,
+                    funding_source: None,
+                    card_type: None,
+                    issuer_name: None,
+                    issuer_country: None,
                 }
             }
             common_enums::PaymentMethodType::ApplePay => {
                 AdditionalPaymentMethodConnectorResponse::ApplePay {
                     auth_code: Some(auth_code),
+                    device_pan_bin: None,
+                    card_bin: None,
+                    card_subtype: None,
+                    card_segment_type: None,
+                    funding_source: None,
+                    issuer_name: None,
+                    issuer_country: None,
                 }
             }
             _ => AdditionalPaymentMethodConnectorResponse::Card {
@@ -818,9 +849,39 @@ pub enum AdditionalPaymentMethodConnectorResponse {
     },
     GooglePay {
         auth_code: Option<String>,
+        /// Bin of the DPAN (device PAN), as returned by the connector
+        device_pan_bin: Option<String>,
+        /// Bin of the underlying card, as returned by the connector
+        card_bin: Option<String>,
+        /// The card's product/subtype, as returned by the connector
+        card_subtype: Option<String>,
+        /// The card's segment (e.g. consumer, commercial), as returned by the connector
+        card_segment_type: Option<common_enums::CardSegmentType>,
+        /// The card's funding source (e.g. credit, debit), as returned by the connector
+        funding_source: Option<common_enums::FundingSource>,
+        /// The card's type (e.g. credit, debit), as returned by the connector
+        card_type: Option<common_enums::CardType>,
+        /// The name of the card issuer, as returned by the connector
+        issuer_name: Option<String>,
+        /// The country of the card issuer, as returned by the connector
+        issuer_country: Option<common_enums::CountryAlpha2>,
     },
     ApplePay {
         auth_code: Option<String>,
+        /// Bin of the DPAN (device PAN), as returned by the connector
+        device_pan_bin: Option<String>,
+        /// Bin of the underlying card, as returned by the connector
+        card_bin: Option<String>,
+        /// The card's product/subtype, as returned by the connector
+        card_subtype: Option<String>,
+        /// The card's segment (e.g. consumer, commercial), as returned by the connector
+        card_segment_type: Option<common_enums::CardSegmentType>,
+        /// The card's funding source (e.g. credit, debit), as returned by the connector
+        funding_source: Option<common_enums::FundingSource>,
+        /// The name of the card issuer, as returned by the connector
+        issuer_name: Option<String>,
+        /// The country of the card issuer, as returned by the connector
+        issuer_country: Option<common_enums::CountryAlpha2>,
     },
     Paypal {
         /// Email address associated with the payer's PayPal account

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -806,6 +806,15 @@ impl ForeignTryFrom<payments_grpc::AdditionalPaymentMethodConnectorResponse>
                 ),
             ) => Ok(Self::GooglePay {
                 auth_code: google_pay_data.auth_code,
+                // UCS's GooglePayConnectorResponse proto does not carry bin/issuer data yet
+                device_pan_bin: None,
+                card_bin: None,
+                card_subtype: None,
+                card_segment_type: None,
+                funding_source: None,
+                card_type: None,
+                issuer_name: None,
+                issuer_country: None,
             }),
             Some(
                 payments_grpc::additional_payment_method_connector_response::PaymentMethodData::ApplePay(
@@ -813,6 +822,14 @@ impl ForeignTryFrom<payments_grpc::AdditionalPaymentMethodConnectorResponse>
                 ),
             ) => Ok(Self::ApplePay {
                 auth_code: apple_pay_data.auth_code,
+                // UCS's ApplePayConnectorResponse proto does not carry bin/issuer data yet
+                device_pan_bin: None,
+                card_bin: None,
+                card_subtype: None,
+                card_segment_type: None,
+                funding_source: None,
+                issuer_name: None,
+                issuer_country: None,
             }),
             Some(payments_grpc::additional_payment_method_connector_response::PaymentMethodData::BankRedirect(bank_redirect_data)) => {
                 let interac = bank_redirect_data.interac.map(|proto_interac| {

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -117,7 +117,7 @@ pub struct StripePaymentMethodData {
 #[serde(rename_all = "snake_case")]
 pub enum StripePaymentMethodDetails {
     Card(StripeCard),
-    Wallet(StripeWallet),
+    Wallet(Box<StripeWallet>),
     Upi(StripeUpi),
 }
 
@@ -165,7 +165,7 @@ impl From<StripePaymentMethodDetails> for payments::PaymentMethodData {
         match item {
             StripePaymentMethodDetails::Card(card) => Self::Card(payments::Card::from(card)),
             StripePaymentMethodDetails::Wallet(wallet) => {
-                Self::Wallet(payments::WalletData::from(wallet))
+                Self::Wallet(payments::WalletData::from(*wallet))
             }
             StripePaymentMethodDetails::Upi(upi) => Self::Upi(payments::UpiData::from(upi)),
         }

--- a/crates/router/src/compatibility/stripe/setup_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents/types.rs
@@ -87,7 +87,7 @@ pub struct StripePaymentMethodData {
 #[serde(rename_all = "snake_case")]
 pub enum StripePaymentMethodDetails {
     Card(StripeCard),
-    Wallet(StripeWallet),
+    Wallet(Box<StripeWallet>),
 }
 
 impl From<StripeCard> for payments::Card {
@@ -125,7 +125,7 @@ impl From<StripePaymentMethodDetails> for payments::PaymentMethodData {
         match item {
             StripePaymentMethodDetails::Card(card) => Self::Card(payments::Card::from(card)),
             StripePaymentMethodDetails::Wallet(wallet) => {
-                Self::Wallet(payments::WalletData::from(wallet))
+                Self::Wallet(payments::WalletData::from(*wallet))
             }
         }
     }

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -6376,24 +6376,55 @@ pub async fn get_additional_payment_data(
         },
         domain::PaymentMethodData::Wallet(wallet) => match wallet {
             domain::WalletData::ApplePay(apple_pay_wallet_data) => {
-                let (card_exp_month, card_exp_year) = match payment_method_token {
-                    Some(PaymentMethodToken::ApplePayDecrypt(token)) => (
-                        Some(token.application_expiration_month.clone()),
-                        Some(token.application_expiration_year.clone()),
-                    ),
+                let apple_pay_decrypted = payment_method_token
+                    .as_ref()
+                    .and_then(|token| token.get_apple_pay_decrypt_data());
 
-                    _ => (None, None),
-                };
+                let card_exp_month = apple_pay_decrypted
+                    .as_ref()
+                    .map(|token| token.get_application_expiration_month());
+                let card_exp_year = apple_pay_decrypted
+                    .as_ref()
+                    .map(|token| token.get_application_expiration_year());
+                let device_pan_bin = apple_pay_decrypted
+                    .as_ref()
+                    .map(|token| token.get_device_pan_bin());
 
                 Ok(Some(api_models::payments::AdditionalPaymentData::Wallet {
                     apple_pay: Some(Box::new(api_models::payments::ApplepayPaymentMethod {
                         display_name: apple_pay_wallet_data.payment_method.display_name.clone(),
                         network: apple_pay_wallet_data.payment_method.network.clone(),
                         pm_type: apple_pay_wallet_data.payment_method.pm_type.clone(),
+                        // card_type for Apple Pay is the same as pm_type. pm_type is
+                        // retained for backward compatibility and is also used for Google Pay's payment_method_data_type.
+                        // We intentionally don't fail if pm_type cannot be deserialized into a valid CardType. We've covered
+                        // all values documented by Apple Pay, but if production sends an unexpected value, the payment
+                        // should not fail because this auxiliary field could not be deserialized.
+                        card_type: apple_pay_wallet_data
+                            .payment_method
+                            .pm_type
+                            .to_uppercase()
+                            .parse::<common_enums::CardType>()
+                            .inspect_err(|error| {
+                                logger::debug!(
+                                    ?error,
+                                    unparsed_card_type = %apple_pay_wallet_data.payment_method.pm_type,
+                                    "Received an unrecognized card_type value from Apple Pay, defaulting to None"
+                                );
+                            })
+                            .ok(),
                         card_exp_month,
                         card_exp_year,
+                        device_pan_bin,
                         // These are filled after calling the processor / connector
                         auth_code: None,
+
+                        card_bin: None,
+                        card_subtype: None,
+                        card_segment_type: None,
+                        funding_source: None,
+                        issuer_name: None,
+                        issuer_country: None,
                     })),
                     google_pay: None,
                     samsung_pay: None,
@@ -6401,13 +6432,22 @@ pub async fn get_additional_payment_data(
                 }))
             }
             domain::WalletData::GooglePay(google_pay_pm_data) => {
-                let (card_exp_month, card_exp_year) = match payment_method_token {
-                    Some(PaymentMethodToken::GooglePayDecrypt(token)) => (
-                        Some(token.card_exp_month.clone()),
-                        Some(token.card_exp_year.clone()),
-                    ),
-                    _ => (None, None),
-                };
+                let google_pay_decrypted = payment_method_token
+                    .as_ref()
+                    .and_then(|token| token.get_google_pay_decrypt_data());
+
+                let card_exp_month = google_pay_decrypted
+                    .as_ref()
+                    .map(|token| token.get_card_exp_month());
+                let card_exp_year = google_pay_decrypted
+                    .as_ref()
+                    .map(|token| token.get_card_exp_year());
+                let device_pan_bin = google_pay_decrypted
+                    .as_ref()
+                    .and_then(|token| token.get_device_pan_bin());
+                let card_bin = google_pay_decrypted
+                    .as_ref()
+                    .and_then(|token| token.get_card_bin());
 
                 Ok(Some(api_models::payments::AdditionalPaymentData::Wallet {
                     apple_pay: None,
@@ -6415,12 +6455,23 @@ pub async fn get_additional_payment_data(
                         payment_additional_types::WalletAdditionalDataForCard {
                             last4: Some(google_pay_pm_data.info.card_details.clone()),
                             card_network: Some(google_pay_pm_data.info.card_network.clone()),
-                            card_type: Some(google_pay_pm_data.pm_type.clone()),
+                            payment_method_data_type: Some(google_pay_pm_data.pm_type.clone()),
                             card_exp_month,
                             card_exp_year,
+                            device_pan_bin,
+                            card_bin,
                             // These are filled after calling the processor / connector
                             auth_code: None,
                             email: None,
+                            card_subtype: None,
+                            card_segment_type: None,
+                            funding_source: None,
+                            // Google Pay's wallet token does not carry a credit/debit
+                            // indicator, so this is only populated once the connector's
+                            // authorization response reports it.
+                            card_type: None,
+                            issuer_name: None,
+                            issuer_country: None,
                         },
                     )),
                     samsung_pay: None,
@@ -6445,12 +6496,20 @@ pub async fn get_additional_payment_data(
                                     .card_brand
                                     .to_string(),
                             ),
+                            payment_method_data_type: None,
                             card_type: None,
                             card_exp_month: None,
                             card_exp_year: None,
                             // These are filled after calling the processor / connector
                             auth_code: None,
                             email: None,
+                            device_pan_bin: None,
+                            card_bin: None,
+                            card_subtype: None,
+                            card_segment_type: None,
+                            funding_source: None,
+                            issuer_name: None,
+                            issuer_country: None,
                         },
                     )),
                     paypal: None,
@@ -8445,18 +8504,69 @@ pub fn add_connector_response_to_additional_payment_data(
                 samsung_pay,
                 paypal,
             },
-            AdditionalPaymentMethodConnectorResponse::GooglePay { auth_code, .. }
-            | AdditionalPaymentMethodConnectorResponse::ApplePay { auth_code, .. },
+            AdditionalPaymentMethodConnectorResponse::ApplePay {
+                auth_code,
+                device_pan_bin,
+                card_bin,
+                card_subtype,
+                card_segment_type,
+                funding_source,
+                issuer_name,
+                issuer_country,
+            },
         ) => api_models::payments::AdditionalPaymentData::Wallet {
             apple_pay: apple_pay.as_ref().map(|apple_pay| {
                 Box::new(api_models::payments::ApplepayPaymentMethod {
                     auth_code: auth_code.clone(),
+                    device_pan_bin: device_pan_bin
+                        .clone()
+                        .or_else(|| apple_pay.device_pan_bin.clone()),
+                    card_bin: card_bin.clone().or_else(|| apple_pay.card_bin.clone()),
+                    card_subtype: card_subtype.clone(),
+                    card_segment_type,
+                    funding_source,
+                    issuer_name: issuer_name.clone(),
+                    issuer_country,
                     ..(**apple_pay).clone()
                 })
             }),
+            google_pay: google_pay.clone(),
+            samsung_pay: samsung_pay.clone(),
+            paypal: paypal.clone(),
+        },
+        (
+            api_models::payments::AdditionalPaymentData::Wallet {
+                apple_pay,
+                google_pay,
+                samsung_pay,
+                paypal,
+            },
+            AdditionalPaymentMethodConnectorResponse::GooglePay {
+                auth_code,
+                device_pan_bin,
+                card_bin,
+                card_subtype,
+                card_segment_type,
+                funding_source,
+                card_type,
+                issuer_name,
+                issuer_country,
+            },
+        ) => api_models::payments::AdditionalPaymentData::Wallet {
+            apple_pay: apple_pay.clone(),
             google_pay: google_pay.as_ref().map(|google_pay| {
                 Box::new(payment_additional_types::WalletAdditionalDataForCard {
                     auth_code: auth_code.clone(),
+                    card_subtype: card_subtype.clone(),
+                    card_segment_type,
+                    funding_source,
+                    card_type,
+                    issuer_name: issuer_name.clone(),
+                    issuer_country,
+                    device_pan_bin: device_pan_bin
+                        .clone()
+                        .or_else(|| google_pay.device_pan_bin.clone()),
+                    card_bin: card_bin.clone().or_else(|| google_pay.card_bin.clone()),
                     ..(**google_pay).clone()
                 })
             }),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Hotfix for: https://github.com/juspay/hyperswitch/pull/14055

Enriches Apple Pay and Google Pay entries in AdditionalPaymentData (ApplepayPaymentMethod / WalletAdditionalDataForCard) with BIN and card-metadata fields, sourced from hyperswitch's own wallet decryption where possible and overridden/supplemented by the connector's response where available.

1. device_pan_bin / card_bin
Added device_pan_bin and card_bin as additional payment method data. These fields are directly populated from Hyperswitch for the merchant/Hyperswitch decrypt flow.

For the connector decrypt flow, support has been added to pass these fields from the connector to the core.

For Google Pay:

For PAN_ONLY payments, card_bin is populated.
For cryptogram-based payments, device_pan_bin is populated.

3. Card metadata: card_subtype, card_segment_type, funding_source, issuer_name, issuer_country

- Added all six fields (connector-response only, no HS-side source) to ApplepayPaymentMethod, WalletAdditionalDataForCard, and AdditionalPaymentMethodConnectorResponse::GooglePay/ApplePay, wired through the same merge path as above.
- Worldpay XML:  added support for mapping issuer_name/issuer_country  . 
- Checkout: added card_type/card_category/issuer/issuer_country/product_type

Googlepay  hs decrypt  response 

```
 "payment_method_data": {
        "wallet": {
            "google_pay": {
                "last4": "Discover 9319",
                "card_network": "VISA",
                "card_type": "credit",
                "type": "CARD",
                "card_exp_month": "01",
                "card_exp_year": "30",
                "auth_code": "1L1RTI",
                "email": null,
                "device_pan_bin": "424242",
                "card_bin": null,
                "card_subtype": "Visa Classic",
                "card_segment_type": "consumer",
                "funding_source": "CREDIT",
                "issuer_name": "CKO, WHERE THE WORLD CHECKS OUT",
                "issuer_country": "GB"
            }
        },
        "billing": null
    },
```

Applepay hs decrypt  response 


```
  "payment_method_data": {
        "wallet": {
            "apple_pay": {
                "last4": "9319",
                "card_network": "Visa",
               "card_type": "credit",
                "type": "debit",
                "card_exp_month": "01",
                "card_exp_year": "30",
                "auth_code": "8NUBSG",
                "email": null,
                "device_pan_bin": "483026",
                "card_bin": null,
                "card_subtype": "Visa Gold",
                "card_segment_type": "consumer",
                "funding_source": "CREDIT",
                "issuer_name": "MARGINALEN BANK BANKAKTIEBOLAG",
                "issuer_country": "SE"
            }
        },
        "billing": null
    },
```

> For MIT payments dpan is not returned 

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
