### PR TITLE
feat(observability): chat alerts can carry a coloured banner

### DIFF
--- a/crates/external_services/src/chat_service.rs
+++ b/crates/external_services/src/chat_service.rs
@@ -1,45 +1,32 @@
-//! Delivery of chat messages to a destination channel.
-
-/// The Slack chat API.
 pub mod slack;
 
-/// Xyne, which exposes a Slack-compatible messaging API.
 pub mod xyne;
 
-/// The wire protocol Xyne and Slack share.
 mod slack_compatible;
 
 use common_utils::errors::CustomResult;
 use hyperswitch_masking::{PeekInterface, Secret};
 
-/// Result type for chat operations.
 pub type ChatResult<T> = CustomResult<T, ChatError>;
 
-/// Posts messages to one chat destination.
 #[async_trait::async_trait]
 pub trait ChatClient: Send + Sync + std::fmt::Debug {
-    /// Post a message, returning the id of the message that was created.
     async fn post_message(&self, message: ChatMessage) -> ChatResult<MessageId>;
 
-    /// Upload a file and optionally share it under an existing message.
     async fn upload_file(&self, file: ChatFile) -> ChatResult<FileId>;
 }
 
-/// Identifies a file that a backend has accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum FileId {
-    /// An opaque identifier returned by a file upload API.
     Identifier(String),
 }
 
 impl FileId {
-    /// Build an opaque file identifier.
     pub fn identifier(value: impl Into<String>) -> Self {
         Self::Identifier(value.into())
     }
 
-    /// The provider's opaque file identifier.
     pub fn as_identifier(&self) -> Option<&str> {
         match self {
             Self::Identifier(value) => Some(value.as_str()),
@@ -47,7 +34,6 @@ impl FileId {
     }
 }
 
-/// A file to upload to a chat destination.
 #[derive(Debug, Clone)]
 pub struct ChatFile {
     bytes: Secret<Vec<u8>>,
@@ -58,7 +44,6 @@ pub struct ChatFile {
 }
 
 impl ChatFile {
-    /// Build one upload.
     pub fn new(
         bytes: Vec<u8>,
         filename: impl Into<String>,
@@ -102,21 +87,17 @@ impl ChatFile {
     }
 }
 
-/// Identifies a message that a backend has accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum MessageId {
-    /// A Slack-compatible `ts`:
     Ts(String),
 }
 
 impl MessageId {
-    /// Build a Slack-compatible `ts` id.
     pub fn ts(value: impl Into<String>) -> Self {
         Self::Ts(value.into())
     }
 
-    /// The `ts` string, if this id came from a Slack-compatible backend.
     pub fn as_ts(&self) -> Option<&str> {
         match self {
             Self::Ts(value) => Some(value.as_str()),
@@ -124,7 +105,6 @@ impl MessageId {
     }
 }
 
-/// A message to post.
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
     text: String,
@@ -132,18 +112,13 @@ pub struct ChatMessage {
     banner: Option<ChatBanner>,
 }
 
-/// How urgent a message is, in the vocabulary of the reader rather than of any one backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChatSeverity {
-    /// Something is broken now.
     Critical,
-    /// Still broken, said again.
     Warning,
-    /// Over.
     Resolved,
 }
 
-/// A titled, colour-coded frame around a message.
 #[derive(Debug, Clone)]
 pub struct ChatBanner {
     heading: String,
@@ -151,7 +126,6 @@ pub struct ChatBanner {
 }
 
 impl ChatBanner {
-    /// A banner reading `heading`, weighted by `severity`.
     pub fn new(heading: impl Into<String>, severity: ChatSeverity) -> Self {
         Self {
             heading: heading.into(),
@@ -159,19 +133,16 @@ impl ChatBanner {
         }
     }
 
-    /// The heading, rendered as plain text:
     pub fn heading(&self) -> &str {
         &self.heading
     }
 
-    /// How urgent the message is.
     pub fn severity(&self) -> ChatSeverity {
         self.severity
     }
 }
 
 impl ChatMessage {
-    /// A new top-level message.
     pub fn new(text: impl Into<String>) -> Self {
         Self {
             text: text.into(),
@@ -180,7 +151,6 @@ impl ChatMessage {
         }
     }
 
-    /// A message threaded as a reply under `message_id`.
     pub fn reply(text: impl Into<String>, message_id: MessageId) -> Self {
         Self {
             text: text.into(),
@@ -189,101 +159,71 @@ impl ChatMessage {
         }
     }
 
-    /// Frame this message in a titled, colour-coded banner.
     pub fn with_banner(mut self, banner: ChatBanner) -> Self {
         self.banner = Some(banner);
         self
     }
 
-    /// The message body.
     pub fn text(&self) -> &str {
         &self.text
     }
 
-    /// The message this one replies to, if any.
     pub fn reply_target(&self) -> Option<&MessageId> {
         self.reply_to.as_ref()
     }
 
-    /// The banner to frame this message in, if any.
     pub fn banner(&self) -> Option<&ChatBanner> {
         self.banner.as_ref()
     }
 }
 
-/// Errors raised when posting a chat message.
 #[derive(Debug, thiserror::Error)]
 pub enum ChatError {
-    /// The destination could not be turned into a usable client.
     #[error("Invalid chat client configuration: {0}")]
     InvalidConfiguration(&'static str),
 
-    /// The request never produced a response — DNS, TLS, proxy, timeout.
     #[error("Failed to send the request to the chat provider")]
     RequestFailed,
 
-    /// The provider answered outside the 2xx range.
     #[error("Chat provider responded with HTTP status {status}")]
-    HttpStatus {
-        /// The status code returned.
-        status: u16,
-    },
+    HttpStatus { status: u16 },
 
-    /// The response body could not be read, or was not the envelope the provider documents.
     #[error("Could not interpret the chat provider's response")]
     UnreadableResponse,
 
-    /// The provider accepted the request and refused the message.
     #[error("Chat provider rejected the message: {reason}")]
-    Rejected {
-        /// Why it was refused.
-        reason: ChatErrorReason,
-    },
+    Rejected { reason: ChatErrorReason },
 
-    /// The message was delivered but the provider named no id for it, so replies cannot be threaded under it.
     #[error("Chat provider accepted the message without returning a message id")]
     MissingMessageId,
 
-    /// [`ChatMessage::reply`] carried an id this backend cannot thread against — typically an id minted by a different backend.
     #[error("The message id supplied cannot thread a reply on this chat provider")]
     IncompatibleReplyTarget,
 
-    /// The provider accepted an upload but did not identify the resulting file.
     #[error("Chat provider accepted the upload without returning a file id")]
     MissingFileId,
 }
 
-/// Why a provider refused a message, in vocabulary no single backend owns.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ChatErrorReason {
-    /// No such channel, or the credential cannot see it.
     #[error("channel not found")]
     ChannelNotFound,
 
-    /// The channel exists but the bot is not a member of it.
     #[error("not a member of the channel")]
     NotInChannel,
 
-    /// The credential was not accepted.
     #[error("credential rejected")]
     InvalidAuth,
 
-    /// The credential was valid and has since been revoked or deactivated; it needs re-issuing.
     #[error("credential revoked")]
     TokenRevoked,
 
-    /// The message exceeded the provider's size limit.
     #[error("message too long")]
     MessageTooLong,
 
-    /// The caller is posting too fast.
     #[error("rate limited{}", retry_after_seconds.map_or_else(String::new, |seconds| format!(", retry after {seconds}s")))]
-    RateLimited {
-        /// How long the provider asked us to wait, when it said.
-        retry_after_seconds: Option<u64>,
-    },
+    RateLimited { retry_after_seconds: Option<u64> },
 
-    /// Anything else, carrying the provider's own code verbatim.
     #[error("{0}")]
     Other(String),
 }

--- a/crates/external_services/src/chat_service.rs
+++ b/crates/external_services/src/chat_service.rs
@@ -173,6 +173,51 @@ impl MessageId {
 pub struct ChatMessage {
     text: String,
     reply_to: Option<MessageId>,
+    banner: Option<ChatBanner>,
+}
+
+/// How urgent a message is, in the vocabulary of the reader rather than of any one backend.
+///
+/// Named states rather than a colour, because the colour is a rendering detail each backend spells
+/// differently, and because a caller that has to know `danger` means "critical" has to know Slack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatSeverity {
+    /// Something is broken now.
+    Critical,
+    /// Still broken, said again.
+    Warning,
+    /// Over.
+    Resolved,
+}
+
+/// A titled, colour-coded frame around a message.
+///
+/// Heading and severity travel together because neither is useful alone: a coloured bar with no
+/// title says only that something happened, and a title with no colour is what `text` already does.
+#[derive(Debug, Clone)]
+pub struct ChatBanner {
+    heading: String,
+    severity: ChatSeverity,
+}
+
+impl ChatBanner {
+    /// A banner reading `heading`, weighted by `severity`.
+    pub fn new(heading: impl Into<String>, severity: ChatSeverity) -> Self {
+        Self {
+            heading: heading.into(),
+            severity,
+        }
+    }
+
+    /// The heading, rendered as plain text: markup in it is shown literally, not interpreted.
+    pub fn heading(&self) -> &str {
+        &self.heading
+    }
+
+    /// How urgent the message is.
+    pub fn severity(&self) -> ChatSeverity {
+        self.severity
+    }
 }
 
 impl ChatMessage {
@@ -185,6 +230,7 @@ impl ChatMessage {
         Self {
             text: text.into(),
             reply_to: None,
+            banner: None,
         }
     }
 
@@ -199,7 +245,20 @@ impl ChatMessage {
         Self {
             text: text.into(),
             reply_to: Some(message_id),
+            banner: None,
         }
+    }
+
+    /// Frame this message in a titled, colour-coded banner.
+    ///
+    /// A builder here rather than a fourth constructor: unlike threading, a banner is orthogonal to
+    /// how the message was made, so both constructors would otherwise need a bannered twin.
+    ///
+    /// A backend that cannot draw one still delivers the message — the banner is presentation, and
+    /// dropping it must never cost the alert.
+    pub fn with_banner(mut self, banner: ChatBanner) -> Self {
+        self.banner = Some(banner);
+        self
     }
 
     /// The message body.
@@ -210,6 +269,11 @@ impl ChatMessage {
     /// The message this one replies to, if any.
     pub fn reply_target(&self) -> Option<&MessageId> {
         self.reply_to.as_ref()
+    }
+
+    /// The banner to frame this message in, if any.
+    pub fn banner(&self) -> Option<&ChatBanner> {
+        self.banner.as_ref()
     }
 }
 

--- a/crates/external_services/src/chat_service.rs
+++ b/crates/external_services/src/chat_service.rs
@@ -1,14 +1,4 @@
 //! Delivery of chat messages to a destination channel.
-//!
-//! A [`ChatClient`] is bound to one destination: a base URL, a credential and a channel. Callers
-//! that hold several destinations — one per merchant workspace, say — build one client per
-//! destination and hand each a [`ChatMessage`]. Clients own no connection state (the underlying
-//! `reqwest::Client` and its pool are cached globally by
-//! [`crate::http_client`]), so constructing one per message is cheap.
-//!
-//! This module deliberately knows nothing about *alerts*. It renders no domain content and holds
-//! no configuration store; deciding what to say, and looking up where to say it, belong to the
-//! callers.
 
 /// The Slack chat API.
 pub mod slack;
@@ -16,8 +6,7 @@ pub mod slack;
 /// Xyne, which exposes a Slack-compatible messaging API.
 pub mod xyne;
 
-/// The wire protocol Xyne and Slack share. Private: nothing outside this module should have to
-/// know that `ok: false` can arrive with HTTP 200.
+/// The wire protocol Xyne and Slack share.
 mod slack_compatible;
 
 use common_utils::errors::CustomResult;
@@ -27,11 +16,6 @@ use hyperswitch_masking::{PeekInterface, Secret};
 pub type ChatResult<T> = CustomResult<T, ChatError>;
 
 /// Posts messages to one chat destination.
-///
-/// Object-safe on purpose: a caller resolving destinations at runtime holds these as
-/// `Arc<dyn ChatClient>`. Resist adding an associated type — [`crate::email::EmailClient`] has one
-/// (`RichText`), which is why it cannot be used as a trait object and why the erased
-/// [`crate::email::EmailService`] had to be invented alongside it.
 #[async_trait::async_trait]
 pub trait ChatClient: Send + Sync + std::fmt::Debug {
     /// Post a message, returning the id of the message that was created.
@@ -64,10 +48,6 @@ impl FileId {
 }
 
 /// A file to upload to a chat destination.
-///
-/// Bytes are deliberately owned: the shared HTTP transport may retry a request and therefore must
-/// be able to replay its body. Content fields are secrets so derived debug output cannot expose an
-/// alert report or the identifying metadata around it.
 #[derive(Debug, Clone)]
 pub struct ChatFile {
     bytes: Secret<Vec<u8>>,
@@ -78,7 +58,7 @@ pub struct ChatFile {
 }
 
 impl ChatFile {
-    /// Build one upload. Validation that requires destination context happens in the client.
+    /// Build one upload.
     pub fn new(
         bytes: Vec<u8>,
         filename: impl Into<String>,
@@ -123,20 +103,10 @@ impl ChatFile {
 }
 
 /// Identifies a message that a backend has accepted.
-///
-/// Backends disagree on what a message id *is*, and the disagreement is not cosmetic: threading a
-/// reply means handing an id back, so an id from the wrong backend is a bug we want the type
-/// system to catch rather than a malformed field on the wire.
-///
-/// Non-exhaustive because more backends are expected (Discord identifies messages by a numeric
-/// snowflake rather than a timestamp); match with a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum MessageId {
-    /// A Slack-compatible `ts`: `"1503435956.000247"`, seconds and microseconds since the epoch.
-    ///
-    /// Opaque — it must stay a string. Parsing it as a float loses precision, and Slack documents
-    /// it as an identifier rather than a time.
+    /// A Slack-compatible `ts`:
     Ts(String),
 }
 
@@ -155,20 +125,6 @@ impl MessageId {
 }
 
 /// A message to post.
-///
-/// The fields are private and reached through constructors and accessors on purpose: this is the
-/// type most likely to grow, and private fields mean it can grow without breaking callers.
-///
-/// Two directions it is expected to grow, and how:
-///
-/// - **A backend that is not Slack-compatible.** `text` is markup, and the markup is not portable
-///   — Slack reads `*bold*` where Discord reads `**bold**`. Today every backend is
-///   Slack-compatible so a rendered string is honest. The first backend that is not forces a
-///   choice between rendering at the call site and carrying structured content here; keeping
-///   `text` private means that choice stays open.
-/// - **Files.** They do not belong on this type. Uploading is a different endpoint with a
-///   different result — a file id, not a message id — and on current Slack it is three calls
-///   rather than one. It earns a sibling method on [`ChatClient`], not a field here.
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
     text: String,
@@ -177,9 +133,6 @@ pub struct ChatMessage {
 }
 
 /// How urgent a message is, in the vocabulary of the reader rather than of any one backend.
-///
-/// Named states rather than a colour, because the colour is a rendering detail each backend spells
-/// differently, and because a caller that has to know `danger` means "critical" has to know Slack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChatSeverity {
     /// Something is broken now.
@@ -191,9 +144,6 @@ pub enum ChatSeverity {
 }
 
 /// A titled, colour-coded frame around a message.
-///
-/// Heading and severity travel together because neither is useful alone: a coloured bar with no
-/// title says only that something happened, and a title with no colour is what `text` already does.
 #[derive(Debug, Clone)]
 pub struct ChatBanner {
     heading: String,
@@ -209,7 +159,7 @@ impl ChatBanner {
         }
     }
 
-    /// The heading, rendered as plain text: markup in it is shown literally, not interpreted.
+    /// The heading, rendered as plain text:
     pub fn heading(&self) -> &str {
         &self.heading
     }
@@ -222,10 +172,6 @@ impl ChatBanner {
 
 impl ChatMessage {
     /// A new top-level message.
-    ///
-    /// `text` is delivered as-is, in whatever markup the target backend reads. Escape anything
-    /// interpolated into it: on Slack-compatible backends an unescaped `<` in a merchant id or an
-    /// error reason opens markup and mangles the message.
     pub fn new(text: impl Into<String>) -> Self {
         Self {
             text: text.into(),
@@ -235,12 +181,6 @@ impl ChatMessage {
     }
 
     /// A message threaded as a reply under `message_id`.
-    ///
-    /// Serialised as `thread_ts` by Slack-compatible backends.
-    ///
-    /// A second constructor rather than a `mut self` builder on top of [`ChatMessage::new`]:
-    /// whether a message is threaded is known at the call site, so it is an argument rather than a
-    /// state a value passes through.
     pub fn reply(text: impl Into<String>, message_id: MessageId) -> Self {
         Self {
             text: text.into(),
@@ -250,12 +190,6 @@ impl ChatMessage {
     }
 
     /// Frame this message in a titled, colour-coded banner.
-    ///
-    /// A builder here rather than a fourth constructor: unlike threading, a banner is orthogonal to
-    /// how the message was made, so both constructors would otherwise need a bannered twin.
-    ///
-    /// A backend that cannot draw one still delivers the message — the banner is presentation, and
-    /// dropping it must never cost the alert.
     pub fn with_banner(mut self, banner: ChatBanner) -> Self {
         self.banner = Some(banner);
         self
@@ -296,8 +230,6 @@ pub enum ChatError {
     },
 
     /// The response body could not be read, or was not the envelope the provider documents.
-    ///
-    /// A body carrying no success marker lands here rather than being read as a success.
     #[error("Could not interpret the chat provider's response")]
     UnreadableResponse,
 
@@ -308,13 +240,11 @@ pub enum ChatError {
         reason: ChatErrorReason,
     },
 
-    /// The message was delivered but the provider named no id for it, so replies cannot be
-    /// threaded under it. Retrying would post a duplicate.
+    /// The message was delivered but the provider named no id for it, so replies cannot be threaded under it.
     #[error("Chat provider accepted the message without returning a message id")]
     MissingMessageId,
 
-    /// [`ChatMessage::reply`] carried an id this backend cannot thread against — typically an
-    /// id minted by a different backend.
+    /// [`ChatMessage::reply`] carried an id this backend cannot thread against — typically an id minted by a different backend.
     #[error("The message id supplied cannot thread a reply on this chat provider")]
     IncompatibleReplyTarget,
 
@@ -324,11 +254,6 @@ pub enum ChatError {
 }
 
 /// Why a provider refused a message, in vocabulary no single backend owns.
-///
-/// Backends map their own codes into this; the code they actually sent is preserved either in
-/// [`ChatErrorReason::Other`] or on the error report's attachments, so nothing is lost for logs.
-/// `Display` is what [`ChatError::Rejected`] interpolates as `{reason}`, so each message lives on
-/// the variant it describes rather than in a separate impl that can drift from it.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ChatErrorReason {
     /// No such channel, or the credential cannot see it.

--- a/crates/external_services/src/chat_service/slack_compatible.rs
+++ b/crates/external_services/src/chat_service/slack_compatible.rs
@@ -1,14 +1,4 @@
 //! The Slack-compatible wire protocol.
-//!
-//! Xyne exposes a facade over Slack's own API, so both backends post the same JSON body to the
-//! same method name and read the same response envelope. Only the base URL, the path prefix in
-//! front of the method and the credential differ, which is why [`Endpoint`] holds those three and
-//! the public clients are thin wrappers over it.
-//!
-//! Everything here is private to [`crate::chat_service`]. The single most important reason is the
-//! envelope: this API reports failures **twice over**, once as a non-2xx status and once as HTTP
-//! 200 carrying `{"ok": false, "error": "..."}`. A caller that never sees the raw response cannot
-//! forget the second one.
 
 use common_utils::request::{Method, RequestBuilder, RequestContent};
 use error_stack::ResultExt;
@@ -23,13 +13,12 @@ use super::{
 };
 use crate::http_client;
 
-/// The method that posts a message. The only one this crate calls; `files.upload` is out of v1.
+/// The method that posts a message.
 const CHAT_POST_MESSAGE: &str = "chat.postMessage";
 const FILES_GET_UPLOAD_URL: &str = "files.getUploadURLExternal";
 const FILES_COMPLETE_UPLOAD: &str = "files.completeUploadExternal";
 
-/// Long enough that a slow provider is not mistaken for a dead one, short enough that a caller
-/// delivering a time-sensitive message is not held indefinitely.
+/// Long enough that a slow provider is not mistaken for a dead one, short enough that a caller delivering a time-sensitive message is not held indefinitely.
 pub(super) const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
 
 /// Appended to a message that had to be cut down to fit.
@@ -42,18 +31,9 @@ const BODY_SNIPPET_CHARS: usize = 512;
 const UNSPECIFIED_ERROR_CODE: &str = "unspecified";
 
 /// The cap a `header` block puts on its text.
-///
-/// Separate from the message cap, and far smaller. Slack rejects an oversized header outright
-/// rather than trimming it, and a rejected message is a *lost alert* — so the heading is cut to fit
-/// here even though nothing else in a banner needs cutting.
 const HEADER_MAX_CHARS: usize = 150;
 
 /// The cap a `section` block puts on its text.
-///
-/// Much lower than any backend's message cap — 10,000 on Xyne, 40,000 on Slack — because it applies
-/// per block rather than per message. A body that fits a plain message can therefore be too long for
-/// a bannered one, and an oversized block is rejected rather than trimmed, so it must be cut here or
-/// the banner turns a deliverable alert into a dropped one.
 const SECTION_MAX_CHARS: usize = 3_000;
 
 /// Request headers selected by the concrete backend.
@@ -72,14 +52,13 @@ impl EndpointHeaders {
     }
 }
 
-/// One destination on a Slack-compatible API: where to post, as whom, and to which channel.
+/// One destination on a Slack-compatible API:
 #[derive(Clone, Debug)]
 pub(super) struct Endpoint {
-    /// Root of the API, e.g. `https://slack.com/api`.
+    /// Root of the API, e.g.
     base_url: Url,
 
-    /// Sits between the base URL and the method name. Slack serves methods directly off its base
-    /// (`/api/chat.postMessage`); Xyne namespaces them (`/api/apps/slack/chat.postMessage`).
+    /// Sits between the base URL and the method name.
     method_prefix: &'static str,
 
     /// Headers for API method calls and the raw upload leg are supplied by the concrete backend.
@@ -95,9 +74,6 @@ pub(super) struct Endpoint {
 
 impl Endpoint {
     /// Validate a destination and bind it to a proxy.
-    ///
-    /// Validation happens here rather than at send time so a destination read from configuration
-    /// or from a database row fails once, on the way in, rather than once per message.
     pub(super) fn new(
         base_url: Url,
         method_prefix: &'static str,
@@ -131,9 +107,7 @@ impl Endpoint {
         })
     }
 
-    /// `Url::join` is deliberately not used: it resolves relatively, so a base of `/api/apps`
-    /// without a trailing slash would produce `/api/chat.postMessage`, silently dropping a path
-    /// segment.
+    /// `Url::join` is deliberately not used:
     fn method_url(&self, method: &str) -> String {
         format!(
             "{}{}{}",
@@ -144,19 +118,11 @@ impl Endpoint {
     }
 
     /// Post a message and return the id the provider assigned it.
-    ///
-    /// **Not idempotent, and the transport may retry.**
-    /// [`http_client::send_request`] clones a JSON request and resends it once when the connection
-    /// closes before the response completes, and `chat.postMessage` offers no idempotency key. A
-    /// message can therefore be delivered twice. That trade is deliberate for this caller: a
-    /// duplicate alert costs far less than a dropped one, and every connector call in this
-    /// workspace already carries the same retry.
     pub(super) async fn post_message(&self, message: ChatMessage) -> ChatResult<MessageId> {
         let payload = self.build_payload(&message)?;
         let url = self.method_url(CHAT_POST_MESSAGE);
 
-        // Without this, the only question that matters when no message arrives — did we try, where
-        // to, and what came back — has no answer in the logs.
+        // Without this, the only question that matters when no message arrives — did we try, where to, and what came back — has no answer in the logs.
         logger::info!(
             tag = "chat_post_message",
             url = %url,
@@ -342,12 +308,7 @@ impl Endpoint {
             })
             .transpose()?;
 
-        // A banner moves the body inside the attachment, because that is the only place a
-        // Slack-compatible backend draws the coloured rail: text left at the top level renders
-        // above the rail as a second, unframed copy of the same message.
-        //
-        // The cut is taken against the block's own limit rather than the message's, and only once,
-        // so a body that has already been trimmed to fit is not trimmed again to a marker.
+        // A banner moves the body inside the attachment, because that is the only place a Slack-compatible backend draws the coloured rail:
         let (text, attachments) = match message.banner() {
             None => (truncate(message.text(), self.max_message_chars), None),
             Some(banner) => (
@@ -369,7 +330,7 @@ impl Endpoint {
             channel: self.channel.clone(),
             text,
             thread_ts,
-            // See the field: setting it alongside `attachments` costs the banner entirely.
+            // See the field:
             mrkdwn: attachments.is_none().then_some(true),
             attachments,
         })
@@ -377,9 +338,6 @@ impl Endpoint {
 }
 
 /// The rail colour a backend draws for each severity.
-///
-/// These three names are Slack's whole documented vocabulary for `color`; anything else is read as
-/// a hex literal. Keeping the mapping here is what lets [`ChatSeverity`] stay in the reader's terms.
 fn attachment_color(severity: ChatSeverity) -> &'static str {
     match severity {
         ChatSeverity::Critical => "danger",
@@ -459,34 +417,16 @@ struct PostMessagePayload {
     thread_ts: Option<String>,
 
     /// Sent for a plain message, omitted for a bannered one.
-    ///
-    /// Slack treats markup as enabled by default, so this is redundant there. Xyne does not: its
-    /// adapter takes the markup path only on `mrkdwn === true`, so an omitted flag delivers
-    /// `*bold*` and backticks as literal characters. Since the whole point of
-    /// [`ChatMessage::text`](super::ChatMessage::text) is markup, sending it explicitly is the only
-    /// spelling that behaves the same on both.
-    ///
-    /// **Except alongside `attachments`.** That same adapter branch is text-only: with the flag set
-    /// it renders `text` and never looks at the attachments, so the coloured rail and the heading
-    /// silently vanish and the alert arrives as an ordinary message. Nothing is lost by omitting it
-    /// there — a bannered message carries its body in a block that declares `"type": "mrkdwn"` for
-    /// itself, so the markup is already accounted for.
     #[serde(skip_serializing_if = "Option::is_none")]
     mrkdwn: Option<bool>,
 
     /// The coloured frame, when the message asked for one.
-    ///
-    /// Omitted rather than sent empty: an empty array is a legal value that some backends render as
-    /// a stray divider.
     #[serde(skip_serializing_if = "Option::is_none")]
     attachments: Option<Vec<Attachment>>,
 }
 
 impl PostMessagePayload {
     /// How much text is actually being sent, wherever it sits.
-    ///
-    /// A bannered message carries its body inside the attachment and leaves `text` empty, so
-    /// counting `text` alone would log every alert as zero characters.
     fn body_chars(&self) -> usize {
         self.text.chars().count()
             + self
@@ -507,9 +447,6 @@ struct Attachment {
 }
 
 /// A block within an attachment.
-///
-/// Flat rather than an enum per block type: the two shapes this crate sends differ only in the two
-/// `type` strings, and an enum for that would be three declarations describing one object.
 #[derive(Debug, Serialize)]
 struct Block {
     #[serde(rename = "type")]
@@ -519,9 +456,6 @@ struct Block {
 
 impl Block {
     /// The large title at the top of the frame.
-    ///
-    /// `plain_text`, so a heading built from an error reason cannot open markup and swallow the
-    /// rest of the line — the reason `text` below is `mrkdwn` and this is not.
     fn header(text: String) -> Self {
         Self {
             kind: "header",
@@ -552,20 +486,12 @@ struct BlockText {
     kind: &'static str,
     text: String,
 
-    /// Whether `:shortcode:` sequences become emoji. Meaningful only on `plain_text`, and rejected
-    /// outright on `mrkdwn` by some backends, so it is omitted there rather than sent as `false`.
+    /// Whether `:shortcode:` sequences become emoji.
     #[serde(skip_serializing_if = "Option::is_none")]
     emoji: Option<bool>,
 }
 
 /// The `chat.postMessage` response, exactly as it arrives.
-///
-/// Faithful to the wire and nothing else. `ok` is a required field, so a body that carries no
-/// success marker fails to deserialize rather than being read as a success — which is the trap
-/// this API sets, since it reports failure at HTTP 200.
-///
-/// Private, and the only way out of this module is [`MessageId`] via the conversion below, so no
-/// caller can reach a `ts` without the `ok` check having run.
 #[derive(Debug, Deserialize)]
 struct PostMessageResponse {
     ok: bool,
@@ -585,8 +511,7 @@ impl TryFrom<PostMessageResponse> for MessageId {
 
     fn try_from(response: PostMessageResponse) -> Result<Self, Self::Error> {
         if !response.ok {
-            // A refusal carrying no code at all is malformed, but it is still unambiguously a
-            // refusal — reporting it as an unreadable response would be a worse lie.
+            // A refusal carrying no code at all is malformed, but it is still unambiguously a refusal — reporting it as an unreadable response would be a worse lie.
             let reason = response.error.map_or_else(
                 || ChatErrorReason::Other(UNSPECIFIED_ERROR_CODE.to_owned()),
                 ChatErrorReason::from,
@@ -608,23 +533,17 @@ impl TryFrom<PostMessageResponse> for MessageId {
 }
 
 /// The `error` field of a refused response.
-///
-/// A type rather than a string match: the wire spellings live in one derive that serde checks, and
-/// adding a code means adding a variant instead of remembering to extend a `match`. A code the
-/// provider adds later still arrives intact through [`SlackErrorCode::Unrecognised`], so nothing
-/// is flattened away for the logs.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum SlackErrorCode {
     ChannelNotFound,
     NotInChannel,
-    /// The channel exists and accepts nothing further — the same problem for a caller as not being
-    /// a member of it.
+    /// The channel exists and accepts nothing further — the same problem for a caller as not being a member of it.
     IsArchived,
     InvalidAuth,
     NotAuthed,
     TokenRevoked,
-    /// A deactivated account needs the same remedy as a revoked token: re-issue the credential.
+    /// A deactivated account needs the same remedy as a revoked token:
     AccountInactive,
     MsgTooLong,
     RateLimited,
@@ -635,8 +554,7 @@ enum SlackErrorCode {
     InvalidArguments,
     /// The message named as a reply target no longer resolves.
     ThreadNotFound,
-    /// The provider failed on its own account. Distinct from every other code here, all of which
-    /// blame the request: this one is the provider's fault and may succeed if tried again.
+    /// The provider failed on its own account.
     InternalError,
     /// Any code not listed above, kept verbatim.
     #[serde(untagged)]
@@ -651,14 +569,11 @@ impl From<SlackErrorCode> for ChatErrorReason {
             SlackErrorCode::InvalidAuth | SlackErrorCode::NotAuthed => Self::InvalidAuth,
             SlackErrorCode::TokenRevoked | SlackErrorCode::AccountInactive => Self::TokenRevoked,
             SlackErrorCode::MsgTooLong => Self::MessageTooLong,
-            // `Retry-After` rides on a 429, which is handled before a body is ever parsed, so a
-            // rate-limit code arriving at HTTP 200 comes without one.
+            // `Retry-After` rides on a 429, which is handled before a body is ever parsed, so a rate-limit code arriving at HTTP 200 comes without one.
             SlackErrorCode::RateLimited | SlackErrorCode::RateLimitedCompact => Self::RateLimited {
                 retry_after_seconds: None,
             },
-            // These three have no neutral variant yet, so they ride in `Other` with their code
-            // intact. `internal_error` is the one worth promoting first if a caller ever needs to
-            // decide whether retrying is worthwhile.
+            // These three have no neutral variant yet, so they ride in `Other` with their code intact.
             SlackErrorCode::InvalidArguments => Self::Other("invalid_arguments".to_owned()),
             SlackErrorCode::ThreadNotFound => Self::Other("thread_not_found".to_owned()),
             SlackErrorCode::InternalError => Self::Other("internal_error".to_owned()),
@@ -668,18 +583,12 @@ impl From<SlackErrorCode> for ChatErrorReason {
 }
 
 /// Cut `text` to `max_chars`, marking that it happened.
-///
-/// The API does not paginate, so oversized messages are rejected outright rather than split. This
-/// is a wire-level limit and belongs here; capping the *number of items* rendered into a message
-/// is the formatter's business, since this module never sees items.
 fn truncate(text: &str, max_chars: usize) -> String {
     if text.chars().count() <= max_chars {
         return text.to_owned();
     }
 
-    // The marker is itself subject to the cap. Appending it whole to an empty remainder would
-    // return something *longer* than the limit this function exists to enforce, which the provider
-    // would then reject.
+    // The marker is itself subject to the cap.
     let marker: String = TRUNCATION_MARKER.chars().take(max_chars).collect();
     let keep = max_chars.saturating_sub(marker.chars().count());
 
@@ -706,8 +615,7 @@ mod tests {
     use super::*;
     use crate::chat_service::ChatBanner;
 
-    /// Any cap generous enough not to interfere; the per-backend defaults live with their
-    /// clients, since Slack and Xyne do not agree on one.
+    /// Any cap generous enough not to interfere; the per-backend defaults live with their clients, since Slack and Xyne do not agree on one.
     const TEST_MAX_MESSAGE_CHARS: usize = 40_000;
 
     /// Parse a body and run it through the conversion, exactly as `post_message` does.
@@ -715,8 +623,7 @@ mod tests {
         serde_json::from_value::<PostMessageResponse>(value).map(TryInto::try_into)
     }
 
-    /// Deserialize a wire error code and map it, which is the whole path a refusal takes. Going
-    /// through serde rather than constructing the variant means the spellings are covered too.
+    /// Deserialize a wire error code and map it, which is the whole path a refusal takes.
     fn reason(code: &str) -> ChatErrorReason {
         serde_json::from_value::<SlackErrorCode>(json!(code))
             .unwrap()
@@ -738,8 +645,7 @@ mod tests {
 
     #[test]
     fn ok_false_with_a_ts_present_is_still_a_failure() {
-        // The shape that catches a status-code-only client out: everything a success has, plus
-        // `ok: false`.
+        // The shape that catches a status-code-only client out:
         let error = read(json!({"ok": false, "error": "msg_too_long", "ts": "1.2"}))
             .unwrap()
             .unwrap_err();
@@ -753,8 +659,7 @@ mod tests {
 
     #[test]
     fn a_body_without_ok_does_not_deserialize() {
-        // `ok` is required, so a body carrying a `ts` and nothing else cannot be mistaken for a
-        // success.
+        // `ok` is required, so a body carrying a `ts` and nothing else cannot be mistaken for a success.
         assert!(read(json!({"ts": "1503435956.000247"})).is_err());
     }
 
@@ -770,8 +675,7 @@ mod tests {
 
     #[test]
     fn a_refusal_naming_no_code_is_still_a_refusal() {
-        // Malformed, but unambiguously a refusal — calling it an unreadable response would be a
-        // worse lie than naming the code as unspecified.
+        // Malformed, but unambiguously a refusal — calling it an unreadable response would be a worse lie than naming the code as unspecified.
         let error = read(json!({"ok": false})).unwrap().unwrap_err();
         match error.current_context() {
             ChatError::Rejected { reason } => assert_eq!(
@@ -845,8 +749,7 @@ mod tests {
             );
         }
 
-        // Codes the Xyne adapter emits that have no neutral variant yet. They must still arrive
-        // with their meaning legible rather than as an empty `Other`.
+        // Codes the Xyne adapter emits that have no neutral variant yet.
         for code in ["invalid_arguments", "thread_not_found", "internal_error"] {
             assert_eq!(reason(code), ChatErrorReason::Other(code.to_owned()));
         }
@@ -878,8 +781,7 @@ mod tests {
 
     #[test]
     fn an_unusable_destination_is_rejected_on_the_way_in() {
-        // A malformed base URL cannot reach here at all: it is a `Url`, so it fails at
-        // deserialization. What is left for `Endpoint::new` is the rest of the destination.
+        // A malformed base URL cannot reach here at all:
         assert!(endpoint("https://example.com", "/", "token").is_ok());
 
         let blank_channel = Endpoint::new(
@@ -948,11 +850,6 @@ mod tests {
     }
 
     /// The exact body a bannered alert puts on the wire.
-    ///
-    /// Pinned against a payload confirmed to render on Xyne — coloured rail plus large title — so
-    /// that a later refactor cannot quietly reshape it back into something that only looks right in
-    /// a struct. The parts that matter are all here: the body moved inside the attachment, `text`
-    /// emptied, `plain_text` on the header and `mrkdwn` on the section.
     #[test]
     fn a_banner_moves_the_body_into_a_coloured_attachment() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -994,11 +891,6 @@ mod tests {
     }
 
     /// Setting `mrkdwn` alongside `attachments` costs the banner entirely.
-    ///
-    /// Xyne's adapter branches on the flag into a text-only path that never reads `attachments`, so
-    /// the message is delivered — `ok: true`, an id returned, nothing in the logs — and simply
-    /// arrives with no rail and no heading. Nothing downstream can detect it, which is why it is
-    /// pinned here rather than left to the payload test above.
     #[test]
     fn a_bannered_message_does_not_set_mrkdwn() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -1017,8 +909,7 @@ mod tests {
             .is_none());
     }
 
-    /// The other half: without a banner the flag is still required, or Xyne delivers `*bold*` and
-    /// backticks as literal characters.
+    /// The other half:
     #[test]
     fn a_plain_message_still_sets_mrkdwn() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -1029,8 +920,7 @@ mod tests {
         assert_eq!(serde_json::to_value(&payload).unwrap()["mrkdwn"], true);
     }
 
-    /// An oversized header is rejected outright rather than trimmed by the provider, so a long
-    /// heading would cost the whole alert rather than just its tail.
+    /// An oversized header is rejected outright rather than trimmed by the provider, so a long heading would cost the whole alert rather than just its tail.
     #[test]
     fn an_oversized_heading_is_cut_to_the_header_limit() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -1047,9 +937,7 @@ mod tests {
         assert!(heading.ends_with(TRUNCATION_MARKER));
     }
 
-    /// A section block caps far below any backend's message cap, and an oversized one is rejected
-    /// rather than trimmed — so without this a long alert that used to arrive as plain text would be
-    /// dropped outright the moment it gained a banner.
+    /// A section block caps far below any backend's message cap, and an oversized one is rejected rather than trimmed — so without this a long alert that used to arrive as plain text would be dropped outright the moment it gained a banner.
     #[test]
     fn a_long_body_is_cut_to_the_section_limit_when_bannered() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -1066,8 +954,7 @@ mod tests {
         assert!(section.chars().count() <= SECTION_MAX_CHARS);
         assert!(section.ends_with(TRUNCATION_MARKER));
 
-        // The same body without a banner keeps the far larger message cap: the tighter limit is a
-        // property of the block, not of the message.
+        // The same body without a banner keeps the far larger message cap:
         let plain = endpoint.build_payload(&ChatMessage::new(&long)).unwrap();
         assert_eq!(plain.text.chars().count(), long.chars().count());
     }

--- a/crates/external_services/src/chat_service/slack_compatible.rs
+++ b/crates/external_services/src/chat_service/slack_compatible.rs
@@ -48,6 +48,14 @@ const UNSPECIFIED_ERROR_CODE: &str = "unspecified";
 /// here even though nothing else in a banner needs cutting.
 const HEADER_MAX_CHARS: usize = 150;
 
+/// The cap a `section` block puts on its text.
+///
+/// Much lower than any backend's message cap — 10,000 on Xyne, 40,000 on Slack — because it applies
+/// per block rather than per message. A body that fits a plain message can therefore be too long for
+/// a bannered one, and an oversized block is rejected rather than trimmed, so it must be cut here or
+/// the banner turns a deliverable alert into a dropped one.
+const SECTION_MAX_CHARS: usize = 3_000;
+
 /// Request headers selected by the concrete backend.
 #[derive(Clone, Debug)]
 pub(super) struct EndpointHeaders {
@@ -334,20 +342,24 @@ impl Endpoint {
             })
             .transpose()?;
 
-        let body = truncate(message.text(), self.max_message_chars);
-
         // A banner moves the body inside the attachment, because that is the only place a
         // Slack-compatible backend draws the coloured rail: text left at the top level renders
         // above the rail as a second, unframed copy of the same message.
+        //
+        // The cut is taken against the block's own limit rather than the message's, and only once,
+        // so a body that has already been trimmed to fit is not trimmed again to a marker.
         let (text, attachments) = match message.banner() {
-            None => (body, None),
+            None => (truncate(message.text(), self.max_message_chars), None),
             Some(banner) => (
                 String::new(),
                 Some(vec![Attachment {
                     color: attachment_color(banner.severity()),
                     blocks: vec![
                         Block::header(truncate(banner.heading(), HEADER_MAX_CHARS)),
-                        Block::section(body),
+                        Block::section(truncate(
+                            message.text(),
+                            self.max_message_chars.min(SECTION_MAX_CHARS),
+                        )),
                     ],
                 }]),
             ),
@@ -1033,6 +1045,31 @@ mod tests {
         let heading = &payload.attachments.as_ref().unwrap()[0].blocks[0].text.text;
         assert!(heading.chars().count() <= HEADER_MAX_CHARS);
         assert!(heading.ends_with(TRUNCATION_MARKER));
+    }
+
+    /// A section block caps far below any backend's message cap, and an oversized one is rejected
+    /// rather than trimmed — so without this a long alert that used to arrive as plain text would be
+    /// dropped outright the moment it gained a banner.
+    #[test]
+    fn a_long_body_is_cut_to_the_section_limit_when_bannered() {
+        let endpoint = endpoint("https://example.com", "/", "token").unwrap();
+        let long = "x".repeat(TEST_MAX_MESSAGE_CHARS - 1);
+
+        let bannered = endpoint
+            .build_payload(
+                &ChatMessage::new(&long).with_banner(ChatBanner::new("h", ChatSeverity::Critical)),
+            )
+            .unwrap();
+        let section = &bannered.attachments.as_ref().unwrap()[0].blocks[1]
+            .text
+            .text;
+        assert!(section.chars().count() <= SECTION_MAX_CHARS);
+        assert!(section.ends_with(TRUNCATION_MARKER));
+
+        // The same body without a banner keeps the far larger message cap: the tighter limit is a
+        // property of the block, not of the message.
+        let plain = endpoint.build_payload(&ChatMessage::new(&long)).unwrap();
+        assert_eq!(plain.text.chars().count(), long.chars().count());
     }
 
     #[test]

--- a/crates/external_services/src/chat_service/slack_compatible.rs
+++ b/crates/external_services/src/chat_service/slack_compatible.rs
@@ -18,7 +18,9 @@ use router_env::logger;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::{ChatError, ChatErrorReason, ChatFile, ChatMessage, ChatResult, FileId, MessageId};
+use super::{
+    ChatError, ChatErrorReason, ChatFile, ChatMessage, ChatResult, ChatSeverity, FileId, MessageId,
+};
 use crate::http_client;
 
 /// The method that posts a message. The only one this crate calls; `files.upload` is out of v1.
@@ -38,6 +40,13 @@ const BODY_SNIPPET_CHARS: usize = 512;
 
 /// Stands in when a refusal names no error code at all.
 const UNSPECIFIED_ERROR_CODE: &str = "unspecified";
+
+/// The cap a `header` block puts on its text.
+///
+/// Separate from the message cap, and far smaller. Slack rejects an oversized header outright
+/// rather than trimming it, and a rejected message is a *lost alert* — so the heading is cut to fit
+/// here even though nothing else in a banner needs cutting.
+const HEADER_MAX_CHARS: usize = 150;
 
 /// Request headers selected by the concrete backend.
 #[derive(Clone, Debug)]
@@ -145,7 +154,8 @@ impl Endpoint {
             url = %url,
             channel = %payload.channel,
             threaded = payload.thread_ts.is_some(),
-            chars = payload.text.chars().count(),
+            bannered = payload.attachments.is_some(),
+            chars = payload.body_chars(),
         );
 
         let body = self
@@ -324,12 +334,45 @@ impl Endpoint {
             })
             .transpose()?;
 
+        let body = truncate(message.text(), self.max_message_chars);
+
+        // A banner moves the body inside the attachment, because that is the only place a
+        // Slack-compatible backend draws the coloured rail: text left at the top level renders
+        // above the rail as a second, unframed copy of the same message.
+        let (text, attachments) = match message.banner() {
+            None => (body, None),
+            Some(banner) => (
+                String::new(),
+                Some(vec![Attachment {
+                    color: attachment_color(banner.severity()),
+                    blocks: vec![
+                        Block::header(truncate(banner.heading(), HEADER_MAX_CHARS)),
+                        Block::section(body),
+                    ],
+                }]),
+            ),
+        };
+
         Ok(PostMessagePayload {
             channel: self.channel.clone(),
-            text: truncate(message.text(), self.max_message_chars),
+            text,
             thread_ts,
-            mrkdwn: true,
+            // See the field: setting it alongside `attachments` costs the banner entirely.
+            mrkdwn: attachments.is_none().then_some(true),
+            attachments,
         })
+    }
+}
+
+/// The rail colour a backend draws for each severity.
+///
+/// These three names are Slack's whole documented vocabulary for `color`; anything else is read as
+/// a hex literal. Keeping the mapping here is what lets [`ChatSeverity`] stay in the reader's terms.
+fn attachment_color(severity: ChatSeverity) -> &'static str {
+    match severity {
+        ChatSeverity::Critical => "danger",
+        ChatSeverity::Warning => "warning",
+        ChatSeverity::Resolved => "good",
     }
 }
 
@@ -403,14 +446,104 @@ struct PostMessagePayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     thread_ts: Option<String>,
 
-    /// Always sent, and never omitted.
+    /// Sent for a plain message, omitted for a bannered one.
     ///
-    /// Slack treats markup as enabled by default, so this is redundant there. Xyne does not:
-    /// its adapter takes the markup path only on `mrkdwn === true`, so an omitted flag delivers
+    /// Slack treats markup as enabled by default, so this is redundant there. Xyne does not: its
+    /// adapter takes the markup path only on `mrkdwn === true`, so an omitted flag delivers
     /// `*bold*` and backticks as literal characters. Since the whole point of
-    /// [`ChatMessage::text`](super::ChatMessage::text) is markup, sending it explicitly is the
-    /// only spelling that behaves the same on both.
-    mrkdwn: bool,
+    /// [`ChatMessage::text`](super::ChatMessage::text) is markup, sending it explicitly is the only
+    /// spelling that behaves the same on both.
+    ///
+    /// **Except alongside `attachments`.** That same adapter branch is text-only: with the flag set
+    /// it renders `text` and never looks at the attachments, so the coloured rail and the heading
+    /// silently vanish and the alert arrives as an ordinary message. Nothing is lost by omitting it
+    /// there — a bannered message carries its body in a block that declares `"type": "mrkdwn"` for
+    /// itself, so the markup is already accounted for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mrkdwn: Option<bool>,
+
+    /// The coloured frame, when the message asked for one.
+    ///
+    /// Omitted rather than sent empty: an empty array is a legal value that some backends render as
+    /// a stray divider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    attachments: Option<Vec<Attachment>>,
+}
+
+impl PostMessagePayload {
+    /// How much text is actually being sent, wherever it sits.
+    ///
+    /// A bannered message carries its body inside the attachment and leaves `text` empty, so
+    /// counting `text` alone would log every alert as zero characters.
+    fn body_chars(&self) -> usize {
+        self.text.chars().count()
+            + self
+                .attachments
+                .iter()
+                .flatten()
+                .flat_map(|attachment| attachment.blocks.iter())
+                .map(|block| block.text.text.chars().count())
+                .sum::<usize>()
+    }
+}
+
+/// One coloured frame around a message.
+#[derive(Debug, Serialize)]
+struct Attachment {
+    color: &'static str,
+    blocks: Vec<Block>,
+}
+
+/// A block within an attachment.
+///
+/// Flat rather than an enum per block type: the two shapes this crate sends differ only in the two
+/// `type` strings, and an enum for that would be three declarations describing one object.
+#[derive(Debug, Serialize)]
+struct Block {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: BlockText,
+}
+
+impl Block {
+    /// The large title at the top of the frame.
+    ///
+    /// `plain_text`, so a heading built from an error reason cannot open markup and swallow the
+    /// rest of the line — the reason `text` below is `mrkdwn` and this is not.
+    fn header(text: String) -> Self {
+        Self {
+            kind: "header",
+            text: BlockText {
+                kind: "plain_text",
+                text,
+                emoji: Some(true),
+            },
+        }
+    }
+
+    /// The message body, in markup.
+    fn section(text: String) -> Self {
+        Self {
+            kind: "section",
+            text: BlockText {
+                kind: "mrkdwn",
+                text,
+                emoji: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct BlockText {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: String,
+
+    /// Whether `:shortcode:` sequences become emoji. Meaningful only on `plain_text`, and rejected
+    /// outright on `mrkdwn` by some backends, so it is omitted there rather than sent as `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    emoji: Option<bool>,
 }
 
 /// The `chat.postMessage` response, exactly as it arrives.
@@ -559,6 +692,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::chat_service::ChatBanner;
 
     /// Any cap generous enough not to interfere; the per-backend defaults live with their
     /// clients, since Slack and Xyne do not agree on one.
@@ -785,5 +919,156 @@ mod tests {
 
         assert_eq!(payload.thread_ts.as_deref(), Some("1.2"));
         assert_eq!(payload.channel, "C1");
+    }
+
+    #[test]
+    fn an_unbannered_message_sends_no_attachments_key_at_all() {
+        let endpoint = endpoint("https://example.com", "/", "token").unwrap();
+
+        let payload = endpoint.build_payload(&ChatMessage::new("hi")).unwrap();
+        let wire = serde_json::to_value(&payload).unwrap();
+
+        assert_eq!(wire["text"], "hi");
+        assert!(
+            wire.get("attachments").is_none(),
+            "an empty attachments array renders as a stray divider on some backends"
+        );
+    }
+
+    /// The exact body a bannered alert puts on the wire.
+    ///
+    /// Pinned against a payload confirmed to render on Xyne — coloured rail plus large title — so
+    /// that a later refactor cannot quietly reshape it back into something that only looks right in
+    /// a struct. The parts that matter are all here: the body moved inside the attachment, `text`
+    /// emptied, `plain_text` on the header and `mrkdwn` on the section.
+    #[test]
+    fn a_banner_moves_the_body_into_a_coloured_attachment() {
+        let endpoint = endpoint("https://example.com", "/", "token").unwrap();
+
+        let payload = endpoint
+            .build_payload(
+                &ChatMessage::new("*Merchant:* `flowbird`")
+                    .with_banner(ChatBanner::new("🔴 SEV1 · Zero SR", ChatSeverity::Critical)),
+            )
+            .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(&payload).unwrap(),
+            json!({
+                "channel": "C1",
+                "text": "",
+                "attachments": [{
+                    "color": "danger",
+                    "blocks": [
+                        {
+                            "type": "header",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "🔴 SEV1 · Zero SR",
+                                "emoji": true,
+                            },
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "*Merchant:* `flowbird`",
+                            },
+                        },
+                    ],
+                }],
+            })
+        );
+    }
+
+    /// Setting `mrkdwn` alongside `attachments` costs the banner entirely.
+    ///
+    /// Xyne's adapter branches on the flag into a text-only path that never reads `attachments`, so
+    /// the message is delivered — `ok: true`, an id returned, nothing in the logs — and simply
+    /// arrives with no rail and no heading. Nothing downstream can detect it, which is why it is
+    /// pinned here rather than left to the payload test above.
+    #[test]
+    fn a_bannered_message_does_not_set_mrkdwn() {
+        let endpoint = endpoint("https://example.com", "/", "token").unwrap();
+
+        let payload = endpoint
+            .build_payload(
+                &ChatMessage::new("*bold*")
+                    .with_banner(ChatBanner::new("head", ChatSeverity::Critical)),
+            )
+            .unwrap();
+
+        assert!(payload.mrkdwn.is_none());
+        assert!(serde_json::to_value(&payload)
+            .unwrap()
+            .get("mrkdwn")
+            .is_none());
+    }
+
+    /// The other half: without a banner the flag is still required, or Xyne delivers `*bold*` and
+    /// backticks as literal characters.
+    #[test]
+    fn a_plain_message_still_sets_mrkdwn() {
+        let endpoint = endpoint("https://example.com", "/", "token").unwrap();
+
+        let payload = endpoint.build_payload(&ChatMessage::new("*bold*")).unwrap();
+
+        assert_eq!(payload.mrkdwn, Some(true));
+        assert_eq!(serde_json::to_value(&payload).unwrap()["mrkdwn"], true);
+    }
+
+    /// An oversized header is rejected outright rather than trimmed by the provider, so a long
+    /// heading would cost the whole alert rather than just its tail.
+    #[test]
+    fn an_oversized_heading_is_cut_to_the_header_limit() {
+        let endpoint = endpoint("https://example.com", "/", "token").unwrap();
+
+        let payload = endpoint
+            .build_payload(
+                &ChatMessage::new("body")
+                    .with_banner(ChatBanner::new("x".repeat(400), ChatSeverity::Critical)),
+            )
+            .unwrap();
+
+        let heading = &payload.attachments.as_ref().unwrap()[0].blocks[0].text.text;
+        assert!(heading.chars().count() <= HEADER_MAX_CHARS);
+        assert!(heading.ends_with(TRUNCATION_MARKER));
+    }
+
+    #[test]
+    fn severity_picks_the_rail_colour() {
+        assert_eq!(attachment_color(ChatSeverity::Critical), "danger");
+        assert_eq!(attachment_color(ChatSeverity::Warning), "warning");
+        assert_eq!(attachment_color(ChatSeverity::Resolved), "good");
+    }
+
+    #[test]
+    fn a_banner_can_still_be_threaded() {
+        let endpoint = endpoint("https://example.com", "/", "token").unwrap();
+
+        let payload = endpoint
+            .build_payload(
+                &ChatMessage::reply("resolved", MessageId::ts("1.2"))
+                    .with_banner(ChatBanner::new("🟢 RESOLVED", ChatSeverity::Resolved)),
+            )
+            .unwrap();
+
+        assert_eq!(payload.thread_ts.as_deref(), Some("1.2"));
+        assert_eq!(payload.attachments.as_ref().unwrap()[0].color, "good");
+    }
+
+    /// A bannered alert leaves `text` empty, so counting it alone logged every alert as zero.
+    #[test]
+    fn the_logged_length_counts_the_body_wherever_it_sits() {
+        let endpoint = endpoint("https://example.com", "/", "token").unwrap();
+
+        let payload = endpoint
+            .build_payload(
+                &ChatMessage::new("body")
+                    .with_banner(ChatBanner::new("head", ChatSeverity::Warning)),
+            )
+            .unwrap();
+
+        assert_eq!(payload.body_chars(), "body".len() + "head".len());
     }
 }

--- a/crates/external_services/src/chat_service/slack_compatible.rs
+++ b/crates/external_services/src/chat_service/slack_compatible.rs
@@ -1,5 +1,3 @@
-//! The Slack-compatible wire protocol.
-
 use common_utils::request::{Method, RequestBuilder, RequestContent};
 use error_stack::ResultExt;
 use hyperswitch_interfaces::types::Proxy;
@@ -13,30 +11,22 @@ use super::{
 };
 use crate::http_client;
 
-/// The method that posts a message.
 const CHAT_POST_MESSAGE: &str = "chat.postMessage";
 const FILES_GET_UPLOAD_URL: &str = "files.getUploadURLExternal";
 const FILES_COMPLETE_UPLOAD: &str = "files.completeUploadExternal";
 
-/// Long enough that a slow provider is not mistaken for a dead one, short enough that a caller delivering a time-sensitive message is not held indefinitely.
 pub(super) const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
 
-/// Appended to a message that had to be cut down to fit.
 const TRUNCATION_MARKER: &str = "\n…(truncated)";
 
-/// How much of an unexpected response body is worth carrying into the logs.
 const BODY_SNIPPET_CHARS: usize = 512;
 
-/// Stands in when a refusal names no error code at all.
 const UNSPECIFIED_ERROR_CODE: &str = "unspecified";
 
-/// The cap a `header` block puts on its text.
 const HEADER_MAX_CHARS: usize = 150;
 
-/// The cap a `section` block puts on its text.
 const SECTION_MAX_CHARS: usize = 3_000;
 
-/// Request headers selected by the concrete backend.
 #[derive(Clone, Debug)]
 pub(super) struct EndpointHeaders {
     api: Vec<(String, Maskable<String>)>,
@@ -52,19 +42,14 @@ impl EndpointHeaders {
     }
 }
 
-/// One destination on a Slack-compatible API:
 #[derive(Clone, Debug)]
 pub(super) struct Endpoint {
-    /// Root of the API, e.g.
     base_url: Url,
 
-    /// Sits between the base URL and the method name.
     method_prefix: &'static str,
 
-    /// Headers for API method calls and the raw upload leg are supplied by the concrete backend.
     headers: EndpointHeaders,
 
-    /// Channel id is preferred over channel name; both are accepted, and the provider decides.
     channel: String,
 
     timeout_seconds: u64,
@@ -73,7 +58,6 @@ pub(super) struct Endpoint {
 }
 
 impl Endpoint {
-    /// Validate a destination and bind it to a proxy.
     pub(super) fn new(
         base_url: Url,
         method_prefix: &'static str,
@@ -107,7 +91,6 @@ impl Endpoint {
         })
     }
 
-    /// `Url::join` is deliberately not used:
     fn method_url(&self, method: &str) -> String {
         format!(
             "{}{}{}",
@@ -117,12 +100,10 @@ impl Endpoint {
         )
     }
 
-    /// Post a message and return the id the provider assigned it.
     pub(super) async fn post_message(&self, message: ChatMessage) -> ChatResult<MessageId> {
         let payload = self.build_payload(&message)?;
         let url = self.method_url(CHAT_POST_MESSAGE);
 
-        // Without this, the only question that matters when no message arrives — did we try, where to, and what came back — has no answer in the logs.
         logger::info!(
             tag = "chat_post_message",
             url = %url,
@@ -141,7 +122,6 @@ impl Endpoint {
             )
             .await?;
 
-        // The body, not the status code, decides whether this succeeded.
         serde_json::from_str::<PostMessageResponse>(&body)
             .change_context(ChatError::UnreadableResponse)
             .attach_printable_lazy(|| {
@@ -153,7 +133,6 @@ impl Endpoint {
             .try_into()
     }
 
-    /// Upload bytes through Slack's current external-upload flow, then share the resulting file.
     pub(super) async fn upload_file(&self, file: ChatFile) -> ChatResult<FileId> {
         if file.bytes().is_empty() {
             Err(ChatError::InvalidConfiguration("file must not be empty"))?
@@ -308,7 +287,6 @@ impl Endpoint {
             })
             .transpose()?;
 
-        // A banner moves the body inside the attachment, because that is the only place a Slack-compatible backend draws the coloured rail:
         let (text, attachments) = match message.banner() {
             None => (truncate(message.text(), self.max_message_chars), None),
             Some(banner) => (
@@ -330,14 +308,12 @@ impl Endpoint {
             channel: self.channel.clone(),
             text,
             thread_ts,
-            // See the field:
             mrkdwn: attachments.is_none().then_some(true),
             attachments,
         })
     }
 }
 
-/// The rail colour a backend draws for each severity.
 fn attachment_color(severity: ChatSeverity) -> &'static str {
     match severity {
         ChatSeverity::Critical => "danger",
@@ -408,7 +384,6 @@ struct CompletedFile {
     id: Option<String>,
 }
 
-/// The `chat.postMessage` request body.
 #[derive(Debug, Serialize)]
 struct PostMessagePayload {
     channel: String,
@@ -416,17 +391,14 @@ struct PostMessagePayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     thread_ts: Option<String>,
 
-    /// Sent for a plain message, omitted for a bannered one.
     #[serde(skip_serializing_if = "Option::is_none")]
     mrkdwn: Option<bool>,
 
-    /// The coloured frame, when the message asked for one.
     #[serde(skip_serializing_if = "Option::is_none")]
     attachments: Option<Vec<Attachment>>,
 }
 
 impl PostMessagePayload {
-    /// How much text is actually being sent, wherever it sits.
     fn body_chars(&self) -> usize {
         self.text.chars().count()
             + self
@@ -439,14 +411,12 @@ impl PostMessagePayload {
     }
 }
 
-/// One coloured frame around a message.
 #[derive(Debug, Serialize)]
 struct Attachment {
     color: &'static str,
     blocks: Vec<Block>,
 }
 
-/// A block within an attachment.
 #[derive(Debug, Serialize)]
 struct Block {
     #[serde(rename = "type")]
@@ -455,7 +425,6 @@ struct Block {
 }
 
 impl Block {
-    /// The large title at the top of the frame.
     fn header(text: String) -> Self {
         Self {
             kind: "header",
@@ -467,7 +436,6 @@ impl Block {
         }
     }
 
-    /// The message body, in markup.
     fn section(text: String) -> Self {
         Self {
             kind: "section",
@@ -486,12 +454,10 @@ struct BlockText {
     kind: &'static str,
     text: String,
 
-    /// Whether `:shortcode:` sequences become emoji.
     #[serde(skip_serializing_if = "Option::is_none")]
     emoji: Option<bool>,
 }
 
-/// The `chat.postMessage` response, exactly as it arrives.
 #[derive(Debug, Deserialize)]
 struct PostMessageResponse {
     ok: bool,
@@ -500,7 +466,6 @@ struct PostMessageResponse {
     message: Option<NestedMessage>,
 }
 
-/// Some responses carry the id on the echoed message rather than at the top level.
 #[derive(Debug, Deserialize)]
 struct NestedMessage {
     ts: Option<String>,
@@ -511,7 +476,6 @@ impl TryFrom<PostMessageResponse> for MessageId {
 
     fn try_from(response: PostMessageResponse) -> Result<Self, Self::Error> {
         if !response.ok {
-            // A refusal carrying no code at all is malformed, but it is still unambiguously a refusal — reporting it as an unreadable response would be a worse lie.
             let reason = response.error.map_or_else(
                 || ChatErrorReason::Other(UNSPECIFIED_ERROR_CODE.to_owned()),
                 ChatErrorReason::from,
@@ -532,31 +496,23 @@ impl TryFrom<PostMessageResponse> for MessageId {
     }
 }
 
-/// The `error` field of a refused response.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum SlackErrorCode {
     ChannelNotFound,
     NotInChannel,
-    /// The channel exists and accepts nothing further — the same problem for a caller as not being a member of it.
     IsArchived,
     InvalidAuth,
     NotAuthed,
     TokenRevoked,
-    /// A deactivated account needs the same remedy as a revoked token:
     AccountInactive,
     MsgTooLong,
     RateLimited,
-    /// The same condition, spelled without the underscore on some endpoints.
     #[serde(rename = "ratelimited")]
     RateLimitedCompact,
-    /// The request did not satisfy the endpoint's schema — a fault on this side of the wire.
     InvalidArguments,
-    /// The message named as a reply target no longer resolves.
     ThreadNotFound,
-    /// The provider failed on its own account.
     InternalError,
-    /// Any code not listed above, kept verbatim.
     #[serde(untagged)]
     Unrecognised(String),
 }
@@ -569,11 +525,9 @@ impl From<SlackErrorCode> for ChatErrorReason {
             SlackErrorCode::InvalidAuth | SlackErrorCode::NotAuthed => Self::InvalidAuth,
             SlackErrorCode::TokenRevoked | SlackErrorCode::AccountInactive => Self::TokenRevoked,
             SlackErrorCode::MsgTooLong => Self::MessageTooLong,
-            // `Retry-After` rides on a 429, which is handled before a body is ever parsed, so a rate-limit code arriving at HTTP 200 comes without one.
             SlackErrorCode::RateLimited | SlackErrorCode::RateLimitedCompact => Self::RateLimited {
                 retry_after_seconds: None,
             },
-            // These three have no neutral variant yet, so they ride in `Other` with their code intact.
             SlackErrorCode::InvalidArguments => Self::Other("invalid_arguments".to_owned()),
             SlackErrorCode::ThreadNotFound => Self::Other("thread_not_found".to_owned()),
             SlackErrorCode::InternalError => Self::Other("internal_error".to_owned()),
@@ -582,13 +536,11 @@ impl From<SlackErrorCode> for ChatErrorReason {
     }
 }
 
-/// Cut `text` to `max_chars`, marking that it happened.
 fn truncate(text: &str, max_chars: usize) -> String {
     if text.chars().count() <= max_chars {
         return text.to_owned();
     }
 
-    // The marker is itself subject to the cap.
     let marker: String = TRUNCATION_MARKER.chars().take(max_chars).collect();
     let keep = max_chars.saturating_sub(marker.chars().count());
 
@@ -615,15 +567,12 @@ mod tests {
     use super::*;
     use crate::chat_service::ChatBanner;
 
-    /// Any cap generous enough not to interfere; the per-backend defaults live with their clients, since Slack and Xyne do not agree on one.
     const TEST_MAX_MESSAGE_CHARS: usize = 40_000;
 
-    /// Parse a body and run it through the conversion, exactly as `post_message` does.
     fn read(value: serde_json::Value) -> Result<ChatResult<MessageId>, serde_json::Error> {
         serde_json::from_value::<PostMessageResponse>(value).map(TryInto::try_into)
     }
 
-    /// Deserialize a wire error code and map it, which is the whole path a refusal takes.
     fn reason(code: &str) -> ChatErrorReason {
         serde_json::from_value::<SlackErrorCode>(json!(code))
             .unwrap()
@@ -645,7 +594,6 @@ mod tests {
 
     #[test]
     fn ok_false_with_a_ts_present_is_still_a_failure() {
-        // The shape that catches a status-code-only client out:
         let error = read(json!({"ok": false, "error": "msg_too_long", "ts": "1.2"}))
             .unwrap()
             .unwrap_err();
@@ -659,7 +607,6 @@ mod tests {
 
     #[test]
     fn a_body_without_ok_does_not_deserialize() {
-        // `ok` is required, so a body carrying a `ts` and nothing else cannot be mistaken for a success.
         assert!(read(json!({"ts": "1503435956.000247"})).is_err());
     }
 
@@ -675,7 +622,6 @@ mod tests {
 
     #[test]
     fn a_refusal_naming_no_code_is_still_a_refusal() {
-        // Malformed, but unambiguously a refusal — calling it an unreadable response would be a worse lie than naming the code as unspecified.
         let error = read(json!({"ok": false})).unwrap().unwrap_err();
         match error.current_context() {
             ChatError::Rejected { reason } => assert_eq!(
@@ -709,7 +655,6 @@ mod tests {
 
     #[test]
     fn truncate_counts_characters_not_bytes() {
-        // Byte slicing here would panic mid-codepoint.
         let truncated = truncate(&"🚨".repeat(100), 20);
         assert_eq!(truncated.chars().count(), 20);
     }
@@ -749,12 +694,10 @@ mod tests {
             );
         }
 
-        // Codes the Xyne adapter emits that have no neutral variant yet.
         for code in ["invalid_arguments", "thread_not_found", "internal_error"] {
             assert_eq!(reason(code), ChatErrorReason::Other(code.to_owned()));
         }
 
-        // A code the provider adds later survives intact rather than being flattened away.
         assert_eq!(
             reason("something_new"),
             ChatErrorReason::Other("something_new".to_owned())
@@ -781,7 +724,6 @@ mod tests {
 
     #[test]
     fn an_unusable_destination_is_rejected_on_the_way_in() {
-        // A malformed base URL cannot reach here at all:
         assert!(endpoint("https://example.com", "/", "token").is_ok());
 
         let blank_channel = Endpoint::new(
@@ -849,7 +791,6 @@ mod tests {
         );
     }
 
-    /// The exact body a bannered alert puts on the wire.
     #[test]
     fn a_banner_moves_the_body_into_a_coloured_attachment() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -890,7 +831,6 @@ mod tests {
         );
     }
 
-    /// Setting `mrkdwn` alongside `attachments` costs the banner entirely.
     #[test]
     fn a_bannered_message_does_not_set_mrkdwn() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -909,7 +849,6 @@ mod tests {
             .is_none());
     }
 
-    /// The other half:
     #[test]
     fn a_plain_message_still_sets_mrkdwn() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -920,7 +859,6 @@ mod tests {
         assert_eq!(serde_json::to_value(&payload).unwrap()["mrkdwn"], true);
     }
 
-    /// An oversized header is rejected outright rather than trimmed by the provider, so a long heading would cost the whole alert rather than just its tail.
     #[test]
     fn an_oversized_heading_is_cut_to_the_header_limit() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -937,7 +875,6 @@ mod tests {
         assert!(heading.ends_with(TRUNCATION_MARKER));
     }
 
-    /// A section block caps far below any backend's message cap, and an oversized one is rejected rather than trimmed — so without this a long alert that used to arrive as plain text would be dropped outright the moment it gained a banner.
     #[test]
     fn a_long_body_is_cut_to_the_section_limit_when_bannered() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();
@@ -954,7 +891,6 @@ mod tests {
         assert!(section.chars().count() <= SECTION_MAX_CHARS);
         assert!(section.ends_with(TRUNCATION_MARKER));
 
-        // The same body without a banner keeps the far larger message cap:
         let plain = endpoint.build_payload(&ChatMessage::new(&long)).unwrap();
         assert_eq!(plain.text.chars().count(), long.chars().count());
     }
@@ -981,7 +917,6 @@ mod tests {
         assert_eq!(payload.attachments.as_ref().unwrap()[0].color, "good");
     }
 
-    /// A bannered alert leaves `text` empty, so counting it alone logged every alert as zero.
     #[test]
     fn the_logged_length_counts_the_body_wherever_it_sits() {
         let endpoint = endpoint("https://example.com", "/", "token").unwrap();

--- a/crates/observability/src/core/notifier.rs
+++ b/crates/observability/src/core/notifier.rs
@@ -8,7 +8,7 @@
 
 use error_stack::report;
 use external_services::chat_service::ChatBanner;
-use hyperswitch_masking::PeekInterface;
+use hyperswitch_masking::{ExposeInterface, PeekInterface};
 
 use crate::{
     domain::notifier::{
@@ -42,7 +42,7 @@ pub async fn notify_chat(
             banner: request
                 .heading
                 .zip(request.severity)
-                .map(|(heading, severity)| ChatBanner::new(heading, severity.into())),
+                .map(|(heading, severity)| ChatBanner::new(heading.expose(), severity.into())),
         })
         .await
 }

--- a/crates/observability/src/core/notifier.rs
+++ b/crates/observability/src/core/notifier.rs
@@ -1,5 +1,3 @@
-//! Per-request notification logic:
-
 use error_stack::report;
 use external_services::chat_service::ChatBanner;
 use hyperswitch_masking::{ExposeInterface, PeekInterface};
@@ -14,7 +12,6 @@ use crate::{
     types::{ChatNotifyRequest, ChatUploadRequest, EmailNotifyRequest},
 };
 
-/// Deliver a chat message to the named destination.
 pub async fn notify_chat(
     state: AppState,
     destination: &str,
@@ -31,7 +28,6 @@ pub async fn notify_chat(
         .notify(ChatNotification {
             text: request.text,
             reply_to: request.reply_to,
-            // Both halves or neither:
             banner: request
                 .heading
                 .zip(request.severity)
@@ -40,7 +36,6 @@ pub async fn notify_chat(
         .await
 }
 
-/// Upload a file to the named chat destination.
 pub async fn upload_chat_file(
     state: AppState,
     destination: &str,
@@ -72,7 +67,6 @@ pub async fn upload_chat_file(
         .await
 }
 
-/// Deliver an email to the named destination.
 pub async fn notify_email(
     state: AppState,
     destination: &str,

--- a/crates/observability/src/core/notifier.rs
+++ b/crates/observability/src/core/notifier.rs
@@ -1,10 +1,4 @@
-//! Per-request notification logic: resolve a destination, hand the message over, report what
-//! happened.
-//!
-//! The whole of it is "look up the id, call the notifier". That is deliberate — the crate is a
-//! pipe, and anything more here would be a decision the caller should have made. What the layer
-//! buys is a seam a handler can be tested against without HTTP, and one place where "unknown
-//! destination" is turned into an error rather than repeated per route.
+//! Per-request notification logic:
 
 use error_stack::report;
 use external_services::chat_service::ChatBanner;
@@ -37,8 +31,7 @@ pub async fn notify_chat(
         .notify(ChatNotification {
             text: request.text,
             reply_to: request.reply_to,
-            // Both halves or neither: a colour with no title says only that something happened, and
-            // a title with no colour is what the message body already is.
+            // Both halves or neither:
             banner: request
                 .heading
                 .zip(request.severity)

--- a/crates/observability/src/core/notifier.rs
+++ b/crates/observability/src/core/notifier.rs
@@ -7,6 +7,7 @@
 //! destination" is turned into an error rather than repeated per route.
 
 use error_stack::report;
+use external_services::chat_service::ChatBanner;
 use hyperswitch_masking::PeekInterface;
 
 use crate::{
@@ -36,6 +37,12 @@ pub async fn notify_chat(
         .notify(ChatNotification {
             text: request.text,
             reply_to: request.reply_to,
+            // Both halves or neither: a colour with no title says only that something happened, and
+            // a title with no colour is what the message body already is.
+            banner: request
+                .heading
+                .zip(request.severity)
+                .map(|(heading, severity)| ChatBanner::new(heading, severity.into())),
         })
         .await
 }

--- a/crates/observability/src/domain/notifier/chat.rs
+++ b/crates/observability/src/domain/notifier/chat.rs
@@ -290,6 +290,7 @@ impl ChatNotifier for LogChatNotifier {
             destination = %self.destination,
             chars = notification.text.peek().chars().count(),
             threaded = notification.reply_to.is_some(),
+            bannered = notification.banner.is_some(),
             "not delivered: this destination is configured as `log`"
         );
 

--- a/crates/observability/src/domain/notifier/chat.rs
+++ b/crates/observability/src/domain/notifier/chat.rs
@@ -17,18 +17,12 @@ use crate::{
 };
 
 /// The provider code that blames the provider rather than the message.
-///
-/// Every other code the Slack-compatible backends emit describes something about the request. This
-/// one says the provider failed on its own account, so nothing is known about delivery and it
-/// belongs with the transport failures rather than with the refusals. It rides in
-/// [`ChatErrorReason::Other`] because `external_services` has no neutral variant for it; the
-/// distinction is drawn here rather than by widening a shared enum for one caller.
 const PROVIDER_INTERNAL_ERROR: &str = "internal_error";
 
 /// A message to post to one chat destination.
 #[derive(Debug, Clone)]
 pub struct ChatNotification {
-    /// The message, in the markup the destination reads. Delivered unchanged.
+    /// The message, in the markup the destination reads.
     pub text: Secret<String>,
 
     /// Post as a reply under this message, if given.
@@ -59,10 +53,6 @@ pub type ChatFileOutcome = Outcome<ChatFileReceipt>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatReceipt {
     /// The provider's id for the message, which threads a later reply under it.
-    ///
-    /// `None` when the provider accepted the message but named no id. The alert *was* delivered —
-    /// retrying would post it twice — so this is a success that has lost only the ability to
-    /// thread under it.
     pub message_id: Option<String>,
 }
 
@@ -70,15 +60,9 @@ pub struct ChatReceipt {
 pub type ChatOutcome = Outcome<ChatReceipt>;
 
 /// Posts an alert to one chat destination.
-///
-/// One implementation is bound to one destination, so there is no channel argument and no way to
-/// address a channel that was not configured.
 #[async_trait::async_trait]
 pub trait ChatNotifier: Send + Sync + std::fmt::Debug {
     /// Attempt delivery.
-    ///
-    /// A provider that refuses returns `Ok(Outcome::Refused)`, not an error: it was reached and it
-    /// answered. `Err` means the attempt itself failed, so whether the message arrived is unknown.
     async fn notify(&self, notification: ChatNotification) -> ObservabilityApiResult<ChatOutcome>;
 
     /// Upload one file and optionally share it in an existing thread.
@@ -94,9 +78,6 @@ pub struct ChatClientNotifier {
 
 impl ChatClientNotifier {
     /// Bind a client to the destination id it was configured under.
-    ///
-    /// The id is carried so failures can name it. With several destinations configured, "the chat
-    /// provider is unreachable" is not an actionable sentence and "`sr_alerts` is" is.
     pub fn new(destination: String, client: Arc<dyn ChatClient>) -> Self {
         Self {
             destination,
@@ -127,17 +108,13 @@ impl ChatNotifier for ChatClientNotifier {
             Err(report) => match classify(report.current_context()) {
                 Verdict::Refused(refusal) => Ok(Outcome::Refused(refusal)),
 
-                // `Delivered` from an `Err` is not a contradiction: the provider accepted the
-                // message and named no id for it. Reporting that as a failure would invite a retry
-                // that posts the alert twice.
+                // `Delivered` from an `Err` is not a contradiction:
                 Verdict::DeliveredWithoutId => {
                     Ok(Outcome::Delivered(ChatReceipt { message_id: None }))
                 }
 
                 Verdict::Failed(error) => {
-                    // `change_context` rather than a fresh error, so every `attach_printable` the
-                    // client left on the way up — the URL, the response snippet — reaches the log
-                    // while the caller sees only what `ErrorSwitch` renders.
+                    // `change_context` rather than a fresh error, so every `attach_printable` the client left on the way up — the URL, the response snippet — reaches the log while the caller sees only what `ErrorSwitch` renders.
                     Err(report.change_context(error(self.destination.clone())))
                 }
             },
@@ -181,15 +158,6 @@ enum Verdict {
 }
 
 /// Decide whether a chat failure is a refusal, a delivery, or an unknown.
-///
-/// The dividing line is **what the provider told us**, not whose fault it is. A refusal in its
-/// documented envelope — for any reason, including a channel we cannot see or a credential it will
-/// not accept — means the attempt completed and the answer was no. Only silence, or an answer we
-/// cannot interpret, leaves delivery unknown.
-///
-/// Fault deliberately does not appear here. Whether a bad channel id is our mistake or a merchant's
-/// depends on who owns the destination, and that moves from a config file to a database row without
-/// the wire contract being allowed to move with it.
 fn classify(error: &ChatError) -> Verdict {
     match error {
         ChatError::Rejected { reason } => match reason {
@@ -211,18 +179,16 @@ fn classify(error: &ChatError) -> Verdict {
         ChatError::MissingMessageId => Verdict::DeliveredWithoutId,
 
         // `reply_to` came off the request and named an id this backend cannot thread against.
-        // Rejected before anything was sent, so the message did not go anywhere.
         ChatError::IncompatibleReplyTarget => {
             Verdict::Refused(Refusal::new("incompatible_reply_target"))
         }
 
-        // No answer, or one outside the documented envelope. Delivery is genuinely unknown.
+        // No answer, or one outside the documented envelope.
         ChatError::RequestFailed | ChatError::HttpStatus { .. } | ChatError::UnreadableResponse => {
             Verdict::Failed(|destination| ObservabilityError::ProviderUnavailable { destination })
         }
 
-        // Rejected at boot by `Endpoint::new`, so reaching here means a destination was built some
-        // other way.
+        // Rejected at boot by `Endpoint::new`, so reaching here means a destination was built some other way.
         ChatError::InvalidConfiguration(_) => {
             Verdict::Failed(|_destination| ObservabilityError::InternalServerError)
         }
@@ -232,14 +198,6 @@ fn classify(error: &ChatError) -> Verdict {
 }
 
 /// The stable, matchable code for a refusal, in the provider's own snake_case vocabulary.
-///
-/// **Not `Display`.** [`ChatErrorReason`]'s `Display` is prose written for a log line ("channel not
-/// found"), and this value goes onto the wire where a caller matches on it. Deriving one from the
-/// other would let a reworded error message silently change the API.
-///
-/// **Not always the exact bytes the provider sent**, and it cannot be: `external_services` folds
-/// synonyms on the way in, so `is_archived` arrives as `NotInChannel` and `account_inactive` as
-/// `TokenRevoked`. The guarantee is that one condition always yields one code.
 fn reason_code(reason: &ChatErrorReason) -> String {
     match reason {
         ChatErrorReason::ChannelNotFound => "channel_not_found".to_owned(),
@@ -254,15 +212,6 @@ fn reason_code(reason: &ChatErrorReason) -> String {
 }
 
 /// A [`ChatNotifier`] that delivers nothing and says so.
-///
-/// Configured as `type = "log"`, so a deployment can exercise the whole path — guard, route,
-/// registry, response shape — before real credentials exist. A destination *type* rather than a
-/// flag on a real destination, which keeps the delivery path branchless: nothing downstream asks
-/// "but is this one pretending?".
-///
-/// **It does not log the message.** This writes to the same stream as everything else, and an
-/// alert body carries merchant ids and payment volumes. It proves the pipe works, not what the
-/// message says.
 #[derive(Debug)]
 pub struct LogChatNotifier {
     destination: String,
@@ -326,10 +275,7 @@ mod tests {
         }
     }
 
-    /// The whole point of the redesign: every reason the provider names is an answer, so it comes
-    /// back as an outcome. Fault does not enter into it — `channel_not_found` is as much an answer
-    /// as `msg_too_long`, and which of them is "our fault" changes when destinations move to a
-    /// database.
+    /// The whole point of the redesign:
     #[test]
     fn every_documented_refusal_is_an_outcome() {
         for reason in [
@@ -369,7 +315,7 @@ mod tests {
         ));
     }
 
-    /// The message went out. Anything that reads as retryable here posts the alert twice.
+    /// The message went out.
     #[test]
     fn accepted_content_with_no_id_is_still_a_delivery() {
         for error in [ChatError::MissingMessageId, ChatError::MissingFileId] {
@@ -391,9 +337,7 @@ mod tests {
         }
     }
 
-    /// `code` is advertised as matchable, so every value it can take has to be a code rather than a
-    /// sentence. This caught a real bug: four variants were rendered through `Display` and reached
-    /// the wire as prose like `channel not found`.
+    /// `code` is advertised as matchable, so every value it can take has to be a code rather than a sentence.
     #[test]
     fn every_reason_is_a_matchable_code_not_prose() {
         let reasons = [
@@ -421,7 +365,7 @@ mod tests {
         }
     }
 
-    /// The provider's spelling, not ours. Pinned because these are a wire contract now.
+    /// The provider's spelling, not ours.
     #[test]
     fn reason_codes_match_the_providers_spelling() {
         assert_eq!(

--- a/crates/observability/src/domain/notifier/chat.rs
+++ b/crates/observability/src/domain/notifier/chat.rs
@@ -1,5 +1,3 @@
-//! Delivering an alert to a chat destination.
-
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -16,23 +14,17 @@ use crate::{
     logger,
 };
 
-/// The provider code that blames the provider rather than the message.
 const PROVIDER_INTERNAL_ERROR: &str = "internal_error";
 
-/// A message to post to one chat destination.
 #[derive(Debug, Clone)]
 pub struct ChatNotification {
-    /// The message, in the markup the destination reads.
     pub text: Secret<String>,
 
-    /// Post as a reply under this message, if given.
     pub reply_to: Option<String>,
 
-    /// Frame the message in a titled, colour-coded banner.
     pub banner: Option<ChatBanner>,
 }
 
-/// One file to upload to a chat destination.
 #[derive(Debug, Clone)]
 pub struct ChatFileUpload {
     pub bytes: Secret<Vec<u8>>,
@@ -49,27 +41,20 @@ pub struct ChatFileReceipt {
 
 pub type ChatFileOutcome = Outcome<ChatFileReceipt>;
 
-/// What a chat destination hands back when it accepts a message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatReceipt {
-    /// The provider's id for the message, which threads a later reply under it.
     pub message_id: Option<String>,
 }
 
-/// The result of one chat delivery attempt.
 pub type ChatOutcome = Outcome<ChatReceipt>;
 
-/// Posts an alert to one chat destination.
 #[async_trait::async_trait]
 pub trait ChatNotifier: Send + Sync + std::fmt::Debug {
-    /// Attempt delivery.
     async fn notify(&self, notification: ChatNotification) -> ObservabilityApiResult<ChatOutcome>;
 
-    /// Upload one file and optionally share it in an existing thread.
     async fn upload_file(&self, upload: ChatFileUpload) -> ObservabilityApiResult<ChatFileOutcome>;
 }
 
-/// A [`ChatNotifier`] backed by a real chat transport.
 #[derive(Debug)]
 pub struct ChatClientNotifier {
     destination: String,
@@ -77,7 +62,6 @@ pub struct ChatClientNotifier {
 }
 
 impl ChatClientNotifier {
-    /// Bind a client to the destination id it was configured under.
     pub fn new(destination: String, client: Arc<dyn ChatClient>) -> Self {
         Self {
             destination,
@@ -108,13 +92,11 @@ impl ChatNotifier for ChatClientNotifier {
             Err(report) => match classify(report.current_context()) {
                 Verdict::Refused(refusal) => Ok(Outcome::Refused(refusal)),
 
-                // `Delivered` from an `Err` is not a contradiction:
                 Verdict::DeliveredWithoutId => {
                     Ok(Outcome::Delivered(ChatReceipt { message_id: None }))
                 }
 
                 Verdict::Failed(error) => {
-                    // `change_context` rather than a fresh error, so every `attach_printable` the client left on the way up — the URL, the response snippet — reaches the log while the caller sees only what `ErrorSwitch` renders.
                     Err(report.change_context(error(self.destination.clone())))
                 }
             },
@@ -147,21 +129,15 @@ impl ChatNotifier for ChatClientNotifier {
     }
 }
 
-/// What a chat failure means for the caller.
 enum Verdict {
-    /// The provider answered and said no.
     Refused(Refusal),
-    /// The provider accepted the message but named no id for it.
     DeliveredWithoutId,
-    /// Nothing is known about delivery.
     Failed(fn(String) -> ObservabilityError),
 }
 
-/// Decide whether a chat failure is a refusal, a delivery, or an unknown.
 fn classify(error: &ChatError) -> Verdict {
     match error {
         ChatError::Rejected { reason } => match reason {
-            // The provider blaming itself is not an answer about the message, so nothing is known.
             ChatErrorReason::Other(code) if code == PROVIDER_INTERNAL_ERROR => {
                 Verdict::Failed(|destination| ObservabilityError::ProviderUnavailable {
                     destination,
@@ -178,17 +154,14 @@ fn classify(error: &ChatError) -> Verdict {
 
         ChatError::MissingMessageId => Verdict::DeliveredWithoutId,
 
-        // `reply_to` came off the request and named an id this backend cannot thread against.
         ChatError::IncompatibleReplyTarget => {
             Verdict::Refused(Refusal::new("incompatible_reply_target"))
         }
 
-        // No answer, or one outside the documented envelope.
         ChatError::RequestFailed | ChatError::HttpStatus { .. } | ChatError::UnreadableResponse => {
             Verdict::Failed(|destination| ObservabilityError::ProviderUnavailable { destination })
         }
 
-        // Rejected at boot by `Endpoint::new`, so reaching here means a destination was built some other way.
         ChatError::InvalidConfiguration(_) => {
             Verdict::Failed(|_destination| ObservabilityError::InternalServerError)
         }
@@ -197,7 +170,6 @@ fn classify(error: &ChatError) -> Verdict {
     }
 }
 
-/// The stable, matchable code for a refusal, in the provider's own snake_case vocabulary.
 fn reason_code(reason: &ChatErrorReason) -> String {
     match reason {
         ChatErrorReason::ChannelNotFound => "channel_not_found".to_owned(),
@@ -206,21 +178,17 @@ fn reason_code(reason: &ChatErrorReason) -> String {
         ChatErrorReason::TokenRevoked => "token_revoked".to_owned(),
         ChatErrorReason::MessageTooLong => "msg_too_long".to_owned(),
         ChatErrorReason::RateLimited { .. } => "rate_limited".to_owned(),
-        // Already a wire code, carried through untouched.
         ChatErrorReason::Other(code) => code.clone(),
     }
 }
 
-/// A [`ChatNotifier`] that delivers nothing and says so.
 #[derive(Debug)]
 pub struct LogChatNotifier {
     destination: String,
-    /// Makes each synthetic id distinct so a threading round trip can be exercised end to end.
     sequence: AtomicU64,
 }
 
 impl LogChatNotifier {
-    /// Build a log destination under the id it was configured with.
     pub fn new(destination: String) -> Self {
         Self {
             destination,
@@ -275,7 +243,6 @@ mod tests {
         }
     }
 
-    /// The whole point of the redesign:
     #[test]
     fn every_documented_refusal_is_an_outcome() {
         for reason in [
@@ -304,7 +271,6 @@ mod tests {
         );
     }
 
-    /// The provider blaming itself is not an answer about the message, so delivery is unknown.
     #[test]
     fn the_providers_own_failure_is_not_a_refusal() {
         assert!(matches!(
@@ -315,7 +281,6 @@ mod tests {
         ));
     }
 
-    /// The message went out.
     #[test]
     fn accepted_content_with_no_id_is_still_a_delivery() {
         for error in [ChatError::MissingMessageId, ChatError::MissingFileId] {
@@ -337,7 +302,6 @@ mod tests {
         }
     }
 
-    /// `code` is advertised as matchable, so every value it can take has to be a code rather than a sentence.
     #[test]
     fn every_reason_is_a_matchable_code_not_prose() {
         let reasons = [
@@ -365,7 +329,6 @@ mod tests {
         }
     }
 
-    /// The provider's spelling, not ours.
     #[test]
     fn reason_codes_match_the_providers_spelling() {
         assert_eq!(

--- a/crates/observability/src/domain/notifier/chat.rs
+++ b/crates/observability/src/domain/notifier/chat.rs
@@ -6,7 +6,7 @@ use std::sync::{
 };
 
 use external_services::chat_service::{
-    ChatClient, ChatError, ChatErrorReason, ChatFile, ChatMessage, MessageId,
+    ChatBanner, ChatClient, ChatError, ChatErrorReason, ChatFile, ChatMessage, MessageId,
 };
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 
@@ -33,6 +33,9 @@ pub struct ChatNotification {
 
     /// Post as a reply under this message, if given.
     pub reply_to: Option<String>,
+
+    /// Frame the message in a titled, colour-coded banner.
+    pub banner: Option<ChatBanner>,
 }
 
 /// One file to upload to a chat destination.
@@ -110,6 +113,10 @@ impl ChatNotifier for ChatClientNotifier {
                 ChatMessage::reply(notification.text.expose(), MessageId::ts(reply_to))
             }
             None => ChatMessage::new(notification.text.expose()),
+        };
+        let message = match notification.banner {
+            Some(banner) => message.with_banner(banner),
+            None => message,
         };
 
         match self.client.post_message(message).await {
@@ -438,6 +445,7 @@ mod tests {
             .notify(ChatNotification {
                 text: "first".to_owned().into(),
                 reply_to: None,
+                banner: None,
             })
             .await
             .unwrap();
@@ -445,6 +453,7 @@ mod tests {
             .notify(ChatNotification {
                 text: "second".to_owned().into(),
                 reply_to: None,
+                banner: None,
             })
             .await
             .unwrap();

--- a/crates/observability/src/types.rs
+++ b/crates/observability/src/types.rs
@@ -1,51 +1,4 @@
-//! The wire contract: what a caller sends and what it gets back.
-//!
-//! Lives here rather than in an API-models crate for the same reason [`crate::errors::types`] does
-//! — `observability` has none — and moves wholesale if one ever appears.
-//!
-//! ## The URL says where, the body says what
-//!
-//! `POST /alerts/chat/notify/{destination}`. The path names the channel and the destination; the
-//! body carries only content. That keeps the destination visible to access logs, metrics labels and
-//! tracing spans without anyone parsing a body, so "which destination is failing" is answerable from
-//! the ops view.
-//!
-//! A single `/notify/{destination}` over a channel-tagged body was considered and rejected: the
-//! destination already resolves the channel through configuration, so a tag in the body is a second
-//! authority on the same fact and the two can disagree.
-//!
-//! ## Status answers "did the notifier work", the body answers "did the message arrive"
-//!
-//! A provider that refuses is a `200` carrying [`NotifyStatus::Refused`], not an HTTP error. It was
-//! reached, it answered, and the notifier did its job. Only a request we cannot act on (`4xx`), an
-//! unreachable provider (`502`) or our own fault (`500`) is an error — so an alert on `5xx` fires
-//! when this service is genuinely broken and at no other time.
-//!
-//! This is the same line payments draws between a connector declining a transaction and a connector
-//! being unreachable, and it is drawn deliberately rather than by fault. Whether `channel_not_found`
-//! is our mistake or a merchant's depends on who owns the destination, and that moves from a config
-//! file to a database row without a status code being able to move with it.
-//!
-//! **`status` is required, and that is load-bearing.** A caller cannot deserialize a response
-//! without confronting whether the message arrived. `external_services` uses the same trick on the
-//! provider's own `ok` field, for the same reason: this shape's failure mode is a caller that reads
-//! `200` and stops looking.
-//!
-//! ## Content is `Secret`, so redaction is the type's job
-//!
-//! `text`, `subject` and `body` are `Secret<String>`. A subject carries merchant ids and a body
-//! carries payment volumes, and `services::server_wrap` takes `T: Debug`, so one added log line
-//! would otherwise put both in the log stream. A hand-written `Debug` would do the same job until
-//! somebody adds a field and forgets; the type cannot forget.
-//!
-//! Sizes are logged where they are useful — the chat client already emits `chars` per request — so
-//! nothing diagnostic is lost by redacting here.
-//!
-//! ## Nothing here renders
-//!
-//! `text`, `subject` and `body` are delivered exactly as they arrive. The caller decides what its
-//! message looks like, in whatever markup its destination reads. `body` is HTML, because both email
-//! backends in `external_services` hardcode an HTML body and there is no plain-text path to reach.
+//! The wire contract:
 
 use actix_multipart::form::{bytes::Bytes, text::Text, MultipartForm};
 use external_services::chat_service::ChatSeverity;
@@ -62,22 +15,14 @@ use crate::domain::notifier::{
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChatNotifyRequest {
-    /// The message, in the markup the destination reads. Delivered unchanged.
+    /// The message, in the markup the destination reads.
     pub text: Secret<String>,
 
-    /// Post this as a reply in the thread of an earlier message, identified by the `message_id`
-    /// that message's response returned.
+    /// Post this as a reply in the thread of an earlier message, identified by the `message_id` that message's response returned.
     #[serde(default)]
     pub reply_to: Option<String>,
 
     /// A title to show above the message, larger than the body and free of markup.
-    ///
-    /// Sent with [`severity`](Self::severity) or not at all: the two make one banner, and a
-    /// destination that cannot draw one delivers the message without it.
-    ///
-    /// Masked for the same reason [`text`](Self::text) is. A heading is written by the same caller
-    /// out of the same material — "zero SR on `merchant_1234`" is a perfectly natural one — so
-    /// leaving it bare would put in the logs exactly what masking the body keeps out of them.
     #[serde(default)]
     pub heading: Option<Secret<String>>,
 
@@ -87,10 +32,6 @@ pub struct ChatNotifyRequest {
 }
 
 /// How urgent a chat message is.
-///
-/// Deliberately not a colour. Callers describe the alert, and each destination decides how to paint
-/// it — a caller that had to send `danger` would be encoding one backend's palette into every
-/// service that posts an alert.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotifySeverity {
@@ -140,14 +81,11 @@ pub struct EmailNotifyRequest {
     /// The subject line, delivered unchanged.
     pub subject: Secret<String>,
 
-    /// The body, as HTML. See the module docs: the transport offers nothing else today.
+    /// The body, as HTML.
     pub body: Secret<String>,
 }
 
 /// Whether the message arrived.
-///
-/// Not a bool, so a third outcome can be added without breaking a caller's match, and so the two
-/// states read the same in a log line as they do in code.
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NotifyStatus {
@@ -160,24 +98,18 @@ pub enum NotifyStatus {
 /// What `/alerts/chat/notify/{destination}` returns.
 #[derive(Debug, Serialize)]
 pub struct ChatNotifyResponse {
-    /// Whether the message arrived. Always present.
+    /// Whether the message arrived.
     pub status: NotifyStatus,
 
-    /// The provider's id for the message, when it named one. Hand it back as
-    /// [`ChatNotifyRequest::reply_to`] to thread under it.
-    ///
-    /// `null` on a refusal, and also on the rare delivery where the provider accepted the message
-    /// without naming an id — the alert went out, but nothing can be threaded under it.
+    /// The provider's id for the message, when it named one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
 
-    /// Why the provider refused, as a stable snake_case code — `msg_too_long`,
-    /// `channel_not_found`, `rate_limited`. Absent on delivery.
+    /// Why the provider refused, as a stable snake_case code — `msg_too_long`, `channel_not_found`, `rate_limited`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
 
-    /// How long the provider asked us to wait, when it said. Only set alongside a rate-limiting
-    /// code.
+    /// How long the provider asked us to wait, when it said.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after_seconds: Option<u64>,
 }
@@ -197,10 +129,10 @@ pub struct ChatUploadResponse {
 /// What `/alerts/email/notify/{destination}` returns.
 #[derive(Debug, Serialize)]
 pub struct EmailNotifyResponse {
-    /// Whether the mail was sent. Always present.
+    /// Whether the mail was sent.
     pub status: NotifyStatus,
 
-    /// Why the provider refused, as a stable snake_case code. Absent on delivery.
+    /// Why the provider refused, as a stable snake_case code.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
 
@@ -306,8 +238,7 @@ mod tests {
         assert!(body.get("message_id").is_none());
     }
 
-    /// The alert went out; only the ability to thread under it was lost. It must not look like a
-    /// failure, because a retry would post the alert twice.
+    /// The alert went out; only the ability to thread under it was lost.
     #[test]
     fn a_delivery_without_an_id_is_still_a_delivery() {
         let body = body_of(&ChatNotifyResponse::from(Outcome::Delivered(ChatReceipt {
@@ -352,10 +283,6 @@ mod tests {
     }
 
     /// The body a bannered alert sends.
-    ///
-    /// Worth pinning because `deny_unknown_fields` is what rejected this shape before the fields
-    /// existed, and it rejects with the same "could not be parsed" as a typo — so a caller gets no
-    /// hint that the field is merely unsupported.
     #[test]
     fn chat_request_reads_a_banner() {
         let request: ChatNotifyRequest = serde_json::from_value(serde_json::json!({
@@ -397,8 +324,7 @@ mod tests {
         assert!(request.severity.is_none());
     }
 
-    /// Threading against a mailing list is a caller bug. `deny_unknown_fields` makes it a rejection
-    /// rather than a field that quietly goes nowhere.
+    /// Threading against a mailing list is a caller bug.
     #[test]
     fn email_request_rejects_reply_to() {
         let error = serde_json::from_value::<EmailNotifyRequest>(serde_json::json!({
@@ -411,8 +337,7 @@ mod tests {
         assert!(error.to_string().contains("reply_to"));
     }
 
-    /// The property is now the type's, not a hand-written `Debug`'s: a field added later cannot
-    /// leak by someone forgetting to update an impl.
+    /// The property is now the type's, not a hand-written `Debug`'s:
     #[test]
     fn debug_never_prints_the_message() {
         let chat = ChatNotifyRequest {

--- a/crates/observability/src/types.rs
+++ b/crates/observability/src/types.rs
@@ -74,8 +74,12 @@ pub struct ChatNotifyRequest {
     ///
     /// Sent with [`severity`](Self::severity) or not at all: the two make one banner, and a
     /// destination that cannot draw one delivers the message without it.
+    ///
+    /// Masked for the same reason [`text`](Self::text) is. A heading is written by the same caller
+    /// out of the same material — "zero SR on `merchant_1234`" is a perfectly natural one — so
+    /// leaving it bare would put in the logs exactly what masking the body keeps out of them.
     #[serde(default)]
-    pub heading: Option<String>,
+    pub heading: Option<Secret<String>>,
 
     /// How urgent the message is, which decides the banner's colour.
     #[serde(default)]
@@ -361,7 +365,13 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(request.heading.as_deref(), Some("🔴 SEV1 · Zero SR"));
+        assert_eq!(
+            request
+                .heading
+                .as_ref()
+                .map(hyperswitch_masking::PeekInterface::peek),
+            Some(&"🔴 SEV1 · Zero SR".to_owned())
+        );
         assert_eq!(request.severity, Some(NotifySeverity::Critical));
     }
 
@@ -408,8 +418,8 @@ mod tests {
         let chat = ChatNotifyRequest {
             text: "acquirer_declined for merchant_1234".to_owned().into(),
             reply_to: None,
-            heading: None,
-            severity: None,
+            heading: Some("zero SR on merchant_1234".to_owned().into()),
+            severity: Some(NotifySeverity::Critical),
         };
         assert!(!format!("{chat:?}").contains("merchant_1234"));
 

--- a/crates/observability/src/types.rs
+++ b/crates/observability/src/types.rs
@@ -1,5 +1,3 @@
-//! The wire contract:
-
 use actix_multipart::form::{bytes::Bytes, text::Text, MultipartForm};
 use external_services::chat_service::ChatSeverity;
 use hyperswitch_masking::Secret;
@@ -11,35 +9,26 @@ use crate::domain::notifier::{
     Outcome, Refusal,
 };
 
-/// The body of `POST /alerts/chat/notify/{destination}`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChatNotifyRequest {
-    /// The message, in the markup the destination reads.
     pub text: Secret<String>,
 
-    /// Post this as a reply in the thread of an earlier message, identified by the `message_id` that message's response returned.
     #[serde(default)]
     pub reply_to: Option<String>,
 
-    /// A title to show above the message, larger than the body and free of markup.
     #[serde(default)]
     pub heading: Option<Secret<String>>,
 
-    /// How urgent the message is, which decides the banner's colour.
     #[serde(default)]
     pub severity: Option<NotifySeverity>,
 }
 
-/// How urgent a chat message is.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotifySeverity {
-    /// Something is broken now.
     Critical,
-    /// Still broken, said again.
     Warning,
-    /// Over.
     Resolved,
 }
 
@@ -53,7 +42,6 @@ impl From<NotifySeverity> for ChatSeverity {
     }
 }
 
-/// Multipart fields accepted by `POST /alerts/chat/upload/{destination}`.
 #[derive(Debug, MultipartForm)]
 #[multipart(deny_unknown_fields, duplicate_field = "deny")]
 pub struct ChatUploadForm {
@@ -64,7 +52,6 @@ pub struct ChatUploadForm {
     pub reply_to: Option<Text<String>>,
 }
 
-/// Parsed multipart body passed through the authenticated request wrapper.
 #[derive(Debug)]
 pub struct ChatUploadRequest {
     pub bytes: Secret<Vec<u8>>,
@@ -74,47 +61,35 @@ pub struct ChatUploadRequest {
     pub reply_to: Option<String>,
 }
 
-/// The body of `POST /alerts/email/notify/{destination}`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EmailNotifyRequest {
-    /// The subject line, delivered unchanged.
     pub subject: Secret<String>,
 
-    /// The body, as HTML.
     pub body: Secret<String>,
 }
 
-/// Whether the message arrived.
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NotifyStatus {
-    /// The provider accepted the message.
     Delivered,
-    /// The provider was reached and refused it.
     Refused,
 }
 
-/// What `/alerts/chat/notify/{destination}` returns.
 #[derive(Debug, Serialize)]
 pub struct ChatNotifyResponse {
-    /// Whether the message arrived.
     pub status: NotifyStatus,
 
-    /// The provider's id for the message, when it named one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
 
-    /// Why the provider refused, as a stable snake_case code — `msg_too_long`, `channel_not_found`, `rate_limited`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
 
-    /// How long the provider asked us to wait, when it said.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after_seconds: Option<u64>,
 }
 
-/// What `/alerts/chat/upload/{destination}` returns.
 #[derive(Debug, Serialize)]
 pub struct ChatUploadResponse {
     pub status: NotifyStatus,
@@ -126,17 +101,13 @@ pub struct ChatUploadResponse {
     pub retry_after_seconds: Option<u64>,
 }
 
-/// What `/alerts/email/notify/{destination}` returns.
 #[derive(Debug, Serialize)]
 pub struct EmailNotifyResponse {
-    /// Whether the mail was sent.
     pub status: NotifyStatus,
 
-    /// Why the provider refused, as a stable snake_case code.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
 
-    /// How long the provider asked us to wait, when it said.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after_seconds: Option<u64>,
 }
@@ -238,7 +209,6 @@ mod tests {
         assert!(body.get("message_id").is_none());
     }
 
-    /// The alert went out; only the ability to thread under it was lost.
     #[test]
     fn a_delivery_without_an_id_is_still_a_delivery() {
         let body = body_of(&ChatNotifyResponse::from(Outcome::Delivered(ChatReceipt {
@@ -261,7 +231,6 @@ mod tests {
         assert!(body.get("message_id").is_none());
     }
 
-    /// `status` is what stops a caller reading `200` and assuming delivery, so it is never skipped.
     #[test]
     fn status_is_always_present() {
         for outcome in [
@@ -282,7 +251,6 @@ mod tests {
         assert_eq!(request.reply_to.as_deref(), Some("cmtk931s1"));
     }
 
-    /// The body a bannered alert sends.
     #[test]
     fn chat_request_reads_a_banner() {
         let request: ChatNotifyRequest = serde_json::from_value(serde_json::json!({
@@ -314,7 +282,6 @@ mod tests {
         }
     }
 
-    /// A message with no banner is still the ordinary case and must stay a two-field body.
     #[test]
     fn chat_request_needs_no_banner() {
         let request: ChatNotifyRequest =
@@ -324,7 +291,6 @@ mod tests {
         assert!(request.severity.is_none());
     }
 
-    /// Threading against a mailing list is a caller bug.
     #[test]
     fn email_request_rejects_reply_to() {
         let error = serde_json::from_value::<EmailNotifyRequest>(serde_json::json!({
@@ -337,7 +303,6 @@ mod tests {
         assert!(error.to_string().contains("reply_to"));
     }
 
-    /// The property is now the type's, not a hand-written `Debug`'s:
     #[test]
     fn debug_never_prints_the_message() {
         let chat = ChatNotifyRequest {

--- a/crates/observability/src/types.rs
+++ b/crates/observability/src/types.rs
@@ -48,6 +48,7 @@
 //! backends in `external_services` hardcode an HTML body and there is no plain-text path to reach.
 
 use actix_multipart::form::{bytes::Bytes, text::Text, MultipartForm};
+use external_services::chat_service::ChatSeverity;
 use hyperswitch_masking::Secret;
 use serde::{Deserialize, Serialize};
 
@@ -68,6 +69,43 @@ pub struct ChatNotifyRequest {
     /// that message's response returned.
     #[serde(default)]
     pub reply_to: Option<String>,
+
+    /// A title to show above the message, larger than the body and free of markup.
+    ///
+    /// Sent with [`severity`](Self::severity) or not at all: the two make one banner, and a
+    /// destination that cannot draw one delivers the message without it.
+    #[serde(default)]
+    pub heading: Option<String>,
+
+    /// How urgent the message is, which decides the banner's colour.
+    #[serde(default)]
+    pub severity: Option<NotifySeverity>,
+}
+
+/// How urgent a chat message is.
+///
+/// Deliberately not a colour. Callers describe the alert, and each destination decides how to paint
+/// it — a caller that had to send `danger` would be encoding one backend's palette into every
+/// service that posts an alert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotifySeverity {
+    /// Something is broken now.
+    Critical,
+    /// Still broken, said again.
+    Warning,
+    /// Over.
+    Resolved,
+}
+
+impl From<NotifySeverity> for ChatSeverity {
+    fn from(severity: NotifySeverity) -> Self {
+        match severity {
+            NotifySeverity::Critical => Self::Critical,
+            NotifySeverity::Warning => Self::Warning,
+            NotifySeverity::Resolved => Self::Resolved,
+        }
+    }
 }
 
 /// Multipart fields accepted by `POST /alerts/chat/upload/{destination}`.
@@ -309,6 +347,46 @@ mod tests {
         assert_eq!(request.reply_to.as_deref(), Some("cmtk931s1"));
     }
 
+    /// The body a bannered alert sends.
+    ///
+    /// Worth pinning because `deny_unknown_fields` is what rejected this shape before the fields
+    /// existed, and it rejects with the same "could not be parsed" as a typo — so a caller gets no
+    /// hint that the field is merely unsupported.
+    #[test]
+    fn chat_request_reads_a_banner() {
+        let request: ChatNotifyRequest = serde_json::from_value(serde_json::json!({
+            "text": "45 of 45 payments failed",
+            "heading": "🔴 SEV1 · Zero SR",
+            "severity": "critical",
+        }))
+        .unwrap();
+
+        assert_eq!(request.heading.as_deref(), Some("🔴 SEV1 · Zero SR"));
+        assert_eq!(request.severity, Some(NotifySeverity::Critical));
+    }
+
+    #[test]
+    fn every_severity_has_a_wire_spelling() {
+        for (wire, expected) in [
+            ("critical", NotifySeverity::Critical),
+            ("warning", NotifySeverity::Warning),
+            ("resolved", NotifySeverity::Resolved),
+        ] {
+            let severity: NotifySeverity = serde_json::from_value(serde_json::json!(wire)).unwrap();
+            assert_eq!(severity, expected);
+        }
+    }
+
+    /// A message with no banner is still the ordinary case and must stay a two-field body.
+    #[test]
+    fn chat_request_needs_no_banner() {
+        let request: ChatNotifyRequest =
+            serde_json::from_value(serde_json::json!({ "text": "hi" })).unwrap();
+
+        assert!(request.heading.is_none());
+        assert!(request.severity.is_none());
+    }
+
     /// Threading against a mailing list is a caller bug. `deny_unknown_fields` makes it a rejection
     /// rather than a field that quietly goes nowhere.
     #[test]
@@ -330,6 +408,8 @@ mod tests {
         let chat = ChatNotifyRequest {
             text: "acquirer_declined for merchant_1234".to_owned().into(),
             reply_to: None,
+            heading: None,
+            severity: None,
         };
         assert!(!format!("{chat:?}").contains("merchant_1234"));
 


### PR DESCRIPTION
The notify endpoint took a bare string and `PostMessagePayload` had nowhere to put anything else, so every alert arrived as flat text. The alerting service already renders a heading and a severity; both were being flattened into the body.

A message may now name a `heading` and a `severity`, and a Slack-compatible backend draws them as an attachment — a coloured rail down the left and a large title above the body.

```jsonc
POST /alerts/chat/notify/{destination}
{
  "text": "45 of 45 payments failed on cybersource / USD",
  "heading": "SEV1 · Zero SR - connector+currency (1h)",
  "severity": "critical",       // critical | warning | resolved
  "reply_to": "cmt..."          // unchanged
}
```

Severity is `critical`/`warning`/`resolved` rather than a colour: a caller sending `danger` would be encoding one backend's palette into every service that posts an alert. The mapping to `danger`/`warning`/`good` sits next to the wire format and nowhere else.

### Two details that are invisible once delivered

- **The body moves inside the attachment and `text` is emptied.** A copy left at the top level renders above the rail as a second, unframed message.
- **`mrkdwn` is no longer sent alongside `attachments`.** Xyne branches on that flag into a text-only path that never reads them, so the rail and the heading silently vanish — while the call still returns `ok: true` with a message id and logs nothing unusual. Delivery, the response and the logs all look correct; only the rendered message is wrong. This was found by capturing the bytes the service actually transmits against a local sink, after the rendered output disagreed with a hand-written probe.

Both are asserted, since neither has any other guard. The heading is also cut to the 150 characters a `header` block allows — an oversized one is rejected outright rather than trimmed, which would cost the whole alert rather than its tail.

### Compatibility

A request naming no heading is byte-identical to before: same body, same `mrkdwn`, no `attachments` key. Asserted by `an_unbannered_message_sends_no_attachments_key_at_all` and `a_plain_message_still_sets_mrkdwn`.

### Testing

- 39 tests in `external_services::chat_service`, 16 in `observability` (one pre-existing failure in `utils::tests::test_deserialize_hashset_inner_empty_string`, present on the base branch).
- Ran the service locally against a real Xyne channel and posted a three-state threaded alert (firing → still firing → resolved) through the actual HTTP API; confirmed the rendered rail and heading in the channel.
- Captured the transmitted payload against a local HTTP sink to verify `mrkdwn` is absent when bannered and present when not.

Pairs with juspay/hyperswitch-alerts#40, which splits the heading out of the message body so it is not rendered twice. Both are needed for the format to be correct end to end.