### PR TITLE
feat(observability): database configuration and connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,7 +3088,6 @@ dependencies = [
  "r2d2",
  "serde_json",
  "time 0.3.41",
- "uuid",
 ]
 
 [[package]]
@@ -3136,7 +3135,6 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 1.0.69",
  "time 0.3.41",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,6 +3088,7 @@ dependencies = [
  "r2d2",
  "serde_json",
  "time 0.3.41",
+ "uuid",
 ]
 
 [[package]]
@@ -3135,6 +3136,7 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 1.0.69",
  "time 0.3.41",
+ "uuid",
 ]
 
 [[package]]
@@ -6483,10 +6485,14 @@ version = "0.1.0"
 dependencies = [
  "actix-multipart",
  "actix-web",
+ "async-bb8-diesel",
  "async-trait",
+ "bb8",
  "clap 4.5.38",
  "common_utils",
  "config",
+ "diesel",
+ "diesel_models",
  "error-stack 0.4.1",
  "external_services",
  "hyperswitch_interfaces",

--- a/config/observability.toml
+++ b/config/observability.toml
@@ -13,6 +13,18 @@ host = "127.0.0.1"
 port = 8085
 workers = 1
 
+# The observability database. Local development points at a database created by
+# `just migrate_observability`; deployed environments override these from the environment, and the
+# password is resolved through `secrets_management`.
+[database]
+host = "localhost"
+port = 5432
+dbname = "observability"
+username = "db_user"
+password = "db_pass"
+pool_size = 5
+connection_timeout = 10
+
 [log.console]
 enabled = true
 level = "DEBUG"

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -17,8 +17,8 @@ license.workspace = true
 # has to think about a choice this crate does not care about. A workspace v2 build
 # (`--no-default-features --features v2`) still selects the other flavour.
 default = ["v1"]
-v1 = ["common_utils/v1", "external_services/v1", "hyperswitch_interfaces/v1"]
-v2 = ["common_utils/v2", "external_services/v2", "hyperswitch_interfaces/v2"]
+v1 = ["common_utils/v1", "diesel_models/v1", "external_services/v1", "hyperswitch_interfaces/v1"]
+v2 = ["common_utils/v2", "diesel_models/v2", "external_services/v2", "hyperswitch_interfaces/v2"]
 release = ["vergen", "external_services/aws_kms", "external_services/gcp_kms"]
 vergen = ["router_env/vergen"]
 
@@ -27,7 +27,11 @@ actix-multipart = "0.6.2"
 actix-web = "4.11.0"
 async-trait = "0.1.88"
 clap = { version = "4.5.38", default-features = false, features = ["std", "derive", "help", "usage"] }
+async-bb8-diesel = "0.2.1"
+bb8 = "0.8"
 config = { version = "0.14.1", features = ["toml"] }
+diesel = { version = "2.2.10", features = ["postgres"] }
+diesel_models = { version = "0.1.0", path = "../diesel_models", features = ["kv_store"], default-features = false }
 error-stack = "0.4.1"
 mime = "0.3.17"
 reqwest = { version = "0.11.27" }

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -46,7 +46,7 @@ pub async fn start_server(state: AppState) -> errors::ObservabilityResult<Server
 
     let web_server = actix_web::HttpServer::new(move || {
         actix_web::App::new()
-            .service(routes::Health::server())
+            .service(routes::Health::server(state.clone()))
             .service(routes::Alerts::server(state.clone()))
             // Order matters and is the reverse of what it reads like: actix runs the *last*
             // registered wrap first, so `RequestIdentifier` must be registered last to run first.

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -1,5 +1,3 @@
-//! The observability plane for Hyperswitch.
-
 pub mod auth;
 pub mod core;
 pub mod domain;
@@ -19,10 +17,8 @@ use hyperswitch_interfaces::secrets_interface::secret_state::RawSecret;
 
 use crate::state::AppState;
 
-/// The configuration, after secrets have been resolved.
 pub type Settings = settings::Settings<RawSecret>;
 
-/// Build the standalone HTTP server.
 pub async fn start_server(state: AppState) -> errors::ObservabilityResult<Server> {
     let server = state.conf.server.clone();
 
@@ -30,11 +26,9 @@ pub async fn start_server(state: AppState) -> errors::ObservabilityResult<Server
         actix_web::App::new()
             .service(routes::Health::server(state.clone()))
             .service(routes::Alerts::server(state.clone()))
-            // Order matters and is the reverse of what it reads like:
             .wrap(router_env::tracing_actix_web::TracingLogger::<
                 router_env::CustomRootSpanBuilder,
             >::new())
-            // `common_utils::consts::X_REQUEST_ID` rather than our own literal:
             .wrap(router_env::RequestIdentifier::new(
                 common_utils::consts::X_REQUEST_ID,
             ))

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -1,17 +1,4 @@
 //! The observability plane for Hyperswitch.
-//!
-//! `observability` delivers alerts. Deciding what is alert-worthy happens elsewhere; alerts
-//! arrive here already decided. Its first concern is [`core::notifier`], and further alerting
-//! concerns are expected to live alongside it.
-//!
-//! Laid out on the router's lines: [`core`] decides, [`routes`] exposes, and the whole route tree
-//! is visible in [`routes::app`].
-//!
-//! The crate ships two ways, on the `drainer` model: as its own binary, and as a library exposing
-//! an actix [`Scope`](actix_web::Scope) the router can mount in-process. Only the standalone path
-//! is wired up today — see [`start_server`] — but routes are defined as `Scope` factories
-//! ([`routes::Alerts::server`], [`routes::Health::server`]) precisely so both paths will share one
-//! definition rather than drifting.
 
 pub mod auth;
 pub mod core;
@@ -36,11 +23,6 @@ use crate::state::AppState;
 pub type Settings = settings::Settings<RawSecret>;
 
 /// Build the standalone HTTP server.
-///
-/// The request-id middleware and root-span logger are mounted here, in the standalone path only.
-/// When the router mounts this crate it already has its own, and running two would produce two
-/// competing ids for one request — which is why they belong on the server rather than on the
-/// scope.
 pub async fn start_server(state: AppState) -> errors::ObservabilityResult<Server> {
     let server = state.conf.server.clone();
 
@@ -48,17 +30,11 @@ pub async fn start_server(state: AppState) -> errors::ObservabilityResult<Server
         actix_web::App::new()
             .service(routes::Health::server(state.clone()))
             .service(routes::Alerts::server(state.clone()))
-            // Order matters and is the reverse of what it reads like: actix runs the *last*
-            // registered wrap first, so `RequestIdentifier` must be registered last to run first.
-            // `CustomRootSpanBuilder` reads the request id out of request extensions, so if the
-            // tracing logger ran first it would find nothing and every root span would carry an
-            // empty `request_id`. This matches the router's ordering at `router/src/lib.rs:574`.
+            // Order matters and is the reverse of what it reads like:
             .wrap(router_env::tracing_actix_web::TracingLogger::<
                 router_env::CustomRootSpanBuilder,
             >::new())
-            // `common_utils::consts::X_REQUEST_ID` rather than our own literal: the router
-            // defaults its trace header to this same constant, so a request id set by an upstream
-            // hop is the one we log rather than a second id for the same request.
+            // `common_utils::consts::X_REQUEST_ID` rather than our own literal:
             .wrap(router_env::RequestIdentifier::new(
                 common_utils::consts::X_REQUEST_ID,
             ))

--- a/crates/observability/src/routes/app.rs
+++ b/crates/observability/src/routes/app.rs
@@ -108,7 +108,10 @@ impl Health {
     /// scope makes "unauthenticated" a structural property visible right here in the route tree,
     /// rather than a condition buried in a guard — so it stays true when someone adds `/healthz`,
     /// a trailing slash, or a route next to this one.
-    pub fn server() -> Scope {
-        web::scope("health").service(web::resource("").route(web::get().to(health_check::health)))
+    pub fn server(state: AppState) -> Scope {
+        web::scope("health")
+            .app_data(web::Data::new(state))
+            .service(web::resource("").route(web::get().to(health_check::health)))
+            .service(web::resource("/ready").route(web::get().to(health_check::deep_health_check)))
     }
 }

--- a/crates/observability/src/routes/app.rs
+++ b/crates/observability/src/routes/app.rs
@@ -1,5 +1,3 @@
-//! The whole route tree, in one place.
-
 use actix_multipart::form::MultipartFormConfig;
 use actix_web::{web, Scope};
 
@@ -10,11 +8,9 @@ use crate::{
     state::AppState,
 };
 
-/// The service's routes, all of them behind the internal API key.
 pub struct Alerts;
 
 impl Alerts {
-    /// Build the guarded scope.
     pub fn server(state: AppState) -> Scope {
         let max_upload_bytes = state.conf.chat.get_inner().max_upload_bytes;
 
@@ -38,7 +34,6 @@ impl Alerts {
     }
 }
 
-/// Make a malformed body render like every other error this service returns.
 fn json_config() -> web::JsonConfig {
     web::JsonConfig::default().error_handler(|error, request| {
         logger::warn!(
@@ -75,11 +70,9 @@ fn multipart_config(max_upload_bytes: usize) -> MultipartFormConfig {
         })
 }
 
-/// Liveness, deliberately unauthenticated.
 pub struct Health;
 
 impl Health {
-    /// Build the unguarded health scope.
     pub fn server(state: AppState) -> Scope {
         web::scope("health")
             .app_data(web::Data::new(state))

--- a/crates/observability/src/routes/app.rs
+++ b/crates/observability/src/routes/app.rs
@@ -1,12 +1,4 @@
 //! The whole route tree, in one place.
-//!
-//! Every route this service serves is visible in this file — mirroring
-//! `crates/router/src/routes/app.rs`, where each area is a unit struct with a `server()` returning
-//! its [`Scope`]. Handlers live in the sibling modules; only the shape of the tree lives here, so
-//! "what does this service expose, and what guards it?" is one file, not a search.
-//!
-//! Exposed as `Scope` factories rather than as an assembled `App` so that the standalone binary
-//! and a future in-router mount share one definition and cannot drift.
 
 use actix_multipart::form::MultipartFormConfig;
 use actix_web::{web, Scope};
@@ -23,14 +15,6 @@ pub struct Alerts;
 
 impl Alerts {
     /// Build the guarded scope.
-    ///
-    /// Everything mounted here is authenticated. Anything that must be reachable without
-    /// credentials belongs in [`Health`] instead — not as a path exception inside a guard, which
-    /// is where auth bypasses come from.
-    ///
-    /// The path carries both facts: which channel, and which destination within it. The body is
-    /// content only. See [`crate::types`] for why the destination is not a body field, and why a
-    /// provider refusing a message comes back as a `200` rather than an error.
     pub fn server(state: AppState) -> Scope {
         let max_upload_bytes = state.conf.chat.get_inner().max_upload_bytes;
 
@@ -55,13 +39,6 @@ impl Alerts {
 }
 
 /// Make a malformed body render like every other error this service returns.
-///
-/// Without this, actix answers its own plain-text 400 and a caller has two error formats to parse
-/// depending on how wrong it got things.
-///
-/// The parse failure itself goes to the log and not to the client, following
-/// [`crate::services::server_wrap`]: serde's message quotes the offending part of the body, and a
-/// body here carries merchant ids and payment volumes.
 fn json_config() -> web::JsonConfig {
     web::JsonConfig::default().error_handler(|error, request| {
         logger::warn!(
@@ -103,11 +80,6 @@ pub struct Health;
 
 impl Health {
     /// Build the unguarded health scope.
-    ///
-    /// Separate from [`Alerts`] because probes do not carry credentials. Keeping it a distinct
-    /// scope makes "unauthenticated" a structural property visible right here in the route tree,
-    /// rather than a condition buried in a guard — so it stays true when someone adds `/healthz`,
-    /// a trailing slash, or a route next to this one.
     pub fn server(state: AppState) -> Scope {
         web::scope("health")
             .app_data(web::Data::new(state))

--- a/crates/observability/src/routes/health_check.rs
+++ b/crates/observability/src/routes/health_check.rs
@@ -1,15 +1,67 @@
 //! Health handlers. The route tree that mounts them is in [`crate::routes::app`].
 //!
-//! Liveness only. A readiness check that dials the chat provider and the mail backend sounds
-//! thorough and turns every third-party blip into a restart loop; the point of this service is to
-//! be up when its dependencies are flaky.
+//! Two probes, answering different questions.
+//!
+//! [`health`] is **liveness**: is the process running. It touches nothing. A liveness check that
+//! dialled the chat provider and the mail backend would sound thorough and turn every third-party
+//! blip into a restart loop; the point of this service is to be up when its dependencies are
+//! flaky.
+//!
+//! [`deep_health_check`] is **readiness**: can this instance do its job. It checks the database and
+//! only the database — chat and email are destinations this service delivers *to*, and a failing
+//! one is already reported per request, but without its own state store there is nothing to serve.
+//!
+//! The split is what lets the pool be built without connecting: a database briefly away makes an
+//! instance unready, which stops traffic, rather than dead, which restarts it. Mirrors the router's
+//! `/health` and `/health/ready` pair.
 
+use std::time::Duration;
+
+use actix_web::web;
 use router_env::{instrument, tracing};
 
-use crate::logger;
+use crate::{logger, state::AppState};
+
+/// How long the probe waits for a connection before answering unready.
+///
+/// Deliberately shorter than the pool's own connection timeout. `Pool::get` waits that full budget
+/// before giving up, so a probe inheriting it answers long after a `timeoutSeconds: 1` readiness
+/// check has already given up and recorded nothing — the 503 would never be seen.
+const PROBE_BUDGET: Duration = Duration::from_millis(900);
 
 #[instrument(skip_all)]
 pub async fn health() -> impl actix_web::Responder {
     logger::info!("Observability health was called");
     actix_web::HttpResponse::Ok().body("Observability health is good")
+}
+
+/// Report whether this instance can reach the observability database.
+///
+/// Answers `503` rather than `500` when it cannot: the service itself is fine, and the condition is
+/// expected to clear without intervention. The reason reaches the log and not the body — a probe
+/// response is read by anyone who can reach the port, and a connection error names the host, the
+/// database and the role.
+#[instrument(skip_all)]
+pub async fn deep_health_check(state: web::Data<AppState>) -> impl actix_web::Responder {
+    match tokio::time::timeout(PROBE_BUDGET, state.database.get()).await {
+        Err(_elapsed) => {
+            logger::error!("Observability deep health check timed out taking a connection");
+            return actix_web::HttpResponse::ServiceUnavailable()
+                .body("Observability database is unreachable");
+        }
+        Ok(result) => match result {
+            Ok(_connection) => {
+                logger::info!("Observability deep health check passed");
+                actix_web::HttpResponse::Ok().body("Observability deep health is good")
+            }
+            Err(error) => {
+                logger::error!(
+                    ?error,
+                    "Observability deep health check failed: database unreachable"
+                );
+                actix_web::HttpResponse::ServiceUnavailable()
+                    .body("Observability database is unreachable")
+            }
+        },
+    }
 }

--- a/crates/observability/src/routes/health_check.rs
+++ b/crates/observability/src/routes/health_check.rs
@@ -1,5 +1,3 @@
-//! Two probes.
-
 use std::time::Duration;
 
 use actix_web::web;
@@ -7,7 +5,6 @@ use router_env::{instrument, tracing};
 
 use crate::{logger, state::AppState};
 
-/// How long the probe waits for a connection before answering unready.
 const PROBE_BUDGET: Duration = Duration::from_millis(900);
 
 #[instrument(skip_all)]
@@ -16,7 +13,6 @@ pub async fn health() -> impl actix_web::Responder {
     actix_web::HttpResponse::Ok().body("Observability health is good")
 }
 
-/// Report whether this instance can reach the observability database.
 #[instrument(skip_all)]
 pub async fn deep_health_check(state: web::Data<AppState>) -> impl actix_web::Responder {
     match tokio::time::timeout(PROBE_BUDGET, state.database.get()).await {

--- a/crates/observability/src/routes/health_check.rs
+++ b/crates/observability/src/routes/health_check.rs
@@ -1,11 +1,4 @@
-//! Two probes. [`health`] is liveness - it touches nothing, because a liveness check that dialled
-//! the chat provider would turn every third-party blip into a restart loop. [`deep_health_check`]
-//! is readiness and checks the database only: chat and email are destinations this service
-//! delivers to and a failing one is already reported per request, but without its own state store
-//! there is nothing to serve.
-//!
-//! That split is what lets the pool be built without connecting - a database briefly away makes an
-//! instance unready rather than dead. Mirrors the router's `/health` and `/health/ready`.
+//! Two probes.
 
 use std::time::Duration;
 
@@ -15,10 +8,6 @@ use router_env::{instrument, tracing};
 use crate::{logger, state::AppState};
 
 /// How long the probe waits for a connection before answering unready.
-///
-/// Deliberately shorter than the pool's own connection timeout. `Pool::get` waits that full budget
-/// before giving up, so a probe inheriting it answers long after a `timeoutSeconds: 1` readiness
-/// check has already given up and recorded nothing — the 503 would never be seen.
 const PROBE_BUDGET: Duration = Duration::from_millis(900);
 
 #[instrument(skip_all)]
@@ -28,11 +17,6 @@ pub async fn health() -> impl actix_web::Responder {
 }
 
 /// Report whether this instance can reach the observability database.
-///
-/// Answers `503` rather than `500` when it cannot: the service itself is fine, and the condition is
-/// expected to clear without intervention. The reason reaches the log and not the body — a probe
-/// response is read by anyone who can reach the port, and a connection error names the host, the
-/// database and the role.
 #[instrument(skip_all)]
 pub async fn deep_health_check(state: web::Data<AppState>) -> impl actix_web::Responder {
     match tokio::time::timeout(PROBE_BUDGET, state.database.get()).await {

--- a/crates/observability/src/routes/health_check.rs
+++ b/crates/observability/src/routes/health_check.rs
@@ -1,19 +1,11 @@
-//! Health handlers. The route tree that mounts them is in [`crate::routes::app`].
+//! Two probes. [`health`] is liveness - it touches nothing, because a liveness check that dialled
+//! the chat provider would turn every third-party blip into a restart loop. [`deep_health_check`]
+//! is readiness and checks the database only: chat and email are destinations this service
+//! delivers to and a failing one is already reported per request, but without its own state store
+//! there is nothing to serve.
 //!
-//! Two probes, answering different questions.
-//!
-//! [`health`] is **liveness**: is the process running. It touches nothing. A liveness check that
-//! dialled the chat provider and the mail backend would sound thorough and turn every third-party
-//! blip into a restart loop; the point of this service is to be up when its dependencies are
-//! flaky.
-//!
-//! [`deep_health_check`] is **readiness**: can this instance do its job. It checks the database and
-//! only the database — chat and email are destinations this service delivers *to*, and a failing
-//! one is already reported per request, but without its own state store there is nothing to serve.
-//!
-//! The split is what lets the pool be built without connecting: a database briefly away makes an
-//! instance unready, which stops traffic, rather than dead, which restarts it. Mirrors the router's
-//! `/health` and `/health/ready` pair.
+//! That split is what lets the pool be built without connecting - a database briefly away makes an
+//! instance unready rather than dead. Mirrors the router's `/health` and `/health/ready`.
 
 use std::time::Duration;
 

--- a/crates/observability/src/secrets_transformers.rs
+++ b/crates/observability/src/secrets_transformers.rs
@@ -1,9 +1,4 @@
 //! Resolving secret values at boot.
-//!
-//! In release builds the values in `observability.toml` may be KMS handles rather than the secrets
-//! themselves. This module performs the one-time transition from `Settings<SecuredSecret>` to
-//! `Settings<RawSecret>`, so that everything downstream is statically known to hold resolved
-//! values. Mirrors `drainer::secrets_transformers`.
 
 use std::collections::HashMap;
 
@@ -53,10 +48,6 @@ impl SecretsHandler for AuthSettings {
 }
 
 /// Chat credentials are resolved one destination at a time.
-///
-/// Sequentially rather than concurrently: this runs once, at boot, against a handful of
-/// destinations, and a failure that names the destination it came from is worth more here than the
-/// milliseconds a join would save.
 #[async_trait::async_trait]
 impl SecretsHandler for ChatSettings {
     async fn convert_to_raw_secret(
@@ -96,12 +87,6 @@ impl SecretsHandler for ChatSettings {
 }
 
 /// Resolve every secret in the configuration.
-///
-/// # Panics
-///
-/// Panics if any secret fails to resolve, or if a resolved secret is unusable. This is
-/// deliberate: a service that cannot read its own API key must not start, and there is no
-/// partially-configured state worth serving traffic from.
 pub async fn fetch_raw_secrets(
     conf: Settings<SecuredSecret>,
     secret_management_client: &dyn SecretManagementInterface,
@@ -111,11 +96,7 @@ pub async fn fetch_raw_secrets(
         .await
         .expect("Failed to decrypt auth internal api key");
 
-    // Re-validate *after* decryption. The check in `main` ran against the `SecuredSecret` value,
-    // which under a KMS backend is a handle, not the key — and a perfectly well-formed handle can
-    // resolve to an empty string. Without this, the service would start with an empty configured
-    // key, and an empty `X-Internal-Api-Key` header would compare equal to it: every request
-    // authenticated. The boot-time check must therefore happen on both sides of the transition.
+    // Re-validate *after* decryption.
     #[allow(clippy::expect_used)]
     auth.get_inner()
         .validate()
@@ -131,10 +112,7 @@ pub async fn fetch_raw_secrets(
         .await
         .expect("Failed to decrypt the database password");
 
-    // Re-validate after decryption, for the reason given above: a well-formed handle can resolve
-    // to an empty string. An empty password would not fail here but at connection time, as an
-    // authentication error against the cluster — which reads as a wrong credential rather than an
-    // absent one.
+    // Re-validate after decryption, for the reason given above:
     #[allow(clippy::expect_used)]
     database
         .get_inner()

--- a/crates/observability/src/secrets_transformers.rs
+++ b/crates/observability/src/secrets_transformers.rs
@@ -15,7 +15,25 @@ use hyperswitch_interfaces::secrets_interface::{
     SecretManagementInterface, SecretsManagementError,
 };
 
-use crate::settings::{AuthSettings, ChatDestination, ChatSettings, Settings};
+use crate::settings::{AuthSettings, ChatDestination, ChatSettings, DatabaseSettings, Settings};
+
+#[async_trait::async_trait]
+impl SecretsHandler for DatabaseSettings {
+    async fn convert_to_raw_secret(
+        value: SecretStateContainer<Self, SecuredSecret>,
+        secret_management_client: &dyn SecretManagementInterface,
+    ) -> CustomResult<SecretStateContainer<Self, RawSecret>, SecretsManagementError> {
+        let secured_database_config = value.get_inner();
+        let raw_password = secret_management_client
+            .get_secret(secured_database_config.password.clone())
+            .await?;
+
+        Ok(value.transition_state(|database| Self {
+            password: raw_password,
+            ..database
+        }))
+    }
+}
 
 #[async_trait::async_trait]
 impl SecretsHandler for AuthSettings {
@@ -108,10 +126,26 @@ pub async fn fetch_raw_secrets(
         .await
         .expect("Failed to decrypt a chat destination credential");
 
+    #[allow(clippy::expect_used)]
+    let database = DatabaseSettings::convert_to_raw_secret(conf.database, secret_management_client)
+        .await
+        .expect("Failed to decrypt the database password");
+
+    // Re-validate after decryption, for the reason given above: a well-formed handle can resolve
+    // to an empty string. An empty password would not fail here but at connection time, as an
+    // authentication error against the cluster — which reads as a wrong credential rather than an
+    // absent one.
+    #[allow(clippy::expect_used)]
+    database
+        .get_inner()
+        .validate()
+        .expect("Decrypted database password is unusable");
+
     Settings {
         server: conf.server,
         log: conf.log,
         auth,
+        database,
         secrets_management: conf.secrets_management,
         proxy: conf.proxy,
         chat,

--- a/crates/observability/src/secrets_transformers.rs
+++ b/crates/observability/src/secrets_transformers.rs
@@ -1,5 +1,3 @@
-//! Resolving secret values at boot.
-
 use std::collections::HashMap;
 
 use common_utils::errors::CustomResult;
@@ -47,7 +45,6 @@ impl SecretsHandler for AuthSettings {
     }
 }
 
-/// Chat credentials are resolved one destination at a time.
 #[async_trait::async_trait]
 impl SecretsHandler for ChatSettings {
     async fn convert_to_raw_secret(
@@ -71,7 +68,6 @@ impl SecretsHandler for ChatSettings {
                         .await?,
                     ..config.clone()
                 }),
-                // Holds no credential, so there is nothing to resolve.
                 ChatDestination::Log => ChatDestination::Log,
             };
 
@@ -86,7 +82,6 @@ impl SecretsHandler for ChatSettings {
     }
 }
 
-/// Resolve every secret in the configuration.
 pub async fn fetch_raw_secrets(
     conf: Settings<SecuredSecret>,
     secret_management_client: &dyn SecretManagementInterface,
@@ -96,7 +91,6 @@ pub async fn fetch_raw_secrets(
         .await
         .expect("Failed to decrypt auth internal api key");
 
-    // Re-validate *after* decryption.
     #[allow(clippy::expect_used)]
     auth.get_inner()
         .validate()
@@ -112,7 +106,6 @@ pub async fn fetch_raw_secrets(
         .await
         .expect("Failed to decrypt the database password");
 
-    // Re-validate after decryption, for the reason given above:
     #[allow(clippy::expect_used)]
     database
         .get_inner()

--- a/crates/observability/src/settings.rs
+++ b/crates/observability/src/settings.rs
@@ -1,13 +1,11 @@
 //! Application configuration.
 //!
-//! Read from `config/observability.toml` (override with `-f`), with every value overridable by an
+//! Read from `config/observability.toml` (override with `-f`), every value overridable by an
 //! `OBSERVABILITY__`-prefixed environment variable using `__` to separate levels.
 //!
-//! [`Settings`] is generic over [`SecretState`]: it is deserialized as `Settings<SecuredSecret>`,
-//! where secret values may be KMS handles, and transitions to `Settings<RawSecret>` at boot once
-//! those handles have been resolved. See [`crate::secrets_transformers`]. Only a `RawSecret`
-//! configuration can be used to serve requests, so "did we remember to decrypt this?" is answered
-//! by the type checker rather than by review.
+//! [`Settings`] is generic over [`SecretState`]: deserialized as `Settings<SecuredSecret>` and
+//! transitioned to `Settings<RawSecret>` at boot once KMS handles resolve, so "did we remember to
+//! decrypt this?" is answered by the type checker. See [`crate::secrets_transformers`].
 
 use std::{collections::HashMap, path::PathBuf};
 
@@ -78,13 +76,10 @@ fn default_max_upload_bytes() -> usize {
 pub struct ChatSettings {
     /// Every chat destination, by id.
     ///
-    /// **Ids arriving from the environment are lowercased and cannot contain `__`.** The `config`
-    /// crate lowercases every environment key before splitting it (`config-0.14.1/src/env.rs`),
-    /// and `__` is the level separator, so
-    /// `OBSERVABILITY__CHAT__DESTINATIONS__SR_ALERTS__CHANNEL` sets
-    /// `chat.destinations.sr_alerts.channel` and there is no spelling that yields `SR_ALERTS` or
-    /// `sr__alerts`. [`ChatSettings::validate`] rejects an id that cannot survive the round trip,
-    /// so this is a boot failure rather than a lookup that mysteriously misses.
+    /// Ids from the environment are lowercased and cannot contain `__`: the `config` crate
+    /// lowercases every env key before splitting and `__` is the level separator, so no spelling
+    /// yields `SR_ALERTS`. [`ChatSettings::validate`] rejects such an id at boot rather than
+    /// leaving a lookup to miss silently.
     pub destinations: HashMap<String, ChatDestination>,
 
     /// Maximum multipart body bytes accepted by the upload route.
@@ -125,14 +120,12 @@ pub enum ChatDestination {
 pub struct EmailSettings {
     /// The transport, shared by every destination: which backend, and who mail comes from.
     ///
-    /// `external_services`' own type, reused wholesale rather than mirrored, so the SES / SMTP /
-    /// no-email selection and its validation come for free and cannot drift from the router's. It
-    /// carries a few fields this service has no use for (`allowed_unverified_days`, the two recon
-    /// recipient addresses); they default and are ignored, which is a smaller price than a second
-    /// representation of the same configuration.
+    /// `external_services`' own type, reused wholesale so the SES / SMTP / no-email selection and
+    /// its validation cannot drift from the router's. A few of its fields are unused here and
+    /// default.
     ///
-    /// Defaults to `NO_EMAIL_CLIENT`, which accepts and logs. That is the off switch: it needs no
-    /// flag of its own, and it is what a deployment runs with before SES credentials exist.
+    /// Defaults to `NO_EMAIL_CLIENT`, which accepts and logs - the off switch, and what a
+    /// deployment runs before SES credentials exist.
     #[serde(flatten)]
     pub client: EmailClientSettings,
 
@@ -145,10 +138,9 @@ pub struct EmailSettings {
 pub struct EmailDestination {
     /// Where the alert goes.
     ///
-    /// A single address, because `EmailClient::send_email` accepts one and both backends build a
-    /// single-recipient message. Reaching three people is three destinations today; when
-    /// a follow-up ticket lands this widens to a list and no caller changes, since a request
-    /// only ever names an id.
+    /// A single address: `EmailClient::send_email` accepts one. Reaching three people is three
+    /// destinations today; widening to a list later changes no caller, since a request only ever
+    /// names an id.
     pub to: pii::Email,
 }
 
@@ -186,10 +178,8 @@ impl EmailSettings {
     /// Reject destination ids that cannot be set from the environment, an unusable transport, and
     /// a destination with no address.
     ///
-    /// The transport check is `external_services`' own, so SES and SMTP are validated exactly as
-    /// the router validates them. It runs only when destinations exist: a deployment with none has
-    /// nothing to misconfigure, and demanding a verified SES sender before anyone has asked for an
-    /// email would make the service undeployable for no gain.
+    /// The transport check is `external_services`' own, and runs only when destinations exist: a
+    /// deployment with none would otherwise need a verified SES sender to be deployable at all.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         validate_destination_ids(&self.destinations, "email")?;
 
@@ -236,9 +226,8 @@ impl EmailSettings {
 pub struct AuthSettings {
     /// The key callers must supply in the `X-Internal-Api-Key` header.
     ///
-    /// Deliberately *not* the router's `secrets.admin_api_key`: reusing that would mean anyone
-    /// holding admin credentials could send alerts, and would tie this service's rotation
-    /// schedule to the router's.
+    /// Deliberately *not* the router's `secrets.admin_api_key`: that would let any admin
+    /// credential send alerts, and tie this service's rotation to the router's.
     pub internal_api_key: Secret<String>,
 }
 
@@ -309,9 +298,8 @@ pub struct DatabaseSettings {
 
 /// Percent-encode a connection-string component.
 ///
-/// A generated password routinely contains `/`, `@`, `?` or `#`, and each of those ends a field in
-/// a URI: libpq would read the host, the database and the query parameters from the wrong side of
-/// the character. Encoding is what makes a correct password a correct URL.
+/// A generated password routinely contains `/`, `@`, `?` or `#`, each of which ends a field in a
+/// URI - libpq would read the host, database and query parameters from the wrong side of it.
 fn encode(value: &str) -> String {
     value
         .bytes()

--- a/crates/observability/src/settings.rs
+++ b/crates/observability/src/settings.rs
@@ -1,5 +1,3 @@
-//! Application configuration.
-
 use std::{collections::HashMap, path::PathBuf};
 
 use common_utils::{ext_traits::ConfigExt, pii};
@@ -20,37 +18,25 @@ use serde::Deserialize;
 
 use crate::errors;
 
-/// The default configuration file name, looked up inside the config directory.
 const CONFIG_FILE_NAME: &str = "observability.toml";
 
-/// Command line arguments accepted by the standalone binary.
 #[derive(clap::Parser, Default)]
 #[cfg_attr(feature = "vergen", command(version = router_env::version!()))]
 pub struct CmdLineConf {
-    /// Config file.
     #[arg(short = 'f', long, value_name = "FILE")]
     pub config_path: Option<PathBuf>,
 }
 
-/// The whole configuration of the service.
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]
 pub struct Settings<S: SecretState> {
-    /// Listener configuration.
     pub server: Server,
-    /// Logging and telemetry.
     pub log: Log,
-    /// Credentials guarding this service's routes.
     pub auth: SecretStateContainer<AuthSettings, S>,
-    /// The observability database.
     pub database: SecretStateContainer<DatabaseSettings, S>,
-    /// How secret values in this file are resolved at boot.
     pub secrets_management: SecretsManagementConfig,
-    /// Outbound HTTP proxy.
     pub proxy: Proxy,
-    /// Chat destinations this service can deliver to.
     pub chat: SecretStateContainer<ChatSettings, S>,
-    /// Email destinations this service can deliver to.
     pub email: EmailSettings,
 }
 
@@ -60,14 +46,11 @@ fn default_max_upload_bytes() -> usize {
     DEFAULT_MAX_UPLOAD_BYTES
 }
 
-/// Chat destinations, keyed by the id a request names.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct ChatSettings {
-    /// Every chat destination, by id.
     pub destinations: HashMap<String, ChatDestination>,
 
-    /// Maximum multipart body bytes accepted by the upload route.
     #[serde(default = "default_max_upload_bytes")]
     pub max_upload_bytes: usize,
 }
@@ -81,38 +64,28 @@ impl Default for ChatSettings {
     }
 }
 
-/// One chat destination, tagged by the kind of backend it talks to.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChatDestination {
-    /// A Xyne channel.
     Xyne(XyneConfig),
-    /// A Slack channel.
     Slack(SlackConfig),
-    /// Accepts messages and delivers nothing.
     Log,
 }
 
-/// Email destinations and the transport that serves them.
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]
 pub struct EmailSettings {
-    /// The transport, shared by every destination:
     #[serde(flatten)]
     pub client: EmailClientSettings,
 
-    /// Every email destination, by id.
     pub destinations: HashMap<String, EmailDestination>,
 }
 
-/// One email destination.
 #[derive(Debug, Deserialize, Clone)]
 pub struct EmailDestination {
-    /// Where the alert goes.
     pub to: pii::Email,
 }
 
-/// Ids are addressed by callers and set from the environment, so they must survive both.
 fn validate_destination_ids<T>(
     destinations: &HashMap<String, T>,
     section: &str,
@@ -129,7 +102,6 @@ fn validate_destination_ids<T>(
 }
 
 impl ChatSettings {
-    /// Reject destination ids that cannot be set from the environment.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         validate_destination_ids(&self.destinations, "chat")?;
         common_utils::fp_utils::when(self.max_upload_bytes == 0, || {
@@ -141,7 +113,6 @@ impl ChatSettings {
 }
 
 impl EmailSettings {
-    /// Reject destination ids that cannot be set from the environment, an unusable transport, and a destination with no address.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         validate_destination_ids(&self.destinations, "email")?;
 
@@ -153,7 +124,6 @@ impl EmailSettings {
             .validate()
             .map_err(|error| errors::ConfigurationError::ConfigParsingError(error.to_owned()))?;
 
-        // `EmailSettings::validate` checks only the backend-specific section — SES's role ARN, SMTP's host — and never the shared sender.
         common_utils::fp_utils::when(
             !matches!(self.client.client_config, EmailClientConfigs::NoEmailClient)
                 && !crate::domain::notifier::email::is_usable_recipient(&self.client.sender_email),
@@ -179,11 +149,9 @@ impl EmailSettings {
     }
 }
 
-/// Credentials guarding this service's routes.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct AuthSettings {
-    /// The key callers must supply in the `X-Internal-Api-Key` header.
     pub internal_api_key: Secret<String>,
 }
 
@@ -196,7 +164,6 @@ impl Default for AuthSettings {
 }
 
 impl AuthSettings {
-    /// Reject an absent internal API key.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         common_utils::fp_utils::when(self.internal_api_key.peek().is_default_or_empty(), || {
             Err(errors::ConfigurationError::ConfigParsingError(
@@ -206,10 +173,8 @@ impl AuthSettings {
     }
 }
 
-/// Default pool size.
 const DEFAULT_POOL_SIZE: u32 = 5;
 
-/// Default seconds to wait for a connection before giving up.
 const DEFAULT_CONNECTION_TIMEOUT: u64 = 10;
 
 fn default_pool_size() -> u32 {
@@ -220,29 +185,20 @@ fn default_connection_timeout() -> u64 {
     DEFAULT_CONNECTION_TIMEOUT
 }
 
-/// The observability database.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct DatabaseSettings {
-    /// Hostname of the cluster.
     pub host: String,
-    /// Port the cluster listens on.
     pub port: u16,
-    /// The database within the cluster.
     pub dbname: String,
-    /// The role this service connects as.
     pub username: String,
-    /// The role's password.
     pub password: Secret<String>,
-    /// Connections held open.
     #[serde(default = "default_pool_size")]
     pub pool_size: u32,
-    /// Seconds to wait for a connection from the pool before giving up.
     #[serde(default = "default_connection_timeout")]
     pub connection_timeout: u64,
 }
 
-/// Percent-encode a connection-string component.
 fn encode(value: &str) -> String {
     value
         .bytes()
@@ -255,7 +211,6 @@ fn encode(value: &str) -> String {
         .collect()
 }
 
-/// Hand-written so that `Default` and the `#[serde(default = ...)]` attributes agree.
 impl Default for DatabaseSettings {
     fn default() -> Self {
         Self {
@@ -271,7 +226,6 @@ impl Default for DatabaseSettings {
 }
 
 impl DatabaseSettings {
-    /// The connection string.
     pub fn database_url(&self) -> String {
         format!(
             "postgres://{}:{}@{}:{}/{}?application_name=observability",
@@ -283,7 +237,6 @@ impl DatabaseSettings {
         )
     }
 
-    /// Reject a configuration that cannot connect.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         common_utils::fp_utils::when(self.host.is_default_or_empty(), || {
             Err(errors::ConfigurationError::ConfigParsingError(
@@ -321,7 +274,6 @@ impl DatabaseSettings {
             ))
         })?;
 
-        // bb8 asserts both of these are non-zero when the pool is built, and an assert names neither the key nor the file it came from.
         common_utils::fp_utils::when(self.connection_timeout == 0, || {
             Err(errors::ConfigurationError::ConfigParsingError(
                 "database connection_timeout must be greater than zero".into(),
@@ -330,15 +282,11 @@ impl DatabaseSettings {
     }
 }
 
-/// Listener configuration for the standalone binary.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct Server {
-    /// Port to bind to.
     pub port: u16,
-    /// Number of actix workers.
     pub workers: usize,
-    /// Host to bind to.
     pub host: String,
 }
 
@@ -353,7 +301,6 @@ impl Default for Server {
 }
 
 impl Server {
-    /// Reject an empty bind host.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         common_utils::fp_utils::when(self.host.is_default_or_empty(), || {
             Err(errors::ConfigurationError::ConfigParsingError(
@@ -364,12 +311,10 @@ impl Server {
 }
 
 impl Settings<SecuredSecret> {
-    /// Read configuration from the default location.
     pub fn new() -> Result<Self, errors::ConfigurationError> {
         Self::with_config_path(None)
     }
 
-    /// Read configuration, optionally from an explicit path.
     pub fn with_config_path(
         explicit_config_path: Option<PathBuf>,
     ) -> Result<Self, errors::ConfigurationError> {
@@ -386,7 +331,6 @@ impl Settings<SecuredSecret> {
             )
             .build()?;
 
-        // The logger may not yet be initialized when constructing the application configuration
         #[allow(clippy::print_stderr)]
         serde_path_to_error::deserialize(config).map_err(|error| {
             logger::error!(%error, "Unable to deserialize application configuration");
@@ -395,7 +339,6 @@ impl Settings<SecuredSecret> {
         })
     }
 
-    /// Reject an unusable configuration.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         self.server.validate()?;
         self.auth.get_inner().validate()?;
@@ -431,7 +374,6 @@ mod tests {
             .unwrap();
     }
 
-    /// Each of these is a lookup that would silently miss when the id came from the environment, because `config` lowercases keys and splits on `__`.
     #[test]
     fn ids_that_cannot_round_trip_through_the_environment_are_rejected() {
         for id in ["SR_ALERTS", "sr__alerts", ""] {
@@ -442,7 +384,6 @@ mod tests {
         }
     }
 
-    /// The tag is what makes Xyne and Slack two variants of one client rather than two integrations, and `log` has to sit in the same enum or the delivery path grows a branch.
     #[test]
     fn a_zero_upload_cap_is_rejected() {
         let settings = ChatSettings {
@@ -488,7 +429,6 @@ mod tests {
         }
     }
 
-    /// Every one of these fails at connection time rather than at boot, and a connection failure names a host and a role — so it reads as a wrong credential rather than an absent one, at whatever hour the first alert run happens to be.
     #[test]
     fn an_incomplete_database_configuration_fails_the_boot() {
         let cases: [(&str, DatabaseSettings); 5] = [
@@ -537,7 +477,6 @@ mod tests {
         }
     }
 
-    /// A pool of zero connections never serves a query and never errors either:
     #[test]
     fn a_zero_pool_size_fails_the_boot() {
         assert!(DatabaseSettings {
@@ -553,7 +492,6 @@ mod tests {
         assert!(database().validate().is_ok());
     }
 
-    /// On a shared cluster `pg_stat_activity` has to be able to answer whose connections are whose.
     #[test]
     fn the_connection_string_names_the_application() {
         assert!(database()
@@ -561,7 +499,6 @@ mod tests {
             .contains("application_name=observability"));
     }
 
-    /// The password reaches the log the moment someone debugs the configuration, unless the type prevents it.
     #[test]
     fn the_database_password_is_not_in_the_debug_output() {
         let rendered = format!("{:?}", database());

--- a/crates/observability/src/settings.rs
+++ b/crates/observability/src/settings.rs
@@ -1,11 +1,4 @@
 //! Application configuration.
-//!
-//! Read from `config/observability.toml` (override with `-f`), every value overridable by an
-//! `OBSERVABILITY__`-prefixed environment variable using `__` to separate levels.
-//!
-//! [`Settings`] is generic over [`SecretState`]: deserialized as `Settings<SecuredSecret>` and
-//! transitioned to `Settings<RawSecret>` at boot once KMS handles resolve, so "did we remember to
-//! decrypt this?" is answered by the type checker. See [`crate::secrets_transformers`].
 
 use std::{collections::HashMap, path::PathBuf};
 
@@ -35,7 +28,6 @@ const CONFIG_FILE_NAME: &str = "observability.toml";
 #[cfg_attr(feature = "vergen", command(version = router_env::version!()))]
 pub struct CmdLineConf {
     /// Config file.
-    /// Application will look for "config/observability.toml" if this option isn't specified.
     #[arg(short = 'f', long, value_name = "FILE")]
     pub config_path: Option<PathBuf>,
 }
@@ -44,19 +36,17 @@ pub struct CmdLineConf {
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]
 pub struct Settings<S: SecretState> {
-    /// Listener configuration. Meaningful only in standalone mode — when the crate is mounted in
-    /// the router, the router owns the listener and this section is ignored.
+    /// Listener configuration.
     pub server: Server,
     /// Logging and telemetry.
     pub log: Log,
     /// Credentials guarding this service's routes.
     pub auth: SecretStateContainer<AuthSettings, S>,
-    /// The observability database. Its schema lives in `diesel_models::observability`.
+    /// The observability database.
     pub database: SecretStateContainer<DatabaseSettings, S>,
     /// How secret values in this file are resolved at boot.
     pub secrets_management: SecretsManagementConfig,
-    /// Outbound HTTP proxy. A deployment fact rather than a property of any destination, which is
-    /// why it sits here and is handed to every chat client rather than repeated per destination.
+    /// Outbound HTTP proxy.
     pub proxy: Proxy,
     /// Chat destinations this service can deliver to.
     pub chat: SecretStateContainer<ChatSettings, S>,
@@ -75,11 +65,6 @@ fn default_max_upload_bytes() -> usize {
 #[serde(default)]
 pub struct ChatSettings {
     /// Every chat destination, by id.
-    ///
-    /// Ids from the environment are lowercased and cannot contain `__`: the `config` crate
-    /// lowercases every env key before splitting and `__` is the level separator, so no spelling
-    /// yields `SR_ALERTS`. [`ChatSettings::validate`] rejects such an id at boot rather than
-    /// leaving a lookup to miss silently.
     pub destinations: HashMap<String, ChatDestination>,
 
     /// Maximum multipart body bytes accepted by the upload route.
@@ -97,9 +82,6 @@ impl Default for ChatSettings {
 }
 
 /// One chat destination, tagged by the kind of backend it talks to.
-///
-/// Xyne and Slack are the same protocol with a different base URL and credential, so they are two
-/// variants over one client rather than two integrations.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChatDestination {
@@ -108,9 +90,6 @@ pub enum ChatDestination {
     /// A Slack channel.
     Slack(SlackConfig),
     /// Accepts messages and delivers nothing.
-    ///
-    /// For exercising the path before credentials exist. A destination *type* rather than a flag
-    /// on a real destination, so the delivery path never has to ask whether it is pretending.
     Log,
 }
 
@@ -118,18 +97,11 @@ pub enum ChatDestination {
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]
 pub struct EmailSettings {
-    /// The transport, shared by every destination: which backend, and who mail comes from.
-    ///
-    /// `external_services`' own type, reused wholesale so the SES / SMTP / no-email selection and
-    /// its validation cannot drift from the router's. A few of its fields are unused here and
-    /// default.
-    ///
-    /// Defaults to `NO_EMAIL_CLIENT`, which accepts and logs - the off switch, and what a
-    /// deployment runs before SES credentials exist.
+    /// The transport, shared by every destination:
     #[serde(flatten)]
     pub client: EmailClientSettings,
 
-    /// Every email destination, by id. Same id constraints as [`ChatSettings::destinations`].
+    /// Every email destination, by id.
     pub destinations: HashMap<String, EmailDestination>,
 }
 
@@ -137,16 +109,10 @@ pub struct EmailSettings {
 #[derive(Debug, Deserialize, Clone)]
 pub struct EmailDestination {
     /// Where the alert goes.
-    ///
-    /// A single address: `EmailClient::send_email` accepts one. Reaching three people is three
-    /// destinations today; widening to a list later changes no caller, since a request only ever
-    /// names an id.
     pub to: pii::Email,
 }
 
-/// Ids are addressed by callers and set from the environment, so they must survive both. `config`
-/// lowercases environment keys and splits on `__`; an id that would come back different is
-/// rejected at boot rather than silently failing to match at lookup time.
+/// Ids are addressed by callers and set from the environment, so they must survive both.
 fn validate_destination_ids<T>(
     destinations: &HashMap<String, T>,
     section: &str,
@@ -175,11 +141,7 @@ impl ChatSettings {
 }
 
 impl EmailSettings {
-    /// Reject destination ids that cannot be set from the environment, an unusable transport, and
-    /// a destination with no address.
-    ///
-    /// The transport check is `external_services`' own, and runs only when destinations exist: a
-    /// deployment with none would otherwise need a verified SES sender to be deployable at all.
+    /// Reject destination ids that cannot be set from the environment, an unusable transport, and a destination with no address.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         validate_destination_ids(&self.destinations, "email")?;
 
@@ -191,10 +153,7 @@ impl EmailSettings {
             .validate()
             .map_err(|error| errors::ConfigurationError::ConfigParsingError(error.to_owned()))?;
 
-        // `EmailSettings::validate` checks only the backend-specific section — SES's role ARN,
-        // SMTP's host — and never the shared sender. It defaults to an empty `pii::Email`, which
-        // SMTP then fails on while building the `From` mailbox and SES submits as an empty sender.
-        // Without this, a missing `sender_email` boots cleanly and turns every alert into a 502.
+        // `EmailSettings::validate` checks only the backend-specific section — SES's role ARN, SMTP's host — and never the shared sender.
         common_utils::fp_utils::when(
             !matches!(self.client.client_config, EmailClientConfigs::NoEmailClient)
                 && !crate::domain::notifier::email::is_usable_recipient(&self.client.sender_email),
@@ -225,9 +184,6 @@ impl EmailSettings {
 #[serde(default)]
 pub struct AuthSettings {
     /// The key callers must supply in the `X-Internal-Api-Key` header.
-    ///
-    /// Deliberately *not* the router's `secrets.admin_api_key`: that would let any admin
-    /// credential send alerts, and tie this service's rotation to the router's.
     pub internal_api_key: Secret<String>,
 }
 
@@ -241,9 +197,6 @@ impl Default for AuthSettings {
 
 impl AuthSettings {
     /// Reject an absent internal API key.
-    ///
-    /// There is deliberately no way to disable authentication. An empty key does not mean "open"
-    /// — it means the service refuses to start.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         common_utils::fp_utils::when(self.internal_api_key.peek().is_default_or_empty(), || {
             Err(errors::ConfigurationError::ConfigParsingError(
@@ -253,9 +206,7 @@ impl AuthSettings {
     }
 }
 
-/// Default pool size. Small on purpose: the service issues a handful of queries per alert run, and
-/// the role it connects as carries a connection limit that the pool has to fit inside — alongside
-/// the migration job, which needs connections of its own at deploy time.
+/// Default pool size.
 const DEFAULT_POOL_SIZE: u32 = 5;
 
 /// Default seconds to wait for a connection before giving up.
@@ -270,9 +221,6 @@ fn default_connection_timeout() -> u64 {
 }
 
 /// The observability database.
-///
-/// Not `hyperswitch_db`: these tables live in their own database, so that alert state is not
-/// written into a store the application owns.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct DatabaseSettings {
@@ -280,13 +228,11 @@ pub struct DatabaseSettings {
     pub host: String,
     /// Port the cluster listens on.
     pub port: u16,
-    /// The database within the cluster. Not the schema — everything lives in `public`.
+    /// The database within the cluster.
     pub dbname: String,
-    /// The role this service connects as. Deliberately not the migration role: this one holds no
-    /// DDL rights, so a running service cannot alter the schema it reads.
+    /// The role this service connects as.
     pub username: String,
-    /// The role's password. Under a KMS backend this is ciphertext until [`crate::secrets_transformers`]
-    /// resolves it.
+    /// The role's password.
     pub password: Secret<String>,
     /// Connections held open.
     #[serde(default = "default_pool_size")]
@@ -297,9 +243,6 @@ pub struct DatabaseSettings {
 }
 
 /// Percent-encode a connection-string component.
-///
-/// A generated password routinely contains `/`, `@`, `?` or `#`, each of which ends a field in a
-/// URI - libpq would read the host, database and query parameters from the wrong side of it.
 fn encode(value: &str) -> String {
     value
         .bytes()
@@ -313,9 +256,6 @@ fn encode(value: &str) -> String {
 }
 
 /// Hand-written so that `Default` and the `#[serde(default = ...)]` attributes agree.
-///
-/// Deriving it would set `pool_size` and `connection_timeout` to zero, which the serde defaults
-/// exist to prevent and which bb8 asserts against — the same reason `ChatSettings` writes its own.
 impl Default for DatabaseSettings {
     fn default() -> Self {
         Self {
@@ -332,10 +272,6 @@ impl Default for DatabaseSettings {
 
 impl DatabaseSettings {
     /// The connection string.
-    ///
-    /// Not [`common_utils::DbConnectionParams::get_database_url`], which sets `application_name` to
-    /// the schema for the router's per-tenant `search_path`. Naming the application is what lets
-    /// `pg_stat_activity` attribute connections on a shared cluster.
     pub fn database_url(&self) -> String {
         format!(
             "postgres://{}:{}@{}:{}/{}?application_name=observability",
@@ -348,11 +284,6 @@ impl DatabaseSettings {
     }
 
     /// Reject a configuration that cannot connect.
-    ///
-    /// Checked before anything is dialled, so a missing value fails the boot rather than the first
-    /// query. Pool size is deliberately not checked against the role's connection limit: this
-    /// service cannot see that limit, and guessing would turn a database-side change into a
-    /// mystery boot failure.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         common_utils::fp_utils::when(self.host.is_default_or_empty(), || {
             Err(errors::ConfigurationError::ConfigParsingError(
@@ -390,9 +321,7 @@ impl DatabaseSettings {
             ))
         })?;
 
-        // bb8 asserts both of these are non-zero when the pool is built, and an assert names
-        // neither the key nor the file it came from. Rejecting them here turns a panic at boot
-        // into a message that says which setting is wrong.
+        // bb8 asserts both of these are non-zero when the pool is built, and an assert names neither the key nor the file it came from.
         common_utils::fp_utils::when(self.connection_timeout == 0, || {
             Err(errors::ConfigurationError::ConfigParsingError(
                 "database connection_timeout must be greater than zero".into(),
@@ -441,18 +370,6 @@ impl Settings<SecuredSecret> {
     }
 
     /// Read configuration, optionally from an explicit path.
-    ///
-    /// Values are resolved in the following priority order (1 being least priority):
-    ///
-    /// 1. Defaults from the implementation of the `Default` trait.
-    /// 2. Values from the config file — `config/observability.toml` unless overridden by `-f`. The
-    ///    config directory itself can be moved with the `CONFIG_DIR` environment variable.
-    /// 3. Environment variables prefixed with `OBSERVABILITY` and each level separated by double
-    ///    underscores, e.g. `OBSERVABILITY__AUTH__INTERNAL_API_KEY`.
-    ///
-    /// Unlike `drainer`, this service reads a file dedicated to it rather than the shared
-    /// per-environment config: it has no runnable defaults to fall back on, since there is no
-    /// sensible default for an API key.
     pub fn with_config_path(
         explicit_config_path: Option<PathBuf>,
     ) -> Result<Self, errors::ConfigurationError> {
@@ -479,10 +396,6 @@ impl Settings<SecuredSecret> {
     }
 
     /// Reject an unusable configuration.
-    ///
-    /// Called before anything is bound or connected, so that a misconfiguration surfaces as a
-    /// failure to start rather than as a failure on the first alert — by which time whoever
-    /// deployed it has stopped watching.
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         self.server.validate()?;
         self.auth.get_inner().validate()?;
@@ -518,8 +431,7 @@ mod tests {
             .unwrap();
     }
 
-    /// Each of these is a lookup that would silently miss when the id came from the environment,
-    /// because `config` lowercases keys and splits on `__`.
+    /// Each of these is a lookup that would silently miss when the id came from the environment, because `config` lowercases keys and splits on `__`.
     #[test]
     fn ids_that_cannot_round_trip_through_the_environment_are_rejected() {
         for id in ["SR_ALERTS", "sr__alerts", ""] {
@@ -530,8 +442,7 @@ mod tests {
         }
     }
 
-    /// The tag is what makes Xyne and Slack two variants of one client rather than two
-    /// integrations, and `log` has to sit in the same enum or the delivery path grows a branch.
+    /// The tag is what makes Xyne and Slack two variants of one client rather than two integrations, and `log` has to sit in the same enum or the delivery path grows a branch.
     #[test]
     fn a_zero_upload_cap_is_rejected() {
         let settings = ChatSettings {
@@ -577,9 +488,7 @@ mod tests {
         }
     }
 
-    /// Every one of these fails at connection time rather than at boot, and a connection failure
-    /// names a host and a role — so it reads as a wrong credential rather than an absent one, at
-    /// whatever hour the first alert run happens to be.
+    /// Every one of these fails at connection time rather than at boot, and a connection failure names a host and a role — so it reads as a wrong credential rather than an absent one, at whatever hour the first alert run happens to be.
     #[test]
     fn an_incomplete_database_configuration_fails_the_boot() {
         let cases: [(&str, DatabaseSettings); 5] = [
@@ -628,8 +537,7 @@ mod tests {
         }
     }
 
-    /// A pool of zero connections never serves a query and never errors either: every caller waits
-    /// for the connection timeout and gets a timeout, which looks like a slow database.
+    /// A pool of zero connections never serves a query and never errors either:
     #[test]
     fn a_zero_pool_size_fails_the_boot() {
         assert!(DatabaseSettings {
@@ -645,8 +553,7 @@ mod tests {
         assert!(database().validate().is_ok());
     }
 
-    /// On a shared cluster `pg_stat_activity` has to be able to answer whose connections are
-    /// whose. Without this the answer is the schema name, which is `public` for every tenant.
+    /// On a shared cluster `pg_stat_activity` has to be able to answer whose connections are whose.
     #[test]
     fn the_connection_string_names_the_application() {
         assert!(database()
@@ -654,9 +561,7 @@ mod tests {
             .contains("application_name=observability"));
     }
 
-    /// The password reaches the log the moment someone debugs the configuration, unless the type
-    /// prevents it. A hand-written `Debug` would do the same job until a field is added and
-    /// somebody forgets.
+    /// The password reaches the log the moment someone debugs the configuration, unless the type prevents it.
     #[test]
     fn the_database_password_is_not_in_the_debug_output() {
         let rendered = format!("{:?}", database());

--- a/crates/observability/src/settings.rs
+++ b/crates/observability/src/settings.rs
@@ -53,6 +53,8 @@ pub struct Settings<S: SecretState> {
     pub log: Log,
     /// Credentials guarding this service's routes.
     pub auth: SecretStateContainer<AuthSettings, S>,
+    /// The observability database. Its schema lives in `diesel_models::observability`.
+    pub database: SecretStateContainer<DatabaseSettings, S>,
     /// How secret values in this file are resolved at boot.
     pub secrets_management: SecretsManagementConfig,
     /// Outbound HTTP proxy. A deployment fact rather than a property of any destination, which is
@@ -262,6 +264,155 @@ impl AuthSettings {
     }
 }
 
+/// Default pool size. Small on purpose: the service issues a handful of queries per alert run, and
+/// the role it connects as carries a connection limit that the pool has to fit inside — alongside
+/// the migration job, which needs connections of its own at deploy time.
+const DEFAULT_POOL_SIZE: u32 = 5;
+
+/// Default seconds to wait for a connection before giving up.
+const DEFAULT_CONNECTION_TIMEOUT: u64 = 10;
+
+fn default_pool_size() -> u32 {
+    DEFAULT_POOL_SIZE
+}
+
+fn default_connection_timeout() -> u64 {
+    DEFAULT_CONNECTION_TIMEOUT
+}
+
+/// The observability database.
+///
+/// Not `hyperswitch_db`: these tables live in their own database, so that alert state is not
+/// written into a store the application owns.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct DatabaseSettings {
+    /// Hostname of the cluster.
+    pub host: String,
+    /// Port the cluster listens on.
+    pub port: u16,
+    /// The database within the cluster. Not the schema — everything lives in `public`.
+    pub dbname: String,
+    /// The role this service connects as. Deliberately not the migration role: this one holds no
+    /// DDL rights, so a running service cannot alter the schema it reads.
+    pub username: String,
+    /// The role's password. Under a KMS backend this is ciphertext until [`crate::secrets_transformers`]
+    /// resolves it.
+    pub password: Secret<String>,
+    /// Connections held open.
+    #[serde(default = "default_pool_size")]
+    pub pool_size: u32,
+    /// Seconds to wait for a connection from the pool before giving up.
+    #[serde(default = "default_connection_timeout")]
+    pub connection_timeout: u64,
+}
+
+/// Percent-encode a connection-string component.
+///
+/// A generated password routinely contains `/`, `@`, `?` or `#`, and each of those ends a field in
+/// a URI: libpq would read the host, the database and the query parameters from the wrong side of
+/// the character. Encoding is what makes a correct password a correct URL.
+fn encode(value: &str) -> String {
+    value
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                char::from(byte).to_string()
+            }
+            other => format!("%{other:02X}"),
+        })
+        .collect()
+}
+
+/// Hand-written so that `Default` and the `#[serde(default = ...)]` attributes agree.
+///
+/// Deriving it would set `pool_size` and `connection_timeout` to zero, which the serde defaults
+/// exist to prevent and which bb8 asserts against — the same reason `ChatSettings` writes its own.
+impl Default for DatabaseSettings {
+    fn default() -> Self {
+        Self {
+            host: String::default(),
+            port: u16::default(),
+            dbname: String::default(),
+            username: String::default(),
+            password: Secret::default(),
+            pool_size: default_pool_size(),
+            connection_timeout: default_connection_timeout(),
+        }
+    }
+}
+
+impl DatabaseSettings {
+    /// The connection string.
+    ///
+    /// Not [`common_utils::DbConnectionParams::get_database_url`], which sets `application_name` to
+    /// the schema for the router's per-tenant `search_path`. Naming the application is what lets
+    /// `pg_stat_activity` attribute connections on a shared cluster.
+    pub fn database_url(&self) -> String {
+        format!(
+            "postgres://{}:{}@{}:{}/{}?application_name=observability",
+            encode(&self.username),
+            encode(self.password.peek()),
+            self.host,
+            self.port,
+            self.dbname,
+        )
+    }
+
+    /// Reject a configuration that cannot connect.
+    ///
+    /// Checked before anything is dialled, so a missing value fails the boot rather than the first
+    /// query. Pool size is deliberately not checked against the role's connection limit: this
+    /// service cannot see that limit, and guessing would turn a database-side change into a
+    /// mystery boot failure.
+    pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
+        common_utils::fp_utils::when(self.host.is_default_or_empty(), || {
+            Err(errors::ConfigurationError::ConfigParsingError(
+                "database host must not be empty".into(),
+            ))
+        })?;
+
+        common_utils::fp_utils::when(self.dbname.is_default_or_empty(), || {
+            Err(errors::ConfigurationError::ConfigParsingError(
+                "database dbname must not be empty".into(),
+            ))
+        })?;
+
+        common_utils::fp_utils::when(self.username.is_default_or_empty(), || {
+            Err(errors::ConfigurationError::ConfigParsingError(
+                "database username must not be empty".into(),
+            ))
+        })?;
+
+        common_utils::fp_utils::when(self.password.peek().is_default_or_empty(), || {
+            Err(errors::ConfigurationError::ConfigParsingError(
+                "database password must not be empty".into(),
+            ))
+        })?;
+
+        common_utils::fp_utils::when(self.port == 0, || {
+            Err(errors::ConfigurationError::ConfigParsingError(
+                "database port must be set".into(),
+            ))
+        })?;
+
+        common_utils::fp_utils::when(self.pool_size == 0, || {
+            Err(errors::ConfigurationError::ConfigParsingError(
+                "database pool_size must be greater than zero".into(),
+            ))
+        })?;
+
+        // bb8 asserts both of these are non-zero when the pool is built, and an assert names
+        // neither the key nor the file it came from. Rejecting them here turns a panic at boot
+        // into a message that says which setting is wrong.
+        common_utils::fp_utils::when(self.connection_timeout == 0, || {
+            Err(errors::ConfigurationError::ConfigParsingError(
+                "database connection_timeout must be greater than zero".into(),
+            ))
+        })
+    }
+}
+
 /// Listener configuration for the standalone binary.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
@@ -347,6 +498,7 @@ impl Settings<SecuredSecret> {
     pub fn validate(&self) -> Result<(), errors::ConfigurationError> {
         self.server.validate()?;
         self.auth.get_inner().validate()?;
+        self.database.get_inner().validate()?;
         self.chat.get_inner().validate()?;
         self.email.validate()?;
         self.secrets_management
@@ -423,5 +575,106 @@ mod tests {
             destinations.get("smoke"),
             Some(ChatDestination::Log)
         ));
+    }
+
+    fn database() -> DatabaseSettings {
+        DatabaseSettings {
+            host: "localhost".to_string(),
+            port: 5432,
+            dbname: "observability".to_string(),
+            username: "alerts_app".to_string(),
+            password: Secret::new("secret".to_string()),
+            pool_size: 5,
+            connection_timeout: 10,
+        }
+    }
+
+    /// Every one of these fails at connection time rather than at boot, and a connection failure
+    /// names a host and a role — so it reads as a wrong credential rather than an absent one, at
+    /// whatever hour the first alert run happens to be.
+    #[test]
+    fn an_incomplete_database_configuration_fails_the_boot() {
+        let cases: [(&str, DatabaseSettings); 5] = [
+            (
+                "host",
+                DatabaseSettings {
+                    host: String::new(),
+                    ..database()
+                },
+            ),
+            (
+                "dbname",
+                DatabaseSettings {
+                    dbname: String::new(),
+                    ..database()
+                },
+            ),
+            (
+                "username",
+                DatabaseSettings {
+                    username: String::new(),
+                    ..database()
+                },
+            ),
+            (
+                "password",
+                DatabaseSettings {
+                    password: Secret::new(String::new()),
+                    ..database()
+                },
+            ),
+            (
+                "port",
+                DatabaseSettings {
+                    port: 0,
+                    ..database()
+                },
+            ),
+        ];
+
+        for (field, settings) in cases {
+            assert!(
+                settings.validate().is_err(),
+                "an absent `{field}` should be rejected"
+            );
+        }
+    }
+
+    /// A pool of zero connections never serves a query and never errors either: every caller waits
+    /// for the connection timeout and gets a timeout, which looks like a slow database.
+    #[test]
+    fn a_zero_pool_size_fails_the_boot() {
+        assert!(DatabaseSettings {
+            pool_size: 0,
+            ..database()
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn a_complete_database_configuration_is_accepted() {
+        assert!(database().validate().is_ok());
+    }
+
+    /// On a shared cluster `pg_stat_activity` has to be able to answer whose connections are
+    /// whose. Without this the answer is the schema name, which is `public` for every tenant.
+    #[test]
+    fn the_connection_string_names_the_application() {
+        assert!(database()
+            .database_url()
+            .contains("application_name=observability"));
+    }
+
+    /// The password reaches the log the moment someone debugs the configuration, unless the type
+    /// prevents it. A hand-written `Debug` would do the same job until a field is added and
+    /// somebody forgets.
+    #[test]
+    fn the_database_password_is_not_in_the_debug_output() {
+        let rendered = format!("{:?}", database());
+        assert!(
+            !rendered.contains("secret"),
+            "password leaked into Debug: {rendered}"
+        );
     }
 }

--- a/crates/observability/src/state.rs
+++ b/crates/observability/src/state.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use diesel_models::DejaPgConnection;
 use external_services::{
     chat_service::{slack::SlackClient, xyne::XyneClient},
     email::{
@@ -22,8 +23,19 @@ use crate::{
     },
     errors::ConfigurationError,
     logger, secrets_transformers,
-    settings::{ChatDestination, ChatSettings, EmailSettings, Settings},
+    settings::{ChatDestination, ChatSettings, DatabaseSettings, EmailSettings, Settings},
 };
+
+/// The observability database's connection pool.
+///
+/// Built directly rather than through `storage_impl`, whose pool types are shaped around the
+/// router's configuration and its per-tenant `search_path`. `drainer` builds its own for the same
+/// reason. Nothing here is multi-tenant: one database, one schema.
+///
+/// The connection is [`DejaPgConnection`] rather than `diesel::PgConnection` so the query helpers
+/// in `diesel_models` accept it. Without the `deja` feature the two are the same type; with it they
+/// are not, and naming the alias means this does not quietly stop compiling when it is turned on.
+pub type DatabasePool = bb8::Pool<async_bb8_diesel::ConnectionManager<DejaPgConnection>>;
 
 /// Everything a request handler needs, cloned per worker.
 ///
@@ -39,6 +51,8 @@ pub struct AppState {
     pub chat: Arc<Registry<dyn ChatNotifier>>,
     /// Email destinations, by the id a request names.
     pub email: Arc<Registry<dyn EmailNotifier>>,
+    /// Connections to the observability database.
+    pub database: DatabasePool,
 }
 
 impl AppState {
@@ -72,6 +86,10 @@ impl AppState {
             .await
             .expect("Failed to build the email destinations");
 
+        #[allow(clippy::expect_used)]
+        let database = build_database_pool(raw_conf.database.get_inner())
+            .expect("Failed to build the database connection pool");
+
         if chat.is_empty() && email.is_empty() {
             logger::warn!(
                 "No chat or email destinations are configured; every notify request will be \
@@ -89,6 +107,7 @@ impl AppState {
             conf: Arc::new(raw_conf),
             chat: Arc::new(chat),
             email: Arc::new(email),
+            database,
         }
     }
 }
@@ -169,6 +188,43 @@ async fn build_email_registry(
             })
             .collect(),
     ))
+}
+
+/// Send connection failures to the log.
+///
+/// bb8's default sink discards them, and it never constructs `RunError::User` — every failure to
+/// connect, authenticate or resolve leaves `Pool::get` as a bare `TimedOut`. Without this, a wrong
+/// password, a bad host and a firewalled port are indistinguishable in the only place anyone looks.
+#[derive(Debug, Clone, Copy)]
+struct LogConnectionErrors;
+
+impl<E: std::fmt::Display> bb8::ErrorSink<E> for LogConnectionErrors {
+    fn sink(&self, error: E) {
+        logger::error!(%error, "Observability database connection failed");
+    }
+
+    fn boxed_clone(&self) -> Box<dyn bb8::ErrorSink<E>> {
+        Box::new(*self)
+    }
+}
+
+/// Build the pool for the observability database.
+///
+/// **Deliberately does not connect.** `bb8`'s checked builder dials on construction, which would
+/// make a brief database blip a failed boot and, under Kubernetes, a crash loop. `/health/ready`
+/// proves the connection instead, so a pod that cannot reach its database reports unready and
+/// stops taking traffic rather than dying.
+pub fn build_database_pool(
+    database: &DatabaseSettings,
+) -> Result<DatabasePool, ConfigurationError> {
+    let manager =
+        async_bb8_diesel::ConnectionManager::<DejaPgConnection>::new(database.database_url());
+
+    Ok(bb8::Pool::builder()
+        .max_size(database.pool_size)
+        .connection_timeout(std::time::Duration::from_secs(database.connection_timeout))
+        .error_sink(Box::new(LogConnectionErrors))
+        .build_unchecked(manager))
 }
 
 /// Build the email transport named in configuration.

--- a/crates/observability/src/state.rs
+++ b/crates/observability/src/state.rs
@@ -1,5 +1,3 @@
-//! Shared application state.
-
 use std::{collections::HashMap, sync::Arc};
 
 use diesel_models::DejaPgConnection;
@@ -26,24 +24,17 @@ use crate::{
     settings::{ChatDestination, ChatSettings, DatabaseSettings, EmailSettings, Settings},
 };
 
-/// The observability database's connection pool.
 pub type DatabasePool = bb8::Pool<async_bb8_diesel::ConnectionManager<DejaPgConnection>>;
 
-/// Everything a request handler needs, cloned per worker.
 #[derive(Clone)]
 pub struct AppState {
-    /// The resolved configuration.
     pub conf: Arc<Settings<RawSecret>>,
-    /// Chat destinations, by the id a request names.
     pub chat: Arc<Registry<dyn ChatNotifier>>,
-    /// Email destinations, by the id a request names.
     pub email: Arc<Registry<dyn EmailNotifier>>,
-    /// Connections to the observability database.
     pub database: DatabasePool,
 }
 
 impl AppState {
-    /// Build the application state, resolving secrets and destinations on the way.
     pub async fn new(conf: Settings<SecuredSecret>) -> Self {
         #[allow(clippy::expect_used)]
         let secret_management_client = conf
@@ -89,7 +80,6 @@ impl AppState {
     }
 }
 
-/// Turn configured chat destinations into the notifiers that serve them.
 fn build_chat_registry(
     settings: &ChatSettings,
     proxy: &Proxy,
@@ -128,7 +118,6 @@ fn build_chat_registry(
     Ok(Registry::new(destinations))
 }
 
-/// Turn configured email destinations into the notifiers that serve them.
 async fn build_email_registry(
     settings: &EmailSettings,
     proxy: &Proxy,
@@ -156,7 +145,6 @@ async fn build_email_registry(
     ))
 }
 
-/// Send connection failures to the log.
 #[derive(Debug, Clone, Copy)]
 struct LogConnectionErrors;
 
@@ -170,7 +158,6 @@ impl<E: std::fmt::Display> bb8::ErrorSink<E> for LogConnectionErrors {
     }
 }
 
-/// Build the pool for the observability database.
 pub fn build_database_pool(
     database: &DatabaseSettings,
 ) -> Result<DatabasePool, ConfigurationError> {
@@ -184,7 +171,6 @@ pub fn build_database_pool(
         .build_unchecked(manager))
 }
 
-/// Build the email transport named in configuration.
 async fn create_email_client(
     settings: &EmailClientSettings,
     proxy: &Proxy,
@@ -204,7 +190,6 @@ async fn create_email_client(
         EmailClientConfigs::Smtp { smtp } => {
             Box::new(SmtpServer::create(settings, smtp.clone()).await)
         }
-        // The default, and the off switch:
         EmailClientConfigs::NoEmailClient => Box::new(NoEmailClient::create().await),
     })
 }
@@ -227,7 +212,6 @@ mod tests {
         assert!(registry.get("missing").is_none());
     }
 
-    /// A destination the endpoint rejects must stop the boot, not quietly vanish from the registry and resurface as "unknown destination" on the first alert.
     #[test]
     fn a_chat_destination_with_no_channel_fails_the_boot() {
         let config: external_services::chat_service::xyne::XyneConfig =
@@ -261,7 +245,6 @@ mod tests {
         }
     }
 
-    /// The default client is `NoEmailClient`, so this builds the whole registry — transport included — without reaching for SES credentials.
     #[tokio::test]
     async fn email_destinations_share_one_client() {
         let registry = build_email_registry(
@@ -276,7 +259,6 @@ mod tests {
         assert!(registry.get("missing").is_none());
     }
 
-    /// No destinations means no transport is built at all, so a deployment that has not configured email does not construct an SES client it will never use.
     #[tokio::test]
     async fn an_empty_registry_reports_itself_as_empty() {
         assert!(
@@ -292,7 +274,6 @@ mod tests {
         );
     }
 
-    /// A destination with no address would accept alerts and send them nowhere.
     #[test]
     fn a_destination_without_an_address_fails_validation() {
         let mut settings = email_settings_with(&["oncall"]);
@@ -307,7 +288,6 @@ mod tests {
         assert!(error.to_string().contains("broken"));
     }
 
-    /// Validation of the transport is skipped when nothing uses it, so a first deployment does not need a verified SES sender before anyone has asked for an email.
     #[test]
     fn an_unused_transport_is_not_validated() {
         EmailSettings::default().validate().unwrap();

--- a/crates/observability/src/state.rs
+++ b/crates/observability/src/state.rs
@@ -27,22 +27,9 @@ use crate::{
 };
 
 /// The observability database's connection pool.
-///
-/// Built directly rather than through `storage_impl`, whose pool types are shaped around the
-/// router's configuration and its per-tenant `search_path`. `drainer` builds its own for the same
-/// reason. Nothing here is multi-tenant: one database, one schema.
-///
-/// The connection is [`DejaPgConnection`] rather than `diesel::PgConnection` so the query helpers
-/// in `diesel_models` accept it. Without the `deja` feature the two are the same type; with it they
-/// are not, and naming the alias means this does not quietly stop compiling when it is turned on.
 pub type DatabasePool = bb8::Pool<async_bb8_diesel::ConnectionManager<DejaPgConnection>>;
 
 /// Everything a request handler needs, cloned per worker.
-///
-/// The registries are built once here rather than per request. A chat destination holds a
-/// validated endpoint and a connection-pool-backed client, so building it per request would move a
-/// configuration failure out of boot and into the delivery path — which is the one place a
-/// service like this must not be discovering problems.
 #[derive(Clone)]
 pub struct AppState {
     /// The resolved configuration.
@@ -57,16 +44,6 @@ pub struct AppState {
 
 impl AppState {
     /// Build the application state, resolving secrets and destinations on the way.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the secrets management client cannot be created, if a secret fails to resolve, or
-    /// if a configured destination cannot be built. All three mean the service cannot serve a
-    /// request correctly, so failing here is preferable to failing later under load.
-    ///
-    /// Having *no* destinations is not one of those cases. It is warned about and started, because
-    /// a first deployment has none until credentials exist and refusing to boot would make the
-    /// service undeployable before them.
     pub async fn new(conf: Settings<SecuredSecret>) -> Self {
         #[allow(clippy::expect_used)]
         let secret_management_client = conf
@@ -113,10 +90,6 @@ impl AppState {
 }
 
 /// Turn configured chat destinations into the notifiers that serve them.
-///
-/// A destination that cannot be built is an error rather than a skipped entry. Dropping it would
-/// leave the service running and answering "unknown destination" to a destination that is very
-/// much configured, which is a far worse thing to debug than a failure to start.
 fn build_chat_registry(
     settings: &ChatSettings,
     proxy: &Proxy,
@@ -156,13 +129,6 @@ fn build_chat_registry(
 }
 
 /// Turn configured email destinations into the notifiers that serve them.
-///
-/// **One client, shared by every destination.** Unlike chat, where a destination *is* an endpoint
-/// with its own credential, email has one transport and many addresses. Building a client per
-/// destination would open a connection pool per recipient for no reason.
-///
-/// A transport that cannot be built is an error, matching the chat side: a destination that is
-/// configured and broken must stop the boot rather than answer every alert with a 502.
 async fn build_email_registry(
     settings: &EmailSettings,
     proxy: &Proxy,
@@ -191,10 +157,6 @@ async fn build_email_registry(
 }
 
 /// Send connection failures to the log.
-///
-/// bb8's default sink discards them, and it never constructs `RunError::User` — every failure to
-/// connect, authenticate or resolve leaves `Pool::get` as a bare `TimedOut`. Without this, a wrong
-/// password, a bad host and a firewalled port are indistinguishable in the only place anyone looks.
 #[derive(Debug, Clone, Copy)]
 struct LogConnectionErrors;
 
@@ -209,11 +171,6 @@ impl<E: std::fmt::Display> bb8::ErrorSink<E> for LogConnectionErrors {
 }
 
 /// Build the pool for the observability database.
-///
-/// **Deliberately does not connect.** `bb8`'s checked builder dials on construction, which would
-/// make a brief database blip a failed boot and, under Kubernetes, a crash loop. `/health/ready`
-/// proves the connection instead, so a pod that cannot reach its database reports unready and
-/// stops taking traffic rather than dying.
 pub fn build_database_pool(
     database: &DatabaseSettings,
 ) -> Result<DatabasePool, ConfigurationError> {
@@ -228,20 +185,6 @@ pub fn build_database_pool(
 }
 
 /// Build the email transport named in configuration.
-///
-/// Mirrors the router's `create_email_client` (`router/src/routes/app.rs:411`), which is private to
-/// that crate. Copied rather than shared because lifting it into `external_services` would mean
-/// moving `Proxy` handling with it, and the function is a three-arm match.
-///
-/// **SES is probed rather than trusted.** `AwsSes::create` builds a client to check the
-/// configuration and then throws the result away — `.map_err(|e| logger::error!(..)).ok()` — so it
-/// returns a usable-looking client even when assuming the role failed. A wrong role ARN would boot
-/// cleanly and turn every alert into a 502 forever. Calling the fallible `create_client` first
-/// makes that a startup failure instead.
-///
-/// The cost is one extra `AssumeRole` at boot, and one trade worth naming: a transient AWS outage
-/// now prevents startup. For a service whose entire job is delivery, refusing to start with a clear
-/// error beats running while silently dropping every alert.
 async fn create_email_client(
     settings: &EmailClientSettings,
     proxy: &Proxy,
@@ -261,8 +204,7 @@ async fn create_email_client(
         EmailClientConfigs::Smtp { smtp } => {
             Box::new(SmtpServer::create(settings, smtp.clone()).await)
         }
-        // The default, and the off switch: accepts and logs. A deployment runs with this until SES
-        // credentials exist, which is why there is no separate "email enabled" flag.
+        // The default, and the off switch:
         EmailClientConfigs::NoEmailClient => Box::new(NoEmailClient::create().await),
     })
 }
@@ -285,8 +227,7 @@ mod tests {
         assert!(registry.get("missing").is_none());
     }
 
-    /// A destination the endpoint rejects must stop the boot, not quietly vanish from the
-    /// registry and resurface as "unknown destination" on the first alert.
+    /// A destination the endpoint rejects must stop the boot, not quietly vanish from the registry and resurface as "unknown destination" on the first alert.
     #[test]
     fn a_chat_destination_with_no_channel_fails_the_boot() {
         let config: external_services::chat_service::xyne::XyneConfig =
@@ -320,8 +261,7 @@ mod tests {
         }
     }
 
-    /// The default client is `NoEmailClient`, so this builds the whole registry — transport
-    /// included — without reaching for SES credentials.
+    /// The default client is `NoEmailClient`, so this builds the whole registry — transport included — without reaching for SES credentials.
     #[tokio::test]
     async fn email_destinations_share_one_client() {
         let registry = build_email_registry(
@@ -336,8 +276,7 @@ mod tests {
         assert!(registry.get("missing").is_none());
     }
 
-    /// No destinations means no transport is built at all, so a deployment that has not configured
-    /// email does not construct an SES client it will never use.
+    /// No destinations means no transport is built at all, so a deployment that has not configured email does not construct an SES client it will never use.
     #[tokio::test]
     async fn an_empty_registry_reports_itself_as_empty() {
         assert!(
@@ -368,8 +307,7 @@ mod tests {
         assert!(error.to_string().contains("broken"));
     }
 
-    /// Validation of the transport is skipped when nothing uses it, so a first deployment does not
-    /// need a verified SES sender before anyone has asked for an email.
+    /// Validation of the transport is skipped when nothing uses it, so a first deployment does not need a verified SES sender before anyone has asked for an email.
     #[test]
     fn an_unused_transport_is_not_validated() {
         EmailSettings::default().validate().unwrap();

--- a/crates/observability/tests/notify.rs
+++ b/crates/observability/tests/notify.rs
@@ -24,7 +24,7 @@ use observability::{
         Registry,
     },
     routes::Alerts,
-    state::AppState,
+    state::{build_database_pool, AppState},
 };
 use serde_json::{json, Value};
 
@@ -53,10 +53,27 @@ async fn state_with_max(max_upload_bytes: usize) -> AppState {
         None,
     ));
 
+    // Nothing under `/alerts` touches the database, and the pool is built without dialling, so
+    // these tests need no server. A pool pointing at an address nothing answers on is therefore
+    // both sufficient and honest: if a notify route ever grows a query, this stops compiling
+    // quietly and starts failing loudly.
+    let database = build_database_pool(
+        &serde_json::from_value(json!({
+            "host": "127.0.0.1",
+            "port": 1,
+            "dbname": "unused",
+            "username": "unused",
+            "password": "unused"
+        }))
+        .expect("the test database configuration should deserialize"),
+    )
+    .expect("an unchecked pool should build without connecting");
+
     AppState {
         conf: Arc::new(conf),
         chat: Arc::new(Registry::new(HashMap::from([(CHAT.to_owned(), chat)]))),
         email: Arc::new(Registry::new(HashMap::from([(EMAIL.to_owned(), email)]))),
+        database,
     }
 }
 

--- a/crates/observability/tests/notify.rs
+++ b/crates/observability/tests/notify.rs
@@ -1,11 +1,3 @@
-//! The notify routes, exercised through actix as a caller would reach them.
-//!
-//! These go through the real route tree rather than calling handlers directly, because most of what
-//! this ticket decided lives *between* the handler and the caller: the guard, the path extractor,
-//! the body extractor's rejection shape, and which outcomes are a `200` versus an error.
-//!
-//! Both destinations are `log` destinations, so nothing here reaches a network.
-
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 
 use std::{collections::HashMap, sync::Arc};
@@ -44,8 +36,6 @@ async fn state_with_max(max_upload_bytes: usize) -> AppState {
     .expect("the test configuration should deserialize");
 
     let chat: Arc<dyn ChatNotifier> = Arc::new(LogChatNotifier::new(CHAT.to_owned()));
-    // The real notifier over `NoEmailClient`, which accepts and logs. Exercises the composition
-    // path rather than a stand-in, and needs no credentials.
     let email: Arc<dyn EmailNotifier> = Arc::new(EmailServiceNotifier::new(
         EMAIL.to_owned(),
         Arc::new(Box::new(NoEmailClient::create().await)),
@@ -53,10 +43,6 @@ async fn state_with_max(max_upload_bytes: usize) -> AppState {
         None,
     ));
 
-    // Nothing under `/alerts` touches the database, and the pool is built without dialling, so
-    // these tests need no server. A pool pointing at an address nothing answers on is therefore
-    // both sufficient and honest: if a notify route ever grows a query, this stops compiling
-    // quietly and starts failing loudly.
     let database = build_database_pool(
         &serde_json::from_value(json!({
             "host": "127.0.0.1",
@@ -125,7 +111,6 @@ async fn a_chat_notification_reports_delivery_and_a_message_id() {
     assert!(body.get("error_code").is_none());
 }
 
-/// The threading round trip a recovery notice needs: post, keep the id, reply under it.
 #[actix_web::test]
 async fn a_chat_notification_can_reply_under_an_earlier_message() {
     let (_, first) = call(post(
@@ -196,8 +181,6 @@ async fn an_email_notification_reports_delivery() {
     assert_eq!(body["status"], "delivered");
 }
 
-/// The load-bearing property of the response shape: a caller cannot read a `200` and assume the
-/// message arrived, because `status` is always there to be checked.
 #[actix_web::test]
 async fn every_success_carries_a_status() {
     for (uri, body) in [
@@ -216,8 +199,6 @@ async fn every_success_carries_a_status() {
     }
 }
 
-/// Threading against a mailing list is a caller bug, and `deny_unknown_fields` makes it loud rather
-/// than a field that quietly goes nowhere.
 #[actix_web::test]
 async fn threading_against_an_email_destination_is_rejected() {
     let (status, body) = call(post(
@@ -238,7 +219,6 @@ async fn an_unknown_destination_is_a_404() {
     assert_eq!(body["error"]["code"], "IR_02");
 }
 
-/// The id a caller guessed must not come back, and nor must the ones that exist.
 #[actix_web::test]
 async fn an_unknown_destination_does_not_echo_or_enumerate() {
     let (_, body) = call(post("/alerts/chat/notify/typo", json!({ "text": "x" }))).await;
@@ -248,7 +228,6 @@ async fn an_unknown_destination_does_not_echo_or_enumerate() {
     assert!(!rendered.contains(CHAT));
 }
 
-/// A malformed body must render like every other error, not as actix's own plain-text 400.
 #[actix_web::test]
 async fn a_missing_field_renders_in_our_error_shape() {
     let (status, body) = call(post(&format!("/alerts/chat/notify/{CHAT}"), json!({}))).await;
@@ -258,8 +237,6 @@ async fn a_missing_field_renders_in_our_error_shape() {
     assert_eq!(body["error"]["type"], "invalid_request");
 }
 
-/// Serde's message quotes the body, and a body carries merchant ids and payment volumes. It goes to
-/// the log; the caller gets the code.
 #[actix_web::test]
 async fn a_parse_failure_does_not_echo_the_body_back() {
     let (_, body) = call(post(
@@ -290,8 +267,6 @@ async fn both_routes_are_behind_the_guard() {
     }
 }
 
-/// The guard runs before the destination is resolved, so an unauthenticated caller cannot probe
-/// which ids exist by watching the status change.
 #[actix_web::test]
 async fn a_bad_key_is_rejected_before_the_destination_is_resolved() {
     let (known, _) = call(
@@ -314,11 +289,6 @@ async fn a_bad_key_is_rejected_before_the_destination_is_resolved() {
     assert_eq!(unknown, StatusCode::UNAUTHORIZED);
 }
 
-/// **Known and accepted:** actix runs the body extractor before the handler, and the guard runs
-/// inside the handler via `server_wrap`, so an unparseable body is answered 400 without its key
-/// being checked. Restoring "guard strictly first" means extracting raw bytes and deserializing by
-/// hand, trading typed extraction for the concealment of a documented schema. Kept as a test so the
-/// ordering is a recorded property rather than something a reviewer rediscovers.
 #[actix_web::test]
 async fn an_unparseable_body_is_rejected_before_the_key_is_checked() {
     let (status, body) = call(


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

[#14121](https://github.com/juspay/hyperswitch/pull/14121) added the alert state schema, but the service had nothing to connect with. This adds the database section, the pool, and a readiness probe.

Implements [#23400](https://github.com/juspay/hyperswitch-cloud/issues/23400); part of [#23153](https://github.com/juspay/hyperswitch-cloud/issues/23153). Targets `observability-plane-i`. No routes that read or write yet: those are the API PRs.

### Configuration, as drainer has it

`[database]` defaults `host`/`port` to `localhost:5432`, `pool_size` to 5 and `connection_timeout` to 10 seconds. `dbname`, `username` and `password` must be set: validation rejects them empty with drainer's messages, and rejects a zero port, pool size or timeout (the last two would panic the pool builder).

### The password rides the existing secrets path

A `SecretStateContainer` alongside the auth key, resolved by the same transformer and validated again after decryption, so a well-formed secret handle that resolves to an empty string fails the boot rather than later as an authentication error.

### The connection string goes through `DbConnectionParams`

`DatabaseSettings` implements only the `common_utils::DbConnectionParams` getters, like drainer's and the router's database configs, and the pool uses the trait's `get_database_url` with the `public` schema (so `application_name` and `search_path` are `public`, as for router and drainer). Credentials are not percent-encoded, the same as those services.

### The pool is built without connecting

bb8 over `async-bb8-diesel` with `DejaPgConnection`, the same dependencies and versions as drainer. `build_unchecked` with no `min_idle`, so a database blip at boot never becomes a failed start or a crash loop; an instance that cannot reach its database reports unready instead.

### Liveness and readiness

`/health` is liveness and touches nothing. `/health/ready` answers `200` when a pooled connection is available within 900 ms and `503` ("Observability database is unreachable") otherwise; the connection failure goes to the log.

## Testing

- `cargo +nightly fmt --all --check`; `cargo clippy -p observability --all-targets -- -D warnings` and `-p diesel_models --features v1`; `cargo check -p diesel_models --features v1,deja`; the v2 check with the workspace's v2 feature set; `cargo test -p observability` (the tests on the base branch pass).
- Against Postgres 16, service started for each case (42 checks):
  - no `[database]` section, or an empty dbname / username / password → boot exits non-zero with the drainer message and nothing listens
  - zero pool size, empty host, zero port or zero timeout → boot fails with the matching message
  - only credentials set → `/health` `200`, `/health/ready` `200`, delivery routes unaffected
  - unreachable database → `/health` `200`, `/health/ready` `503` within about 940 ms
  - reachable database → `/health/ready` `200`, and `pg_stat_activity` shows `application_name=public`

### Additional Changes

- [x] This PR modifies application configuration/environment variables
