### PR TITLE
feat(external_services): add GCP Cloud Storage backend for FileStorageinterface

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1317,11 +1317,14 @@ account_updater_topic = "topic"         # Kafka topic to be used for account upd
 
 # File storage configuration
 [file_storage]
-file_storage_backend = "aws_s3" # File storage backend to be used
+file_storage_backend = "aws_s3" # File storage backend to be used (file_system | aws_s3 | gcp_storage)
 
 [file_storage.aws_s3]
 region = "us-east-1"    # The AWS region used by the AWS S3 for file storage
 bucket_name = "bucket1" # The AWS S3 bucket name for file storage
+
+# [file_storage.gcp_storage]
+# bucket_name = "bucket1" # The GCP Cloud Storage bucket name for file storage
 
 [secrets_management]
 secrets_manager = "aws_kms" # Secrets manager client to be used (no_encryption | aws_kms | hashicorp_vault | gcp_kms)

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -12,6 +12,7 @@ aws_kms = ["dep:aws-config", "dep:aws-sdk-kms"]
 email = ["dep:aws-config"]
 aws_s3 = ["dep:aws-config", "dep:aws-sdk-s3"]
 gcp_kms = ["dep:google-cloud-kms"]
+gcp_storage = ["dep:google-cloud-storage", "dep:bytes"]
 hashicorp-vault = ["dep:vaultrs"]
 superposition = [
     "dep:open-feature",
@@ -65,6 +66,7 @@ aws-smithy-types = "1.3.1"
 base64 = "0.22.1"
 dyn-clone = "1.0.19"
 google-cloud-kms = { version = "0.6.0", optional = true }
+google-cloud-storage = { version = "1.17", optional = true }
 deja = { git = "https://github.com/juspay/deja", rev = "1838093c7f29938022ba0614d7b78fd2a2e92c4d", optional = true, default-features = false }
 error-stack = "0.4.1"
 hex = "0.4.3"

--- a/crates/external_services/src/file_storage.rs
+++ b/crates/external_services/src/file_storage.rs
@@ -6,10 +6,16 @@ use std::{
 };
 
 use common_utils::errors::CustomResult;
+#[cfg(feature = "gcp_storage")]
+use error_stack::ResultExt;
 
 /// Includes functionality for AWS S3 storage operations.
 #[cfg(feature = "aws_s3")]
 mod aws_s3;
+
+/// Includes functionality for GCP Cloud Storage operations.
+#[cfg(feature = "gcp_storage")]
+mod gcs;
 
 mod file_system;
 
@@ -24,6 +30,12 @@ pub enum FileStorageConfig {
         /// Configuration for AWS S3 file storage.
         aws_s3: aws_s3::AwsFileStorageConfig,
     },
+    /// GCP Cloud Storage configuration.
+    #[cfg(feature = "gcp_storage")]
+    GcpStorage {
+        /// Configuration for GCP Cloud Storage file storage.
+        gcp_storage: gcs::GcsFileStorageConfig,
+    },
     /// Local file system storage configuration.
     #[default]
     FileSystem,
@@ -35,17 +47,27 @@ impl FileStorageConfig {
         match self {
             #[cfg(feature = "aws_s3")]
             Self::AwsS3 { aws_s3 } => aws_s3.validate(),
+            #[cfg(feature = "gcp_storage")]
+            Self::GcpStorage { gcp_storage } => gcp_storage.validate(),
             Self::FileSystem => Ok(()),
         }
     }
 
     /// Retrieves the appropriate file storage client based on the file storage configuration.
-    pub async fn get_file_storage_client(&self) -> Arc<dyn FileStorageInterface> {
-        match self {
+    pub async fn get_file_storage_client(
+        &self,
+    ) -> CustomResult<Arc<dyn FileStorageInterface>, FileStorageError> {
+        Ok(match self {
             #[cfg(feature = "aws_s3")]
             Self::AwsS3 { aws_s3 } => Arc::new(aws_s3::AwsFileStorageClient::new(aws_s3).await),
+            #[cfg(feature = "gcp_storage")]
+            Self::GcpStorage { gcp_storage } => Arc::new(
+                gcs::GcsFileStorageClient::new(gcp_storage)
+                    .await
+                    .change_context(FileStorageError::ClientCreationFailed)?,
+            ),
             Self::FileSystem => Arc::new(file_system::FileSystem),
-        }
+        })
     }
 }
 
@@ -94,4 +116,8 @@ pub enum FileStorageError {
     /// Indicates that the file deletion operation failed.
     #[error("Failed to delete file")]
     DeleteFailed,
+
+    /// Indicates that the file storage client could not be created.
+    #[error("Failed to create file storage client")]
+    ClientCreationFailed,
 }

--- a/crates/external_services/src/file_storage/gcs.rs
+++ b/crates/external_services/src/file_storage/gcs.rs
@@ -1,0 +1,207 @@
+use common_utils::{errors::CustomResult, ext_traits::ConfigExt};
+use error_stack::ResultExt;
+use google_cloud_storage::client::{Storage, StorageControl};
+
+use super::InvalidFileStorageConfig;
+use crate::file_storage::{FileStorageError, FileStorageInterface};
+
+/// Configuration for GCP Cloud Storage file storage.
+#[derive(Debug, serde::Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct GcsFileStorageConfig {
+    /// The GCS bucket to send file uploads
+    bucket_name: String,
+}
+
+impl GcsFileStorageConfig {
+    /// Validates the GCP Cloud Storage file storage configuration.
+    pub(super) fn validate(&self) -> Result<(), InvalidFileStorageConfig> {
+        use common_utils::fp_utils::when;
+
+        when(self.bucket_name.is_default_or_empty(), || {
+            Err(InvalidFileStorageConfig(
+                "gcp storage bucket name must not be empty",
+            ))
+        })
+    }
+}
+
+/// GCP Cloud Storage file storage client.
+#[derive(Debug, Clone)]
+pub(super) struct GcsFileStorageClient {
+    /// GCS client for object uploads and downloads.
+    data: Storage,
+    /// GCS client for object deletes.
+    control: StorageControl,
+    /// The name of the GCS bucket, pre-formatted as `projects/_/buckets/{bucket_id}`.
+    bucket_name: String,
+}
+
+impl GcsFileStorageClient {
+    /// Creates a new GCP Cloud Storage file storage client.
+    pub(super) async fn new(config: &GcsFileStorageConfig) -> CustomResult<Self, GcsError> {
+        let data = Storage::builder()
+            .build()
+            .await
+            .change_context(GcsError::ClientCreationFailed)?;
+        let control = StorageControl::builder()
+            .build()
+            .await
+            .change_context(GcsError::ClientCreationFailed)?;
+        Ok(Self {
+            data,
+            control,
+            bucket_name: format!("projects/_/buckets/{}", config.bucket_name),
+        })
+    }
+
+    /// Uploads a file to GCS.
+    async fn upload_file(&self, file_key: &str, file: Vec<u8>) -> CustomResult<(), GcsError> {
+        Box::pin(
+            self.data
+                .write_object(
+                    self.bucket_name.clone(),
+                    file_key.to_owned(),
+                    bytes::Bytes::from(file),
+                )
+                .send_unbuffered(),
+        )
+        .await
+        .change_context(GcsError::UploadFailed)?;
+        Ok(())
+    }
+
+    /// Deletes a file from GCS.
+    async fn delete_file(&self, file_key: &str) -> CustomResult<(), GcsError> {
+        self.control
+            .delete_object()
+            .set_bucket(self.bucket_name.clone())
+            .set_object(file_key.to_owned())
+            .send()
+            .await
+            .change_context(GcsError::DeleteFailed)?;
+        Ok(())
+    }
+
+    /// Retrieves a file from GCS.
+    async fn retrieve_file(&self, file_key: &str) -> CustomResult<Vec<u8>, GcsError> {
+        let mut response = self
+            .data
+            .read_object(self.bucket_name.clone(), file_key.to_owned())
+            .send()
+            .await
+            .change_context(GcsError::RetrieveFailed)?;
+        let mut contents = Vec::new();
+        while let Some(chunk) = response
+            .next()
+            .await
+            .transpose()
+            .change_context(GcsError::RetrieveFailed)?
+        {
+            contents.extend_from_slice(&chunk);
+        }
+        Ok(contents)
+    }
+}
+
+#[async_trait::async_trait]
+impl FileStorageInterface for GcsFileStorageClient {
+    /// Uploads a file to GCS.
+    async fn upload_file(
+        &self,
+        file_key: &str,
+        file: Vec<u8>,
+    ) -> CustomResult<(), FileStorageError> {
+        Box::pin(self.upload_file(file_key, file))
+            .await
+            .change_context(FileStorageError::UploadFailed)?;
+        Ok(())
+    }
+
+    /// Deletes a file from GCS.
+    async fn delete_file(&self, file_key: &str) -> CustomResult<(), FileStorageError> {
+        self.delete_file(file_key)
+            .await
+            .change_context(FileStorageError::DeleteFailed)?;
+        Ok(())
+    }
+
+    /// Retrieves a file from GCS.
+    async fn retrieve_file(&self, file_key: &str) -> CustomResult<Vec<u8>, FileStorageError> {
+        Ok(self
+            .retrieve_file(file_key)
+            .await
+            .change_context(FileStorageError::RetrieveFailed)?)
+    }
+}
+
+/// Enum representing errors that can occur during GCP Cloud Storage file storage operations.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, thiserror::Error)]
+pub enum GcsError {
+    /// Error indicating that file upload to GCS failed.
+    #[error("File upload to GCS failed")]
+    UploadFailed,
+
+    /// Error indicating that file retrieval from GCS failed.
+    #[error("File retrieve from GCS failed")]
+    RetrieveFailed,
+
+    /// Error indicating that file deletion from GCS failed.
+    #[error("File delete from GCS failed")]
+    DeleteFailed,
+
+    /// Error indicating that the GCS client could not be created.
+    #[error("Failed to create GCS client")]
+    ClientCreationFailed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_fails_when_bucket_name_is_empty() {
+        let config = GcsFileStorageConfig {
+            bucket_name: String::new(),
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_succeeds_when_bucket_name_is_populated() {
+        let config = GcsFileStorageConfig {
+            bucket_name: "bucket".to_string(),
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    /// Requires a real GCS bucket and `GOOGLE_APPLICATION_CREDENTIALS` to pass.
+    #[tokio::test]
+    async fn check_gcs_file_round_trip() {
+        let config = GcsFileStorageConfig {
+            bucket_name: "YOUR GCP STORAGE BUCKET NAME".to_string(),
+        };
+        let client = GcsFileStorageClient::new(&config)
+            .await
+            .expect("gcs client creation failed");
+
+        let file_key = "gcs-file-storage-round-trip-test.txt";
+        let contents = b"hello".to_vec();
+
+        Box::pin(client.upload_file(file_key, contents.clone()))
+            .await
+            .expect("gcs file upload failed");
+
+        let retrieved_contents = client
+            .retrieve_file(file_key)
+            .await
+            .expect("gcs file retrieval failed");
+        assert_eq!(retrieved_contents, contents);
+
+        client
+            .delete_file(file_key)
+            .await
+            .expect("gcs file deletion failed");
+    }
+}

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -68,6 +68,7 @@ release = [
     "external_services/aws_kms",
     "gcp_kms",
     "external_services/aws_s3",
+    "external_services/gcp_storage",
     "keymanager_mtls",
     "keymanager_create",
     "encryption_service",

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -520,8 +520,19 @@ impl AppState {
             #[cfg(feature = "email")]
             let email_client = Arc::new(create_email_client(&conf).await);
 
-            let file_storage_client = conf.file_storage.get_file_storage_client().await;
-            let theme_storage_client = conf.theme.storage.get_file_storage_client().await;
+            #[allow(clippy::expect_used)]
+            let file_storage_client = conf
+                .file_storage
+                .get_file_storage_client()
+                .await
+                .expect("Failed to initialize file storage client");
+            #[allow(clippy::expect_used)]
+            let theme_storage_client = conf
+                .theme
+                .storage
+                .get_file_storage_client()
+                .await
+                .expect("Failed to initialize theme storage client");
             let crm_client = conf.crm.get_crm_client().await;
 
             let grpc_client = conf.grpc_client.get_grpc_client_interface().await;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds a `GcpStorage` backend to `FileStorageInterface`, backed by the official
`google-cloud-storage` crate.

This enables both `[file_storage]` and `[theme.storage]` to use GCP Cloud
Storage in addition to the existing AWS S3 and local filesystem backends.

`FileStorageConfig` uses a tagged backend configuration:

`file_storage_backend = "file_system" | "aws_s3" | "gcp_storage"`

The configuration is deserialized independently for `[file_storage]` and
`[theme.storage]`, allowing them to use different storage backends within the
same deployment.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Adds GCP Cloud Storage as a supported file-storage backend, allowing
self-hosted deployments running on GCP to use native GCP object storage
instead of relying on AWS S3 or the local filesystem.

The storage configuration remains independent between `[file_storage]` and
`[theme.storage]`, allowing each to use a different backend within the same
deployment.

This PR depends on #<tracing-pr-number> (`chore/tracing-direct-dependency-fix`).
Adding `google-cloud-storage` changes the workspace's resolved `tracing`
version, so the tracing dependency fix is required as a prerequisite. This
branch is stacked on top of that PR.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible