### PR TITLE
fix(payouts): remove duplicate private_key headers for CertificateAuth connectors in UCS

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2793,13 +2793,8 @@ fn build_connector_auth_metadata(
                     auth_type: consts::UCS_AUTH_MULTI_KEY.to_string(),
                     api_key: Some(certificate.clone()),
                     key1: Some(private_key.clone()),
-                    // UCS's "multi-auth-key" header parsing unconditionally requires x-key2
-                    // and x-api-secret to be present. Connectors reaching this branch (e.g.
-                    // Santander) only supply certificate/private_key, so duplicate
-                    // private_key here purely to satisfy UCS's presence check; the connector
-                    // implementation itself never reads key2/api_secret.
-                    key2: Some(private_key.clone()),
-                    api_secret: Some(private_key.clone()),
+                    key2: None,
+                    api_secret: None,
                     auth_key_map: None,
                     merchant_id: Secret::new(merchant_id.to_string()),
                     connector_config,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

For connectors using `CertificateAuth` (e.g. Santander) routed via UCS, the `build_connector_auth_metadata` function was duplicating the PEM `private_key` into `x-key2` and `x-api-secret` gRPC metadata headers solely to satisfy UCS's unconditional presence check on those fields. Combined with the `x-connector-config` JSON header (which already contains the full certificate and private_key), this pushed the total gRPC metadata size to ~8–13 KB, exceeding the UCS server's HTTP/2 header size limit.

The UCS server then returned HTTP 431 (Request Header Fields Too Large) without a `grpc-status` header, which Hyperswitch surfaces as:

```
UCS error: Unknown - grpc-status header missing, mapped from HTTP status code 431
Failed to create access token
Could not refresh access token
Payout creation failed
```

**Fix:** Set `key2` and `api_secret` to `None` for `CertificateAuth` (non-Netcetera) connectors. The actual credentials (`certificate` and `private_key`) are still sent via `api_key` / `key1`, and both PEM fields remain available to UCS via the `x-connector-config` header.



### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Santander payout `create_access_token` calls were failing in sandbox with HTTP 431 due to oversized gRPC metadata headers. The root cause was 3× duplication of the PEM private key (≥1 KB each) in `x-key1`, `x-key2`, and `x-api-secret`, on top of the PEM certificate in `x-api-key` and both fields again inside the `x-connector-config` JSON.

## How did you test it?

### Payout Create 
```
{
  "amount": 1500,
  "currency": "BRL",
  "customer_id": "cus_bw5T9ISg3KE6XP0pripr",
  "payout_type": "bank",

  "payout_method_data": {
    "bank_transfer": {
      "payout_method_type": "pix_key",
      "pix_key": "@santander.com.br"
    }
  },
  "source_bank_data": {
  "payout_method_type": "pix",
  "bank_branch": "",
  "bank_account_number": ""
},
  "billing": {
    "address": {
      "line1": "Av. Paulista, 1578",
      "line2": "Bela Vista",
      "line3": "",
      "city": "São Paulo",
      "state": "SP",
      "zip": "01310-200",
      "country": "BR",
      "first_name": "João",
      "last_name": "Silva"
    },
    "phone": {
      "number": "11987654321",
      "country_code": "+55"
    }
  },
  "description": "Santander PIX payout",
  "profile_id": "pro_2yqWrI7io2BuICguW2GK",
  "confirm": true,
  "auto_fulfill": true
}
```

### Response 
```
{
    "payout_id": "payout_pO723VASZrFIPBluMrVv",
    "merchant_id": "merchant_1781624290",
    "merchant_order_reference_id": null,
    "amount": 1500,
    "currency": "BRL",
    "connector": "santander",
    "payout_type": "bank",
    "payout_method_data": {
        "bank": {
            "pix_key": "test*_***_*******_********@*********.**m.br",
            "emv": null,
            "tax_id": null,
            "bank_account_number": null,
            "bank_name": null,
            "bank_branch": null,
            "ispb": null,
            "account_holder_name": null,
            "bank_code": null,
            "bank_account_type": null
        }
    },
    "source_bank_data": {
        "pix_key": null,
        "emv": null,
        "tax_id": null,
        "bank_account_number": "*****5431",
        "bank_name": null,
        "bank_branch": "0001",
        "ispb": null,
        "account_holder_name": null,
        "bank_code": null,
        "bank_account_type": null
    },
    "billing": {
        "address": {
            "city": "São Paulo",
            "country": "BR",
            "line1": "Av. Paulista, 1578",
            "line2": "Bela Vista",
            "line3": "",
            "zip": "01310-200",
            "state": "SP",
            "first_name": "João",
            "last_name": "Silva",
            "origin_zip": null
        },
        "phone": {
            "number": "11987654321",
            "country_code": "+55"
        },
        "email": null
    },
    "auto_fulfill": true,
    "customer_id": "cus_bw5T9ISg3KE6XP0pripr",
    "customer": {
        "id": "cus_bw5T9ISg3KE6XP0pripr",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "9876543210",
        "phone_country_code": "+65",
        "customer_document_details": null
    },
    "client_secret": "payout_payout_pO723VASZrFIPBluMrVv_secret_63mXBKdyfFAw6mJpDiD5",
    "return_url": null,
    "business_country": null,
    "business_label": null,
    "description": "Santander PIX payout",
    "billing_descriptor": null,
    "entity_type": "Individual",
    "recurring": false,
    "metadata": {},
    "merchant_connector_id": "mca_eyh3Ubvy6Juaxzz89qQz",
    "status": "success",
    "error_message": null,
    "error_code": null,
    "profile_id": "pro_2yqWrI7io2BuICguW2GK",
    "created": "2026-09-09T11:05:38.491Z",
    "connector_transaction_id": "02626e8e-5de2-450a-8309-aa1fe69f9056",
    "connector_eligibility_reference_id": null,
    "priority": null,
    "payout_link": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "9876543210",
    "phone_country_code": "+65",
    "unified_code": null,
    "unified_message": null,
    "payout_method_id": null
}
```

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
