### PR TITLE
fix(deps): give tracing-dependent crates a direct tracing dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time 0.3.41",
  "tokio 1.48.0",
+ "tracing",
 ]
 
 [[package]]
@@ -2239,6 +2240,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time 0.3.41",
  "tokio 1.48.0",
+ "tracing",
  "url 2.5.4",
  "urlencoding",
  "utoipa",
@@ -3136,6 +3138,7 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 1.0.69",
  "time 0.3.41",
+ "tracing",
 ]
 
 [[package]]
@@ -3233,6 +3236,7 @@ dependencies = [
  "storage_impl",
  "thiserror 1.0.69",
  "tokio 1.48.0",
+ "tracing",
 ]
 
 [[package]]
@@ -3609,6 +3613,7 @@ dependencies = [
  "tonic-prost-build",
  "tonic-reflection",
  "tonic-types",
+ "tracing",
  "typed-builder 0.21.2",
  "url 2.5.4",
  "vaultrs",
@@ -4834,6 +4839,7 @@ dependencies = [
  "sha2",
  "strum 0.26.3",
  "time 0.3.41",
+ "tracing",
  "unicode-normalization",
  "unidecode",
  "url 2.5.4",
@@ -4881,6 +4887,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "time 0.3.41",
+ "tracing",
  "url 2.5.4",
  "utoipa",
 ]
@@ -4914,6 +4921,7 @@ dependencies = [
  "time 0.3.41",
  "tokio 1.48.0",
  "tonic 0.14.5",
+ "tracing",
  "url 2.5.4",
 ]
 
@@ -6971,6 +6979,7 @@ dependencies = [
  "storage_impl",
  "thiserror 1.0.69",
  "time 0.3.41",
+ "tracing",
  "url 2.5.4",
 ]
 
@@ -7216,7 +7225,7 @@ dependencies = [
  "regex-cache",
  "serde",
  "serde_derive",
- "strum 0.25.0",
+ "strum 0.26.3",
  "thiserror 1.0.69",
 ]
 
@@ -8488,6 +8497,7 @@ dependencies = [
  "time 0.3.41",
  "tokio 1.48.0",
  "totp-rs",
+ "tracing",
  "tracing-futures",
  "tracing-subscriber",
  "ucs_cards",
@@ -8962,6 +8972,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time 0.3.41",
  "tokio 1.48.0",
+ "tracing",
  "uuid",
 ]
 
@@ -9856,6 +9867,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio 1.48.0",
+ "tracing",
 ]
 
 [[package]]
@@ -9979,6 +9991,7 @@ dependencies = [
  "serde_json",
  "storage_impl",
  "time 0.3.41",
+ "tracing",
 ]
 
 [[package]]
@@ -11185,9 +11198,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log 0.4.27",
  "pin-project-lite",
@@ -11225,9 +11238,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11236,9 +11249,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ package.rust-version = "1.85.0"
 package.license = "Apache-2.0"
 
 [workspace.dependencies]
-tracing = { version = "0.1.41" }
+tracing = { version = "0.1.44" }
 
 # Most of the lint configuration is based on https://github.com/EmbarkStudios/rust-ecosystem/blob/main/lints.toml
 [workspace.lints.rust]

--- a/crates/analytics/Cargo.toml
+++ b/crates/analytics/Cargo.toml
@@ -11,6 +11,7 @@ v1 = ["api_models/v1", "diesel_models/v1", "storage_impl/v1", "common_utils/v1"]
 v2 = ["api_models/v2", "diesel_models/v2", "storage_impl/v2", "common_utils/v2"]
 
 [dependencies]
+tracing = { workspace = true }
 # First party crates
 api_models = { version = "0.1.0", path = "../api_models", features = ["errors"] }
 common_enums = { version = "0.1.0", path = "../common_enums" }

