### PR TITLE
feat(user): block reuse of the last 4 passwords

### DIFF
--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -1949,6 +1949,7 @@ diesel::table! {
         last_password_modified_at -> Nullable<Timestamp>,
         lineage_context -> Nullable<Jsonb>,
         is_active -> Nullable<Bool>,
+        password_history -> Nullable<Array<Nullable<Text>>>,
     }
 }
 

--- a/crates/diesel_models/src/schema_v2.rs
+++ b/crates/diesel_models/src/schema_v2.rs
@@ -1891,6 +1891,7 @@ diesel::table! {
         last_password_modified_at -> Nullable<Timestamp>,
         lineage_context -> Nullable<Jsonb>,
         is_active -> Nullable<Bool>,
+        password_history -> Nullable<Array<Nullable<Text>>>,
     }
 }
 

--- a/crates/diesel_models/src/user.rs
+++ b/crates/diesel_models/src/user.rs
@@ -185,10 +185,9 @@ impl From<UserUpdate> for UserUpdateInternal {
                 totp_recovery_codes: Some(None),
                 lineage_context: Some(None),
                 is_active: Some(false),
-                // Intentionally left untouched while every other credential on this arm is
-                // cleared: preserving history stops a reactivated user from cycling back to a
-                // pre-deactivation password.
-                password_history: None,
+                // Cleared alongside every other credential on this arm; a deactivated user's
+                // password hashes are not retained.
+                password_history: Some(None),
             },
         }
     }

--- a/crates/diesel_models/src/user.rs
+++ b/crates/diesel_models/src/user.rs
@@ -27,6 +27,8 @@ pub struct User {
     pub last_password_modified_at: Option<PrimitiveDateTime>,
     pub lineage_context: Option<LineageContext>,
     pub is_active: Option<bool>,
+    #[diesel(deserialize_as = OptionalDieselArray<Secret<String>>)]
+    pub password_history: Option<Vec<Secret<String>>>,
 }
 
 #[derive(
@@ -47,6 +49,7 @@ pub struct UserNew {
     pub last_password_modified_at: Option<PrimitiveDateTime>,
     pub lineage_context: Option<LineageContext>,
     pub is_active: bool,
+    pub password_history: Option<Vec<Secret<String>>>,
 }
 
 #[derive(Clone, Debug, AsChangeset, router_derive::DebugAsDisplay)]
@@ -62,6 +65,7 @@ pub struct UserUpdateInternal {
     last_password_modified_at: Option<Option<PrimitiveDateTime>>,
     lineage_context: Option<Option<LineageContext>>,
     is_active: Option<bool>,
+    password_history: Option<Option<Vec<Secret<String>>>>,
 }
 
 #[derive(Debug)]
