### PR TITLE
feat(diesel_models): observability schema and its own migration lineage

### DIFF
--- a/crates/diesel_models/src/lib.rs
+++ b/crates/diesel_models/src/lib.rs
@@ -37,6 +37,7 @@ pub mod mandate;
 pub mod merchant_account;
 pub mod merchant_connector_account;
 pub mod merchant_key_store;
+pub mod observability;
 pub mod organization;
 pub mod payment_attempt;
 pub mod payment_intent;

--- a/crates/diesel_models/src/observability.rs
+++ b/crates/diesel_models/src/observability.rs
@@ -1,0 +1,7 @@
+//! The observability plane's own state: alert configuration, lifecycle, and what was announced.
+//!
+//! These tables are not part of `hyperswitch_db`. They live in a database the observability plane
+//! owns, with its own migration lineage under `crates/observability/migrations` and its own diesel
+//! configuration in `diesel_observability.toml`.
+
+pub mod schema;

--- a/crates/diesel_models/src/observability/schema.rs
+++ b/crates/diesel_models/src/observability/schema.rs
@@ -1,0 +1,296 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    alerts_dicts (id) {
+        id -> Uuid,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 255]
+        key_ -> Varchar,
+        product -> Nullable<Json>,
+        values_ -> Nullable<Json>,
+        ts_created -> Nullable<Timestamp>,
+        is_enabled -> Nullable<Bool>,
+        #[max_length = 64]
+        username -> Nullable<Varchar>,
+        metadata -> Nullable<Json>,
+    }
+}
+
+diesel::table! {
+    alerts_info (id) {
+        id -> Uuid,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        #[max_length = 255]
+        dimensions -> Nullable<Varchar>,
+        period -> Nullable<Int4>,
+        #[max_length = 64]
+        default_channel -> Nullable<Varchar>,
+        default_critical -> Nullable<Bool>,
+        blacklist -> Nullable<Json>,
+        snooze -> Nullable<Json>,
+        history_window -> Nullable<Int4>,
+        thresholds -> Nullable<Json>,
+        metadata -> Nullable<Json>,
+        is_enabled -> Nullable<Bool>,
+        comments -> Nullable<Json>,
+        call_period -> Nullable<Int4>,
+        #[max_length = 64]
+        author -> Nullable<Varchar>,
+        #[max_length = 64]
+        approver -> Nullable<Varchar>,
+        last_updated_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    alerts_intermediate (id_intermediate) {
+        id_intermediate -> Uuid,
+        id -> Nullable<Uuid>,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        dimensions -> Nullable<Jsonb>,
+        #[max_length = 255]
+        ts_slack -> Nullable<Varchar>,
+        ts_alert -> Nullable<Timestamp>,
+        latest_ts_alert -> Nullable<Timestamp>,
+        max_duration -> Nullable<Int4>,
+        other_metrics -> Nullable<Jsonb>,
+        metadata -> Nullable<Jsonb>,
+        metadata_alert_details -> Nullable<Jsonb>,
+        rca_metadata -> Nullable<Jsonb>,
+        #[max_length = 64]
+        group_id -> Varchar,
+        #[max_length = 64]
+        priority -> Nullable<Varchar>,
+        last_updated_at -> Nullable<Timestamp>,
+        recovered_ts -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    alerts_intermediate_xyne (id_intermediate) {
+        id_intermediate -> Uuid,
+        id -> Nullable<Uuid>,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        dimensions -> Nullable<Jsonb>,
+        #[max_length = 255]
+        ts_slack -> Nullable<Varchar>,
+        ts_alert -> Nullable<Timestamp>,
+        latest_ts_alert -> Nullable<Timestamp>,
+        max_duration -> Nullable<Int4>,
+        other_metrics -> Nullable<Jsonb>,
+        metadata -> Nullable<Jsonb>,
+        metadata_alert_details -> Nullable<Jsonb>,
+        rca_metadata -> Nullable<Jsonb>,
+        #[max_length = 64]
+        group_id -> Varchar,
+        #[max_length = 64]
+        priority -> Nullable<Varchar>,
+        last_updated_at -> Nullable<Timestamp>,
+        recovered_ts -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    alerts_main (id) {
+        id -> Uuid,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        dimensions -> Nullable<Json>,
+        #[max_length = 255]
+        ts_slack -> Nullable<Varchar>,
+        ts_alert -> Nullable<Timestamp>,
+        duration -> Nullable<Int4>,
+        sent -> Nullable<Bool>,
+        critical -> Nullable<Bool>,
+        rca_metadata -> Nullable<Jsonb>,
+        metadata -> Nullable<Json>,
+        last_updated_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    alerts_main_xyne (id) {
+        id -> Uuid,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        dimensions -> Nullable<Json>,
+        #[max_length = 255]
+        ts_slack -> Nullable<Varchar>,
+        ts_alert -> Nullable<Timestamp>,
+        duration -> Nullable<Int4>,
+        sent -> Nullable<Bool>,
+        critical -> Nullable<Bool>,
+        rca_metadata -> Nullable<Jsonb>,
+        metadata -> Nullable<Json>,
+        last_updated_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    merchants_alert_external (id_merchant_table) {
+        id -> Nullable<Uuid>,
+        id_merchant_table -> Uuid,
+        id_intermediate -> Nullable<Uuid>,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        #[max_length = 64]
+        merchant_id -> Varchar,
+        dimensions -> Nullable<Jsonb>,
+        auxiliary_dimensions -> Nullable<Jsonb>,
+        current_metric -> Float8,
+        expected_metric -> Float8,
+        #[max_length = 255]
+        attribution -> Nullable<Varchar>,
+        max_duration -> Int4,
+        start_time -> Timestamp,
+        is_visible -> Bool,
+        recovered_ts -> Nullable<Timestamp>,
+        #[max_length = 255]
+        ts_slack -> Varchar,
+        ts_alert -> Timestamp,
+        latest_ts_alert -> Nullable<Timestamp>,
+        last_updated_at -> Nullable<Timestamp>,
+        slack_info -> Nullable<Jsonb>,
+        communication_info -> Nullable<Jsonb>,
+        metadata -> Nullable<Jsonb>,
+        metadata_alert_details -> Nullable<Jsonb>,
+        #[max_length = 64]
+        priority -> Nullable<Varchar>,
+        #[max_length = 64]
+        tenant_id -> Nullable<Varchar>,
+    }
+}
+
+diesel::table! {
+    merchants_alert_external_config (name, product) {
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        #[max_length = 64]
+        category -> Nullable<Varchar>,
+        is_enabled -> Nullable<Bool>,
+        metadata -> Nullable<Jsonb>,
+        last_updated_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
+    merchants_alert_external_dimension (id_merchant_table) {
+        id -> Nullable<Uuid>,
+        id_merchant_table -> Uuid,
+        id_intermediate -> Nullable<Uuid>,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        #[max_length = 64]
+        dimension_key -> Varchar,
+        #[max_length = 255]
+        dimension_value -> Varchar,
+        dimensions -> Nullable<Jsonb>,
+        auxiliary_dimensions -> Nullable<Jsonb>,
+        current_metric -> Float8,
+        expected_metric -> Float8,
+        #[max_length = 255]
+        attribution -> Nullable<Varchar>,
+        max_duration -> Int4,
+        is_visible -> Bool,
+        start_time -> Timestamp,
+        recovered_ts -> Nullable<Timestamp>,
+        #[max_length = 255]
+        ts_slack -> Nullable<Varchar>,
+        ts_alert -> Timestamp,
+        latest_ts_alert -> Nullable<Timestamp>,
+        last_updated_at -> Nullable<Timestamp>,
+        slack_info -> Nullable<Jsonb>,
+        communication_info -> Nullable<Jsonb>,
+        metadata -> Nullable<Jsonb>,
+        metadata_alert_details -> Nullable<Jsonb>,
+        #[max_length = 64]
+        priority -> Nullable<Varchar>,
+        #[max_length = 64]
+        tenant_id -> Nullable<Varchar>,
+    }
+}
+
+diesel::table! {
+    merchants_alert_external_xyne (id_merchant_table) {
+        id -> Nullable<Uuid>,
+        id_merchant_table -> Uuid,
+        id_intermediate -> Nullable<Uuid>,
+        #[max_length = 64]
+        name -> Varchar,
+        #[max_length = 64]
+        product -> Varchar,
+        #[max_length = 64]
+        merchant_id -> Varchar,
+        dimensions -> Nullable<Jsonb>,
+        auxiliary_dimensions -> Nullable<Jsonb>,
+        current_metric -> Float8,
+        expected_metric -> Float8,
+        #[max_length = 255]
+        attribution -> Nullable<Varchar>,
+        max_duration -> Int4,
+        start_time -> Timestamp,
+        is_visible -> Bool,
+        recovered_ts -> Nullable<Timestamp>,
+        #[max_length = 255]
+        ts_slack -> Varchar,
+        ts_alert -> Timestamp,
+        latest_ts_alert -> Nullable<Timestamp>,
+        last_updated_at -> Nullable<Timestamp>,
+        slack_info -> Nullable<Jsonb>,
+        communication_info -> Nullable<Jsonb>,
+        metadata -> Nullable<Jsonb>,
+        metadata_alert_details -> Nullable<Jsonb>,
+        #[max_length = 64]
+        priority -> Nullable<Varchar>,
+        #[max_length = 64]
+        tenant_id -> Nullable<Varchar>,
+    }
+}
+
+diesel::table! {
+    notification_reads (user_name) {
+        #[max_length = 255]
+        user_name -> Varchar,
+        last_read_at -> Timestamp,
+    }
+}
+
+diesel::joinable!(alerts_intermediate -> alerts_main (id));
+diesel::joinable!(alerts_intermediate_xyne -> alerts_main_xyne (id));
+diesel::joinable!(merchants_alert_external -> alerts_main (id));
+diesel::joinable!(merchants_alert_external_dimension -> alerts_main (id));
+diesel::joinable!(merchants_alert_external_xyne -> alerts_main_xyne (id));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    alerts_dicts,
+    alerts_info,
+    alerts_intermediate,
+    alerts_intermediate_xyne,
+    alerts_main,
+    alerts_main_xyne,
+    merchants_alert_external,
+    merchants_alert_external_config,
+    merchants_alert_external_dimension,
+    merchants_alert_external_xyne,
+    notification_reads,
+);

--- a/crates/observability/diesel.toml
+++ b/crates/observability/diesel.toml
@@ -1,0 +1,15 @@
+# The observability plane's migration lineage.
+#
+# Separate from diesel.toml and diesel_v2.toml, which describe hyperswitch_db. This one targets the
+# observability database: the two lineages share no tables and no version table.
+#
+#   diesel migration run \
+#     --config-file diesel_observability.toml \
+#     --migration-dir crates/observability/migrations \
+#     --database-url "$OBSERVABILITY_DATABASE_URL"
+
+[print_schema]
+file = "crates/diesel_models/src/observability/schema.rs"
+
+[migrations_directory]
+dir = "crates/observability/migrations"

--- a/crates/observability/migrations/2026-09-09-000001_create_alert_state_tables/down.sql
+++ b/crates/observability/migrations/2026-09-09-000001_create_alert_state_tables/down.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS notification_reads;
+DROP TABLE IF EXISTS merchants_alert_external_config;
+DROP TABLE IF EXISTS merchants_alert_external_dimension;
+DROP TABLE IF EXISTS merchants_alert_external_xyne;
+DROP TABLE IF EXISTS merchants_alert_external;
+DROP TABLE IF EXISTS alerts_dicts;
+DROP TABLE IF EXISTS alerts_intermediate_xyne;
+DROP TABLE IF EXISTS alerts_intermediate;
+DROP TABLE IF EXISTS alerts_main_xyne;
+DROP TABLE IF EXISTS alerts_main;
+DROP TABLE IF EXISTS alerts_info;

--- a/crates/observability/migrations/2026-09-09-000001_create_alert_state_tables/up.sql
+++ b/crates/observability/migrations/2026-09-09-000001_create_alert_state_tables/up.sql
@@ -1,0 +1,263 @@
+-- The observability plane's own state.
+--
+-- These tables are not part of hyperswitch_db. They live in a database this plane owns, so that
+-- alert state is not written into a store the application owns.
+--
+-- Two things are worth knowing before changing a column here:
+--
+--   * `json` and `jsonb` are not interchangeable. The columns holding values the dashboard sends
+--     already serialised are `json`, which preserves the bytes it was given; `jsonb` re-encodes
+--     and would hand back something different from what was saved.
+--   * `alerts_main` records each announcement that was sent, separately from `alerts_intermediate`,
+--     which holds current lifecycle state. Keeping them apart is what makes it possible to say
+--     whether an alert was delivered.
+--
+-- Timestamps are naive TIMESTAMP, as elsewhere in this repository, which holds UTC by discipline
+-- rather than by column type.
+
+-- Alert definitions: one row per alert, and the whole of its configuration.
+-- blacklist, snooze and thresholds live here as JSON rather than as side tables,
+-- so everything about an alert is in one place.
+CREATE TABLE IF NOT EXISTS alerts_info (
+    id               UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name             VARCHAR(64) NOT NULL,
+    product          VARCHAR(64) NOT NULL,
+    dimensions       VARCHAR(255),
+    period           INTEGER,
+    default_channel  VARCHAR(64),
+    default_critical BOOLEAN,
+    blacklist        JSON,
+    snooze           JSON,
+    history_window   INTEGER,
+    thresholds       JSON,
+    metadata         JSON,
+    is_enabled       BOOLEAN DEFAULT FALSE,
+    comments         JSON,
+    call_period      INTEGER,
+    author           VARCHAR(64) DEFAULT 'reliability_team',
+    approver         VARCHAR(64),
+    last_updated_at  TIMESTAMP DEFAULT date_trunc('second', CURRENT_TIMESTAMP)
+);
+
+-- Announcements actually sent, one row per alert per delivery. `sent` and
+-- `ts_slack` are the record that an alert reached a channel; without them a
+-- failed delivery is indistinguishable from a successful one on the next run.
+CREATE TABLE IF NOT EXISTS alerts_main (
+    id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name            VARCHAR(64) NOT NULL,
+    product         VARCHAR(64) NOT NULL,
+    dimensions      JSON,
+    ts_slack        VARCHAR(255),
+    ts_alert        TIMESTAMP,
+    duration        INTEGER,
+    sent            BOOLEAN,
+    critical        BOOLEAN,
+    rca_metadata    JSONB,
+    metadata        JSON,
+    last_updated_at TIMESTAMP DEFAULT date_trunc('second', CURRENT_TIMESTAMP)
+);
+
+CREATE TABLE IF NOT EXISTS alerts_main_xyne (
+    id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name            VARCHAR(64) NOT NULL,
+    product         VARCHAR(64) NOT NULL,
+    dimensions      JSON,
+    ts_slack        VARCHAR(255),
+    ts_alert        TIMESTAMP,
+    duration        INTEGER,
+    sent            BOOLEAN,
+    critical        BOOLEAN,
+    rca_metadata    JSONB,
+    metadata        JSON,
+    last_updated_at TIMESTAMP DEFAULT date_trunc('second', CURRENT_TIMESTAMP)
+);
+
+-- Current lifecycle state: what is firing now, since when, and what recovered.
+-- This is what the classifier diffs against; `alerts_main` is the log of what
+-- was said about it.
+CREATE TABLE IF NOT EXISTS alerts_intermediate (
+    id_intermediate        UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    id                     UUID REFERENCES alerts_main(id) ON DELETE CASCADE,
+    name                   VARCHAR(64) NOT NULL,
+    product                VARCHAR(64) NOT NULL,
+    dimensions             JSONB,
+    ts_slack               VARCHAR(255),
+    ts_alert               TIMESTAMP,
+    latest_ts_alert        TIMESTAMP,
+    max_duration           INTEGER,
+    other_metrics          JSONB,
+    metadata               JSONB,
+    metadata_alert_details JSONB,
+    rca_metadata           JSONB,
+    group_id               VARCHAR(64) NOT NULL DEFAULT '',
+    priority               VARCHAR(64),
+    last_updated_at        TIMESTAMP,
+    recovered_ts           TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS alerts_intermediate_xyne (
+    id_intermediate        UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    id                     UUID REFERENCES alerts_main_xyne(id) ON DELETE CASCADE,
+    name                   VARCHAR(64) NOT NULL,
+    product                VARCHAR(64) NOT NULL,
+    dimensions             JSONB,
+    ts_slack               VARCHAR(255),
+    ts_alert               TIMESTAMP,
+    latest_ts_alert        TIMESTAMP,
+    max_duration           INTEGER,
+    other_metrics          JSONB,
+    metadata               JSONB,
+    metadata_alert_details JSONB,
+    rca_metadata           JSONB,
+    group_id               VARCHAR(64) NOT NULL DEFAULT '',
+    priority               VARCHAR(64),
+    last_updated_at        TIMESTAMP,
+    recovered_ts           TIMESTAMP
+);
+
+-- The mappers screen. product and values_ are `json` rather than `jsonb`: the
+-- dashboard sends them already serialised and reads them back expecting the
+-- same bytes.
+CREATE TABLE IF NOT EXISTS alerts_dicts (
+    id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name       VARCHAR(64) NOT NULL,
+    key_       VARCHAR(255) NOT NULL,
+    product    JSON,
+    values_    JSON,
+    ts_created TIMESTAMP,
+    is_enabled BOOLEAN DEFAULT TRUE,
+    username   VARCHAR(64) DEFAULT 'reliability_team',
+    metadata   JSON
+);
+
+-- One enabled entry per name and key; superseded rows stay for history.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_alerts_dicts_enabled_unique
+    ON alerts_dicts USING btree (name, key_) WHERE is_enabled IS TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_alerts_dicts_latest
+    ON alerts_dicts USING btree (name, key_, ts_created DESC);
+
+-- Per-merchant alert instances. current_metric against expected_metric is the
+-- generic form of "what is wrong", so a detector that is not about success rate
+-- needs no schema change.
+CREATE TABLE IF NOT EXISTS merchants_alert_external (
+    id                     UUID REFERENCES alerts_main(id) ON DELETE CASCADE,
+    id_merchant_table      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id_intermediate        UUID,
+    name                   VARCHAR(64) NOT NULL,
+    product                VARCHAR(64) NOT NULL,
+    merchant_id            VARCHAR(64) NOT NULL,
+    dimensions             JSONB,
+    auxiliary_dimensions   JSONB,
+    current_metric         DOUBLE PRECISION NOT NULL,
+    expected_metric        DOUBLE PRECISION NOT NULL,
+    attribution            VARCHAR(255),
+    max_duration           INTEGER NOT NULL,
+    start_time             TIMESTAMP NOT NULL,
+    is_visible             BOOLEAN NOT NULL DEFAULT TRUE,
+    recovered_ts           TIMESTAMP,
+    ts_slack               VARCHAR(255) NOT NULL,
+    ts_alert               TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    latest_ts_alert        TIMESTAMP,
+    last_updated_at        TIMESTAMP,
+    slack_info             JSONB,
+    communication_info     JSONB,
+    metadata               JSONB,
+    metadata_alert_details JSONB,
+    priority               VARCHAR(64),
+    tenant_id              VARCHAR(64)
+);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_external
+    ON merchants_alert_external (merchant_id);
+CREATE INDEX IF NOT EXISTS idx_ts_alerts_external
+    ON merchants_alert_external USING btree (ts_alert);
+
+CREATE TABLE IF NOT EXISTS merchants_alert_external_xyne (
+    id                     UUID REFERENCES alerts_main_xyne(id) ON DELETE CASCADE,
+    id_merchant_table      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id_intermediate        UUID,
+    name                   VARCHAR(64) NOT NULL,
+    product                VARCHAR(64) NOT NULL,
+    merchant_id            VARCHAR(64) NOT NULL,
+    dimensions             JSONB,
+    auxiliary_dimensions   JSONB,
+    current_metric         DOUBLE PRECISION NOT NULL,
+    expected_metric        DOUBLE PRECISION NOT NULL,
+    attribution            VARCHAR(255),
+    max_duration           INTEGER NOT NULL,
+    start_time             TIMESTAMP NOT NULL,
+    is_visible             BOOLEAN NOT NULL DEFAULT TRUE,
+    recovered_ts           TIMESTAMP,
+    ts_slack               VARCHAR(255) NOT NULL,
+    ts_alert               TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    latest_ts_alert        TIMESTAMP,
+    last_updated_at        TIMESTAMP,
+    slack_info             JSONB,
+    communication_info     JSONB,
+    metadata               JSONB,
+    metadata_alert_details JSONB,
+    priority               VARCHAR(64),
+    tenant_id              VARCHAR(64)
+);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_external_xyne
+    ON merchants_alert_external_xyne (merchant_id);
+CREATE INDEX IF NOT EXISTS idx_ts_alerts_external_xyne
+    ON merchants_alert_external_xyne USING btree (ts_alert);
+
+-- One row per dimension of an instance, so a single alert can be broken down by
+-- connector, method or anything else without widening the instance table.
+CREATE TABLE IF NOT EXISTS merchants_alert_external_dimension (
+    id                     UUID REFERENCES alerts_main(id) ON DELETE CASCADE,
+    id_merchant_table      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id_intermediate        UUID,
+    name                   VARCHAR(64) NOT NULL,
+    product                VARCHAR(64) NOT NULL,
+    dimension_key          VARCHAR(64) NOT NULL,
+    dimension_value        VARCHAR(255) NOT NULL,
+    dimensions             JSONB,
+    auxiliary_dimensions   JSONB,
+    current_metric         DOUBLE PRECISION NOT NULL,
+    expected_metric        DOUBLE PRECISION NOT NULL,
+    attribution            VARCHAR(255),
+    max_duration           INTEGER NOT NULL,
+    is_visible             BOOLEAN NOT NULL DEFAULT TRUE,
+    start_time             TIMESTAMP NOT NULL,
+    recovered_ts           TIMESTAMP,
+    ts_slack               VARCHAR(255),
+    ts_alert               TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    latest_ts_alert        TIMESTAMP,
+    last_updated_at        TIMESTAMP,
+    slack_info             JSONB,
+    communication_info     JSONB,
+    metadata               JSONB,
+    metadata_alert_details JSONB,
+    priority               VARCHAR(64),
+    tenant_id              VARCHAR(64)
+);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_external_dimension
+    ON merchants_alert_external_dimension (name, product, dimension_key);
+
+-- Which alerts are on, per name and product.
+--
+-- (name, product) is the natural key: without it two rows can disagree about
+-- whether the same alert is enabled. Diesel also refuses to model a table with
+-- no primary key, and this table has to be readable.
+CREATE TABLE IF NOT EXISTS merchants_alert_external_config (
+    name            VARCHAR(64) NOT NULL,
+    product         VARCHAR(64) NOT NULL,
+    category        VARCHAR(64) DEFAULT '',
+    is_enabled      BOOLEAN DEFAULT TRUE,
+    metadata        JSONB DEFAULT '{}',
+    last_updated_at TIMESTAMP,
+    PRIMARY KEY (name, product)
+);
+
+-- Notification bell read watermarks. Keyed by user, though with authentication
+-- disabled every read arrives under the same empty name and there is one row.
+CREATE TABLE IF NOT EXISTS notification_reads (
+    user_name    VARCHAR(255) PRIMARY KEY,
+    last_read_at TIMESTAMP NOT NULL
+);

--- a/justfile
+++ b/justfile
@@ -236,6 +236,16 @@ run_migration operation=default_operation migration_dir=v1_migration_dir config_
 # Run database migrations for v1
 migrate operation=default_operation *args='': (run_migration operation v1_migration_dir v1_config_file_dir database_url args)
 
+# The observability plane's state lives in its own database with its own lineage: these tables are
+# not part of hyperswitch_db and the two share no version table. See diesel_observability.toml.
+observability_db_name := env_var_or_default('OBSERVABILITY_DB_NAME', 'observability')
+observability_db_url := env_var_or_default('OBSERVABILITY_DATABASE_URL', 'postgresql://' + db_user + ':' + db_password + '@' + db_host + ':' + db_port / observability_db_name)
+observability_migration_dir := source_directory() / 'crates/observability/migrations'
+observability_config_file_dir := source_directory() / 'diesel_observability.toml'
+
+# Run database migrations for the observability database
+migrate_observability operation=default_operation *args='': (run_migration operation observability_migration_dir observability_config_file_dir observability_db_url args)
+
 v2_config_file_dir := source_directory() / 'diesel_v2.toml'
 
 # Run database migrations for v2


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

The alert manager writes its own operational state — alert configuration and alert history — into **the application's ClickHouse**, the same store it queries for payments analytics. This adds the schema that state moves to: Postgres, in a database the observability plane owns rather than `hyperswitch_db`.

Part of [#23153](https://github.com/juspay/hyperswitch-cloud/issues/23153); implements [#23398](https://github.com/juspay/hyperswitch-cloud/issues/23398).

Schema only. Nothing reads or writes these tables yet — the connection pool, the API routes and the alert manager's client are separate changes. Purely additive, and inert on merge.

### Models here, lineage under the crate

The models live in `diesel_models`, where models live. Nothing is paid for that: the `observability` crate already reaches this one through `hyperswitch_interfaces`, so the dependency and its feature matrix are already compiled in.

The **lineage** stays separate — `crates/observability/migrations` with `diesel_observability.toml` naming its own generated schema. The two lineages share no tables and no version table, and they target different databases: putting these tables in `hyperswitch_db` would repeat, in Postgres, exactly the boundary this move exists to end.

### Two properties worth knowing before changing a column

- **`json` and `jsonb` are not interchangeable here.** The columns holding values the dashboard sends already serialised are `json`, which preserves the bytes it was given. `jsonb` re-encodes and would hand back something different from what was saved.
- **`alerts_main` is separate from `alerts_intermediate`.** One records each announcement that was sent, the other holds current lifecycle state. Keeping them apart is what makes it possible to say whether an alert was delivered — see [#23304](https://github.com/juspay/hyperswitch-cloud/issues/23304).

### Two deliberate calls, both commented in the migration

- **`hyperswitch_alerts_app_user` is not carried across.** It holds local login accounts, both environments run with `localUsers: false`, and nothing reads it.
- **`merchants_alert_external_config` gets `PRIMARY KEY (name, product)`**, without which two rows can disagree about whether the same alert is enabled — and diesel cannot model a table with no key at all.

Timestamps are naive `TIMESTAMP` and identifiers are sized `VARCHAR`, matching the rest of the repository.

## Testing

Verified against Postgres 16:

- applies to an empty database; re-running is a no-op
- `redo` round-trips; `revert` leaves only the version table
- foreign keys cascade — deleting an announcement clears its lifecycle and instance rows
- the partial unique index on `alerts_dicts` rejects a second **enabled** row for the same `(name, key_)` while allowing a disabled one
- a full alert inserted and read back joined across definition, announcement, lifecycle and instance
- `diesel migration redo --locked-schema` passes, and was confirmed non-vacuous by deliberately editing the generated schema and watching it fail

`cargo check -p diesel_models` is clean under **both** `v1` and `v2` — the new module and its UUID columns compile on both sides of the feature matrix. `cargo +nightly fmt --all --check` is clean.

### Additional Changes

- [x] This PR modifies the database schema
