### PR TITLE
test(cypress): cover cybersource cvc omission

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
@@ -686,6 +686,116 @@ export const connectorDetails = {
         },
       },
     },
+    CvcOmitAndRiskMessages: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          value: "connector_1",
+        },
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        mandate_data: singleUseMandateData,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    CvcOmitNoBilling: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          value: "connector_1",
+        },
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+        billing: {
+          address: {
+            first_name: "Test",
+            last_name: "User",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+          error_code: "MISSING_FIELD",
+        },
+      },
+    },
+    CvcOmitEmptyCvc: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          value: "connector_1",
+        },
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            ...successfulNo3DSCardDetails,
+            card_cvc: "",
+          },
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Invalid card_cvc length",
+            code: "IR_16",
+          },
+        },
+      },
+    },
+    CvcOmitOmittedCvc: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          value: "connector_1",
+        },
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            card_number: "4242424242424242",
+            card_exp_month: "01",
+            card_exp_year: "50",
+            card_holder_name: "joseph Doe",
+          },
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            error_type: "invalid_request",
+            message: "Json deserialize error: missing field `card_cvc`",
+            code: "IR_06",
+          },
+        },
+      },
+    },
     MandateSingleUseNo3DSManualCapture: {
       Configs: {
         CONNECTOR_CREDENTIAL: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -822,6 +822,7 @@ export const CONNECTOR_LISTS = {
     WEBHOOK_CONFIG: ["stripe"],
     REQUIRES_CVV: ["bankofamerica"],
     BLOCK_IMPLICIT_CUSTOMER_CREATION: ["adyen"],
+    CVC_OMIT: ["cybersource"],
     // Add more inclusion lists
   },
 };

--- a/cypress-tests/cypress/e2e/spec/Payment/57-CvcOmitAndRiskMessages.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/57-CvcOmitAndRiskMessages.cy.js
@@ -1,0 +1,182 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, * as utils from "../../configs/Payment/Utils";
+
+let globalState;
+
+describe("Card - CVC Omit and Risk Messages flow test", () => {
+  before("seed global state", function () {
+    let skip = false;
+
+    cy.task("getGlobalState")
+      .then((state) => {
+        globalState = new State(state);
+        if (
+          utils.shouldIncludeConnector(
+            globalState.get("connectorId"),
+            utils.CONNECTOR_LISTS.INCLUDE.CVC_OMIT
+          )
+        ) {
+          skip = true;
+        }
+      })
+      .then(() => {
+        if (skip) {
+          this.skip();
+        }
+      });
+  });
+
+  afterEach("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("CVC omission via mandate MIT flow", () => {
+    let shouldContinue = true;
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("cit-mandate-setup-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["CvcOmitAndRiskMessages"];
+
+      cy.citForMandatesCallTest(
+        fixtures.citConfirmBody,
+        data,
+        100,
+        true,
+        "automatic",
+        "setup_mandate",
+        globalState
+      );
+
+      if (shouldContinue) {
+        shouldContinue = utils.should_continue_further(data);
+      }
+    });
+
+    it("mit-no-cvc-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["MITAutoCapture"];
+
+      cy.mitForMandatesCallTest(
+        fixtures.mitConfirmBody,
+        data,
+        200,
+        true,
+        "automatic",
+        globalState
+      );
+
+      if (shouldContinue) {
+        shouldContinue = utils.should_continue_further(data);
+      }
+    });
+
+    it("retrieve-mit-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["MITAutoCapture"];
+
+      cy.retrievePaymentCallTest({
+        globalState,
+        data,
+        expectedIntentStatus: "succeeded",
+      });
+    });
+  });
+
+  context("baseline payment with valid CVC", () => {
+    let shouldContinue = true;
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("create-confirm-payment-with-cvc-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["No3DSAutoCapture"];
+
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+
+      if (shouldContinue) {
+        shouldContinue = utils.should_continue_further(data);
+      }
+    });
+
+    it("retrieve-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["No3DSAutoCapture"];
+
+      cy.retrievePaymentCallTest({
+        globalState,
+        data,
+        expectedIntentStatus: "succeeded",
+      });
+    });
+  });
+
+  context("payment with missing billing fields", () => {
+    it("payment-with-missing-billing-fields-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["CvcOmitNoBilling"];
+
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+  });
+
+  context("negative - payment with empty CVC", () => {
+    it("payment-with-empty-cvc-error-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["CvcOmitEmptyCvc"];
+
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+  });
+
+  context("negative - payment with omitted CVC field", () => {
+    it("payment-with-omitted-cvc-error-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["CvcOmitOmittedCvc"];
+
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/spec/Payment/57-CvcOmitAndRiskMessages.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/57-CvcOmitAndRiskMessages.cy.js
@@ -11,12 +11,14 @@ describe("Card - CVC Omit and Risk Messages flow test", () => {
     cy.task("getGlobalState")
       .then((state) => {
         globalState = new State(state);
-        if (
-          utils.shouldIncludeConnector(
-            globalState.get("connectorId"),
-            utils.CONNECTOR_LISTS.INCLUDE.CVC_OMIT
-          )
-        ) {
+        // `shouldIncludeConnector` follows the existing suite convention: a
+        // true result means the connector is outside the allowlist and should
+        // be skipped. Cybersource is listed, so its cases run.
+        const shouldSkipConnector = utils.shouldIncludeConnector(
+          globalState.get("connectorId"),
+          utils.CONNECTOR_LISTS.INCLUDE.CVC_OMIT
+        );
+        if (shouldSkipConnector) {
           skip = true;
         }
       })


### PR DESCRIPTION
## Summary

Adds Cypress coverage for issue #13743 and the Cybersource CVC omission and risk message behavior from PR #13630.

- Covers mandate setup and MIT without a CVC, with retrieval assertions for succeeded payments.
- Covers a baseline valid CVC payment and retrieval.
- Covers missing billing risk responses plus empty and omitted CVC validation errors.
- Restricts the new spec to Cybersource through the connector inclusion list.

## Testing

- `npm run format:check -- --ignore-path .gitignore` — passed
- `npm run lint -- --no-warn-ignored` — passed with existing warnings only
- `CYPRESS_CONNECTOR=cybersource npm run cypress:specs -- payments --print-specs` — passed; the new spec is selected
- `git diff --check` — passed
- `npm run build:ts` — blocked by existing errors in `mock-server/Connectors/Affirm.ts`, `Celero.ts`, and `Silverflow.ts`
- Live Cybersource Cypress execution was unavailable because this environment has no connector credentials or test API URL.

Fixes #13743.
