### PR TITLE
fix(router): correct field mapping in browse offers response

### DIFF
--- a/crates/router/src/core/offer_engine/types.rs
+++ b/crates/router/src/core/offer_engine/types.rs
@@ -144,6 +144,8 @@ pub struct OfferDescription {
     pub title: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
+    pub display_title: Option<String>,
 }
 
 /// Request body for `/offers/apply`.
@@ -349,25 +351,42 @@ pub struct BrowseOfferListEntry {
     pub status: OfferStatus,
     pub offer_code: String,
     pub offer_description: Option<OfferDescription>,
-    pub display_title: Option<String>,
-    pub currency: Option<common_enums::Currency>,
+    pub offer_rules: Option<BrowseOfferRules>,
+    // Offer Engine names the validity window `start_time_utc`/`end_time_utc`; only the end is
+    // surfaced, as `valid_till`.
     #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
-    pub valid_till: Option<time::PrimitiveDateTime>,
+    pub end_time_utc: Option<time::PrimitiveDateTime>,
+}
+
+/// The subset of `offer_rules` browse reads; the currency lives under `amount`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct BrowseOfferRules {
+    pub amount: Option<BrowseOfferAmount>,
+}
+
+/// The subset of `offer_rules.amount` browse reads.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct BrowseOfferAmount {
+    pub currency: Option<common_enums::Currency>,
 }
 
 impl From<BrowseOfferListEntry> for api_models::offer_engine::BrowseOffer {
     fn from(entry: BrowseOfferListEntry) -> Self {
-        let (title, description) = entry.offer_description.map_or((None, None), |description| {
-            (description.title, description.description)
-        });
+        let (title, description, display_title) =
+            entry.offer_description.map_or((None, None, None), |value| {
+                (value.title, value.description, value.display_title)
+            });
 
         Self {
             code: entry.offer_code,
             title,
-            display_title: entry.display_title,
+            display_title,
             description,
-            currency: entry.currency,
-            valid_till: entry.valid_till,
+            currency: entry
+                .offer_rules
+                .and_then(|rules| rules.amount)
+                .and_then(|amount| amount.currency),
+            valid_till: entry.end_time_utc,
         }
     }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

`POST /offer_engine/offers/list` (added in #13999) always returned `null` for `display_title`, `currency` and `valid_till`. All three were read at the wrong nesting level of Offer Engine's `v1/offers/list` response, so serde never found them.

| Field | Where the code looked | Where Offer Engine actually puts it |
|---|---|---|
| `display_title` | entry top level | `offer_description.display_title` |
| `currency` | entry top level | `offer_rules.amount.currency` |
| `valid_till` | `valid_till` | `end_time_utc` |

`BrowseOfferListEntry` doesn't use `deny_unknown_fields`, so the real keys were silently dropped and the missing ones defaulted to `None` — no error, no log line.

Reading each field from its actual location fixes all three. `display_title` is added to the shared `OfferDescription` as `Option` + `#[serde(default)]`, so the payment flow's `OfferListEntry` is unaffected. `currency` is reached through two deserialise-only structs that declare only the field browse reads.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

Same endpoint, same fields, same types. Three fields that were always `null` now carry their values. The outbound request to Offer Engine is unchanged.

## Motivation and Context

The mapping was written against an assumed response shape before Offer Engine was reachable. The deserialiser degrades to `null` rather than failing, so nothing surfaced the mismatch — the fields were simply always empty.

## How did you test it?

Hit the endpoint on `main` and on this branch with the same request and merchant, and compared the responses.

**Request**

```
curl --location 'http://localhost:8080/offer_engine/offers/list' \
--header 'api-key: <api_key>' \
--header 'content-type: application/json' \
--data '{"offer_payment_info": {"currency": "USD"}}'
```

**Response on `main`**

```json
{
  "offers": [
    {
      "code": "HSBINVELO1",
      "title": "HS BIN 15% Once-Per-Card",
      "display_title": null,
      "description": "15% off whitelisted BINs, once per card",
      "currency": null,
      "valid_till": null
    }
  ]
}
```

**Response on this branch**

```json
{
  "offers": [
    {
      "code": "HSBINVELO1",
      "title": "HS BIN 15% Once-Per-Card",
      "display_title": "HS BIN 15% Test",
      "description": "15% off whitelisted BINs, once per card",
      "currency": "USD",
      "valid_till": "2026-12-31T18:29:59.000Z"
    }
  ]
}
```

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
