### PR TITLE
feat(core): Add amount_captured field to manual update api

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -11771,6 +11771,8 @@ pub struct PaymentsManualUpdateRequest {
     /// Whether to update amount_captured using amount_to_capture from the attempt.
     /// When true, amount_captured will be set to amount_to_capture
     pub update_amount_captured: Option<bool>,
+    /// The amount that has been captured for the payment.
+    pub amount_captured: Option<MinorUnit>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, ToSchema)]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -13753,6 +13753,7 @@ pub async fn payments_manual_update(
         connector_transaction_id,
         amount_capturable,
         update_amount_captured,
+        amount_captured,
     } = req;
     let key_store = state
         .store
@@ -13790,6 +13791,23 @@ pub async fn payments_manual_update(
             || {
                 Err(errors::ApiErrorResponse::InvalidRequestData {
                     message: "amount_capturable should be less than or equal to amount".to_string(),
+                })
+            },
+        )?;
+    }
+
+    if let Some(amount_captured) = amount_captured {
+        utils::when(update_amount_captured == Some(true), || {
+            Err(errors::ApiErrorResponse::InvalidRequestData {
+                message: "amount_captured cannot be provided when update_amount_captured is true"
+                    .to_string(),
+            })
+        })?;
+        utils::when(
+            amount_captured > payment_attempt.net_amount.get_total_amount(),
+            || {
+                Err(errors::ApiErrorResponse::InvalidRequestData {
+                    message: "amount_captured should be less than or equal to amount".to_string(),
                 })
             },
         )?;
@@ -13845,7 +13863,7 @@ pub async fn payments_manual_update(
             .unwrap_or(payment_attempt.net_amount.get_total_amount());
         Some(new_captured_amount)
     } else {
-        None
+        amount_captured
     };
 
     let option_gsm = if let Some(((code, message), connector_name)) = error_code


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR introduces support for updating the amount captured in the Payments Manual Update API.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Request:

```

curl --location --request PUT 'http://localhost:8080/payments/pay_K2iHqrRhFprp2dTWnc2k/manual-update' \
--header 'Content-Type: application/json' \
--header 'api-key: ' \
--header 'x-merchant-id: merchant_1788953912' \
--data '{
    "attempt_id": "pay_K2iHqrRhFprp2dTWnc2k_1",
    "merchant_id": "merchant_1788953912",
    "attempt_status": "charged",
    "amount_captured": 100
}'

```

Response:

```

{
    "payment_id": "pay_K2iHqrRhFprp2dTWnc2k",
    "attempt_id": "pay_K2iHqrRhFprp2dTWnc2k_1",
    "merchant_id": "merchant_1788953912",
    "attempt_status": "charged",
    "error_code": null,
    "error_message": null,
    "error_reason": null,
    "connector_transaction_id": "pay_K2iHqrRhFprp2dTWnc2k_1",
    "amount_capturable": 110,
    "amount_captured": 100
}

```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