@@ -78,6 +82,7 @@ pub enum UserUpdate {
     },
     PasswordUpdate {
         password: Secret<String>,
+        password_history: Vec<Secret<String>>,
     },
     LineageContextUpdate {
         lineage_context: LineageContext,
@@ -90,6 +95,7 @@ pub struct ReactivateUserUpdate {
     pub new_name: Option<String>,
     pub new_password: Option<Secret<String>>,
     pub last_password_modified_at: Option<PrimitiveDateTime>,
+    pub password_history: Option<Vec<Secret<String>>>,
 }
 
 impl From<UserUpdate> for UserUpdateInternal {
@@ -107,6 +113,7 @@ impl From<UserUpdate> for UserUpdateInternal {
                 last_password_modified_at: None,
                 lineage_context: None,
                 is_active: None,
+                password_history: None,
             },
             UserUpdate::AccountUpdate { name, is_verified } => Self {
                 name,
@@ -119,6 +126,7 @@ impl From<UserUpdate> for UserUpdateInternal {
                 last_password_modified_at: None,
                 lineage_context: None,
                 is_active: None,
+                password_history: None,
             },
             UserUpdate::TotpUpdate {
                 totp_status,
@@ -135,8 +143,12 @@ impl From<UserUpdate> for UserUpdateInternal {
                 last_password_modified_at: None,
                 lineage_context: None,
                 is_active: None,
+                password_history: None,
             },
-            UserUpdate::PasswordUpdate { password } => Self {
+            UserUpdate::PasswordUpdate {
+                password,
+                password_history,
+            } => Self {
                 name: None,
                 password: Some(Some(password)),
                 is_verified: None,
@@ -147,6 +159,7 @@ impl From<UserUpdate> for UserUpdateInternal {
                 totp_recovery_codes: None,
                 lineage_context: None,
                 is_active: None,
+                password_history: Some(Some(password_history)),
             },
             UserUpdate::LineageContextUpdate { lineage_context } => Self {
                 name: None,
@@ -159,6 +172,7 @@ impl From<UserUpdate> for UserUpdateInternal {
                 totp_recovery_codes: None,
                 lineage_context: Some(Some(lineage_context)),
                 is_active: None,
+                password_history: None,
             },
             UserUpdate::DeactivateUpdate => Self {
                 name: None,
@@ -171,6 +185,10 @@ impl From<UserUpdate> for UserUpdateInternal {
                 totp_recovery_codes: Some(None),
                 lineage_context: Some(None),
                 is_active: Some(false),
+                // Intentionally left untouched while every other credential on this arm is
+                // cleared: preserving history stops a reactivated user from cycling back to a
+                // pre-deactivation password.
+                password_history: None,
             },
         }
     }
@@ -190,6 +208,7 @@ impl From<ReactivateUserUpdate> for UserUpdateInternal {
             totp_recovery_codes: Some(None),
             lineage_context: Some(None),
             is_active: Some(true),
+            password_history: Some(user_update.password_history),
         }
     }
 }

--- a/crates/router/src/consts/user.rs
+++ b/crates/router/src/consts/user.rs
@@ -24,8 +24,10 @@ pub const ORG_LIST_LIMIT_FOR_TENANT: u32 = 20;
 
 pub const MAX_PASSWORD_LENGTH: usize = 70;
 pub const MIN_PASSWORD_LENGTH: usize = 12;
-/// Number of most recent passwords, including the current one, that a user may not reuse
-pub const PASSWORD_HISTORY_LIMIT: usize = 4;
+/// Number of previous passwords retained for the reuse check. The current password is not
+/// stored alongside them - it lives in `users.password` - so the reuse window a user sees is
+/// this many plus the current one.
+pub const PREVIOUS_PASSWORDS_RETAINED: usize = 3;
 
 pub const REDIS_TOTP_PREFIX: &str = "TOTP_";
 pub const REDIS_RECOVERY_CODE_PREFIX: &str = "RC_";

--- a/crates/router/src/consts/user.rs
+++ b/crates/router/src/consts/user.rs
@@ -24,6 +24,8 @@ pub const ORG_LIST_LIMIT_FOR_TENANT: u32 = 20;
 
 pub const MAX_PASSWORD_LENGTH: usize = 70;
 pub const MIN_PASSWORD_LENGTH: usize = 12;
+/// Number of most recent passwords, including the current one, that a user may not reuse
+pub const PASSWORD_HISTORY_LIMIT: usize = 4;
 
 pub const REDIS_TOTP_PREFIX: &str = "TOTP_";
 pub const REDIS_RECOVERY_CODE_PREFIX: &str = "RC_";

--- a/crates/router/src/core/errors/user.rs
+++ b/crates/router/src/core/errors/user.rs
@@ -1,6 +1,6 @@
 use common_utils::errors::CustomResult;
 
-use crate::services::ApplicationResponse;
+use crate::{consts, services::ApplicationResponse};
 
 pub type UserResult<T> = CustomResult<T, UserErrors>;
 pub type UserResponse<T> = CustomResult<ApplicationResponse<T>, UserErrors>;
@@ -54,6 +54,8 @@ pub enum UserErrors {
     MerchantIdParsingError,
     #[error("ChangePasswordError")]
     ChangePasswordError,
+    #[error("PasswordReuseError")]
+    PasswordReuseError,
     #[error("InvalidDeleteOperation")]
     InvalidDeleteOperation,
     #[error("MaxInvitationsError")]
@@ -211,6 +213,9 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             Self::ChangePasswordError => {
                 AER::BadRequest(ApiError::new(sub_code, 29, self.get_error_message(), None))
             }
+            Self::PasswordReuseError => {
+                AER::BadRequest(ApiError::new(sub_code, 66, self.get_error_message(), None))
+            }
             Self::InvalidDeleteOperation => {
                 AER::BadRequest(ApiError::new(sub_code, 30, self.get_error_message(), None))
             }
@@ -362,6 +367,10 @@ impl UserErrors {
             Self::InvalidMetadataRequest => "Invalid Metadata Request".to_string(),
             Self::MerchantIdParsingError => "Invalid Merchant Id".to_string(),
             Self::ChangePasswordError => "Old and new password cannot be same".to_string(),
+            Self::PasswordReuseError => format!(
+                "You cannot reuse your last {} passwords. Please choose a different password",
+                consts::user::PASSWORD_HISTORY_LIMIT
+            ),
             Self::InvalidDeleteOperation => "Delete Operation Not Supported".to_string(),
             Self::MaxInvitationsError => "Maximum invite count per request exceeded".to_string(),
             Self::RoleNotFound => "Role Not Found".to_string(),

--- a/crates/router/src/core/errors/user.rs
+++ b/crates/router/src/core/errors/user.rs
@@ -369,7 +369,9 @@ impl UserErrors {
             Self::ChangePasswordError => "Old and new password cannot be same".to_string(),
             Self::PasswordReuseError => format!(
                 "You cannot reuse your last {} passwords. Please choose a different password",
-                consts::user::PASSWORD_HISTORY_LIMIT
+                // The current password is not in `password_history`, so the window is the
+                // retained count plus the current one.
+                consts::user::PREVIOUS_PASSWORDS_RETAINED + 1
             ),
             Self::InvalidDeleteOperation => "Delete Operation Not Supported".to_string(),
             Self::MaxInvitationsError => "Maximum invite count per request exceeded".to_string(),

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -485,8 +485,24 @@ pub async fn change_password(
     }
     let new_password = domain::UserPassword::new(request.new_password)?;
 
+    // Password history is read here and written back below, without a lock. Two concurrent
+    // password changes for the same user can therefore both check against the same snapshot,
+    // and the later write wins - costing one entry of history (3 passwords protected instead
+    // of 4). Accepted: it needs two authenticated changes for one user inside the same ~100ms
+    // window, and it degrades a deterrent rather than weakening authentication. Closing it
+    // properly means a transaction holding SELECT ... FOR UPDATE across the read, check and
+    // write - not an atomic array splice in SQL, which would leave the check racing.
+    let mut password_history = user.get_password_history().unwrap_or_default();
+
+    if utils::user::password::is_password_reused(&new_password.get_secret(), &password_history)? {
+        return Err(UserErrors::PasswordReuseError.into());
+    }
+
     let new_password_hash =
         utils::user::password::generate_password_hash(new_password.get_secret())?;
+
+    password_history.insert(0, new_password_hash.clone());
+    password_history.truncate(consts::user::PASSWORD_HISTORY_LIMIT);
 
     let _ = state
         .global_store
@@ -494,6 +510,7 @@ pub async fn change_password(
             user.get_user_id(),
             diesel_models::user::UserUpdate::PasswordUpdate {
                 password: new_password_hash,
+                password_history,
             },
         )
         .await
@@ -590,11 +607,21 @@ pub async fn rotate_password(
         .into();
 
     let password = domain::UserPassword::new(request.password.to_owned())?;
-    let hash_password = utils::user::password::generate_password_hash(password.get_secret())?;
 
     if user.compare_password(&request.password).is_ok() {
         return Err(UserErrors::ChangePasswordError.into());
     }
+
+    let mut password_history = user.get_password_history().unwrap_or_default();
+
+    if utils::user::password::is_password_reused(&password.get_secret(), &password_history)? {
+        return Err(UserErrors::PasswordReuseError.into());
+    }
+
+    let hash_password = utils::user::password::generate_password_hash(password.get_secret())?;
+
+    password_history.insert(0, hash_password.clone());
+    password_history.truncate(consts::user::PASSWORD_HISTORY_LIMIT);
 
     let user = state
         .global_store
@@ -602,6 +629,7 @@ pub async fn rotate_password(
             &user_token.user_id,
             storage_user::UserUpdate::PasswordUpdate {
                 password: hash_password,
+                password_history,
             },
         )
         .await
@@ -639,7 +667,17 @@ pub async fn reset_password_token_only_flow(
     }
 
     let password = domain::UserPassword::new(request.password)?;
+
+    let mut password_history = user_from_db.get_password_history().unwrap_or_default();
+
+    if utils::user::password::is_password_reused(&password.get_secret(), &password_history)? {
+        return Err(UserErrors::PasswordReuseError.into());
+    }
+
     let hash_password = utils::user::password::generate_password_hash(password.get_secret())?;
+
+    password_history.insert(0, hash_password.clone());
+    password_history.truncate(consts::user::PASSWORD_HISTORY_LIMIT);
 
     let user = state
         .global_store
@@ -647,6 +685,7 @@ pub async fn reset_password_token_only_flow(
             user_from_db.get_user_id(),
             storage_user::UserUpdate::PasswordUpdate {
                 password: hash_password,
+                password_history,
             },
         )
         .await

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -485,13 +485,8 @@ pub async fn change_password(
     }
     let new_password = domain::UserPassword::new(request.new_password)?;
 
-    // Password history is read here and written back below, without a lock. Two concurrent
-    // password changes for the same user can therefore both check against the same snapshot,
-    // and the later write wins - costing one entry of history (3 passwords protected instead
-    // of 4). Accepted: it needs two authenticated changes for one user inside the same ~100ms
-    // window, and it degrades a deterrent rather than weakening authentication. Closing it
-    // properly means a transaction holding SELECT ... FOR UPDATE across the read, check and
-    // write - not an atomic array splice in SQL, which would leave the check racing.
+    // The current password is not in `password_history`; the `old_password == new_password`
+    // check above already rejects it.
     let mut password_history = user.get_password_history().unwrap_or_default();
 
     if utils::user::password::is_password_reused(&new_password.get_secret(), &password_history)? {
@@ -501,8 +496,11 @@ pub async fn change_password(
     let new_password_hash =
         utils::user::password::generate_password_hash(new_password.get_secret())?;
 
-    password_history.insert(0, new_password_hash.clone());
-    password_history.truncate(consts::user::PASSWORD_HISTORY_LIMIT);
+    // The password being replaced becomes the most recent history entry.
+    if let Some(outgoing_password) = user.get_password_hash() {
+        password_history.insert(0, outgoing_password);
+    }
+    password_history.truncate(consts::user::PREVIOUS_PASSWORDS_RETAINED);
 
     let _ = state
         .global_store
@@ -612,6 +610,8 @@ pub async fn rotate_password(
         return Err(UserErrors::ChangePasswordError.into());
     }
 
+    // The current password is not in `password_history`; the `compare_password` check above
+    // already rejects it.
     let mut password_history = user.get_password_history().unwrap_or_default();
 
     if utils::user::password::is_password_reused(&password.get_secret(), &password_history)? {
@@ -620,8 +620,11 @@ pub async fn rotate_password(
 
     let hash_password = utils::user::password::generate_password_hash(password.get_secret())?;
 
-    password_history.insert(0, hash_password.clone());
-    password_history.truncate(consts::user::PASSWORD_HISTORY_LIMIT);
+    // The password being replaced becomes the most recent history entry.
+    if let Some(outgoing_password) = user.get_password_hash() {
+        password_history.insert(0, outgoing_password);
+    }
+    password_history.truncate(consts::user::PREVIOUS_PASSWORDS_RETAINED);
 
     let user = state
         .global_store
@@ -670,14 +673,23 @@ pub async fn reset_password_token_only_flow(
 
     let mut password_history = user_from_db.get_password_history().unwrap_or_default();
 
-    if utils::user::password::is_password_reused(&password.get_secret(), &password_history)? {
+    // Unlike the other two password flows, this one has no old-vs-new check of its own, so the
+    // current password is rejected here rather than being carried in `password_history`.
+    if user_from_db
+        .compare_password(&password.get_secret())
+        .is_ok()
+        || utils::user::password::is_password_reused(&password.get_secret(), &password_history)?
+    {
         return Err(UserErrors::PasswordReuseError.into());
     }
 
     let hash_password = utils::user::password::generate_password_hash(password.get_secret())?;
 
-    password_history.insert(0, hash_password.clone());
-    password_history.truncate(consts::user::PASSWORD_HISTORY_LIMIT);
+    // The password being replaced becomes the most recent history entry.
+    if let Some(outgoing_password) = user_from_db.get_password_hash() {
+        password_history.insert(0, outgoing_password);
+    }
+    password_history.truncate(consts::user::PREVIOUS_PASSWORDS_RETAINED);
 
     let user = state
         .global_store

--- a/crates/router/src/db/user.rs
+++ b/crates/router/src/db/user.rs
@@ -362,6 +362,7 @@ impl UserInterface for MockDb {
                 is_verified: false,
                 lineage_context: None,
                 is_active: Some(false),
+                password_history: None,
                 ..user.to_owned()
             },
         };
@@ -440,6 +441,7 @@ impl UserInterface for MockDb {
                 is_verified: false,
                 lineage_context: None,
                 is_active: Some(false),
+                password_history: None,
                 ..user.to_owned()
             },
         };

--- a/crates/router/src/db/user.rs
+++ b/crates/router/src/db/user.rs
@@ -217,6 +217,7 @@ impl UserInterface for MockDb {
             last_password_modified_at: user_data.last_password_modified_at,
             lineage_context: user_data.lineage_context,
             is_active: Some(user_data.is_active),
+            password_history: user_data.password_history,
         };
         users.push(user.clone());
         Ok(user)
@@ -335,9 +336,13 @@ impl UserInterface for MockDb {
                 ..user.to_owned()
             },
 
-            storage::UserUpdate::PasswordUpdate { password } => storage::User {
+            storage::UserUpdate::PasswordUpdate {
+                password,
+                password_history,
+            } => storage::User {
                 password: Some(password.clone()),
                 last_password_modified_at: Some(common_utils::date_time::now()),
+                password_history: Some(password_history.clone()),
                 ..user.to_owned()
             },
 
@@ -409,9 +414,13 @@ impl UserInterface for MockDb {
                 ..user.to_owned()
             },
 
-            storage::UserUpdate::PasswordUpdate { password } => storage::User {
+            storage::UserUpdate::PasswordUpdate {
+                password,
+                password_history,
+            } => storage::User {
                 password: Some(password),
                 last_password_modified_at: Some(common_utils::date_time::now()),
+                password_history: Some(password_history),
                 ..user.to_owned()
             },
 
@@ -481,6 +490,7 @@ impl UserInterface for MockDb {
                     last_password_modified_at: Some(last_modified_at),
                     lineage_context: None,
                     is_active: Some(true),
+                    password_history: user_update.password_history,
                 };
                 user.to_owned()
             })

--- a/crates/router/src/types/domain/user.rs
+++ b/crates/router/src/types/domain/user.rs
@@ -864,18 +864,13 @@ impl NewUser {
                     .transpose()?;
                 let last_password_modified_at =
                     hashed_password.is_some().then(common_utils::date_time::now);
-                let mut password_history = user_from_db.get_password_history().unwrap_or_default();
-                if let Some(hashed_password) = hashed_password.clone() {
-                    password_history.insert(0, hashed_password);
-                    password_history.truncate(consts::user::PASSWORD_HISTORY_LIMIT);
-                }
                 db.reactivate_user_by_user_id(
                     user_from_db.get_user_id(),
                     storage_user::ReactivateUserUpdate {
                         new_name: Some(self.get_name().expose()),
                         new_password: hashed_password,
                         last_password_modified_at,
-                        password_history: Some(password_history),
+                        password_history: user_from_db.get_password_history(),
                     },
                 )
                 .await
@@ -1025,7 +1020,7 @@ impl TryFrom<NewUser> for storage_user::UserNew {
             user_id: generate_user_id(),
             name: value.get_name(),
             email: value.get_email().into_inner(),
-            password: hashed_password.clone(),
+            password: hashed_password,
             is_verified: false,
             created_at: Some(now),
             last_modified_at: Some(now),
@@ -1037,7 +1032,7 @@ impl TryFrom<NewUser> for storage_user::UserNew {
                 .and_then(|password_inner| password_inner.is_temporary.not().then_some(now)),
             lineage_context: None,
             is_active: true,
-            password_history: hashed_password.map(|hash| vec![hash]),
+            password_history: None,
         })
     }
 }
@@ -1322,6 +1317,12 @@ impl UserFromStorage {
 
     pub fn get_password_history(&self) -> Option<Vec<Secret<String>>> {
         self.0.password_history.clone()
+    }
+
+    /// The stored hash of the user's current password, which becomes the most recent entry in
+    /// `password_history` when the password is replaced.
+    pub fn get_password_hash(&self) -> Option<Secret<String>> {
+        self.0.password.clone()
     }
 
     pub fn is_active(&self) -> bool {

--- a/crates/router/src/types/domain/user.rs
+++ b/crates/router/src/types/domain/user.rs
@@ -864,12 +864,18 @@ impl NewUser {
                     .transpose()?;
                 let last_password_modified_at =
                     hashed_password.is_some().then(common_utils::date_time::now);
+                let mut password_history = user_from_db.get_password_history().unwrap_or_default();
+                if let Some(hashed_password) = hashed_password.clone() {
+                    password_history.insert(0, hashed_password);
+                    password_history.truncate(consts::user::PASSWORD_HISTORY_LIMIT);
+                }
                 db.reactivate_user_by_user_id(
                     user_from_db.get_user_id(),
                     storage_user::ReactivateUserUpdate {
                         new_name: Some(self.get_name().expose()),
                         new_password: hashed_password,
                         last_password_modified_at,
+                        password_history: Some(password_history),
                     },
                 )
                 .await
@@ -1019,7 +1025,7 @@ impl TryFrom<NewUser> for storage_user::UserNew {
             user_id: generate_user_id(),
             name: value.get_name(),
             email: value.get_email().into_inner(),
-            password: hashed_password,
+            password: hashed_password.clone(),
             is_verified: false,
             created_at: Some(now),
             last_modified_at: Some(now),
@@ -1031,6 +1037,7 @@ impl TryFrom<NewUser> for storage_user::UserNew {
                 .and_then(|password_inner| password_inner.is_temporary.not().then_some(now)),
             lineage_context: None,
             is_active: true,
+            password_history: hashed_password.map(|hash| vec![hash]),
         })
     }
 }
@@ -1311,6 +1318,10 @@ impl UserFromStorage {
 
     pub fn get_recovery_codes(&self) -> Option<Vec<Secret<String>>> {
         self.0.totp_recovery_codes.clone()
+    }
+
+    pub fn get_password_history(&self) -> Option<Vec<Secret<String>>> {
+        self.0.password_history.clone()
     }
 
     pub fn is_active(&self) -> bool {

--- a/crates/router/src/utils/user/password.rs
+++ b/crates/router/src/utils/user/password.rs
@@ -74,6 +74,19 @@ pub fn get_index_for_correct_recovery_code(
     Ok(None)
 }
 
+pub fn is_password_reused(
+    candidate: &Secret<String>,
+    password_history: &[Secret<String>],
+) -> CustomResult<bool, UserErrors> {
+    for old_password in password_history {
+        let is_match = is_correct_password(candidate, old_password)?;
+        if is_match {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 pub fn get_temp_password() -> Secret<String> {
     let uuid_pass = uuid::Uuid::new_v4().to_string();
     let mut rng = rand::thread_rng();

--- a/migrations/2026-09-08-000001_add_password_history_to_users/down.sql
+++ b/migrations/2026-09-08-000001_add_password_history_to_users/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE users DROP COLUMN password_history;

--- a/migrations/2026-09-08-000001_add_password_history_to_users/up.sql
+++ b/migrations/2026-09-08-000001_add_password_history_to_users/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+ALTER TABLE users ADD COLUMN IF NOT EXISTS password_history TEXT[] DEFAULT NULL;
+
+-- Backfill so every existing user is protected against reusing their current password
+-- from day one. Older passwords were never stored, so history fills in over time.
+UPDATE users SET password_history = ARRAY[password] WHERE password IS NOT NULL;

--- a/migrations/2026-09-08-000001_add_password_history_to_users/up.sql
+++ b/migrations/2026-09-08-000001_add_password_history_to_users/up.sql
@@ -1,6 +1,2 @@
 -- Your SQL goes here
 ALTER TABLE users ADD COLUMN IF NOT EXISTS password_history TEXT[] DEFAULT NULL;
-
--- Backfill so every existing user is protected against reusing their current password
--- from day one. Older passwords were never stored, so history fills in over time.
-UPDATE users SET password_history = ARRAY[password] WHERE password IS NOT NULL;


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Prevents a user from setting a password matching any of their last 4 passwords (current + previous 3), as required by PCI DSS.

A new nullable `users.password_history TEXT[]` column stores Argon2 hashes of the user's **previous** passwords, most-recent-first, capped at 3 (`PREVIOUS_PASSWORDS_RETAINED`). The current password is not duplicated into the array — it stays in `users.password`, which remains the sole source of truth for both authentication and the current-password half of the check. So the reuse window is the 3 retained plus the current one.

The check runs in the `core` layer after `UserPassword::new` validation and before hashing, on all three paths that write a password:

| Flow | Rejects the current password via | Rejects the previous 3 via |
|---|---|---|
| `change_password` | existing plaintext `old == new` check (free, no Argon2) | `password_history` |
| `rotate_password` | existing `compare_password` guard | `password_history` |
| `reset_password_token_only_flow` | **new** `compare_password` check — this flow has no old password to compare against | `password_history` |

Reuse returns a new `UserErrors::PasswordReuseError` (400, sub-code 66). The message interpolates `PREVIOUS_PASSWORDS_RETAINED + 1`, so users still read "your last 4 passwords".

On each successful change the **outgoing** password is pushed to the front of the array and the array is truncated to 3, so history holds strictly previous passwords and the oldest is evicted.

The column mirrors the existing `totp_recovery_codes` plumbing end-to-end — same Postgres type, same `OptionalDieselArray` diesel adapter, same loop shape as `get_index_for_correct_recovery_code`. No new patterns introduced.

`UserUpdate::PasswordUpdate` gains a second required field so that `password` and `password_history` are always written in one `UPDATE`, and the compiler enumerates every call site rather than leaving a path that updates one without the other.

`UserUpdate::DeactivateUpdate` clears `password_history` alongside every other credential on that arm, so a deactivated user's password hashes are not retained. Reactivation therefore starts from an empty history.

**Behaviour change worth flagging:** `reset_password_token_only_flow` (the forgot-password email link) has no old-vs-new check today, so a user can currently reset to their existing password. After this change they cannot — they get `PasswordReuseError`. This is the intended compliance outcome, but it is user-visible and support may see it reported as "the reset link is broken".


### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

Migration: `migrations/2026-09-08-000001_add_password_history_to_users/` — adds the column only. No backfill: since the current password is checked against `users.password` directly, writing a copy of it into the array would be redundant, and this avoids rewriting every row of `users`.

## Motivation and Context

PCI DSS requires that a new password not match any of the last 4 passwords used. No such control exists today: `change_password` and `rotate_password` only reject the immediately-preceding password, and the forgot-password reset flow performs no comparison at all.

Closes https://github.com/juspay/hyperswitch-control-center-cloud/issues/402

## How did you test it?

 Ran the migration locally and tested `POST /user/change_password` from the control center (Profile → Change Password).

  Passwords used in order: `Password@123` → `@456` → `@12345` → `@100`. The history holds the 3 previous passwords, and the current one is stored in `users.password`.

  **1. Reusing a password from the last 4 is rejected**

  ```bash
  curl --location 'http://localhost:8080/user/change_password' \
    --header 'Content-Type: application/json' \
    --header 'Authorization: Bearer <JWT>' \
    --data-raw '{"old_password":"Password@100","new_password":"Password@123"}'

  Response 400 Bad Request:
  {
    "error": {
      "type": "invalid_request",
      "message": "You cannot reuse your last 4 passwords. Please choose a different password",
      "code": "UR_66"
    }
  }
```
  **2. A new password succeeds and pushes the oldest entry out of history**

```bash
  curl --location 'http://localhost:8080/user/change_password' \
    --header 'Content-Type: application/json' \
    --header 'Authorization: Bearer <JWT>' \
    --data-raw '{"old_password":"Password@100","new_password":"Password@1000"}'

  Response 200 OK, empty body. History is now [@100, @12345, @456], so @123 is no longer in the last 4.
```

  3. The dropped password can be used again

```bash
  curl --location 'http://localhost:8080/user/change_password' \
    --header 'Content-Type: application/json' \
    --header 'Authorization: Bearer <JWT>' \
    --data-raw '{"old_password":"Password@1000","new_password":"Password@123"}'

  Response 200 OK, empty body.
```

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