--- a/crates/analytics/src/active_payments/core.rs
+++ b/crates/analytics/src/active_payments/core.rs
@@ -7,7 +7,7 @@ use api_models::analytics::{
     AnalyticsMetadata, GetActivePaymentsMetricRequest, MetricsResponse,
 };
 use error_stack::ResultExt;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::ActivePaymentsMetricsAccumulator;
 use crate::{

--- a/crates/analytics/src/auth_events/core.rs
+++ b/crates/analytics/src/auth_events/core.rs
@@ -10,7 +10,7 @@ use api_models::analytics::{
 };
 use common_utils::types::TimeRange;
 use error_stack::{report, ResultExt};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{
     filters::{get_auth_events_filter_for_dimension, AuthEventFilterRow},

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -64,11 +64,7 @@ use api_models::analytics::{
 use clickhouse::ClickhouseClient;
 pub use clickhouse::ClickhouseConfig;
 use error_stack::report;
-use router_env::{
-    logger,
-    tracing::instrument,
-    types::FlowMetric,
-};
+use router_env::{logger, tracing::instrument, types::FlowMetric};
 use storage_impl::config::Database;
 use strum::Display;
 

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -66,7 +66,7 @@ pub use clickhouse::ClickhouseConfig;
 use error_stack::report;
 use router_env::{
     logger,
-    tracing::{self, instrument},
+    tracing::instrument,
     types::FlowMetric,
 };
 use storage_impl::config::Database;

--- a/crates/analytics/src/sdk_events/core.rs
+++ b/crates/analytics/src/sdk_events/core.rs
@@ -9,7 +9,7 @@ use api_models::analytics::{
 };
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::{
     events::{get_sdk_event, SdkEventsResult},

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -26,6 +26,7 @@ tokenization_v2 = []
 deja = ["dep:deja"]
 
 [dependencies]
+tracing = { workspace = true }
 async-trait = { version = "0.1.88", optional = true }
 base64 = "0.22.1"
 base64-serde = "0.8.0"

--- a/crates/common_utils/src/keymanager.rs
+++ b/crates/common_utils/src/keymanager.rs
@@ -8,9 +8,7 @@ use error_stack::ResultExt;
 use http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use hyperswitch_masking::{PeekInterface, StrongSecret};
 use once_cell::sync::OnceCell;
-use router_env::{
-    global_meter, histogram_metric_f64, instrument, logger, metric_attributes, tracing,
-};
+use router_env::{global_meter, histogram_metric_f64, instrument, logger, metric_attributes};
 use time::OffsetDateTime;
 
 #[cfg(feature = "ext_services_latency")]

--- a/crates/diesel_models/Cargo.toml
+++ b/crates/diesel_models/Cargo.toml
@@ -16,6 +16,7 @@ tokenization_v2 = []
 deja = ["dep:deja", "deja/diesel-pg"]
 
 [dependencies]
+tracing = { workspace = true }
 async-bb8-diesel = "0.2.1"
 base64 = "0.22.1"
 bb8 = "0.8.6"

--- a/crates/diesel_models/src/query/connector_response.rs
+++ b/crates/diesel_models/src/query/connector_response.rs
@@ -1,7 +1,7 @@
 use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods};
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
-use super::generics;
+use super::generics;  
 use crate::{
     connector_response::{
         ConnectorResponse, ConnectorResponseNew, ConnectorResponseUpdate,

--- a/crates/diesel_models/src/query/process_tracker.rs
+++ b/crates/diesel_models/src/query/process_tracker.rs
@@ -1,5 +1,5 @@
 use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods, Table};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use time::PrimitiveDateTime;
 
 use super::generics;

--- a/crates/drainer/Cargo.toml
+++ b/crates/drainer/Cargo.toml
@@ -17,6 +17,7 @@ fred     = ["redis_interface/fred",     "redis_interface/metrics", "storage_impl
 redis-rs = ["redis_interface/redis-rs", "redis_interface/metrics", "storage_impl/redis-rs"]
 
 [dependencies]
+tracing = { workspace = true }
 actix-web = "4.11.0"
 async-bb8-diesel = "0.2.1"
 async-trait = "0.1.88"

--- a/crates/drainer/src/health_check.rs
+++ b/crates/drainer/src/health_check.rs
@@ -5,7 +5,7 @@ use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl};
 use common_utils::{errors::CustomResult, id_type};
 use diesel_models::{Config, ConfigNew};
 use error_stack::ResultExt;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use crate::{
     connection::pg_connection,

--- a/crates/drainer/src/stream.rs
+++ b/crates/drainer/src/stream.rs
@@ -1,5 +1,5 @@
 use redis_interface as redis;
-use router_env::{logger, tracing};
+use router_env::logger;
 
 use crate::{errors, metrics, Store};
 

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -50,6 +50,7 @@ dynamic_routing = [
 ]
 
 [dependencies]
+tracing = { workspace = true }
 async-trait = "0.1.88"
 aws-config = { version = "1.5.10", optional = true, features = [
     "behavior-version-latest",

--- a/crates/external_services/src/grpc_client/dynamic_routing/elimination_based_client.rs
+++ b/crates/external_services/src/grpc_client/dynamic_routing/elimination_based_client.rs
@@ -9,7 +9,7 @@ pub use elimination_rate::{
     LabelWithBucketName, UpdateEliminationBucketRequest, UpdateEliminationBucketResponse,
 };
 use error_stack::ResultExt;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 #[allow(
     missing_docs,
     unused_qualifications,

--- a/crates/external_services/src/grpc_client/dynamic_routing/success_rate_client.rs
+++ b/crates/external_services/src/grpc_client/dynamic_routing/success_rate_client.rs
@@ -4,7 +4,7 @@ use api_models::routing::{
 };
 use common_utils::{ext_traits::OptionExt, transformers::ForeignTryFrom};
 use error_stack::ResultExt;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 pub use success_rate::{
     success_rate_calculator_client::SuccessRateCalculatorClient, CalGlobalSuccessRateConfig,
     CalGlobalSuccessRateRequest, CalGlobalSuccessRateResponse, CalSuccessRateConfig,

--- a/crates/external_services/src/http_client.rs
+++ b/crates/external_services/src/http_client.rs
@@ -5,7 +5,7 @@ use quick_xml::{
     Writer,
 };
 use request::{HeaderExt, RequestBuilderExt};
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 /// client module
 pub mod client;
 /// metrics module

--- a/crates/external_services/src/http_client/request.rs
+++ b/crates/external_services/src/http_client/request.rs
@@ -5,7 +5,7 @@ pub use common_utils::{errors::CustomResult, request::ContentType};
 use error_stack::ResultExt;
 use hyperswitch_interfaces::errors::HttpClientError;
 pub use hyperswitch_masking::{Mask, Maskable};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[allow(missing_docs)]
 pub trait HeaderExt {

--- a/crates/hyperswitch_connectors/Cargo.toml
+++ b/crates/hyperswitch_connectors/Cargo.toml
@@ -18,6 +18,7 @@ dummy_connector = [
 ]
 
 [dependencies]
+tracing = { workspace = true }
 actix-web = "4.11.0"
 async-trait = "0.1.88"
 base64 = "0.22.1"

--- a/crates/hyperswitch_connectors/src/connectors/adyen.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen.rs
@@ -94,7 +94,7 @@ use hyperswitch_interfaces::{
 };
 use hyperswitch_masking::{ExposeInterface, Mask, Maskable, Secret};
 use ring::hmac;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use transformers as adyen;
 
 #[cfg(feature = "payouts")]

--- a/crates/hyperswitch_connectors/src/connectors/adyenplatform.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyenplatform.rs
@@ -58,7 +58,7 @@ use hyperswitch_masking::{Mask as _, Maskable, Secret};
 #[cfg(feature = "payouts")]
 use ring::hmac;
 #[cfg(feature = "payouts")]
-use router_env::{instrument, tracing};
+use router_env::instrument;
 #[cfg(feature = "payouts")]
 use transformers::get_adyen_payout_webhook_event;
 

--- a/crates/hyperswitch_connectors/src/connectors/ebanx.rs
+++ b/crates/hyperswitch_connectors/src/connectors/ebanx.rs
@@ -46,7 +46,7 @@ use hyperswitch_interfaces::{
 #[cfg(feature = "payouts")]
 use hyperswitch_masking::Maskable;
 #[cfg(feature = "payouts")]
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use transformers as ebanx;
 
 #[cfg(feature = "payouts")]

--- a/crates/hyperswitch_connectors/src/connectors/gigadat.rs
+++ b/crates/hyperswitch_connectors/src/connectors/gigadat.rs
@@ -57,7 +57,7 @@ use hyperswitch_masking::ExposeInterface;
 use hyperswitch_masking::{Mask, PeekInterface};
 use lazy_static::lazy_static;
 #[cfg(feature = "payouts")]
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use transformers as gigadat;
 use uuid::Uuid;
 

--- a/crates/hyperswitch_connectors/src/connectors/nomupay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nomupay.rs
@@ -61,7 +61,7 @@ use josekit::{
     Map, Value,
 };
 #[cfg(feature = "payouts")]
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use serde_json::json;
 use transformers as nomupay;
 

--- a/crates/hyperswitch_connectors/src/connectors/payone.rs
+++ b/crates/hyperswitch_connectors/src/connectors/payone.rs
@@ -54,7 +54,7 @@ use hyperswitch_interfaces::{
 use hyperswitch_masking::{ExposeInterface, Mask, Maskable, PeekInterface};
 use ring::hmac;
 #[cfg(feature = "payouts")]
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use self::transformers as payone;
 #[cfg(feature = "payouts")]

--- a/crates/hyperswitch_connectors/src/connectors/paypal.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal.rs
@@ -78,7 +78,7 @@ use hyperswitch_interfaces::{
 };
 use hyperswitch_masking::{ExposeInterface, Mask, Maskable, PeekInterface, Secret};
 #[cfg(feature = "payouts")]
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use transformers::{
     self as paypal, auth_headers, PaypalAuthResponse, PaypalIncrementalAuthResponse, PaypalMeta,
     PaypalWebhookEventType,

--- a/crates/hyperswitch_connectors/src/connectors/stripe.rs
+++ b/crates/hyperswitch_connectors/src/connectors/stripe.rs
@@ -78,7 +78,7 @@ use hyperswitch_interfaces::{
     webhooks::{IncomingWebhook, IncomingWebhookRequestDetails, WebhookContext},
 };
 use hyperswitch_masking::{Mask as _, Maskable, PeekInterface};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use stripe::auth_headers;
 
 use self::transformers as stripe;

--- a/crates/hyperswitch_connectors/src/connectors/wise.rs
+++ b/crates/hyperswitch_connectors/src/connectors/wise.rs
@@ -52,7 +52,7 @@ use hyperswitch_interfaces::{
 use hyperswitch_masking::PeekInterface;
 use hyperswitch_masking::{Mask as _, Maskable};
 #[cfg(feature = "payouts")]
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use self::transformers as wise;
 use crate::constants::headers;

--- a/crates/hyperswitch_connectors/src/connectors/worldline.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldline.rs
@@ -89,7 +89,7 @@ impl Worldline {
     }
 
     pub fn get_current_date_time() -> CustomResult<String, errors::ConnectorError> {
-        let format = format_description::parse(
+        let format = format_description::parse_borrowed::<1>(
             "[weekday repr:short], [day] [month repr:short] [year] [hour]:[minute]:[second] GMT",
         )
         .change_context(errors::ConnectorError::InvalidDateFormat)?;

--- a/crates/hyperswitch_domain_models/Cargo.toml
+++ b/crates/hyperswitch_domain_models/Cargo.toml
@@ -21,6 +21,7 @@ revenue_recovery= []
 deja = ["diesel_models/deja"]
 
 [dependencies]
+tracing = { workspace = true }
 # First party deps
 api_models = { version = "0.1.0", path = "../api_models", features = ["errors"] }
 cards = { version = "0.1.0", path = "../cards" }

--- a/crates/hyperswitch_domain_models/src/customer.rs
+++ b/crates/hyperswitch_domain_models/src/customer.rs
@@ -16,7 +16,7 @@ use diesel_models::query::customers as query;
 #[cfg(feature = "v1")]
 use hyperswitch_masking::ExposeInterface;
 use hyperswitch_masking::Secret;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use rustc_hash::FxHashMap;
 #[cfg(feature = "v1")]
 use serde_json::Value;

--- a/crates/hyperswitch_domain_models/src/type_encryption.rs
+++ b/crates/hyperswitch_domain_models/src/type_encryption.rs
@@ -9,7 +9,7 @@ use common_utils::{
 };
 use encrypt::TypeEncryption;
 use hyperswitch_masking::Secret;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use rustc_hash::FxHashMap;
 
 mod encrypt {
@@ -30,7 +30,7 @@ mod encrypt {
     use error_stack::ResultExt;
     use http::Method;
     use hyperswitch_masking::{PeekInterface, Secret};
-    use router_env::{instrument, logger, tracing};
+    use router_env::{instrument, logger};
     use rustc_hash::FxHashMap;
 
     use super::{metrics, obtain_data_to_decrypt_locally, EncryptedJsonType};

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -17,6 +17,7 @@ revenue_recovery = []
 ext_services_latency = []
 
 [dependencies]
+tracing = { workspace = true }
 actix-web = "4.11.0"
 async-trait = "0.1.88"
 bytes = "1.10.1"

--- a/crates/hyperswitch_interfaces/src/api/gateway.rs
+++ b/crates/hyperswitch_interfaces/src/api/gateway.rs
@@ -460,7 +460,7 @@ where
                     )
                     .await;
                 }
-                .instrument(router_env::tracing::Span::current()),
+                .instrument(tracing::Span::current()),
             );
             direct_result
         }
@@ -605,7 +605,7 @@ where
                     )
                     .await;
                 }
-                .instrument(router_env::tracing::Span::current()),
+                .instrument(tracing::Span::current()),
             );
             direct_result
         }

--- a/crates/payment_methods/Cargo.toml
+++ b/crates/payment_methods/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+tracing = { workspace = true }
 actix-multipart = "0.6.2"
 actix-web = "4.11.0"
 async-trait = "0.1.88"

--- a/crates/payment_methods/src/core/migration.rs
+++ b/crates/payment_methods/src/core/migration.rs
@@ -7,7 +7,7 @@ use error_stack::ResultExt;
 use hyperswitch_domain_models::{api, platform};
 use hyperswitch_masking::PeekInterface;
 use rdkafka::message::ToBytes;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::core::errors;
 #[cfg(feature = "v1")]

--- a/crates/payment_methods/src/core/migration/payment_methods.rs
+++ b/crates/payment_methods/src/core/migration/payment_methods.rs
@@ -23,7 +23,7 @@ use hyperswitch_masking::PeekInterface;
 #[cfg(feature = "v1")]
 use hyperswitch_masking::Secret;
 #[cfg(feature = "v1")]
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 #[cfg(feature = "v1")]
 use serde_json::json;
 use storage_impl::cards_info;

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -182,6 +182,7 @@ redis-rs = [
 ]
 
 [dependencies]
+tracing = { workspace = true }
 actix-cors = "0.6.5"
 actix-http = "3.11.0"
 actix-multipart = "0.6.2"

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -15,10 +15,7 @@ use router::{
     services::{self, api},
     workflows,
 };
-use router_env::{
-    instrument,
-    tracing::Instrument,
-};
+use router_env::{instrument, tracing::Instrument};
 use scheduler::{
     consumer::workflows::ProcessTrackerWorkflow, errors::ProcessTrackerError,
     workflows::ProcessTrackerWorkflows, SchedulerSessionState,

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -17,7 +17,7 @@ use router::{
 };
 use router_env::{
     instrument,
-    tracing::{self, Instrument},
+    tracing::Instrument,
 };
 use scheduler::{
     consumer::workflows::ProcessTrackerWorkflow, errors::ProcessTrackerError,

--- a/crates/router/src/compatibility/stripe/customers.rs
+++ b/crates/router/src/compatibility/stripe/customers.rs
@@ -6,7 +6,7 @@ use common_utils::id_type;
 #[cfg(feature = "v1")]
 use error_stack::report;
 #[cfg(feature = "v1")]
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 #[cfg(feature = "v1")]
 use crate::{

--- a/crates/router/src/compatibility/stripe/setup_intents.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents.rs
@@ -6,7 +6,7 @@ use api_models::payments as payment_types;
 #[cfg(feature = "v1")]
 use error_stack::report;
 #[cfg(feature = "v1")]
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 #[cfg(feature = "v1")]
 use crate::{

--- a/crates/router/src/core/account_updater.rs
+++ b/crates/router/src/core/account_updater.rs
@@ -7,7 +7,7 @@ pub mod types;
 use api_models::payment_methods::RawPaymentMethodData;
 use common_utils::errors::CustomResult;
 use error_stack::report;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 pub use self::store::apply_card_refresh_result;
 use self::{

--- a/crates/router/src/core/account_updater/eligibility.rs
+++ b/crates/router/src/core/account_updater/eligibility.rs
@@ -5,7 +5,7 @@ use common_enums::{PaymentMethod, PaymentMethodStatus};
 use common_utils::{errors::CustomResult, fp_utils::when};
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::payment_method_data::PaymentMethodsData;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use unified_connector_service_cards::CardNumber;
 use unified_connector_service_client::payments as payments_grpc;
 

--- a/crates/router/src/core/account_updater/refresh.rs
+++ b/crates/router/src/core/account_updater/refresh.rs
@@ -2,7 +2,7 @@ use common_enums::{connector_enums::Connector, ExecutionMode};
 use common_utils::errors::CustomResult;
 use error_stack::{report, ResultExt};
 use external_services::grpc_client::LineageIds;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use unified_connector_service_client::payments::{
     self as payments_grpc, refresh_result, CardRefreshOutcome as Outcome,
 };

--- a/crates/router/src/core/account_updater/store.rs
+++ b/crates/router/src/core/account_updater/store.rs
@@ -9,7 +9,7 @@ use common_utils::{
 };
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::payment_method_data::CardDetailsPaymentMethod;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use unified_connector_service_client::payments as payments_grpc;
 
 use super::types::{AccountUpdaterError, CardRefreshedData, RefreshedCard};

--- a/crates/router/src/core/api_keys.rs
+++ b/crates/router/src/core/api_keys.rs
@@ -3,7 +3,7 @@ use common_utils::date_time;
 use diesel_models::{api_keys::ApiKey, enums as storage_enums};
 use error_stack::{report, ResultExt};
 use hyperswitch_masking::{PeekInterface, StrongSecret};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     configs::settings,

--- a/crates/router/src/core/blocklist/batch.rs
+++ b/crates/router/src/core/blocklist/batch.rs
@@ -4,7 +4,7 @@ use common_utils::{date_time, id_type};
 use csv::{ReaderBuilder, Trim, WriterBuilder};
 use error_stack::{report, ResultExt};
 use futures::future;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use scheduler::utils as pt_utils;
 use serde::Deserialize;
 

--- a/crates/router/src/core/blocklist/transformers.rs
+++ b/crates/router/src/core/blocklist/transformers.rs
@@ -1,7 +1,7 @@
 use api_models::blocklist;
 use error_stack::ResultExt;
 use hyperswitch_masking::StrongSecret;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     core::{

--- a/crates/router/src/core/card_issuer.rs
+++ b/crates/router/src/core/card_issuer.rs
@@ -1,7 +1,7 @@
 use api_models::card_issuer as api_types;
 use common_utils::{date_time, id_type};
 use diesel_models::card_issuer::{NewCardIssuer, UpdateCardIssuer};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     core::errors::{self, RouterResponse, StorageErrorExt},

--- a/crates/router/src/core/cards_info.rs
+++ b/crates/router/src/core/cards_info.rs
@@ -6,7 +6,7 @@ use diesel_models::cards_info as card_info_models;
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::cards_info;
 use rdkafka::message::ToBytes;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     core::{

--- a/crates/router/src/core/customers.rs
+++ b/crates/router/src/core/customers.rs
@@ -19,7 +19,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_masking::{ExposeInterface, Secret, SwitchStrategy};
 use payment_methods::controller::PaymentMethodsController;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "v2")]
 use crate::core::payment_methods::delete_payment_method_by_record;

--- a/crates/router/src/core/disputes.rs
+++ b/crates/router/src/core/disputes.rs
@@ -5,10 +5,7 @@ use api_models::{
 };
 use common_utils::ext_traits::{Encode, ValueExt};
 use error_stack::ResultExt;
-use router_env::{
-    instrument, logger,
-    tracing::Instrument,
-};
+use router_env::{instrument, logger, tracing::Instrument};
 use strum::IntoEnumIterator;
 pub mod transformers;
 

--- a/crates/router/src/core/disputes.rs
+++ b/crates/router/src/core/disputes.rs
@@ -7,7 +7,7 @@ use common_utils::ext_traits::{Encode, ValueExt};
 use error_stack::ResultExt;
 use router_env::{
     instrument, logger,
-    tracing::{self, Instrument},
+    tracing::Instrument,
 };
 use strum::IntoEnumIterator;
 pub mod transformers;
@@ -789,9 +789,11 @@ pub async fn connector_sync_disputes(
         common_utils::id_type::MerchantConnectorAccountId::wrap(merchant_connector_id)
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Failed to parse merchant connector account id format")?;
-    let format = time::format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]")
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Failed to parse the date-time format")?;
+    let format = time::format_description::parse_borrowed::<1>(
+        "[year]-[month]-[day]T[hour]:[minute]:[second]",
+    )
+    .change_context(errors::ApiErrorResponse::InternalServerError)
+    .attach_printable("Failed to parse the date-time format")?;
     let created_from = time::PrimitiveDateTime::parse(&payload.fetch_from, &format)
         .change_context(errors::ApiErrorResponse::InvalidDataFormat {
             field_name: "fetch_from".into(),

--- a/crates/router/src/core/fraud_check.rs
+++ b/crates/router/src/core/fraud_check.rs
@@ -6,7 +6,7 @@ use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
 use router_env::{
     logger,
-    tracing::{self, instrument},
+    tracing::instrument,
 };
 
 use self::{

--- a/crates/router/src/core/fraud_check.rs
+++ b/crates/router/src/core/fraud_check.rs
@@ -4,10 +4,7 @@ use api_models::{self, enums as api_enums};
 use common_enums::CaptureMethod;
 use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
-use router_env::{
-    logger,
-    tracing::instrument,
-};
+use router_env::{logger, tracing::instrument};
 
 use self::{
     flows::{self as frm_flows, FeatureFrm},

--- a/crates/router/src/core/fraud_check/flows/fulfillment_flow.rs
+++ b/crates/router/src/core/fraud_check/flows/fulfillment_flow.rs
@@ -1,6 +1,6 @@
 use common_utils::ext_traits::{OptionExt, ValueExt};
 use error_stack::ResultExt;
-use router_env::tracing::{self, instrument};
+use router_env::tracing::instrument;
 
 use crate::{
     core::{

--- a/crates/router/src/core/fraud_check/operation/fraud_check_post.rs
+++ b/crates/router/src/core/fraud_check/operation/fraud_check_post.rs
@@ -4,7 +4,7 @@ use common_utils::ext_traits::Encode;
 use hyperswitch_domain_models::payments::{
     payment_attempt::PaymentAttemptUpdate, payment_intent::PaymentIntentUpdate, HeaderPayload,
 };
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::{Domain, FraudCheckOperation, GetTracker, UpdateTracker};
 use crate::{

--- a/crates/router/src/core/fraud_check/operation/fraud_check_pre.rs
+++ b/crates/router/src/core/fraud_check/operation/fraud_check_pre.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use common_enums::FrmSuggestion;
 use common_utils::ext_traits::Encode;
 use diesel_models::enums::FraudCheckLastStep;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use uuid::Uuid;
 
 use super::{Domain, FraudCheckOperation, GetTracker, UpdateTracker};

--- a/crates/router/src/core/gsm.rs
+++ b/crates/router/src/core/gsm.rs
@@ -1,6 +1,6 @@
 use api_models::gsm as gsm_api_types;
 use error_stack::ResultExt;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     core::errors::{self, RouterResponse, StorageErrorExt},

--- a/crates/router/src/core/mandate.rs
+++ b/crates/router/src/core/mandate.rs
@@ -6,7 +6,7 @@ use diesel_models::enums as storage_enums;
 use error_stack::{report, ResultExt};
 use futures::future;
 use hyperswitch_domain_models::mandates::{MandateData, MandateIds};
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::payments::helpers as payment_helper;
 use crate::{

--- a/crates/router/src/core/merchant_connector_webhook_management/transformers.rs
+++ b/crates/router/src/core/merchant_connector_webhook_management/transformers.rs
@@ -13,7 +13,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_interfaces::api::ConnectorSpecifications;
 use hyperswitch_masking::{ExposeInterface, Secret};
-use router_env::tracing::{self, instrument};
+use router_env::tracing::instrument;
 
 use crate::{
     consts,

--- a/crates/router/src/core/payment_method_balance.rs
+++ b/crates/router/src/core/payment_method_balance.rs
@@ -20,7 +20,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_interfaces::connector_integration_interface::RouterDataConversion;
 use hyperswitch_masking::ExposeInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     consts,

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -66,7 +66,7 @@ use hyperswitch_interfaces::connector_integration_interface::RouterDataConversio
 #[cfg(feature = "v2")]
 use hyperswitch_masking::ExposeInterface;
 use hyperswitch_masking::{PeekInterface, Secret};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 #[cfg(feature = "v2")]
 use storage_impl::behaviour::Conversion;
 use time::Duration;

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -55,7 +55,7 @@ use hyperswitch_interfaces::secrets_interface::secret_state::RawSecret;
 use hyperswitch_masking::Secret;
 #[cfg(feature = "v1")]
 use kgraph_utils::transformers::IntoDirValue;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use scheduler::errors as sch_errors;
 use strum::IntoEnumIterator;
 

--- a/crates/router/src/core/payment_methods/client.rs
+++ b/crates/router/src/core/payment_methods/client.rs
@@ -16,7 +16,7 @@ use api_models::payment_methods::{
 };
 use common_utils::{consts, ext_traits::AsyncExt, generate_id, id_type};
 use error_stack::ResultExt;
-use router_env::{instrument, logger, tracing, Flow};
+use router_env::{instrument, logger, Flow};
 
 use crate::{
     core::{

--- a/crates/router/src/core/payment_methods/surcharge_decision_configs.rs
+++ b/crates/router/src/core/payment_methods/surcharge_decision_configs.rs
@@ -15,7 +15,7 @@ use euclid::{
     backend,
     backend::{inputs as dsl_inputs, EuclidBackend},
 };
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use serde::{Deserialize, Serialize};
 use storage_impl::redis::cache::{self, SURCHARGE_CACHE};
 

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -21,7 +21,7 @@ use hyperswitch_domain_models::{
 use hyperswitch_masking::PeekInterface;
 #[cfg(feature = "v2")]
 use payment_methods::controller::DeleteCardResp;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use scheduler::{types::process_data, utils as process_tracker_utils};
 
 #[cfg(feature = "payouts")]

--- a/crates/router/src/core/payments/client_session.rs
+++ b/crates/router/src/core/payments/client_session.rs
@@ -7,7 +7,7 @@ use common_utils::{
     id_type::{self, GenerateId, MerchantId, PaymentId},
 };
 use error_stack::ResultExt;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use serde::{Deserialize, Serialize};
 use time::{Duration, PrimitiveDateTime};
 

--- a/crates/router/src/core/payments/conditional_configs.rs
+++ b/crates/router/src/core/payments/conditional_configs.rs
@@ -2,7 +2,7 @@ use api_models::{conditional_configs::DecisionManagerRecord, routing};
 use common_utils::ext_traits::StringExt;
 use error_stack::ResultExt;
 use euclid::backend::{self, inputs as dsl_inputs, EuclidBackend};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::redis::cache::{self, DECISION_MANAGER_CACHE};
 
 use super::routing::make_dsl_input;

--- a/crates/router/src/core/payments/customers.rs
+++ b/crates/router/src/core/payments/customers.rs
@@ -1,7 +1,7 @@
 pub use hyperswitch_domain_models::customer::update_connector_customer_in_customers;
 use hyperswitch_interfaces::api::{gateway, ConnectorSpecifications};
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "v2")]
 use crate::types::domain;

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -67,7 +67,7 @@ use openssl::{
 use rand::Rng;
 #[cfg(feature = "v2")]
 use redis_interface::errors::RedisError;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use rust_decimal::Decimal;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::{serde_as, VecSkipError};

--- a/crates/router/src/core/payments/operations.rs
+++ b/crates/router/src/core/payments/operations.rs
@@ -79,7 +79,7 @@ use async_trait::async_trait;
 #[cfg(feature = "v1")]
 use common_utils::ext_traits::AsyncExt;
 use error_stack::{report, ResultExt};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "v2")]
 pub use self::payment_attempt_list::PaymentGetListAttempts;

--- a/crates/router/src/core/payments/operations/external_vault_proxy_payment_intent.rs
+++ b/crates/router/src/core/payments/operations/external_vault_proxy_payment_intent.rs
@@ -12,7 +12,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_interfaces::api::ConnectorSpecifications;
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{Domain, GetTracker, Operation, PostUpdateTracker, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_approve.rs
+++ b/crates/router/src/core/payments/operations/payment_approve.rs
@@ -4,7 +4,7 @@ use api_models::enums::{AttemptStatus, FrmSuggestion, IntentStatus};
 use async_trait::async_trait;
 use error_stack::ResultExt;
 use router_derive::PaymentOperation;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_attempt_list.rs
+++ b/crates/router/src/core/payments/operations/payment_attempt_list.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use api_models::{enums::FrmSuggestion, payments::PaymentAttemptListRequest};
 use async_trait::async_trait;
 use common_utils::errors::CustomResult;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_attempt_record.rs
+++ b/crates/router/src/core/payments/operations/payment_attempt_record.rs
@@ -10,7 +10,7 @@ use common_utils::{
 use error_stack::ResultExt;
 use hyperswitch_domain_models::payments::PaymentAttemptRecordData;
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_cancel.rs
+++ b/crates/router/src/core/payments/operations/payment_cancel.rs
@@ -4,7 +4,7 @@ use api_models::enums::FrmSuggestion;
 use async_trait::async_trait;
 use common_utils::ext_traits::AsyncExt;
 use error_stack::ResultExt;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_cancel_post_capture.rs
+++ b/crates/router/src/core/payments/operations/payment_cancel_post_capture.rs
@@ -4,7 +4,7 @@ use api_models::enums::FrmSuggestion;
 use async_trait::async_trait;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_cancel_post_capture_sync.rs
+++ b/crates/router/src/core/payments/operations/payment_cancel_post_capture_sync.rs
@@ -4,7 +4,7 @@ use api_models::enums::FrmSuggestion;
 use async_trait::async_trait;
 use common_utils::id_type;
 use error_stack::ResultExt;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_cancel_v2.rs
+++ b/crates/router/src/core/payments/operations/payment_cancel_v2.rs
@@ -4,7 +4,7 @@ use api_models::enums::FrmSuggestion;
 use async_trait::async_trait;
 use common_utils::{ext_traits::AsyncExt, id_type::GlobalPaymentId};
 use error_stack::ResultExt;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{
     BoxedOperation, Domain, GetTracker, Operation, OperationSessionSetters, UpdateTracker,

--- a/crates/router/src/core/payments/operations/payment_capture.rs
+++ b/crates/router/src/core/payments/operations/payment_capture.rs
@@ -4,7 +4,7 @@ use api_models::enums::FrmSuggestion;
 use async_trait::async_trait;
 use common_utils::ext_traits::AsyncExt;
 use error_stack::ResultExt;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_capture_v2.rs
+++ b/crates/router/src/core/payments/operations/payment_capture_v2.rs
@@ -2,7 +2,7 @@ use api_models::{enums::FrmSuggestion, payments::PaymentsCaptureRequest};
 use async_trait::async_trait;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::payments::PaymentCaptureData;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_complete_authorize.rs
+++ b/crates/router/src/core/payments/operations/payment_complete_authorize.rs
@@ -6,7 +6,7 @@ use common_utils::ext_traits::{AsyncExt, ValueExt};
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::mandates;
 use router_derive::PaymentOperation;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -22,7 +22,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_masking::{ExposeInterface, PeekInterface};
 use router_derive::PaymentOperation;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use tracing_futures::Instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};

--- a/crates/router/src/core/payments/operations/payment_confirm_external_vault_proxy.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm_external_vault_proxy.rs
@@ -9,7 +9,7 @@ use hyperswitch_domain_models::{
     mandates::MandateTransactionType, payment_methods::VaultPaymentMethodData,
 };
 use hyperswitch_masking::{ExposeInterface, Secret};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_confirm_intent.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm_intent.rs
@@ -6,7 +6,7 @@ use futures::FutureExt;
 use hyperswitch_domain_models::{mandates, payments::PaymentConfirmData};
 use hyperswitch_interfaces::api::ConnectorSpecifications;
 use hyperswitch_masking::{ExposeOptionInterface, PeekInterface};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -25,7 +25,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 use router_derive::PaymentOperation;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use storage_impl::platform_wrapper;
 use time::PrimitiveDateTime;
 

--- a/crates/router/src/core/payments/operations/payment_create_intent.rs
+++ b/crates/router/src/core/payments/operations/payment_create_intent.rs
@@ -9,7 +9,7 @@ use common_utils::{
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_get.rs
+++ b/crates/router/src/core/payments/operations/payment_get.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use common_utils::ext_traits::AsyncExt;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::payments::PaymentStatusData;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_get_intent.rs
+++ b/crates/router/src/core/payments/operations/payment_get_intent.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use api_models::{enums::FrmSuggestion, payments::PaymentsGetIntentRequest};
 use async_trait::async_trait;
 use common_utils::errors::CustomResult;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_post_session_tokens.rs
+++ b/crates/router/src/core/payments/operations/payment_post_session_tokens.rs
@@ -6,7 +6,7 @@ use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates::MandateTransactionType;
 use hyperswitch_masking::PeekInterface;
 use router_derive::PaymentOperation;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_recurrence.rs
+++ b/crates/router/src/core/payments/operations/payment_recurrence.rs
@@ -7,7 +7,7 @@ use error_stack::{report, ResultExt};
 use futures::FutureExt;
 use hyperswitch_masking::ExposeInterface;
 use router_derive::PaymentOperation;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use tracing_futures::Instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};

--- a/crates/router/src/core/payments/operations/payment_reject.rs
+++ b/crates/router/src/core/payments/operations/payment_reject.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use api_models::{enums::FrmSuggestion, payments::PaymentsCancelRequest};
 use async_trait::async_trait;
 use error_stack::ResultExt;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -31,7 +31,7 @@ use hyperswitch_masking::ExposeInterface;
 #[cfg(feature = "v2")]
 use hyperswitch_masking::PeekInterface;
 use router_derive;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 #[cfg(feature = "v1")]
 use tracing_futures::Instrument;
 

--- a/crates/router/src/core/payments/operations/payment_session.rs
+++ b/crates/router/src/core/payments/operations/payment_session.rs
@@ -6,7 +6,7 @@ use common_utils::ext_traits::{AsyncExt, ValueExt};
 use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates;
 use router_derive::PaymentOperation;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_session_intent.rs
+++ b/crates/router/src/core/payments/operations/payment_session_intent.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use common_utils::{errors::CustomResult, ext_traits::Encode};
 use error_stack::ResultExt;
 use hyperswitch_domain_models::customer;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_start.rs
+++ b/crates/router/src/core/payments/operations/payment_start.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates;
 use router_derive::PaymentOperation;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -6,7 +6,7 @@ use common_utils::ext_traits::AsyncExt;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates::{self, MandateTransactionType};
 use router_derive::PaymentOperation;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -17,7 +17,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_interfaces::api::ConnectorSpecifications;
 use router_derive::PaymentOperation;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_update_intent.rs
+++ b/crates/router/src/core/payments/operations/payment_update_intent.rs
@@ -17,7 +17,7 @@ use hyperswitch_domain_models::{
     ApiModelToDieselModelConvertor,
 };
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payment_update_metadata.rs
+++ b/crates/router/src/core/payments/operations/payment_update_metadata.rs
@@ -6,7 +6,7 @@ use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates;
 use hyperswitch_masking::ExposeInterface;
 use router_derive::PaymentOperation;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payments_extend_authorization.rs
+++ b/crates/router/src/core/payments/operations/payments_extend_authorization.rs
@@ -4,7 +4,7 @@ use api_models::enums::FrmSuggestion;
 use async_trait::async_trait;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/payments_incremental_authorization.rs
+++ b/crates/router/src/core/payments/operations/payments_incremental_authorization.rs
@@ -6,7 +6,7 @@ use common_utils::errors::CustomResult;
 use diesel_models::authorization::AuthorizationNew;
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::mandates::MandateTransactionType;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/proxy_payments_intent.rs
+++ b/crates/router/src/core/payments/operations/proxy_payments_intent.rs
@@ -8,7 +8,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_interfaces::api::ConnectorSpecifications;
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{Domain, GetTracker, Operation, PostUpdateTracker, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/operations/tax_calculation.rs
+++ b/crates/router/src/core/payments/operations/tax_calculation.rs
@@ -7,7 +7,7 @@ use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates::MandateTransactionType;
 use hyperswitch_masking::PeekInterface;
 use router_derive::PaymentOperation;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, ValidateRequest};
 use crate::{

--- a/crates/router/src/core/payments/retry.rs
+++ b/crates/router/src/core/payments/retry.rs
@@ -4,10 +4,7 @@ use common_utils::{ext_traits::Encode, types::MinorUnit};
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{ext_traits::OptionExt, mandates};
-use router_env::{
-    logger,
-    tracing::instrument,
-};
+use router_env::{logger, tracing::instrument};
 
 use crate::{
     consts,

--- a/crates/router/src/core/payments/retry.rs
+++ b/crates/router/src/core/payments/retry.rs
@@ -6,7 +6,7 @@ use error_stack::ResultExt;
 use hyperswitch_domain_models::{ext_traits::OptionExt, mandates};
 use router_env::{
     logger,
-    tracing::{self, instrument},
+    tracing::instrument,
 };
 
 use crate::{

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -53,7 +53,7 @@ use rand::distributions::{self, Distribution};
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
 use rand::SeedableRng;
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use rustc_hash::FxHashMap;
 use storage_impl::redis::cache::{CacheKey, CGRAPH_CACHE, ROUTING_CACHE};
 

--- a/crates/router/src/core/payments/session_operation.rs
+++ b/crates/router/src/core/payments/session_operation.rs
@@ -18,7 +18,7 @@ use hyperswitch_interfaces::{
     connector_integration_v2::{ConnectorIntegrationV2, ConnectorV2},
 };
 use hyperswitch_masking::ExposeInterface;
-use router_env::{env::Env, instrument, tracing};
+use router_env::{env::Env, instrument};
 
 use crate::{
     core::{

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -25,7 +25,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_interfaces::api::gateway;
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::helpers;
 #[cfg(feature = "v1")]

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -56,7 +56,7 @@ use hyperswitch_interfaces::connector_integration_interface::RouterDataConversio
 use hyperswitch_masking::{ExposeInterface, Maskable, Secret};
 #[cfg(feature = "v2")]
 use hyperswitch_masking::{ExposeOptionInterface, PeekInterface};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{flows::Feature, types::AuthenticationData, OperationSessionGetters, PaymentData};
 use crate::{

--- a/crates/router/src/core/payments/types.rs
+++ b/crates/router/src/core/payments/types.rs
@@ -12,7 +12,7 @@ pub use hyperswitch_domain_models::router_request_types::{
     self, AuthenticationData, SplitRefundsRequest, StripeSplitRefund, SurchargeDetails,
 };
 use redis_interface::errors::RedisError;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use crate::{
     consts as router_consts,

--- a/crates/router/src/core/payouts.rs
+++ b/crates/router/src/core/payouts.rs
@@ -41,7 +41,7 @@ use hyperswitch_interfaces::api::gateway as payout_gateway;
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 #[cfg(feature = "payout_retry")]
 use retry::GsmValidation;
-use router_env::{instrument, logger, tracing, Env};
+use router_env::{instrument, logger, Env};
 use scheduler::utils as pt_utils;
 use time::Duration;
 

--- a/crates/router/src/core/payouts/retry.rs
+++ b/crates/router/src/core/payouts/retry.rs
@@ -5,7 +5,7 @@ use error_stack::ResultExt;
 use hyperswitch_domain_models::payments::HeaderPayload;
 use router_env::{
     logger,
-    tracing::{self, instrument},
+    tracing::instrument,
 };
 
 use super::{call_connector_payout, PayoutData};

--- a/crates/router/src/core/payouts/retry.rs
+++ b/crates/router/src/core/payouts/retry.rs
@@ -3,10 +3,7 @@ use std::vec::IntoIter;
 use common_enums::PayoutRetryType;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::payments::HeaderPayload;
-use router_env::{
-    logger,
-    tracing::instrument,
-};
+use router_env::{logger, tracing::instrument};
 
 use super::{call_connector_payout, PayoutData};
 use crate::{

--- a/crates/router/src/core/payouts/validator.rs
+++ b/crates/router/src/core/payouts/validator.rs
@@ -10,7 +10,7 @@ use common_utils::{
 use diesel_models::generic_link::PayoutLink;
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::payment_methods::PaymentMethod;
-use router_env::{instrument, tracing, which as router_env_which, Env};
+use router_env::{instrument, which as router_env_which, Env};
 use url::Url;
 
 use super::helpers;

--- a/crates/router/src/core/poll.rs
+++ b/crates/router/src/core/poll.rs
@@ -1,7 +1,7 @@
 use api_models::poll::PollResponse;
 use common_utils::ext_traits::StringExt;
 use error_stack::ResultExt;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::errors;
 use crate::{

--- a/crates/router/src/core/relay.rs
+++ b/crates/router/src/core/relay.rs
@@ -16,7 +16,7 @@ use hyperswitch_interfaces::{
     relay::{ConnectorRelayIntegration, UnreferencedRefundRouterData},
 };
 use hyperswitch_masking::Secret;
-use router_env::tracing::{self, instrument};
+use router_env::tracing::instrument;
 
 use super::errors::{self, ConnectorErrorExt, RouterResponse, RouterResult, StorageErrorExt};
 use crate::{

--- a/crates/router/src/core/revenue_recovery/retry_stats/record.rs
+++ b/crates/router/src/core/revenue_recovery/retry_stats/record.rs
@@ -5,7 +5,7 @@ use hyperswitch_domain_models::revenue_recovery::{
     retry_stats_cluster_key::RetryStatsClusterKey, retry_stats_document::StatsDocument,
 };
 use redis_interface::SetnxReply;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use storage_impl::{
     errors::StorageError, revenue_recovery_retry_stats::RevenueRecoveryRetryStatsInterface,
 };

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -28,7 +28,7 @@ use external_services::grpc_client::dynamic_routing::{
 use hyperswitch_domain_models::api::ApplicationResponse;
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
 use hyperswitch_interfaces::events::routing_api_logs as routing_events;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use rustc_hash::FxHashSet;
 use storage_impl::redis::cache;
 #[cfg(all(feature = "dynamic_routing", feature = "v1"))]

--- a/crates/router/src/core/three_ds_decision_rule.rs
+++ b/crates/router/src/core/three_ds_decision_rule.rs
@@ -8,7 +8,7 @@ use euclid::{
     frontend::ast,
 };
 use hyperswitch_domain_models::platform::Platform;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use crate::{
     core::{

--- a/crates/router/src/core/tokenization.rs
+++ b/crates/router/src/core/tokenization.rs
@@ -13,7 +13,7 @@ use common_utils::{
 #[cfg(all(feature = "v2", feature = "tokenization_v2"))]
 use error_stack::ResultExt;
 #[cfg(all(feature = "v2", feature = "tokenization_v2"))]
-use router_env::{instrument, logger, tracing, Flow};
+use router_env::{instrument, logger, Flow};
 #[cfg(all(feature = "v2", feature = "tokenization_v2"))]
 use serde::Serialize;
 

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -22,7 +22,7 @@ use diesel_models::{
 };
 use error_stack::{report, ResultExt};
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
-use router_env::{env, instrument, logger, tracing};
+use router_env::{env, instrument, logger};
 use storage_impl::errors::StorageError;
 #[cfg(feature = "v1")]
 use subscriptions::RouterResponse;

--- a/crates/router/src/core/user/launch_sage.rs
+++ b/crates/router/src/core/user/launch_sage.rs
@@ -11,7 +11,7 @@ use diesel_models::enums::UserStatus;
 use error_stack::ResultExt;
 use external_services::http_client;
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use crate::{
     core::errors::launch_sage::LaunchSageErrors,

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -42,7 +42,7 @@ use hyperswitch_masking::Secret;
 use hyperswitch_masking::{ExposeInterface, PeekInterface};
 use maud::{html, PreEscaped};
 use regex::Regex;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::StorageError;
 
 use super::payments::helpers;

--- a/crates/router/src/core/utils/refunds_validator.rs
+++ b/crates/router/src/core/utils/refunds_validator.rs
@@ -4,7 +4,7 @@ use error_stack::report;
 use hyperswitch_domain_models::router_response_types::SupportedPaymentMethodsExt;
 #[cfg(feature = "v1")]
 use hyperswitch_interfaces::{self, api::ConnectorSpecifications};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use time::PrimitiveDateTime;
 
 use crate::{

--- a/crates/router/src/core/webhooks/incoming_v2.rs
+++ b/crates/router/src/core/webhooks/incoming_v2.rs
@@ -13,7 +13,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_interfaces::webhooks::{IncomingWebhookRequestDetails, WebhookResourceData};
 use hyperswitch_masking::Secret;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{types, utils, MERCHANT_ID};
 #[cfg(feature = "revenue_recovery")]

--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -19,7 +19,7 @@ use hyperswitch_interfaces::{consts, webhooks::WebhookResourceData};
 use hyperswitch_masking::{ExposeInterface, Mask, PeekInterface, Secret};
 use router_env::{
     instrument,
-    tracing::{self, Instrument},
+    tracing::Instrument,
 };
 
 use super::{types, utils, MERCHANT_CONNECTOR_ACCOUNT_ID, MERCHANT_ID};

--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -17,10 +17,7 @@ use error_stack::{report, Report, ResultExt};
 use hyperswitch_domain_models::type_encryption::{crypto_operation, CryptoOperation};
 use hyperswitch_interfaces::{consts, webhooks::WebhookResourceData};
 use hyperswitch_masking::{ExposeInterface, Mask, PeekInterface, Secret};
-use router_env::{
-    instrument,
-    tracing::Instrument,
-};
+use router_env::{instrument, tracing::Instrument};
 
 use super::{types, utils, MERCHANT_CONNECTOR_ACCOUNT_ID, MERCHANT_ID};
 #[cfg(feature = "stripe")]

--- a/crates/router/src/core/webhooks/outgoing_v2.rs
+++ b/crates/router/src/core/webhooks/outgoing_v2.rs
@@ -6,10 +6,7 @@ use diesel_models::process_tracker::business_status;
 use error_stack::{report, Report, ResultExt};
 use hyperswitch_domain_models::type_encryption::{crypto_operation, CryptoOperation};
 use hyperswitch_interfaces::consts;
-use router_env::{
-    instrument,
-    tracing::Instrument,
-};
+use router_env::{instrument, tracing::Instrument};
 
 use super::{
     types,

--- a/crates/router/src/core/webhooks/outgoing_v2.rs
+++ b/crates/router/src/core/webhooks/outgoing_v2.rs
@@ -8,7 +8,7 @@ use hyperswitch_domain_models::type_encryption::{crypto_operation, CryptoOperati
 use hyperswitch_interfaces::consts;
 use router_env::{
     instrument,
-    tracing::{self, Instrument},
+    tracing::Instrument,
 };
 
 use super::{

--- a/crates/router/src/core/webhooks/recovery_incoming.rs
+++ b/crates/router/src/core/webhooks/recovery_incoming.rs
@@ -19,7 +19,7 @@ use hyperswitch_domain_models::{
 };
 use hyperswitch_interfaces::webhooks as interface_webhooks;
 use hyperswitch_masking::{PeekInterface, Secret};
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use services::kafka;
 use storage::business_status;
 

--- a/crates/router/src/core/webhooks/webhook_events.rs
+++ b/crates/router/src/core/webhooks/webhook_events.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use common_utils::{self, errors::CustomResult, fp_utils};
 use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     core::errors::{self, RouterResponse, StorageErrorExt},

--- a/crates/router/src/db/address.rs
+++ b/crates/router/src/db/address.rs
@@ -78,7 +78,7 @@ where
 mod storage {
     use common_utils::{ext_traits::AsyncExt, id_type, types::keymanager::KeyManagerState};
     use error_stack::{report, ResultExt};
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
 
     use super::AddressInterface;
     use crate::{
@@ -300,7 +300,7 @@ mod storage {
     use diesel_models::{enums::MerchantStorageScheme, AddressUpdateInternal};
     use error_stack::{report, ResultExt};
     use redis_interface::HsetnxReply;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
     use storage_impl::redis::kv_store::{
         decide_storage_scheme, kv_wrapper, KvOperation, Op, PartitionKey,
     };

--- a/crates/router/src/db/api_keys.rs
+++ b/crates/router/src/db/api_keys.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 #[cfg(feature = "accounts_cache")]
 use storage_impl::redis::cache::{self, CacheKind, ACCOUNTS_CACHE};
 

--- a/crates/router/src/db/authorization.rs
+++ b/crates/router/src/db/authorization.rs
@@ -1,6 +1,6 @@
 use diesel_models::authorization::AuthorizationUpdateInternal;
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{MockDb, Store};
 use crate::{

--- a/crates/router/src/db/batch_blocklist_job.rs
+++ b/crates/router/src/db/batch_blocklist_job.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::MockDb;
 
 use super::Store;

--- a/crates/router/src/db/blocklist.rs
+++ b/crates/router/src/db/blocklist.rs
@@ -1,5 +1,5 @@
 use error_stack::{report, ResultExt};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::MockDb;
 
 use super::Store;

--- a/crates/router/src/db/blocklist_fingerprint.rs
+++ b/crates/router/src/db/blocklist_fingerprint.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::MockDb;
 
 use super::Store;

--- a/crates/router/src/db/blocklist_lookup.rs
+++ b/crates/router/src/db/blocklist_lookup.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::MockDb;
 
 use super::Store;

--- a/crates/router/src/db/callback_mapper.rs
+++ b/crates/router/src/db/callback_mapper.rs
@@ -1,6 +1,6 @@
 use error_stack::report;
 use hyperswitch_domain_models::callback_mapper as domain;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::{DataModelExt, MockDb};
 
 use super::Store;

--- a/crates/router/src/db/capture.rs
+++ b/crates/router/src/db/capture.rs
@@ -1,4 +1,4 @@
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::MockDb;
 use crate::{
@@ -34,7 +34,7 @@ pub trait CaptureInterface {
 mod storage {
     use error_stack::{report, ResultExt};
     use redis_interface::HsetnxReply;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
     use storage_impl::{
         redis::kv_store::{decide_storage_scheme, kv_wrapper, KvOperation, Op, PartitionKey},
         utils::find_all_combined_kv_database,
@@ -244,7 +244,7 @@ mod storage {
 #[cfg(not(feature = "kv_store"))]
 mod storage {
     use error_stack::report;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
 
     use super::CaptureInterface;
     use crate::{

--- a/crates/router/src/db/card_issuer.rs
+++ b/crates/router/src/db/card_issuer.rs
@@ -1,6 +1,6 @@
 use common_utils::id_type;
 use hyperswitch_domain_models::card_issuer::CardIssuersInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     core::errors::{self, CustomResult},

--- a/crates/router/src/db/dashboard_metadata.rs
+++ b/crates/router/src/db/dashboard_metadata.rs
@@ -1,7 +1,7 @@
 use common_utils::id_type;
 use diesel_models::{enums, user::dashboard_metadata as storage};
 use error_stack::{report, ResultExt};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::MockDb;
 
 use crate::{

--- a/crates/router/src/db/dispute.rs
+++ b/crates/router/src/db/dispute.rs
@@ -65,7 +65,7 @@ pub trait DisputeInterface {
 mod storage_impl {
     use error_stack::report;
     use hyperswitch_domain_models::disputes;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
 
     use super::DisputeInterface;
     use crate::{
@@ -234,7 +234,7 @@ mod storage_impl {
     use error_stack::{report, ResultExt};
     use hyperswitch_domain_models::disputes;
     use redis_interface::HsetnxReply;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
     use storage_impl::{
         redis::kv_store::{decide_storage_scheme, kv_wrapper, KvOperation, Op, PartitionKey},
         utils as storage_impl_utils, KvSupportedEntity,

--- a/crates/router/src/db/dynamic_routing_stats.rs
+++ b/crates/router/src/db/dynamic_routing_stats.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::MockDb;
 
 use super::Store;

--- a/crates/router/src/db/ephemeral_key.rs
+++ b/crates/router/src/db/ephemeral_key.rs
@@ -64,7 +64,7 @@ mod storage {
     #[cfg(feature = "v2")]
     use redis_interface::errors::RedisError;
     use redis_interface::HsetnxReply;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
     use storage_impl::redis::kv_store::RedisConnInterface;
     use time::ext::NumericalDuration;
 

--- a/crates/router/src/db/events.rs
+++ b/crates/router/src/db/events.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use common_utils::ext_traits::AsyncExt;
 use error_stack::{report, ResultExt};
 use futures::future::try_join_all;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{MockDb, Store};
 use crate::{

--- a/crates/router/src/db/file.rs
+++ b/crates/router/src/db/file.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{MockDb, Store};
 use crate::{

--- a/crates/router/src/db/fraud_check.rs
+++ b/crates/router/src/db/fraud_check.rs
@@ -1,6 +1,6 @@
 use diesel_models::fraud_check::{self as storage, FraudCheck, FraudCheckUpdate};
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::MockDb;
 use crate::{

--- a/crates/router/src/db/generic_link.rs
+++ b/crates/router/src/db/generic_link.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     connection,

--- a/crates/router/src/db/gsm.rs
+++ b/crates/router/src/db/gsm.rs
@@ -1,6 +1,6 @@
 use diesel_models::gsm as storage;
 use error_stack::{report, ResultExt};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::MockDb;
 use crate::{

--- a/crates/router/src/db/health_check.rs
+++ b/crates/router/src/db/health_check.rs
@@ -1,7 +1,7 @@
 use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl};
 use diesel_models::ConfigNew;
 use error_stack::ResultExt;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use super::{MockDb, Store};
 use crate::{

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -40,7 +40,7 @@ use hyperswitch_domain_models::{
 use hyperswitch_domain_models::{PayoutAttemptInterface, PayoutsInterface};
 use hyperswitch_masking::Secret;
 use redis_interface::{errors::RedisError, RedisEntryId};
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 use scheduler::{
     db::{process_tracker::ProcessTrackerInterface, queue::QueueInterface},
     SchedulerInterface,

--- a/crates/router/src/db/locker_mock_up.rs
+++ b/crates/router/src/db/locker_mock_up.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{MockDb, Store};
 use crate::{

--- a/crates/router/src/db/mandate.rs
+++ b/crates/router/src/db/mandate.rs
@@ -62,7 +62,7 @@ mod storage {
     use common_utils::{fallback_reverse_lookup_not_found, id_type};
     use error_stack::{report, ResultExt};
     use redis_interface::HsetnxReply;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
     use storage_impl::redis::kv_store::{
         decide_storage_scheme, kv_wrapper, KvOperation, Op, PartitionKey,
     };
@@ -402,7 +402,7 @@ mod storage {
 mod storage {
     use common_utils::id_type;
     use error_stack::report;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
 
     use super::MandateInterface;
     use crate::{

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -1,7 +1,7 @@
 use common_utils::ext_traits::{ByteSliceExt, Encode};
 use error_stack::ResultExt;
 pub use hyperswitch_domain_models::merchant_connector_account::MerchantConnectorAccountInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::redis::kv_store::RedisConnInterface;
 
 use super::{MockDb, Store};

--- a/crates/router/src/db/organization.rs
+++ b/crates/router/src/db/organization.rs
@@ -1,7 +1,7 @@
 use common_utils::{errors::CustomResult, id_type};
 use diesel_models::{organization as storage, organization::OrganizationBridge};
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 #[cfg(feature = "accounts_cache")]
 use storage_impl::redis::cache::{self, CacheKind, ACCOUNTS_CACHE};
 

--- a/crates/router/src/db/payment_link.rs
+++ b/crates/router/src/db/payment_link.rs
@@ -1,5 +1,5 @@
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     connection,

--- a/crates/router/src/db/payment_method_session.rs
+++ b/crates/router/src/db/payment_method_session.rs
@@ -42,7 +42,7 @@ impl PaymentMethodsSessionInterface for crate::services::Store {}
 #[cfg(feature = "v2")]
 mod storage {
     use error_stack::ResultExt;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
     use storage_impl::{
         behaviour::{Conversion, ReverseConversion},
         redis::kv_store::RedisConnInterface,

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -135,7 +135,7 @@ pub trait RefundInterface {
 mod storage {
     use error_stack::report;
     use hyperswitch_domain_models::refunds;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
 
     use super::RefundInterface;
     use crate::{
@@ -494,7 +494,7 @@ mod storage {
     use error_stack::{report, ResultExt};
     use hyperswitch_domain_models::refunds;
     use redis_interface::HsetnxReply;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
     use storage_impl::redis::kv_store::{
         decide_storage_scheme, kv_wrapper, KvOperation, Op, PartitionKey,
     };

--- a/crates/router/src/db/reverse_lookup.rs
+++ b/crates/router/src/db/reverse_lookup.rs
@@ -24,7 +24,7 @@ pub trait ReverseLookupInterface {
 #[cfg(not(feature = "kv_store"))]
 mod storage {
     use error_stack::report;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
 
     use super::{ReverseLookupInterface, Store};
     use crate::{
@@ -68,7 +68,7 @@ mod storage {
 mod storage {
     use error_stack::{report, ResultExt};
     use redis_interface::SetnxReply;
-    use router_env::{instrument, tracing};
+    use router_env::instrument;
     use storage_impl::redis::kv_store::{
         decide_storage_scheme, kv_wrapper, KvOperation, Op, PartitionKey,
     };

--- a/crates/router/src/db/role.rs
+++ b/crates/router/src/db/role.rs
@@ -4,7 +4,7 @@ use diesel_models::{
     role as storage,
 };
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::MockDb;
 use crate::{

--- a/crates/router/src/db/routing_algorithm.rs
+++ b/crates/router/src/db/routing_algorithm.rs
@@ -2,7 +2,7 @@ use diesel_models::{
     enums as storage_enums, errors::DatabaseError, routing_algorithm as routing_storage,
 };
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::mock_db::MockDb;
 
 use crate::{

--- a/crates/router/src/db/user.rs
+++ b/crates/router/src/db/user.rs
@@ -1,7 +1,7 @@
 use diesel_models::{enums::TotpStatus, user as storage};
 use error_stack::report;
 use hyperswitch_masking::Secret;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::{domain, MockDb};
 use crate::{

--- a/crates/router/src/db/user_authentication_method.rs
+++ b/crates/router/src/db/user_authentication_method.rs
@@ -1,6 +1,6 @@
 use diesel_models::user_authentication_method as storage;
 use error_stack::report;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::MockDb;
 use crate::{

--- a/crates/router/src/db/user_key_store.rs
+++ b/crates/router/src/db/user_key_store.rs
@@ -1,7 +1,7 @@
 use common_utils::{errors::CustomResult, types::keymanager};
 use error_stack::{report, ResultExt};
 use hyperswitch_masking::Secret;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use storage_impl::MockDb;
 
 use crate::{

--- a/crates/router/src/db/user_role.rs
+++ b/crates/router/src/db/user_role.rs
@@ -5,7 +5,7 @@ use diesel_models::{
     user_role as storage,
 };
 use error_stack::{report, ResultExt};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::MockDb;
 use crate::{

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -84,10 +84,10 @@ where
         Box::pin(
             async move {
                 if let Some(tenant) = tenant_id_clone {
-                    router_env::tracing::Span::current().record("tenant_id", tenant);
+                    tracing::Span::current().record("tenant_id", tenant);
                 }
                 let response = response_fut.await;
-                router_env::tracing::Span::current().record("golden_log_line", true);
+                tracing::Span::current().record("golden_log_line", true);
                 response
             }
             .instrument(

--- a/crates/router/src/routes/admin.rs
+++ b/crates/router/src/routes/admin.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/api_keys.rs
+++ b/crates/router/src/routes/api_keys.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/authentication.rs
+++ b/crates/router/src/routes/authentication.rs
@@ -7,7 +7,7 @@ use api_models::authentication::{
     AuthenticationSyncPostUpdateRequest, AuthenticationSyncRequest,
 };
 use hyperswitch_masking::Secret;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     core::{api_locking, unified_authentication_service},

--- a/crates/router/src/routes/cache.rs
+++ b/crates/router/src/routes/cache.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::AppState;
 use crate::{

--- a/crates/router/src/routes/card_issuer.rs
+++ b/crates/router/src/routes/card_issuer.rs
@@ -1,7 +1,7 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::card_issuer as api_types;
 use common_utils::id_type;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/cards_info.rs
+++ b/crates/router/src/routes/cards_info.rs
@@ -1,7 +1,7 @@
 use actix_multipart::form::MultipartForm;
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use api_models::cards_info as cards_info_api_types;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/configs.rs
+++ b/crates/router/src/routes/configs.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/customers.rs
+++ b/crates/router/src/routes/customers.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use common_utils::id_type;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 #[cfg(feature = "v2")]
 pub mod migrate;

--- a/crates/router/src/routes/customers/migrate.rs
+++ b/crates/router/src/routes/customers/migrate.rs
@@ -9,7 +9,7 @@ use api_models::customers::migrate::{
 use common_enums::ApiVersion;
 use common_utils::id_type;
 use error_stack::{report, ResultExt};
-use router_env::{instrument, logger, tracing, Flow};
+use router_env::{instrument, logger, Flow};
 
 use crate::{
     core::{api_locking, customers, errors},

--- a/crates/router/src/routes/disputes.rs
+++ b/crates/router/src/routes/disputes.rs
@@ -1,7 +1,7 @@
 use actix_multipart::Multipart;
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::disputes as dispute_models;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{core::api_locking, services::authorization::permissions::Permission};
 pub mod utils;

--- a/crates/router/src/routes/dummy_connector.rs
+++ b/crates/router/src/routes/dummy_connector.rs
@@ -1,5 +1,5 @@
 use actix_web::web;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::app;
 use crate::{

--- a/crates/router/src/routes/ephemeral_key.rs
+++ b/crates/router/src/routes/ephemeral_key.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::AppState;
 #[cfg(feature = "v2")]

--- a/crates/router/src/routes/feature_matrix.rs
+++ b/crates/router/src/routes/feature_matrix.rs
@@ -5,7 +5,7 @@ use hyperswitch_domain_models::{
     api::ApplicationResponse, router_response_types::PaymentMethodTypeMetadata,
 };
 use hyperswitch_interfaces::api::{ConnectorCommon, ConnectorSpecifications};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 use strum::IntoEnumIterator;
 
 use crate::{

--- a/crates/router/src/routes/files.rs
+++ b/crates/router/src/routes/files.rs
@@ -1,7 +1,7 @@
 use actix_multipart::Multipart;
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::files as file_types;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::core::api_locking;
 pub mod transformers;

--- a/crates/router/src/routes/gsm.rs
+++ b/crates/router/src/routes/gsm.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, Responder};
 use api_models::gsm as gsm_api_types;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/health.rs
+++ b/crates/router/src/routes/health.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest};
 use api_models::health_check::RouterHealthCheckResponse;
-use router_env::{instrument, logger, tracing, Flow};
+use router_env::{instrument, logger, Flow};
 
 use super::app;
 use crate::{

--- a/crates/router/src/routes/mandates.rs
+++ b/crates/router/src/routes/mandates.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/offer_engine.rs
+++ b/crates/router/src/routes/offer_engine.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::offer_engine as offer_engine_api;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app;
 use crate::{

--- a/crates/router/src/routes/oidc.rs
+++ b/crates/router/src/routes/oidc.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::oidc as oidc_types;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     core::api_locking,

--- a/crates/router/src/routes/payment_link.rs
+++ b/crates/router/src/routes/payment_link.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     core::{api_locking, payment_link::*},

--- a/crates/router/src/routes/payment_methods.rs
+++ b/crates/router/src/routes/payment_methods.rs
@@ -19,7 +19,7 @@ use hyperswitch_domain_models::{
 };
 #[cfg(feature = "v1")]
 pub use migrate::modular_migrate_payment_methods;
-use router_env::{instrument, logger, tracing, Flow};
+use router_env::{instrument, logger, Flow};
 
 use super::app::{AppState, SessionState};
 #[cfg(feature = "v2")]

--- a/crates/router/src/routes/payment_methods/migrate.rs
+++ b/crates/router/src/routes/payment_methods/migrate.rs
@@ -12,7 +12,7 @@ use common_utils::id_type;
 use error_stack::{report, ResultExt};
 use futures::future;
 use hyperswitch_domain_models::platform;
-use router_env::{instrument, logger, tracing, Flow};
+use router_env::{instrument, logger, Flow};
 
 use crate::{
     core::{api_locking, errors, payment_methods::cards},

--- a/crates/router/src/routes/pm_auth.rs
+++ b/crates/router/src/routes/pm_auth.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, Responder};
 use api_models as api_types;
-use router_env::{instrument, tracing, types::Flow};
+use router_env::{instrument, types::Flow};
 
 use crate::{
     core::api_locking,

--- a/crates/router/src/routes/poll.rs
+++ b/crates/router/src/routes/poll.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/profile_acquirer.rs
+++ b/crates/router/src/routes/profile_acquirer.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::profile_acquirer::{ProfileAcquirerCreate, ProfileAcquirerUpdate};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/profiles.rs
+++ b/crates/router/src/routes/profiles.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/proxy.rs
+++ b/crates/router/src/routes/proxy.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     self as app,

--- a/crates/router/src/routes/recovery_webhooks.rs
+++ b/crates/router/src/routes/recovery_webhooks.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/relay.rs
+++ b/crates/router/src/routes/relay.rs
@@ -1,7 +1,7 @@
 use actix_web::{web, Responder};
 use common_utils::ext_traits::OptionExt;
 use error_stack::ResultExt;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     self as app,

--- a/crates/router/src/routes/revenue_recovery_data_backfill.rs
+++ b/crates/router/src/routes/revenue_recovery_data_backfill.rs
@@ -4,7 +4,7 @@ use api_models::revenue_recovery_data_backfill::{
     BackfillQuery, GetRedisDataQuery, RetryStatsMigrationForm, RevenueRecoveryDataBackfillForm,
     UnlockStatusRequest, UnlockStatusResponse, UpdateTokenStatusRequest,
 };
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     core::{

--- a/crates/router/src/routes/revenue_recovery_redis.rs
+++ b/crates/router/src/routes/revenue_recovery_redis.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::revenue_recovery_data_backfill::GetRedisDataQuery;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     core::{api_locking, revenue_recovery_data_backfill},

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -16,7 +16,7 @@ use api_models::{
 use error_stack::ResultExt;
 use payment_methods::core::errors::ApiErrorResponse;
 use router_env::{
-    tracing::{self, instrument},
+    tracing::instrument,
     Flow,
 };
 

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -15,10 +15,7 @@ use api_models::{
 };
 use error_stack::ResultExt;
 use payment_methods::core::errors::ApiErrorResponse;
-use router_env::{
-    tracing::instrument,
-    Flow,
-};
+use router_env::{tracing::instrument, Flow};
 
 use crate::{
     core::{

--- a/crates/router/src/routes/subscription.rs
+++ b/crates/router/src/routes/subscription.rs
@@ -10,7 +10,7 @@ use api_models::subscription as subscription_types;
 use error_stack::report;
 use hyperswitch_domain_models::errors;
 use router_env::{
-    tracing::{self, instrument},
+    tracing::instrument,
     Flow,
 };
 

--- a/crates/router/src/routes/subscription.rs
+++ b/crates/router/src/routes/subscription.rs
@@ -9,10 +9,7 @@ use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use api_models::subscription as subscription_types;
 use error_stack::report;
 use hyperswitch_domain_models::errors;
-use router_env::{
-    tracing::instrument,
-    Flow,
-};
+use router_env::{tracing::instrument, Flow};
 
 use crate::{
     core::api_locking,

--- a/crates/router/src/routes/superposition_proxy.rs
+++ b/crates/router/src/routes/superposition_proxy.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use external_services::superposition::{ContextPutRequest, ResolveConfigBody};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/superposition_sdk_config.rs
+++ b/crates/router/src/routes/superposition_sdk_config.rs
@@ -4,7 +4,7 @@ use error_stack::ResultExt;
 #[cfg(feature = "v1")]
 use hyperswitch_domain_models::sdk_auth::SdkAuthorization;
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 #[cfg(feature = "v1")]

--- a/crates/router/src/routes/three_ds_decision_rule.rs
+++ b/crates/router/src/routes/three_ds_decision_rule.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     self as app,

--- a/crates/router/src/routes/tokenization.rs
+++ b/crates/router/src/routes/tokenization.rs
@@ -13,7 +13,7 @@ use error_stack::ResultExt;
 #[cfg(all(feature = "v2", feature = "tokenization_v2"))]
 use hyperswitch_masking::Secret;
 #[cfg(all(feature = "v2", feature = "tokenization_v2"))]
-use router_env::{instrument, logger, tracing, Flow};
+use router_env::{instrument, logger, Flow};
 #[cfg(all(feature = "v2", feature = "tokenization_v2"))]
 use serde::Serialize;
 

--- a/crates/router/src/routes/unified_connector_service.rs
+++ b/crates/router/src/routes/unified_connector_service.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/verification.rs
+++ b/crates/router/src/routes/verification.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, Responder};
 use api_models::verifications;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/routes/verify_connector.rs
+++ b/crates/router/src/routes/verify_connector.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use api_models::verify_connector::VerifyConnectorRequest;
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::AppState;
 use crate::{

--- a/crates/router/src/routes/webhook_events.rs
+++ b/crates/router/src/routes/webhook_events.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use crate::{
     core::{api_locking, webhooks::webhook_events},

--- a/crates/router/src/routes/webhooks.rs
+++ b/crates/router/src/routes/webhooks.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, Responder};
-use router_env::{instrument, tracing, Flow};
+use router_env::{instrument, Flow};
 
 use super::app::AppState;
 use crate::{

--- a/crates/router/src/utils/currency.rs
+++ b/crates/router/src/utils/currency.rs
@@ -11,7 +11,7 @@ use currency_conversion::types::{CurrencyFactors, ExchangeRates};
 use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
 use redis_interface::DelReply;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use rust_decimal::Decimal;
 use strum::IntoEnumIterator;
 use tokio::sync::RwLock;

--- a/crates/router/src/utils/user.rs
+++ b/crates/router/src/utils/user.rs
@@ -16,7 +16,7 @@ use error_stack::ResultExt;
 use hyperswitch_domain_models::merchant_connector_account::MerchantConnectorAccount as DomainMerchantConnectorAccount;
 use hyperswitch_masking::{ExposeInterface, Secret};
 use redis_interface::RedisConnectionWithContext;
-use router_env::{env, instrument, logger, tracing, tracing::Instrument};
+use router_env::{env, instrument, logger, tracing::Instrument};
 
 use crate::{
     consts::user::{REDIS_SSO_PREFIX, REDIS_SSO_TTL},

--- a/crates/router/src/workflows/batch_blocklist_upload.rs
+++ b/crates/router/src/workflows/batch_blocklist_upload.rs
@@ -1,6 +1,6 @@
 use common_utils::{ext_traits::ValueExt, id_type};
 use error_stack::ResultExt;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use scheduler::{
     consumer::{self, types::process_data},
     utils as pt_utils,

--- a/crates/router/src/workflows/outgoing_webhook_retry.rs
+++ b/crates/router/src/workflows/outgoing_webhook_retry.rs
@@ -13,7 +13,7 @@ use common_utils::{
 use diesel_models::process_tracker::business_status;
 use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
-use router_env::tracing::{self, instrument};
+use router_env::tracing::instrument;
 use scheduler::{
     consumer::{self, workflows::ProcessTrackerWorkflow},
     utils as scheduler_utils,

--- a/crates/router/src/workflows/revenue_recovery.rs
+++ b/crates/router/src/workflows/revenue_recovery.rs
@@ -39,10 +39,7 @@ use hyperswitch_domain_models::{
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 #[cfg(feature = "v2")]
 use rand::Rng;
-use router_env::{
-    logger,
-    tracing::instrument,
-};
+use router_env::{logger, tracing::instrument};
 use scheduler::{
     consumer::{self, workflows::ProcessTrackerWorkflow},
     errors,

--- a/crates/router/src/workflows/revenue_recovery.rs
+++ b/crates/router/src/workflows/revenue_recovery.rs
@@ -41,7 +41,7 @@ use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 use rand::Rng;
 use router_env::{
     logger,
-    tracing::{self, instrument},
+    tracing::instrument,
 };
 use scheduler::{
     consumer::{self, workflows::ProcessTrackerWorkflow},

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -16,6 +16,7 @@ fred     = ["redis_interface/fred",     "storage_impl/fred"]
 redis-rs = ["redis_interface/redis-rs", "storage_impl/redis-rs"]
 
 [dependencies]
+tracing = { workspace = true }
 # Third party crates
 async-trait = "0.1.88"
 error-stack = "0.4.1"

--- a/crates/scheduler/src/producer.rs
+++ b/crates/scheduler/src/producer.rs
@@ -3,10 +3,7 @@ use std::sync::Arc;
 use common_utils::{errors::CustomResult, id_type};
 use diesel_models::enums::ProcessTrackerStatus;
 use error_stack::{report, ResultExt};
-use router_env::{
-    instrument,
-    tracing::Instrument,
-};
+use router_env::{instrument, tracing::Instrument};
 use time::Duration;
 use tokio::sync::mpsc;
 

--- a/crates/scheduler/src/producer.rs
+++ b/crates/scheduler/src/producer.rs
@@ -5,7 +5,7 @@ use diesel_models::enums::ProcessTrackerStatus;
 use error_stack::{report, ResultExt};
 use router_env::{
     instrument,
-    tracing::{self, Instrument},
+    tracing::Instrument,
 };
 use time::Duration;
 use tokio::sync::mpsc;

--- a/crates/scheduler/src/utils.rs
+++ b/crates/scheduler/src/utils.rs
@@ -5,7 +5,7 @@ use diesel_models::enums::{self, ProcessTrackerStatus};
 pub use diesel_models::process_tracker as storage;
 use error_stack::{report, ResultExt};
 use redis_interface::{RedisConnectionWithContext, RedisEntryId};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 use uuid::Uuid;
 
 use super::{

--- a/crates/storage_impl/Cargo.toml
+++ b/crates/storage_impl/Cargo.toml
@@ -24,6 +24,7 @@ fred     = ["redis_interface/fred"]
 redis-rs = ["redis_interface/redis-rs"]
 
 [dependencies]
+tracing = { workspace = true }
 # First Party dependencies
 api_models = { version = "0.1.0", path = "../api_models" }
 common_enums = { version = "0.1.0", path = "../common_enums" }

--- a/crates/storage_impl/src/authentication.rs
+++ b/crates/storage_impl/src/authentication.rs
@@ -13,7 +13,7 @@ use hyperswitch_domain_models::{
     merchant_key_store::MerchantKeyStore,
 };
 use redis_interface::HsetnxReply;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     diesel_error_to_data_error,

--- a/crates/storage_impl/src/business_profile.rs
+++ b/crates/storage_impl/src/business_profile.rs
@@ -9,7 +9,7 @@ use hyperswitch_domain_models::{
 };
 #[cfg(feature = "accounts_cache")]
 use router_env::logger;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "accounts_cache")]
 use crate::redis::{

--- a/crates/storage_impl/src/business_profile.rs
+++ b/crates/storage_impl/src/business_profile.rs
@@ -7,9 +7,9 @@ use hyperswitch_domain_models::{
     },
     merchant_key_store::MerchantKeyStore,
 };
+use router_env::instrument;
 #[cfg(feature = "accounts_cache")]
 use router_env::logger;
-use router_env::instrument;
 
 #[cfg(feature = "accounts_cache")]
 use crate::redis::{

--- a/crates/storage_impl/src/card_issuer.rs
+++ b/crates/storage_impl/src/card_issuer.rs
@@ -2,7 +2,7 @@ use common_utils::id_type;
 pub use diesel_models::card_issuer::{CardIssuer, NewCardIssuer, UpdateCardIssuer};
 use error_stack::report;
 use hyperswitch_domain_models::card_issuer::CardIssuersInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     errors::StorageError,

--- a/crates/storage_impl/src/cards_info.rs
+++ b/crates/storage_impl/src/cards_info.rs
@@ -1,7 +1,7 @@
 pub use diesel_models::{CardInfo, UpdateCardInfo};
 use error_stack::report;
 use hyperswitch_domain_models::cards_info::CardsInfoInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     errors::StorageError,

--- a/crates/storage_impl/src/configs.rs
+++ b/crates/storage_impl/src/configs.rs
@@ -1,7 +1,7 @@
 use diesel_models::configs as storage;
 use error_stack::report;
 use hyperswitch_domain_models::configs::ConfigInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     connection,

--- a/crates/storage_impl/src/customers.rs
+++ b/crates/storage_impl/src/customers.rs
@@ -7,7 +7,7 @@ use hyperswitch_domain_models::{
     customer as domain, merchant_key_store::MerchantKeyStore, type_encryption::AsyncLift,
 };
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     behaviour::{Conversion, ForeignFrom, ForeignInto, ReverseConversion},

--- a/crates/storage_impl/src/invoice.rs
+++ b/crates/storage_impl/src/invoice.rs
@@ -6,7 +6,7 @@ pub use hyperswitch_domain_models::{
     invoice::{Invoice as DomainInvoice, InvoiceInterface, InvoiceUpdate as DomainInvoiceUpdate},
     merchant_key_store::MerchantKeyStore,
 };
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     connection, errors::StorageError, kv_router_store::KVRouterStore, DatabaseStore, MockDb,

--- a/crates/storage_impl/src/merchant_account.rs
+++ b/crates/storage_impl/src/merchant_account.rs
@@ -11,7 +11,7 @@ use hyperswitch_domain_models::{
     merchant_key_store::{MerchantKeyStore, MerchantKeyStoreInterface},
 };
 use hyperswitch_masking::PeekInterface;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "accounts_cache")]
 use crate::redis::{

--- a/crates/storage_impl/src/merchant_connector_account.rs
+++ b/crates/storage_impl/src/merchant_connector_account.rs
@@ -7,7 +7,7 @@ use hyperswitch_domain_models::{
     merchant_connector_account::{self as domain, MerchantConnectorAccountInterface},
     merchant_key_store::MerchantKeyStore,
 };
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "accounts_cache")]
 use crate::redis::cache;

--- a/crates/storage_impl/src/merchant_key_store.rs
+++ b/crates/storage_impl/src/merchant_key_store.rs
@@ -5,7 +5,7 @@ use hyperswitch_domain_models::{
     merchant_key_store::MerchantKeyStoreInterface,
 };
 use hyperswitch_masking::Secret;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "accounts_cache")]
 use crate::redis::{

--- a/crates/storage_impl/src/payment_method.rs
+++ b/crates/storage_impl/src/payment_method.rs
@@ -16,7 +16,7 @@ use hyperswitch_domain_models::{
         PaymentMethod as DomainPaymentMethod, PaymentMethodCompatAction, PaymentMethodInterface,
     },
 };
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use super::MockDb;
 use crate::{

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -28,7 +28,7 @@ use hyperswitch_domain_models::{
 #[cfg(feature = "v2")]
 use label::*;
 use redis_interface::HsetnxReply;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "v2")]
 use crate::behaviour::{Conversion, ReverseConversion};

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -45,9 +45,9 @@ use hyperswitch_domain_models::{
 };
 #[cfg(feature = "v2")]
 use redis_interface::HsetnxReply;
+use router_env::instrument;
 #[cfg(feature = "olap")]
 use router_env::logger;
-use router_env::instrument;
 
 #[cfg(feature = "olap")]
 use crate::connection;

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -47,7 +47,7 @@ use hyperswitch_domain_models::{
 use redis_interface::HsetnxReply;
 #[cfg(feature = "olap")]
 use router_env::logger;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "olap")]
 use crate::connection;

--- a/crates/storage_impl/src/payouts/payout_attempt.rs
+++ b/crates/storage_impl/src/payouts/payout_attempt.rs
@@ -20,7 +20,7 @@ use hyperswitch_domain_models::payouts::{
     payouts::Payouts,
 };
 use redis_interface::HsetnxReply;
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use crate::{
     diesel_error_to_data_error, errors,

--- a/crates/storage_impl/src/payouts/payouts.rs
+++ b/crates/storage_impl/src/payouts/payouts.rs
@@ -34,7 +34,7 @@ use hyperswitch_domain_models::payouts::{
 use redis_interface::HsetnxReply;
 #[cfg(feature = "olap")]
 use router_env::logger;
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 #[cfg(feature = "olap")]
 use crate::connection;

--- a/crates/storage_impl/src/payouts/payouts.rs
+++ b/crates/storage_impl/src/payouts/payouts.rs
@@ -32,9 +32,9 @@ use hyperswitch_domain_models::payouts::{
     payouts::{Payouts, PayoutsInterface, PayoutsNew, PayoutsUpdate},
 };
 use redis_interface::HsetnxReply;
+use router_env::instrument;
 #[cfg(feature = "olap")]
 use router_env::logger;
-use router_env::instrument;
 
 #[cfg(feature = "olap")]
 use crate::connection;

--- a/crates/storage_impl/src/redis/cache.rs
+++ b/crates/storage_impl/src/redis/cache.rs
@@ -13,10 +13,7 @@ use dyn_clone::DynClone;
 use error_stack::{Report, ResultExt};
 use moka::future::Cache as MokaCache;
 use redis_interface::{errors::RedisError, RedisConnectionWithContext, RedisValue};
-use router_env::{
-    logger,
-    tracing::instrument,
-};
+use router_env::{logger, tracing::instrument};
 
 use crate::{
     errors::StorageError,

--- a/crates/storage_impl/src/redis/cache.rs
+++ b/crates/storage_impl/src/redis/cache.rs
@@ -15,7 +15,7 @@ use moka::future::Cache as MokaCache;
 use redis_interface::{errors::RedisError, RedisConnectionWithContext, RedisValue};
 use router_env::{
     logger,
-    tracing::{self, instrument},
+    tracing::instrument,
 };
 
 use crate::{

--- a/crates/storage_impl/src/revenue_recovery_retry_stats.rs
+++ b/crates/storage_impl/src/revenue_recovery_retry_stats.rs
@@ -12,7 +12,7 @@ use hyperswitch_domain_models::revenue_recovery::{
     retry_stats_cluster_key::RetryStatsClusterKey, retry_stats_document::StatsDocument,
 };
 use hyperswitch_masking::{PeekInterface, Secret};
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     behaviour::Conversion, connection, errors::StorageError, kv_router_store::KVRouterStore,

--- a/crates/storage_impl/src/subscription.rs
+++ b/crates/storage_impl/src/subscription.rs
@@ -9,7 +9,7 @@ pub use hyperswitch_domain_models::{
         SubscriptionUpdate as DomainSubscriptionUpdate,
     },
 };
-use router_env::{instrument, tracing};
+use router_env::instrument;
 
 use crate::{
     connection, errors::StorageError, kv_router_store::KVRouterStore, DatabaseStore, MockDb,

--- a/crates/subscriptions/Cargo.toml
+++ b/crates/subscriptions/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+tracing = { workspace = true }
 async-trait = "0.1.88"
 dyn-clone = "1.0.19"
 error-stack = "0.4.1"

--- a/crates/subscriptions/src/webhooks.rs
+++ b/crates/subscriptions/src/webhooks.rs
@@ -12,7 +12,7 @@ use hyperswitch_interfaces::{
     api::ConnectorCommon, connector_integration_interface, errors::ConnectorError,
     webhooks::IncomingWebhook,
 };
-use router_env::{instrument, logger, tracing};
+use router_env::{instrument, logger};
 
 use crate::state::SubscriptionState as SessionState;
 #[cfg(feature = "v1")]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds `tracing = { workspace = true }` as a direct dependency to 13 crates that currently rely on `tracing` transitively through `router_env`, and bumps the workspace `tracing` version from `0.1.41` to `0.1.44`.

This is required because `tracing-attributes` 0.1.31+ generates `#[instrument]` expansions using absolute `::tracing::...` paths. These paths require `tracing` to be available as a direct dependency of the crate and cannot resolve through `router_env`'s `pub use tracing;` re-export.

Changes include:

- Bumped workspace `tracing` from `0.1.41` to `0.1.44`.
- Added `tracing = { workspace = true }` directly to:
  - `common_utils`
  - `analytics`
  - `diesel_models`
  - `drainer`
  - `external_services`
  - `hyperswitch_connectors`
  - `hyperswitch_domain_models`
  - `hyperswitch_interfaces`
  - `payment_methods`
  - `router`
  - `scheduler`
  - `storage_impl`
  - `subscriptions`
- Removed redundant `tracing` imports/qualifications where the direct dependency makes them unnecessary.
- Kept the required `instrument` import where it is used as a bare attribute.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

The workspace is currently pinned to `tracing 0.1.41`, which masks a latent dependency issue.

When a dependency requires `tracing >= 0.1.44` (for example, the GCP Cloud Storage dependency chain through `google-cloud-gax-internal`), Cargo resolves to a newer `tracing`/`tracing-attributes` version and crates relying only on `router_env`'s re-export fail to compile with:

`error[E0433]: cannot find tracing in the crate root`

This was reproduced by temporarily adding `google-cloud-storage` to the workspace. Reverting the fix reproduces the failure, while applying the fix allows the same dependency to compile successfully.

This change proactively fixes the dependency boundary before the GCP Cloud Storage work lands, avoiding a compile-time blocker when the dependency graph moves to `tracing >= 0.1.44`.

The GCP Cloud Storage backend itself is **not part of this PR** and is tracked separately.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- `cargo check --workspace` — passed with the updated dependency resolution.
- `cargo test --workspace` — full test suite passed.
- Verified the failure by reverting this change and adding `google-cloud-storage`; the workspace reproduces `E0433`.
- Verified that applying this change allows the same `google-cloud-storage` dependency to compile successfully.
- Confirmed the `revenue_recovery.rs` `unused_qualification` warning is absent after removing the redundant `self` import.
- Confirmed no other `tracing` family crates require version changes; their existing `tracing` version requirements are satisfied by `0.1.44`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible