### PR TITLE
feat(connector): [datatrans] add required billing fields for google pay

### DIFF
--- a/config/superposition_seed.toml
+++ b/config/superposition_seed.toml
@@ -4649,6 +4649,12 @@ _context_ = { connector = "cybersource", payment_method = "Wallet", payment_meth
 "dynamic_fields.billing.email._is_required" = true
 
 [[overrides]]
+_context_ = { connector = "datatrans", payment_method = "Wallet", payment_method_type = "GooglePay" }
+"dynamic_fields.billing.address.first_name._is_required" = true
+"dynamic_fields.billing.address.last_name._is_required" = true
+"dynamic_fields.billing.email._is_required" = true
+
+[[overrides]]
 _context_ = { connector = "multisafepay", payment_method = "Wallet", payment_method_type = "GooglePay" }
 "dynamic_fields.billing.address.city._is_required" = true
 "dynamic_fields.billing.address.country._is_required" = true

--- a/crates/payment_methods/src/configs/payment_connector_required_fields.rs
+++ b/crates/payment_methods/src/configs/payment_connector_required_fields.rs
@@ -2837,6 +2837,24 @@ fn get_wallet_required_fields() -> HashMap<enums::PaymentMethodType, ConnectorFi
                 (Connector::Airwallex, fields(vec![], vec![], vec![])),
                 (Connector::Authorizedotnet, fields(vec![], vec![], vec![])),
                 (Connector::Checkout, fields(vec![], vec![], vec![])),
+                (
+                    Connector::Datatrans,
+                    fields(
+                        vec![],
+                        vec![],
+                        vec![
+                            RequiredField::BillingFirstName(
+                                "billing_first_name",
+                                FieldType::UserBillingName,
+                            ),
+                            RequiredField::BillingLastName(
+                                "billing_last_name",
+                                FieldType::UserBillingName,
+                            ),
+                            RequiredField::BillingEmail,
+                        ],
+                    ),
+                ),
                 (Connector::Globalpay, fields(vec![], vec![], vec![])),
                 (
                     Connector::Multisafepay,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Marks the following billing fields as required for Datatrans Google Pay:

1. `billing.address.first_name` (`payment_method_data.billing.address.first_name`)
2. `billing.address.last_name` (`payment_method_data.billing.address.last_name`)
3. `billing.email` (`payment_method_data.billing.email`)

Changes:

1. `config/superposition_seed.toml` — added a superposition override for `{ connector = "datatrans", payment_method = "Wallet", payment_method_type = "GooglePay" }` setting `dynamic_fields.billing.address.first_name._is_required`, `dynamic_fields.billing.address.last_name._is_required` and `dynamic_fields.billing.email._is_required` to `true`.
2. `crates/payment_methods/src/configs/payment_connector_required_fields.rs` — added a `Connector::Datatrans` entry to the Google Pay wallet required fields (`BillingFirstName`, `BillingLastName`, `BillingEmail`).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

- `config/superposition_seed.toml`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
Datatrans Google Pay transactions require the billing first name, last name and email to be collected from the shopper. Marking these as required fields so the SDK collects them in the payment sheet.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Validated that `config/superposition_seed.toml` parses successfully as valid TOML and the override follows the same pattern as other connectors (cybersource, nuvei, etc.).
- `cargo check` passes.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible