### PR TITLE
feat(Googlepay): [Googlepay] InternalGateway flow

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -24485,6 +24485,14 @@
           }
         }
       },
+      "GooglePayTokenizationSpecificationType": {
+        "type": "string",
+        "description": "The tokenization type sent to the Google Pay SDK.\n\nUnlike [`GooglePayTokenizationType`], this holds only the values Google itself understands:\nthe Hyperswitch-internal `INTERNAL_GATEWAY` marker is resolved into `PAYMENT_GATEWAY` during\nthe session flow before this is built, so it can never leak into an SDK response.",
+        "enum": [
+          "PAYMENT_GATEWAY",
+          "DIRECT"
+        ]
+      },
       "GooglePayWalletData": {
         "type": "object",
         "required": [

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -24708,8 +24708,7 @@
         ],
         "properties": {
           "type": {
-            "type": "string",
-            "description": "The token specification type(ex: PAYMENT_GATEWAY)"
+            "$ref": "#/components/schemas/GooglePayTokenizationSpecificationType"
           },
           "parameters": {
             "$ref": "#/components/schemas/GpayTokenParameters"

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -17183,8 +17183,7 @@
         ],
         "properties": {
           "type": {
-            "type": "string",
-            "description": "The token specification type(ex: PAYMENT_GATEWAY)"
+            "$ref": "#/components/schemas/GooglePayTokenizationSpecificationType"
           },
           "parameters": {
             "$ref": "#/components/schemas/GpayTokenParameters"

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -16960,6 +16960,14 @@
           }
         }
       },
+      "GooglePayTokenizationSpecificationType": {
+        "type": "string",
+        "description": "The tokenization type sent to the Google Pay SDK.\n\nUnlike [`GooglePayTokenizationType`], this holds only the values Google itself understands:\nthe Hyperswitch-internal `INTERNAL_GATEWAY` marker is resolved into `PAYMENT_GATEWAY` during\nthe session flow before this is built, so it can never leak into an SDK response.",
+        "enum": [
+          "PAYMENT_GATEWAY",
+          "DIRECT"
+        ]
+      },
       "GooglePayWalletData": {
         "type": "object",
         "required": [

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1186,6 +1186,9 @@ paze_private_key_passphrase = "PAZE_PRIVATE_KEY_PASSPHRASE" # PEM Passphrase use
 
 [google_pay_decrypt_keys]
 google_pay_root_signing_keys = "GOOGLE_PAY_ROOT_SIGNING_KEYS" # Base 64 Encoded Root Signing Keys provided by Google Pay (https://developers.google.com/pay/api/web/guides/resources/payment-data-cryptography)
+google_pay_private_key = "GOOGLE_PAY_PRIVATE_KEY"             # Base 64 Encoded PKCS#8 private key of the Hyperswitch registered Google Pay gateway, used by the INTERNAL_GATEWAY tokenization flow
+google_pay_common_merchant_id = "GOOGLE_PAY_COMMON_MERCHANT_ID" # Google Pay Business Console merchant id used when an INTERNAL_GATEWAY merchant does not supply one of its own. Not a secret, it is sent to the SDK
+google_pay_gateway_id = "GOOGLE_PAY_GATEWAY_ID"               # Gateway identifier registered with Google, also used to derive the `gateway:<id>` recipient. google_pay_private_key, google_pay_gateway_id and google_pay_common_merchant_id must either all be set or all be unset
 
 [applepay_merchant_configs]
 # Run below command to get common merchant identifier for applepay in shell

--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -48,6 +48,10 @@ paze_private_key_passphrase = "PAZE_PRIVATE_KEY_PASSPHRASE" # PEM Passphrase use
 
 [google_pay_decrypt_keys]
 google_pay_root_signing_keys = "GOOGLE_PAY_ROOT_SIGNING_KEYS" # Base 64 Encoded Root Signing Keys provided by Google Pay (https://developers.google.com/pay/api/web/guides/resources/payment-data-cryptography)
+verify_signature = false                                      # Verify the ECv2 signature chain on Google Pay tokens. Requires root signing keys for the matching environment and a correct per-MCA recipient_id
+google_pay_private_key = "GOOGLE_PAY_PRIVATE_KEY"             # Base 64 Encoded PKCS#8 private key of the Hyperswitch registered Google Pay gateway, used by the INTERNAL_GATEWAY tokenization flow
+google_pay_common_merchant_id = "GOOGLE_PAY_COMMON_MERCHANT_ID" # Google Pay Business Console merchant id used when an INTERNAL_GATEWAY merchant does not supply one of its own. Not a secret, it is sent to the SDK
+google_pay_gateway_id = "GOOGLE_PAY_GATEWAY_ID"               # Gateway identifier registered with Google, also used to derive the `gateway:<id>` recipient. google_pay_private_key, google_pay_gateway_id and google_pay_common_merchant_id must either all be set or all be unset
 
 [applepay_merchant_configs]
 common_merchant_identifier = "APPLE_PAY_COMMON_MERCHANT_IDENTIFIER"                        # Refer to config.example.toml to learn how you can generate this value

--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -48,7 +48,6 @@ paze_private_key_passphrase = "PAZE_PRIVATE_KEY_PASSPHRASE" # PEM Passphrase use
 
 [google_pay_decrypt_keys]
 google_pay_root_signing_keys = "GOOGLE_PAY_ROOT_SIGNING_KEYS" # Base 64 Encoded Root Signing Keys provided by Google Pay (https://developers.google.com/pay/api/web/guides/resources/payment-data-cryptography)
-verify_signature = false                                      # Verify the ECv2 signature chain on Google Pay tokens. Requires root signing keys for the matching environment and a correct per-MCA recipient_id
 google_pay_private_key = "GOOGLE_PAY_PRIVATE_KEY"             # Base 64 Encoded PKCS#8 private key of the Hyperswitch registered Google Pay gateway, used by the INTERNAL_GATEWAY tokenization flow
 google_pay_common_merchant_id = "GOOGLE_PAY_COMMON_MERCHANT_ID" # Google Pay Business Console merchant id used when an INTERNAL_GATEWAY merchant does not supply one of its own. Not a secret, it is sent to the SDK
 google_pay_gateway_id = "GOOGLE_PAY_GATEWAY_ID"               # Gateway identifier registered with Google, also used to derive the `gateway:<id>` recipient. google_pay_private_key, google_pay_gateway_id and google_pay_common_merchant_id must either all be set or all be unset

--- a/config/development.toml
+++ b/config/development.toml
@@ -1361,6 +1361,9 @@ paze_private_key_passphrase = "PAZE_PRIVATE_KEY_PASSPHRASE"
 
 [google_pay_decrypt_keys]
 google_pay_root_signing_keys = "GOOGLE_PAY_ROOT_SIGNING_KEYS" # Base 64 Encoded Root Signing Keys provided by Google Pay (https://developers.google.com/pay/api/web/guides/resources/payment-data-cryptography)
+google_pay_private_key = "GOOGLE_PAY_PRIVATE_KEY"             # Base 64 Encoded PKCS#8 private key of the Hyperswitch registered Google Pay gateway, used by the INTERNAL_GATEWAY tokenization flow
+google_pay_common_merchant_id = "GOOGLE_PAY_COMMON_MERCHANT_ID" # Google Pay Business Console merchant id used when an INTERNAL_GATEWAY merchant does not supply one of its own. Not a secret, it is sent to the SDK
+google_pay_gateway_id = "GOOGLE_PAY_GATEWAY_ID"               # Gateway identifier registered with Google, also used to derive the `gateway:<id>` recipient. google_pay_private_key, google_pay_gateway_id and google_pay_common_merchant_id must either all be set or all be unset
 
 [generic_link]
 [generic_link.payment_method_collect]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -10091,6 +10091,44 @@ pub struct GpayTokenParameters {
     pub public_key: Option<Secret<String>>,
 }
 
+/// The tokenization type sent to the Google Pay SDK.
+///
+/// Unlike [`GooglePayTokenizationType`], this holds only the values Google itself understands:
+/// the Hyperswitch-internal `INTERNAL_GATEWAY` marker is resolved into `PAYMENT_GATEWAY` during
+/// the session flow before this is built, so it can never leak into an SDK response.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    ToSchema,
+    strum::Display,
+    strum::EnumString,
+)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub enum GooglePayTokenizationSpecificationType {
+    PaymentGateway,
+    Direct,
+}
+
+/// Resolves the caller-facing [`GooglePayTokenizationType`] into the SDK-side equivalent.
+///
+/// `INTERNAL_GATEWAY` is not a tokenization type Google understands: sessions served through it
+/// go through Hyperswitch's own registered gateway, which the SDK knows as `PAYMENT_GATEWAY`.
+impl From<GooglePayTokenizationType> for GooglePayTokenizationSpecificationType {
+    fn from(tokenization_type: GooglePayTokenizationType) -> Self {
+        match tokenization_type {
+            GooglePayTokenizationType::Direct => Self::Direct,
+            GooglePayTokenizationType::PaymentGateway
+            | GooglePayTokenizationType::InternalGateway => Self::PaymentGateway,
+        }
+    }
+}
+
 #[derive(
     Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel,
 )]
@@ -10098,8 +10136,8 @@ pub struct GpayTokenParameters {
 pub struct GpayTokenizationSpecification {
     /// The token specification type(ex: PAYMENT_GATEWAY)
     #[serde(rename = "type")]
-    #[smithy(value_type = "String")]
-    pub token_specification_type: String,
+    #[smithy(value_type = "GooglePayTokenizationSpecificationType")]
+    pub token_specification_type: GooglePayTokenizationSpecificationType,
     /// The parameters for the token specification Google Pay
     #[smithy(value_type = "GpayTokenParameters")]
     pub parameters: GpayTokenParameters,

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -10640,18 +10640,25 @@ pub struct GooglePayMerchantInfo {
 pub struct GooglePayTokenizationSpecification {
     #[serde(rename = "type")]
     pub tokenization_type: GooglePayTokenizationType,
+    /// Absent for `INTERNAL_GATEWAY`, where the merchant supplies no key material at all.
+    #[serde(default)]
     pub parameters: GooglePayTokenizationParameters,
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, strum::Display)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, strum::Display,
+)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum GooglePayTokenizationType {
     PaymentGateway,
     Direct,
+    /// Hyperswitch-internal marker: the token is encrypted to Hyperswitch's own registered
+    /// gateway key. Never sent to Google as-is; resolved to `PAYMENT_GATEWAY` in the session flow.
+    InternalGateway,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct GooglePayTokenizationParameters {
     pub gateway: Option<String>,
     pub public_key: Option<Secret<String>>,

--- a/crates/hyperswitch_connectors/src/connectors/trustpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/trustpay/transformers.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 use api_models::payments::SessionToken;
 use cards::NetworkToken;
@@ -1581,8 +1581,8 @@ pub(crate) fn get_google_pay_session<F, T>(
                         allowed_payment_methods: google_pay_init_result
                             .allowed_payment_methods
                             .into_iter()
-                            .map(Into::into)
-                            .collect(),
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()?,
                         transaction_info: google_pay_init_result.transaction_info.into(),
                         secrets: Some((*secrets).clone().into()),
                         shipping_address_required: false,
@@ -1622,13 +1622,15 @@ impl From<GooglePayMerchantInfo> for api_models::payments::GpayMerchantInfo {
     }
 }
 
-impl From<GooglePayAllowedPaymentMethods> for api_models::payments::GpayAllowedPaymentMethods {
-    fn from(value: GooglePayAllowedPaymentMethods) -> Self {
-        Self {
+impl TryFrom<GooglePayAllowedPaymentMethods> for api_models::payments::GpayAllowedPaymentMethods {
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(value: GooglePayAllowedPaymentMethods) -> Result<Self, Self::Error> {
+        Ok(Self {
             payment_method_type: value.payment_method_type,
             parameters: value.parameters.into(),
-            tokenization_specification: value.tokenization_specification.into(),
-        }
+            tokenization_specification: value.tokenization_specification.try_into()?,
+        })
     }
 }
 
@@ -1645,12 +1647,23 @@ impl From<GpayAllowedMethodsParameters> for api_models::payments::GpayAllowedMet
     }
 }
 
-impl From<GpayTokenizationSpecification> for api_models::payments::GpayTokenizationSpecification {
-    fn from(value: GpayTokenizationSpecification) -> Self {
-        Self {
-            token_specification_type: value.token_specification_type,
+impl TryFrom<GpayTokenizationSpecification>
+    for api_models::payments::GpayTokenizationSpecification
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(value: GpayTokenizationSpecification) -> Result<Self, Self::Error> {
+        Ok(Self {
+            token_specification_type:
+                api_models::payments::GooglePayTokenizationSpecificationType::from_str(
+                    &value.token_specification_type,
+                )
+                .change_context(errors::ConnectorError::ParsingFailed)
+                .attach_printable(
+                    "unsupported google pay tokenization type received from trustpay",
+                )?,
             parameters: value.parameters.into(),
-        }
+        })
     }
 }
 

--- a/crates/hyperswitch_domain_models/src/router_data.rs
+++ b/crates/hyperswitch_domain_models/src/router_data.rs
@@ -627,6 +627,9 @@ impl ApplePayPredecryptDataInternal {
 pub struct GooglePayPredecryptDataInternal {
     pub message_expiration: String,
     pub message_id: String,
+    /// Present when the card was tokenized for a gateway, carrying the `gateway_merchant_id` that
+    /// was sent to Google in the session response. Absent for `DIRECT` tokenization.
+    pub gateway_merchant_id: Option<String>,
     #[serde(rename = "paymentMethod")]
     pub payment_method_type: String,
     pub payment_method_details: GooglePayPaymentMethodDetails,

--- a/crates/hyperswitch_interfaces/src/configs.rs
+++ b/crates/hyperswitch_interfaces/src/configs.rs
@@ -149,6 +149,13 @@ impl MerchantConnectorAccountType {
         None
     }
 
+    pub fn get_merchant_id(&self) -> Option<id_type::MerchantId> {
+        match self {
+            Self::DbVal(db_val) => Some(db_val.merchant_id.clone()),
+            Self::CacheVal(_) => None,
+        }
+    }
+
     pub fn get_mca_id(&self) -> Option<id_type::MerchantConnectorAccountId> {
         match self {
             Self::DbVal(db_val) => Some(db_val.get_id()),

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -739,6 +739,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::GpayAllowedPaymentMethods,
         api_models::payments::GpayAllowedMethodsParameters,
         api_models::payments::GpayTokenizationSpecification,
+        api_models::payments::GooglePayTokenizationSpecificationType,
         api_models::payments::GpayTokenParameters,
         api_models::payments::GpayTransactionInfo,
         api_models::payments::GpaySessionTokenResponse,

--- a/crates/openapi/src/openapi_v2.rs
+++ b/crates/openapi/src/openapi_v2.rs
@@ -609,6 +609,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::GpayAllowedPaymentMethods,
         api_models::payments::GpayAllowedMethodsParameters,
         api_models::payments::GpayTokenizationSpecification,
+        api_models::payments::GooglePayTokenizationSpecificationType,
         api_models::payments::GpayTokenParameters,
         api_models::payments::GpayTransactionInfo,
         api_models::payments::GpaySessionTokenResponse,

--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -194,6 +194,33 @@ impl SecretsHandler for settings::PazeDecryptConfig {
 }
 
 #[async_trait::async_trait]
+impl SecretsHandler for settings::GooglePayDecryptConfig {
+    async fn convert_to_raw_secret(
+        value: SecretStateContainer<Self, SecuredSecret>,
+        secret_management_client: &dyn SecretManagementInterface,
+    ) -> CustomResult<SecretStateContainer<Self, RawSecret>, SecretsManagementError> {
+        let google_pay_decrypt_keys = value.get_inner();
+
+        // The private key is the only secret managed value here. The root signing keys are
+        // Google's public certificates, the gateway id is a plain identifier, and the common
+        // merchant id is sent to the SDK in the session response, so none of them are fetched.
+        let google_pay_private_key = google_pay_decrypt_keys
+            .google_pay_private_key
+            .clone()
+            .async_map(|private_key| async move {
+                secret_management_client.get_secret(private_key).await
+            })
+            .await
+            .transpose()?;
+
+        Ok(value.transition_state(|google_pay_decrypt_keys| Self {
+            google_pay_private_key,
+            ..google_pay_decrypt_keys
+        }))
+    }
+}
+
+#[async_trait::async_trait]
 impl SecretsHandler for settings::ApplepayMerchantConfigs {
     async fn convert_to_raw_secret(
         value: SecretStateContainer<Self, SecuredSecret>,
@@ -545,6 +572,20 @@ pub(crate) async fn fetch_raw_secrets(
     };
 
     #[allow(clippy::expect_used)]
+    let google_pay_decrypt_keys = if let Some(google_pay_keys) = conf.google_pay_decrypt_keys {
+        Some(
+            settings::GooglePayDecryptConfig::convert_to_raw_secret(
+                google_pay_keys,
+                secret_management_client,
+            )
+            .await
+            .expect("Failed to decrypt google pay decrypt configs"),
+        )
+    } else {
+        None
+    };
+
+    #[allow(clippy::expect_used)]
     let applepay_merchant_configs = settings::ApplepayMerchantConfigs::convert_to_raw_secret(
         conf.applepay_merchant_configs,
         secret_management_client,
@@ -712,7 +753,7 @@ pub(crate) async fn fetch_raw_secrets(
         payouts: conf.payouts,
         applepay_decrypt_keys,
         paze_decrypt_keys,
-        google_pay_decrypt_keys: conf.google_pay_decrypt_keys,
+        google_pay_decrypt_keys,
         multiple_api_version_supported_connectors: conf.multiple_api_version_supported_connectors,
         applepay_merchant_configs,
         lock_settings: conf.lock_settings,

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -148,7 +148,7 @@ pub struct Settings<S: SecretState> {
     pub debit_routing_config: DebitRoutingConfig,
     pub applepay_decrypt_keys: SecretStateContainer<ApplePayDecryptConfig, S>,
     pub paze_decrypt_keys: Option<SecretStateContainer<PazeDecryptConfig, S>>,
-    pub google_pay_decrypt_keys: Option<GooglePayDecryptConfig>,
+    pub google_pay_decrypt_keys: Option<SecretStateContainer<GooglePayDecryptConfig, S>>,
     pub multiple_api_version_supported_connectors: MultipleApiVersionSupportedConnectors,
     pub applepay_merchant_configs: SecretStateContainer<ApplepayMerchantConfigs, S>,
     pub lock_settings: LockSettings,
@@ -1342,6 +1342,17 @@ pub struct PazeDecryptConfig {
 #[derive(Debug, Deserialize, Clone)]
 pub struct GooglePayDecryptConfig {
     pub google_pay_root_signing_keys: Secret<String>,
+    /// Private key of Hyperswitch's own registered Google Pay gateway. Used by the
+    /// `INTERNAL_GATEWAY` tokenization flow, where the merchant registers no key of its own.
+    pub google_pay_private_key: Option<Secret<String>>,
+    /// Google Pay Business Console merchant id used when an `INTERNAL_GATEWAY` merchant chooses
+    /// not to supply one of its own. Not secret managed: it is sent to the SDK in the session
+    /// response.
+    pub google_pay_common_merchant_id: Option<Secret<String>>,
+    /// Gateway identifier registered with Google, sent as
+    /// `tokenizationSpecification.parameters.gateway` and used to derive the `gateway:<id>`
+    /// recipient the token is signed against.
+    pub google_pay_gateway_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -1587,7 +1598,7 @@ impl Settings<SecuredSecret> {
 
         self.google_pay_decrypt_keys
             .as_ref()
-            .map(|x| x.validate())
+            .map(|x| x.get_inner().validate())
             .transpose()?;
 
         self.key_manager.get_inner().validate()?;

--- a/crates/router/src/configs/validations.rs
+++ b/crates/router/src/configs/validations.rs
@@ -292,7 +292,10 @@ impl super::settings::GooglePayDecryptConfig {
                 "google_pay_private_key",
                 self.google_pay_private_key.is_none(),
             ),
-            ("google_pay_gateway_id", self.google_pay_gateway_id.is_none()),
+            (
+                "google_pay_gateway_id",
+                self.google_pay_gateway_id.is_none(),
+            ),
             (
                 "google_pay_common_merchant_id",
                 self.google_pay_common_merchant_id.is_none(),

--- a/crates/router/src/configs/validations.rs
+++ b/crates/router/src/configs/validations.rs
@@ -279,6 +279,51 @@ impl super::settings::GooglePayDecryptConfig {
                     "google_pay_root_signing_keys must not be empty".into(),
                 ))
             },
+        )?;
+
+        // The private key, gateway id and common merchant id together describe Hyperswitch's
+        // registered Google Pay gateway: the key decrypts the token, the id derives the
+        // `gateway:<id>` recipient it was signed against, and the common merchant id is sent to
+        // the SDK for INTERNAL_GATEWAY merchants that do not supply one of their own. Either all
+        // of them are configured or none is, otherwise the INTERNAL_GATEWAY flow raises a payment
+        // sheet whose token cannot be decrypted.
+        let internal_gateway_fields = [
+            (
+                "google_pay_private_key",
+                self.google_pay_private_key.is_none(),
+            ),
+            ("google_pay_gateway_id", self.google_pay_gateway_id.is_none()),
+            (
+                "google_pay_common_merchant_id",
+                self.google_pay_common_merchant_id.is_none(),
+            ),
+        ];
+        let missing_fields = internal_gateway_fields
+            .iter()
+            .filter_map(|(field, is_missing)| is_missing.then_some(*field))
+            .collect::<Vec<_>>();
+
+        when(
+            !missing_fields.is_empty() && missing_fields.len() != internal_gateway_fields.len(),
+            || {
+                Err(ApplicationError::InvalidConfigurationValueError(format!(
+                    "google_pay_private_key, google_pay_gateway_id and \
+                     google_pay_common_merchant_id must either all be set or all be unset; \
+                     missing: {}",
+                    missing_fields.join(", ")
+                )))
+            },
+        )?;
+
+        when(
+            self.google_pay_gateway_id
+                .as_ref()
+                .is_some_and(|gateway_id| gateway_id.trim().is_empty()),
+            || {
+                Err(ApplicationError::InvalidConfigurationValueError(
+                    "google_pay_gateway_id must not be empty".into(),
+                ))
+            },
         )
     }
 }

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -286,6 +286,11 @@ pub(crate) const PROTOCOL: &str = "ECv2";
 /// Sender ID for Google Pay Decryption
 pub(crate) const SENDER_ID: &[u8] = b"Google";
 
+/// Prefix of the recipient identifier Google signs a gateway tokenized card against, i.e.
+/// `gateway:<gateway id>`. Used by the `INTERNAL_GATEWAY` google pay flow, which derives the
+/// recipient from configuration instead of taking it from the merchant.
+pub(crate) const GOOGLE_PAY_GATEWAY_RECIPIENT_PREFIX: &str = "gateway:";
+
 /// Default value for the number of attempts to retry fetching forex rates
 pub const DEFAULT_ANALYTICS_FOREX_RETRY_ATTEMPTS: u64 = 3;
 

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -270,6 +270,8 @@ pub enum GooglePayDecryptionError {
     DecryptedTokenExpired,
     #[error("Failed to parse the given value")]
     ParsingFailed,
+    #[error("Gateway merchant id in the token does not match the merchant being paid")]
+    InvalidGatewayMerchantId,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -7875,21 +7875,48 @@ async fn decrypt_google_pay_wallet_data(
             .clone(),
         payment_processing_details.google_pay_recipient_id.clone(),
         payment_processing_details.google_pay_private_key.clone(),
+        // INTERNAL_GATEWAY makes the decryptor verify the token unconditionally. DIRECT
+        // recipients are merchant supplied and are therefore left unverified, as they are today.
+        payment_processing_details.google_pay_tokenization_type,
+        payment_processing_details
+            .google_pay_gateway_merchant_id
+            .clone(),
     )
     .change_context(errors::ApiErrorResponse::InternalServerError)
     .attach_printable("failed to create google pay token decryptor")?;
 
+    let google_pay_token = google_pay_wallet_data
+        .tokenization_data
+        .get_encrypted_google_pay_token()
+        .change_context(errors::ApiErrorResponse::InternalServerError)?
+        .clone();
+
     // should_verify_token is set to false to disable verification of token
     let google_pay_data_internal = decryptor
-        .decrypt_token(
-            google_pay_wallet_data
-                .tokenization_data
-                .get_encrypted_google_pay_token()
-                .change_context(errors::ApiErrorResponse::InternalServerError)?
-                .clone(),
-            false,
-        )
-        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .decrypt_token(google_pay_token, false)
+        .map_err(|error| {
+            logger::warn!(?error, "failed to decrypt google pay token");
+            let api_error = match error.current_context() {
+                // The gateway merchant id carried by the token does not match the gateway
+                // merchant id configured for the merchant (or is missing from either side).
+                // Authorization was never attempted with the connector; this is a gateway
+                // configuration mismatch, so report it as an invalid request instead of a
+                // connector authorization failure.
+                errors::GooglePayDecryptionError::InvalidGatewayMerchantId => {
+                    errors::ApiErrorResponse::InvalidRequestData {
+                        message: "Failed to decrypt the Google Pay token: gateway merchant id \
+                                  in the token does not match the gateway merchant id \
+                                  configured for the merchant"
+                            .to_string(),
+                    }
+                }
+
+                // Everything else, including a recipient that does not match the configured
+                // gateway, is our own fault and stays a server error as it is today.
+                _ => errors::ApiErrorResponse::InternalServerError,
+            };
+            error.change_context(api_error)
+        })
         .attach_printable("failed to decrypt google pay token")?;
     Ok(common_types::payments::GPayPredecryptData::from(
         google_pay_data_internal,
@@ -9276,10 +9303,12 @@ fn get_google_pay_connector_wallet_details(
     state: &SessionState,
     merchant_connector_account: &helpers::MerchantConnectorAccountType,
 ) -> Option<GooglePayPaymentProcessingDetails> {
-    let google_pay_root_signing_keys = state
+    let google_pay_decrypt_keys = state
         .conf
         .google_pay_decrypt_keys
         .as_ref()
+        .map(|google_pay_keys| google_pay_keys.get_inner());
+    let google_pay_root_signing_keys = google_pay_decrypt_keys
         .map(|google_pay_keys| google_pay_keys.google_pay_root_signing_keys.clone());
     match merchant_connector_account.get_connector_wallets_details() {
         Some(wallet_details) => {
@@ -9297,31 +9326,68 @@ fn get_google_pay_connector_wallet_details(
                     |google_pay_wallet_details| {
                         match google_pay_wallet_details.provider_details {
                             api_models::payments::GooglePayProviderDetails::GooglePayMerchantDetails(merchant_details) => {
-                                match (
-                                    merchant_details
-                                        .merchant_info
-                                        .tokenization_specification
-                                        .parameters
-                                        .private_key,
-                                    google_pay_root_signing_keys,
-                                    merchant_details
-                                        .merchant_info
-                                        .tokenization_specification
-                                        .parameters
-                                        .recipient_id,
-                                    ) {
-                                        (Some(google_pay_private_key), Some(google_pay_root_signing_keys), Some(google_pay_recipient_id)) => {
-                                            Some(GooglePayPaymentProcessingDetails {
-                                                google_pay_private_key,
-                                                google_pay_root_signing_keys,
-                                                google_pay_recipient_id
-                                            })
-                                        }
-                                        _ => {
-                                            logger::warn!("One or more of the following fields are missing in GooglePayMerchantDetails: google_pay_private_key, google_pay_root_signing_keys, google_pay_recipient_id");
-                                            None
+                                let tokenization_specification = merchant_details.merchant_info.tokenization_specification;
+
+                                match tokenization_specification.tokenization_type {
+                                    // The merchant registered no key of its own: the token is
+                                    // encrypted to Hyperswitch's gateway key, and the recipient is
+                                    // derived from the same gateway id that was sent to Google in
+                                    // the session response.
+                                    api_models::payments::GooglePayTokenizationType::InternalGateway => {
+                                        let google_pay_gateway_id = google_pay_decrypt_keys
+                                            .and_then(|google_pay_keys| google_pay_keys.google_pay_gateway_id.clone());
+                                        let google_pay_private_key = google_pay_decrypt_keys
+                                            .and_then(|google_pay_keys| google_pay_keys.google_pay_private_key.clone());
+                                        // The same merchant id that was sent to Google as
+                                        // gateway_merchant_id when the sheet was raised.
+                                        let google_pay_gateway_merchant_id = merchant_connector_account
+                                            .get_merchant_id()
+                                            .map(|merchant_id| merchant_id.get_string_repr().to_owned());
+
+                                        match (google_pay_private_key, google_pay_root_signing_keys, google_pay_gateway_id) {
+                                            (Some(google_pay_private_key), Some(google_pay_root_signing_keys), Some(google_pay_gateway_id)) => {
+                                                Some(GooglePayPaymentProcessingDetails {
+                                                    google_pay_private_key,
+                                                    google_pay_root_signing_keys,
+                                                    google_pay_recipient_id: Secret::new(format!(
+                                                        "{}{}",
+                                                        consts::GOOGLE_PAY_GATEWAY_RECIPIENT_PREFIX,
+                                                        google_pay_gateway_id
+                                                    )),
+                                                    google_pay_tokenization_type: api_models::payments::GooglePayTokenizationType::InternalGateway,
+                                                    google_pay_gateway_merchant_id,
+                                                })
+                                            }
+                                            _ => {
+                                                logger::warn!("One or more of the following fields are missing in google_pay_decrypt_keys for an INTERNAL_GATEWAY merchant: google_pay_private_key, google_pay_root_signing_keys, google_pay_gateway_id");
+                                                None
+                                            }
                                         }
                                     }
+                                    // The connector decrypts the token, Hyperswitch never sees the card.
+                                    api_models::payments::GooglePayTokenizationType::PaymentGateway => None,
+                                    api_models::payments::GooglePayTokenizationType::Direct => {
+                                        match (
+                                            tokenization_specification.parameters.private_key,
+                                            google_pay_root_signing_keys,
+                                            tokenization_specification.parameters.recipient_id,
+                                            ) {
+                                                (Some(google_pay_private_key), Some(google_pay_root_signing_keys), Some(google_pay_recipient_id)) => {
+                                                    Some(GooglePayPaymentProcessingDetails {
+                                                        google_pay_private_key,
+                                                        google_pay_root_signing_keys,
+                                                        google_pay_recipient_id,
+                                                        google_pay_tokenization_type: api_models::payments::GooglePayTokenizationType::Direct,
+                                                        google_pay_gateway_merchant_id: None,
+                                                    })
+                                                }
+                                                _ => {
+                                                    logger::warn!("One or more of the following fields are missing in GooglePayMerchantDetails: google_pay_private_key, google_pay_root_signing_keys, google_pay_recipient_id");
+                                                    None
+                                                }
+                                            }
+                                    }
+                                }
                             }
                         }
                     }
@@ -9437,6 +9503,14 @@ pub struct GooglePayPaymentProcessingDetails {
     pub google_pay_private_key: Secret<String>,
     pub google_pay_root_signing_keys: Secret<String>,
     pub google_pay_recipient_id: Secret<String>,
+    /// Tokenization type configured on the MCA. `INTERNAL_GATEWAY` turns signature verification
+    /// on: the recipient is derived by Hyperswitch in that flow, so it is known to be correct and
+    /// can be enforced. `DIRECT` recipients are typed by the merchant and are therefore left
+    /// unverified, as they are today.
+    pub google_pay_tokenization_type: api_models::payments::GooglePayTokenizationType,
+    /// Hyperswitch merchant id sent to Google as `gateway_merchant_id`, checked against the
+    /// decrypted token. Set for `INTERNAL_GATEWAY` only.
+    pub google_pay_gateway_merchant_id: Option<String>,
 }
 #[cfg(feature = "v1")]
 #[derive(Clone, Debug)]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -7875,8 +7875,9 @@ async fn decrypt_google_pay_wallet_data(
             .clone(),
         payment_processing_details.google_pay_recipient_id.clone(),
         payment_processing_details.google_pay_private_key.clone(),
-        // INTERNAL_GATEWAY makes the decryptor verify the token unconditionally. DIRECT
-        // recipients are merchant supplied and are therefore left unverified, as they are today.
+        // INTERNAL_GATEWAY additionally enforces that the decrypted token's
+        // gatewayMerchantId matches the merchant being paid. Signature verification stays
+        // off, and DIRECT recipients are merchant supplied and left unverified, as today.
         payment_processing_details.google_pay_tokenization_type,
         payment_processing_details
             .google_pay_gateway_merchant_id
@@ -9503,10 +9504,10 @@ pub struct GooglePayPaymentProcessingDetails {
     pub google_pay_private_key: Secret<String>,
     pub google_pay_root_signing_keys: Secret<String>,
     pub google_pay_recipient_id: Secret<String>,
-    /// Tokenization type configured on the MCA. `INTERNAL_GATEWAY` turns signature verification
-    /// on: the recipient is derived by Hyperswitch in that flow, so it is known to be correct and
-    /// can be enforced. `DIRECT` recipients are typed by the merchant and are therefore left
-    /// unverified, as they are today.
+    /// Tokenization type configured on the MCA. `INTERNAL_GATEWAY` additionally enforces that
+    /// the decrypted token's `gatewayMerchantId` matches the merchant being paid; signature
+    /// verification stays off, as it does for `DIRECT`, whose recipients are typed by the
+    /// merchant and are therefore left unverified.
     pub google_pay_tokenization_type: api_models::payments::GooglePayTokenizationType,
     /// Hyperswitch merchant id sent to Google as `gateway_merchant_id`, checked against the
     /// decrypted token. Set for `INTERNAL_GATEWAY` only.

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -1438,10 +1438,7 @@ fn resolve_google_pay_merchant_id(
 ) -> Option<String> {
     match merchant_info.merchant_id.clone() {
         Some(merchant_id) => Some(merchant_id),
-        None => match merchant_info
-            .tokenization_specification
-            .tokenization_type
-        {
+        None => match merchant_info.tokenization_specification.tokenization_type {
             payment_types::GooglePayTokenizationType::InternalGateway => {
                 match state
                     .conf

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -1357,7 +1357,8 @@ fn resolve_google_pay_tokenization_specification(
         payment_types::GooglePayTokenizationType::InternalGateway => {
             // A missing gateway id is a hard error rather than a silent skip: the SDK would
             // otherwise raise a payment sheet whose token nothing can decrypt.
-            let gateway = google_pay_gateway_id(state)
+            let gateway = state
+                .google_pay_gateway_id()
                 .ok_or(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable(
                     "google_pay_decrypt_keys.google_pay_gateway_id is not configured, cannot \
@@ -1365,8 +1366,10 @@ fn resolve_google_pay_tokenization_specification(
                 )?;
 
             Ok(payment_types::GpayTokenizationSpecification {
-                token_specification_type: payment_types::GooglePayTokenizationType::PaymentGateway
-                    .to_string(),
+                token_specification_type:
+                    payment_types::GooglePayTokenizationSpecificationType::from(
+                        gpay_token_specific_data.tokenization_type,
+                    ),
                 parameters: payment_types::GpayTokenParameters {
                     gateway: Some(gateway),
                     // The Hyperswitch merchant id keeps each merchant individually identifiable
@@ -1383,6 +1386,11 @@ fn resolve_google_pay_tokenization_specification(
         }
         payment_types::GooglePayTokenizationType::Direct
         | payment_types::GooglePayTokenizationType::PaymentGateway => {
+            let token_specification_type =
+                payment_types::GooglePayTokenizationSpecificationType::from(
+                    gpay_token_specific_data.tokenization_type,
+                );
+
             let protocol_version: Option<String> = gpay_token_specific_data
                 .parameters
                 .public_key
@@ -1390,7 +1398,7 @@ fn resolve_google_pay_tokenization_specification(
                 .map(|_| PROTOCOL.to_string());
 
             Ok(payment_types::GpayTokenizationSpecification {
-                token_specification_type: gpay_token_specific_data.tokenization_type.to_string(),
+                token_specification_type,
                 parameters: payment_types::GpayTokenParameters {
                     protocol_version,
                     public_key: gpay_token_specific_data.parameters.public_key.clone(),
@@ -1428,44 +1436,40 @@ fn resolve_google_pay_merchant_id(
     state: &routes::SessionState,
     merchant_info: &payment_types::GooglePayMerchantInfo,
 ) -> Option<String> {
-    merchant_info.merchant_id.clone().or_else(|| {
-        if matches!(
-            merchant_info.tokenization_specification.tokenization_type,
-            payment_types::GooglePayTokenizationType::InternalGateway
-        ) {
-            let common_merchant_id = state
-                .conf
-                .google_pay_decrypt_keys
-                .as_ref()
-                .and_then(|google_pay_keys| {
-                    google_pay_keys
-                        .get_inner()
-                        .google_pay_common_merchant_id
-                        .clone()
-                })
-                .map(|merchant_id| merchant_id.expose());
-
-            if common_merchant_id.is_none() {
-                logger::warn!(
-                    "google_pay_common_merchant_id is not configured and the merchant did not \
-                     supply a merchant_id, the google pay sheet will be raised without one"
-                );
+    match merchant_info.merchant_id.clone() {
+        Some(merchant_id) => Some(merchant_id),
+        None => match merchant_info
+            .tokenization_specification
+            .tokenization_type
+        {
+            payment_types::GooglePayTokenizationType::InternalGateway => {
+                match state
+                    .conf
+                    .google_pay_decrypt_keys
+                    .as_ref()
+                    .and_then(|google_pay_keys| {
+                        google_pay_keys
+                            .get_inner()
+                            .google_pay_common_merchant_id
+                            .clone()
+                    })
+                    .map(|merchant_id| merchant_id.expose())
+                {
+                    Some(common_merchant_id) => Some(common_merchant_id),
+                    None => {
+                        logger::warn!(
+                            "google_pay_common_merchant_id is not configured and the merchant \
+                             did not supply a merchant_id, the google pay sheet will be raised \
+                             without one"
+                        );
+                        None
+                    }
+                }
             }
-
-            common_merchant_id
-        } else {
-            None
-        }
-    })
-}
-
-/// Gateway identifier of Hyperswitch's own Google Pay gateway registration.
-fn google_pay_gateway_id(state: &routes::SessionState) -> Option<String> {
-    state
-        .conf
-        .google_pay_decrypt_keys
-        .as_ref()
-        .and_then(|google_pay_keys| google_pay_keys.get_inner().google_pay_gateway_id.clone())
+            payment_types::GooglePayTokenizationType::Direct
+            | payment_types::GooglePayTokenizationType::PaymentGateway => None,
+        },
+    }
 }
 
 fn construct_stripe_publishable_key(

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -1152,11 +1152,16 @@ async fn create_gpay_session_token(
                 provider_details.clone();
 
             let gpay_allowed_payment_methods = get_allowed_payment_methods_from_cards(
+                state,
+                &router_data.merchant_id,
                 cards,
                 &gpay_info.merchant_info.tokenization_specification,
                 is_billing_details_required,
                 wallet_blocking_config,
             )?;
+
+            let google_pay_merchant_id =
+                resolve_google_pay_merchant_id(state, &gpay_info.merchant_info);
 
             Ok(types::PaymentsSessionRouterData {
                 response: Ok(types::PaymentsResponseData::SessionResponse {
@@ -1165,7 +1170,7 @@ async fn create_gpay_session_token(
                             payment_types::GooglePaySessionResponse {
                                 merchant_info: payment_types::GpayMerchantInfo {
                                     merchant_name: gpay_info.merchant_info.merchant_name,
-                                    merchant_id: gpay_info.merchant_info.merchant_id,
+                                    merchant_id: google_pay_merchant_id,
                                 },
                                 allowed_payment_methods: vec![gpay_allowed_payment_methods],
                                 transaction_info,
@@ -1302,6 +1307,8 @@ async fn create_gpay_session_token(
 pub(crate) const CARD: &str = "CARD";
 
 fn get_allowed_payment_methods_from_cards(
+    state: &routes::SessionState,
+    merchant_id: &common_utils::id_type::MerchantId,
     gpay_cards: payment_types::GpayAllowedMethodsParameters,
     gpay_token_specific_data: &payment_types::GooglePayTokenizationSpecification,
     is_billing_details_required: bool,
@@ -1313,13 +1320,13 @@ fn get_allowed_payment_methods_from_cards(
             format: payment_types::GpayBillingAddressFormat::FULL,
         });
 
-    let protocol_version: Option<String> = gpay_token_specific_data
-        .parameters
-        .public_key
-        .as_ref()
-        .map(|_| PROTOCOL.to_string());
-
     let allow_credit_cards = get_google_pay_card_type_restrictions(wallet_blocking_config);
+
+    let tokenization_specification = resolve_google_pay_tokenization_specification(
+        state,
+        merchant_id,
+        gpay_token_specific_data,
+    )?;
 
     Ok(payment_types::GpayAllowedPaymentMethods {
         parameters: payment_types::GpayAllowedMethodsParameters {
@@ -1329,30 +1336,136 @@ fn get_allowed_payment_methods_from_cards(
             ..gpay_cards
         },
         payment_method_type: CARD.to_string(),
-        tokenization_specification: payment_types::GpayTokenizationSpecification {
-            token_specification_type: gpay_token_specific_data.tokenization_type.to_string(),
-            parameters: payment_types::GpayTokenParameters {
-                protocol_version,
-                public_key: gpay_token_specific_data.parameters.public_key.clone(),
-                gateway: gpay_token_specific_data.parameters.gateway.clone(),
-                gateway_merchant_id: gpay_token_specific_data
-                    .parameters
-                    .gateway_merchant_id
-                    .clone()
-                    .expose_option(),
-                stripe_publishable_key: gpay_token_specific_data
-                    .parameters
-                    .stripe_publishable_key
-                    .clone()
-                    .expose_option(),
-                stripe_version: gpay_token_specific_data
-                    .parameters
-                    .stripe_version
-                    .clone()
-                    .expose_option(),
-            },
-        },
+        tokenization_specification,
     })
+}
+
+/// Resolve the tokenization specification that is sent to the Google Pay SDK.
+///
+/// `INTERNAL_GATEWAY` is a Hyperswitch internal marker and is not a tokenization type Google
+/// understands, so it is resolved here into a `PAYMENT_GATEWAY` specification pointing at
+/// Hyperswitch's own registered gateway. The card is then encrypted to a key we hold, which is
+/// what lets the merchant onboard without registering a keypair of its own.
+///
+/// `DIRECT` and `PAYMENT_GATEWAY` are passed through exactly as the merchant configured them.
+fn resolve_google_pay_tokenization_specification(
+    state: &routes::SessionState,
+    merchant_id: &common_utils::id_type::MerchantId,
+    gpay_token_specific_data: &payment_types::GooglePayTokenizationSpecification,
+) -> RouterResult<payment_types::GpayTokenizationSpecification> {
+    match gpay_token_specific_data.tokenization_type {
+        payment_types::GooglePayTokenizationType::InternalGateway => {
+            // A missing gateway id is a hard error rather than a silent skip: the SDK would
+            // otherwise raise a payment sheet whose token nothing can decrypt.
+            let gateway = google_pay_gateway_id(state)
+                .ok_or(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable(
+                    "google_pay_decrypt_keys.google_pay_gateway_id is not configured, cannot \
+                     serve an INTERNAL_GATEWAY google pay session",
+                )?;
+
+            Ok(payment_types::GpayTokenizationSpecification {
+                token_specification_type: payment_types::GooglePayTokenizationType::PaymentGateway
+                    .to_string(),
+                parameters: payment_types::GpayTokenParameters {
+                    gateway: Some(gateway),
+                    // The Hyperswitch merchant id keeps each merchant individually identifiable
+                    // in the token, which a fixed constant would not.
+                    gateway_merchant_id: Some(merchant_id.get_string_repr().to_owned()),
+                    // A gateway specification carries no public key, and therefore no protocol
+                    // version.
+                    protocol_version: None,
+                    public_key: None,
+                    stripe_publishable_key: None,
+                    stripe_version: None,
+                },
+            })
+        }
+        payment_types::GooglePayTokenizationType::Direct
+        | payment_types::GooglePayTokenizationType::PaymentGateway => {
+            let protocol_version: Option<String> = gpay_token_specific_data
+                .parameters
+                .public_key
+                .as_ref()
+                .map(|_| PROTOCOL.to_string());
+
+            Ok(payment_types::GpayTokenizationSpecification {
+                token_specification_type: gpay_token_specific_data.tokenization_type.to_string(),
+                parameters: payment_types::GpayTokenParameters {
+                    protocol_version,
+                    public_key: gpay_token_specific_data.parameters.public_key.clone(),
+                    gateway: gpay_token_specific_data.parameters.gateway.clone(),
+                    gateway_merchant_id: gpay_token_specific_data
+                        .parameters
+                        .gateway_merchant_id
+                        .clone()
+                        .expose_option(),
+                    stripe_publishable_key: gpay_token_specific_data
+                        .parameters
+                        .stripe_publishable_key
+                        .clone()
+                        .expose_option(),
+                    stripe_version: gpay_token_specific_data
+                        .parameters
+                        .stripe_version
+                        .clone()
+                        .expose_option(),
+                },
+            })
+        }
+    }
+}
+
+/// Google Pay merchant id sent back to the SDK.
+///
+/// Under `INTERNAL_GATEWAY` the merchant chooses whether to register with the Google Pay Business
+/// Console itself. If it did, its own id is used exactly as under `DIRECT`; if it did not, the
+/// common Hyperswitch merchant id from config is substituted. Both are supported configurations.
+///
+/// Never applied to `DIRECT` or `PAYMENT_GATEWAY`: substituting our merchant id into a merchant's
+/// own integration would change who Google treats as the merchant of record.
+fn resolve_google_pay_merchant_id(
+    state: &routes::SessionState,
+    merchant_info: &payment_types::GooglePayMerchantInfo,
+) -> Option<String> {
+    merchant_info.merchant_id.clone().or_else(|| {
+        if matches!(
+            merchant_info.tokenization_specification.tokenization_type,
+            payment_types::GooglePayTokenizationType::InternalGateway
+        ) {
+            let common_merchant_id = state
+                .conf
+                .google_pay_decrypt_keys
+                .as_ref()
+                .and_then(|google_pay_keys| {
+                    google_pay_keys
+                        .get_inner()
+                        .google_pay_common_merchant_id
+                        .clone()
+                })
+                .map(|merchant_id| merchant_id.expose());
+
+            if common_merchant_id.is_none() {
+                logger::warn!(
+                    "google_pay_common_merchant_id is not configured and the merchant did not \
+                     supply a merchant_id, the google pay sheet will be raised without one"
+                );
+            }
+
+            common_merchant_id
+        } else {
+            None
+        }
+    })
+}
+
+/// Gateway identifier of Hyperswitch's own Google Pay gateway registration.
+fn google_pay_gateway_id(state: &routes::SessionState) -> Option<String> {
+    state
+        .conf
+        .google_pay_decrypt_keys
+        .as_ref()
+        .and_then(|google_pay_keys| google_pay_keys.get_inner().google_pay_gateway_id.clone())
 }
 
 fn construct_stripe_publishable_key(

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -7352,8 +7352,9 @@ pub struct GooglePayTokenDecryptor {
     root_signing_keys: Vec<GooglePayRootSigningKey>,
     recipient_id: hyperswitch_masking::Secret<String>,
     private_key: PKey<openssl::pkey::Private>,
-    /// Tokenization type the merchant configured on its MCA. `INTERNAL_GATEWAY` tokens are
-    /// verified unconditionally; every other type keeps today's behaviour.
+    /// Tokenization type the merchant configured on its MCA. `INTERNAL_GATEWAY` tokens get the
+    /// additional `gatewayMerchantId` check after decryption; every other type keeps today's
+    /// behaviour.
     tokenization_type: api_models::payments::GooglePayTokenizationType,
     /// Hyperswitch merchant id that was sent to Google as `gateway_merchant_id`. Set for
     /// `INTERNAL_GATEWAY` only, and checked against the decrypted token.

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -7352,6 +7352,12 @@ pub struct GooglePayTokenDecryptor {
     root_signing_keys: Vec<GooglePayRootSigningKey>,
     recipient_id: hyperswitch_masking::Secret<String>,
     private_key: PKey<openssl::pkey::Private>,
+    /// Tokenization type the merchant configured on its MCA. `INTERNAL_GATEWAY` tokens are
+    /// verified unconditionally; every other type keeps today's behaviour.
+    tokenization_type: api_models::payments::GooglePayTokenizationType,
+    /// Hyperswitch merchant id that was sent to Google as `gateway_merchant_id`. Set for
+    /// `INTERNAL_GATEWAY` only, and checked against the decrypted token.
+    gateway_merchant_id: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -7459,6 +7465,8 @@ impl GooglePayTokenDecryptor {
         root_keys: hyperswitch_masking::Secret<String>,
         recipient_id: hyperswitch_masking::Secret<String>,
         private_key: hyperswitch_masking::Secret<String>,
+        tokenization_type: api_models::payments::GooglePayTokenizationType,
+        gateway_merchant_id: Option<String>,
     ) -> CustomResult<Self, errors::GooglePayDecryptionError> {
         // base64 decode the private key
         let decoded_key = BASE64_ENGINE
@@ -7485,6 +7493,8 @@ impl GooglePayTokenDecryptor {
             root_signing_keys: filtered_root_signing_keys,
             recipient_id,
             private_key,
+            tokenization_type,
+            gateway_merchant_id,
         })
     }
 
@@ -7502,7 +7512,6 @@ impl GooglePayTokenDecryptor {
             .parse_struct("EncryptedData")
             .change_context(errors::GooglePayDecryptionError::DeserializationFailed)?;
 
-        // verify the signature if required
         if should_verify_signature {
             self.verify_signature(&encrypted_data)?;
         }
@@ -7532,6 +7541,16 @@ impl GooglePayTokenDecryptor {
                 .parse_struct("GooglePayPredecryptDataInternal")
                 .change_context(errors::GooglePayDecryptionError::DeserializationFailed)?;
 
+        // `gatewayMerchantId` only exists once the message is decrypted, so this half of the
+        // INTERNAL_GATEWAY verification necessarily runs here rather than alongside the signature
+        // checks above.
+        if matches!(
+            self.tokenization_type,
+            api_models::payments::GooglePayTokenizationType::InternalGateway
+        ) {
+            self.verify_internal_gateway_merchant_id(&decrypted_data)?;
+        }
+
         // check the expiration date of the decrypted data
 
         if matches!(
@@ -7544,6 +7563,44 @@ impl GooglePayTokenDecryptor {
         }
     }
 
+    /// Check that the decrypted token was minted for the merchant now being paid.
+    ///
+    /// Under `INTERNAL_GATEWAY` every merchant's card is encrypted to the same gateway key, so the
+    /// key alone no longer separates one merchant from another. `gateway_merchant_id` is what
+    /// does: Google echoes back the Hyperswitch merchant id that was sent in the session response,
+    /// and a mismatch means the token belongs to a different merchant's payment.
+    fn verify_internal_gateway_merchant_id(
+        &self,
+        decrypted_data: &hyperswitch_domain_models::router_data::GooglePayPredecryptDataInternal,
+    ) -> CustomResult<(), errors::GooglePayDecryptionError> {
+        let expected_gateway_merchant_id = self
+            .gateway_merchant_id
+            .as_ref()
+            .ok_or(errors::GooglePayDecryptionError::InvalidGatewayMerchantId)
+            .attach_printable(
+                "gateway merchant id is not set on the decryptor for an INTERNAL_GATEWAY token",
+            )?;
+
+        let token_gateway_merchant_id = decrypted_data
+            .gateway_merchant_id
+            .as_ref()
+            .ok_or(errors::GooglePayDecryptionError::InvalidGatewayMerchantId)
+            .attach_printable(
+                "decrypted INTERNAL_GATEWAY token does not carry a gateway merchant id",
+            )?;
+
+        if token_gateway_merchant_id != expected_gateway_merchant_id {
+            logger::warn!(
+                expected_gateway_merchant_id,
+                token_gateway_merchant_id,
+                "gateway merchant id in the token does not match the merchant"
+            );
+            Err(errors::GooglePayDecryptionError::InvalidGatewayMerchantId)
+                .attach_printable("gateway merchant id in the token does not match the merchant")?;
+        }
+
+        Ok(())
+    }
     // Verify the signature of the token
     fn verify_signature(
         &self,

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -3,9 +3,9 @@ use std::{collections::HashMap, str::FromStr};
 use api_models::payments::{
     AdditionalCardInfo, AdditionalPaymentData, AmountInfo, ApplePayAddressParameters,
     ApplePayPaymentRequest, ApplePaySessionResponse, ApplepaySessionTokenResponse,
-    GooglePaySessionResponse, GpayAllowedMethodsParameters, GpayAllowedPaymentMethods,
-    GpayBillingAddressFormat, GpayBillingAddressParameters, GpayMerchantInfo,
-    GpaySessionTokenResponse, GpayShippingAddressParameters, GpayTokenParameters,
+    GooglePaySessionResponse, GooglePayTokenizationSpecificationType, GpayAllowedMethodsParameters,
+    GpayAllowedPaymentMethods, GpayBillingAddressFormat, GpayBillingAddressParameters,
+    GpayMerchantInfo, GpaySessionTokenResponse, GpayShippingAddressParameters, GpayTokenParameters,
     GpayTokenizationSpecification, GpayTransactionInfo, NextActionCall, PaypalFlow,
     PaypalSessionTokenResponse, PaypalTransactionInfo, RecipientAccount, RecipientBankAccount,
     RecipientDetails, SdkNextAction, SecretInfoToInitiateSdk, SessionToken,
@@ -7098,7 +7098,11 @@ impl transformers::ForeignTryFrom<payments_grpc::GpayTokenizationSpecification>
         value: payments_grpc::GpayTokenizationSpecification,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            token_specification_type: value.token_specification_type,
+            token_specification_type: GooglePayTokenizationSpecificationType::from_str(
+                &value.token_specification_type,
+            )
+            .change_context(UnifiedConnectorServiceError::ParsingFailed)
+            .attach_printable("invalid gpay token_specification_type received from ucs")?,
             parameters: value
                 .parameters
                 .map(GpayTokenParameters::foreign_try_from)

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -219,6 +219,13 @@ impl SessionState {
             request_id: self.request_id.as_ref().map(|req_id| req_id.to_string()),
         }
     }
+    /// Gateway identifier of Hyperswitch's own Google Pay gateway registration.
+    pub fn google_pay_gateway_id(&self) -> Option<String> {
+        self.conf
+            .google_pay_decrypt_keys
+            .as_ref()
+            .and_then(|google_pay_keys| google_pay_keys.get_inner().google_pay_gateway_id.clone())
+    }
 }
 
 pub trait SessionStateInfo {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds a third Google Pay tokenization type — **`INTERNAL_GATEWAY`** — for the simplified Google Pay flow.

Today, a merchant that wants Hyperswitch to decrypt Google Pay tokens must generate its own EC P-256 keypair, register the public key in the Google Pay Business Console, and paste both halves into the MCA (`tokenization_specification.type = "DIRECT"`). Hyperswitch/Juspay is already a registered Google Pay gateway, so with this PR a merchant onboards with **no key material at all**: Google encrypts the card to Hyperswitch's gateway key and Hyperswitch decrypts it server-side with a private key held in application config.

This is still the gateway tokenization model — to Google the card is encrypted exactly as it would be for any `PAYMENT_GATEWAY` integration. The difference from a normal gateway flow is **who decrypts**: in a regular `PAYMENT_GATEWAY` setup the token is encrypted to the gateway's key and the gateway/connector decrypts it, so Hyperswitch never sees the card. Here the gateway (Juspay, as the Google Pay registered gateway) **agrees to share its gateway private key directly with us**, and we hold that key in application config (`google_pay_decrypt_keys.google_pay_private_key`) and decrypt the token ourselves. That shared key is what makes the whole flow possible: the merchant registers nothing with Google, yet Hyperswitch can still decrypt and forward the decrypted PAN to any connector.

How it works:

- **MCA** — the merchant sets `connector_wallets_details.google_pay.provider_details.merchant_info.tokenization_specification.type = "INTERNAL_GATEWAY"` and supplies no `parameters` at all (`parameters` is now `#[serde(default)]`). `merchant_info.merchant_id` stays optional.
- **Session flow** (`session_flow.rs`) — `INTERNAL_GATEWAY` is a Hyperswitch-internal marker Google does not understand, so it is resolved to `PAYMENT_GATEWAY` before being sent to the SDK, with `parameters.gateway` from `google_pay_decrypt_keys.google_pay_gateway_id` and `parameters.gateway_merchant_id` = the **Hyperswitch merchant id** (keeps each merchant individually identifiable in the token). A missing `google_pay_gateway_id` here is a hard error, not a silent skip. `merchant_info.merchant_id` falls back to `google_pay_decrypt_keys.google_pay_common_merchant_id` only when the MCA omits it — and only for `INTERNAL_GATEWAY`; `DIRECT` / `PAYMENT_GATEWAY` pass through unchanged.
- **Confirm / decrypt flow** (`payments.rs`, `helpers.rs`) — for `INTERNAL_GATEWAY` the private key is sourced from `google_pay_decrypt_keys.google_pay_private_key` and the recipient is derived as `gateway:<google_pay_gateway_id>`. After decryption, the `gatewayMerchantId` embedded in the token payload (`GooglePayPredecryptDataInternal.gateway_merchant_id`) is checked against the merchant being paid: since every `INTERNAL_GATEWAY` merchant's card is encrypted to the same gateway key, this field is what prevents one merchant's token from being replayed against another merchant's payment. A mismatch fails with `IR_06` ("gateway merchant id in the token does not match the gateway merchant id configured for the merchant") as an **invalid request**, not a connector authorization failure, because authorization was never attempted. `DIRECT` behaviour is untouched (merchant-typed `recipient_id` remains unverified, as today).
- **Config** — `google_pay_decrypt_keys` moves behind the secrets manager (`SecretStateContainer`, mirroring `paze_decrypt_keys`) so the private key can be KMS-encrypted at rest, and gains three new optional fields: `google_pay_private_key`, `google_pay_common_merchant_id`, `google_pay_gateway_id`. Only the private key is fetched via the secret management client; the root signing keys are Google's public certificates and the gateway id / common merchant id are plain identifiers.

### What the `google_pay_private_key` looks like

It is **base64 of the PKCS#8 DER of an EC P-256 (`prime256v1`) private key** — not PEM text, and not the SEC1 `-----BEGIN EC PRIVATE KEY-----` format (which `PKey::private_key_from_pkcs8` cannot parse).

- 138 bytes of DER → **184 base64 characters**
- Always starts with `MIGHAgEAMBMGByqGSM49...`

Generate it with:

```bash
openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out private-key.pem
openssl pkey -in private-key.pem -outform DER | base64 | tr -d '\n'
```

Example value:

```
MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgAznzgfBuGqIodoCwvX7Lq5kiuYEdrtaGP922AhXKh+mhRANCAAScY/g5Niz0Qb0ZKzejCdHP5fgI+OoTjQBwvUixb0g6wRQm2DxZ1VN50W3kisAqFW7v8aFGPUuBBxw8yaiSM88l
```

Do not confuse it with the other two base64 values in this flow — all three are different encodings:

| Value | Underlying bytes | Length (P-256) | Starts with |
|---|---|---|---|
| `google_pay_private_key` | PKCS#8 DER | 138 bytes → 184 chars | `MIGHAgEAMBMGByqGSM49...` |
| Google Pay public key | 65-byte uncompressed EC point | 65 bytes → 88 chars | `B` (first byte is `0x04`) |
| `google_pay_root_signing_keys` | JSON array text (ECv2 entries only) | varies | `W3si` (`[{"`) |

Recognize the key formats at a glance (the most common setup failure is pasting the right key in the wrong container):

```
-----BEGIN PRIVATE KEY-----          → PKCS#8 PEM           ✗ strip the header/footer and unwrap the lines first
-----BEGIN EC PRIVATE KEY-----       → SEC1 PEM             ✗ wrong container — convert to PKCS#8 first (see below)
MIGHAgEAMBMGByqGSM49... (184 chars)  → base64 PKCS#8 DER    ✓ THIS ONE — goes into the config verbatim
MHcCAQEEI... (~160 chars, ends "==") → base64 SEC1 DER      ✗ wrong container
```

Note that PEM and the config value are the **same key** — PEM is just `base64(DER)` plus a `BEGIN/END` wrapper and line wrapping, so PEM → config value is purely mechanical:

```bash
# PEM file → config value
openssl pkey -in private-key.pem -outform DER | base64 | tr -d '\n'

# config value → PEM file (for inspection)
(echo "-----BEGIN PRIVATE KEY-----"; echo "<value>" | fold -w 64; echo "-----END PRIVATE KEY-----") > private-key.pem

# SEC1 PEM → PKCS#8 PEM (if all you have is a BEGIN EC PRIVATE KEY file)
openssl pkcs8 -topk8 -nocrypt -in sec1.pem -out private-key.pem
```

Config validation: `google_pay_private_key`, `google_pay_gateway_id` and `google_pay_common_merchant_id` must either **all be set or all be unset** — the router refuses to boot on a half-configured gateway (see test case 6).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

New keys under `[google_pay_decrypt_keys]` in `config/development.toml`, `config/config.example.toml` and `config/deployments/env_specific.toml`:

```toml
[google_pay_decrypt_keys]
google_pay_root_signing_keys  = "GOOGLE_PAY_ROOT_SIGNING_KEYS" # existing
google_pay_private_key        = "GOOGLE_PAY_PRIVATE_KEY"       # base64 PKCS#8 DER, secret-managed
google_pay_common_merchant_id = "GOOGLE_PAY_COMMON_MERCHANT_ID" # sent to the SDK; not a secret
google_pay_gateway_id         = "GOOGLE_PAY_GATEWAY_ID"        # e.g. "juspay"
```

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Removes Google Pay onboarding friction: a merchant no longer needs to generate an EC P-256 keypair, register it in the Google Pay Business Console, or hold a console merchant id of its own (the common merchant id covers them) to accept Google Pay wallet payments with Hyperswitch-side decryption.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested end-to-end locally against **worldpayxml** with a real ECv2 Google Pay token minted to the `juspay` gateway (Google Pay TEST environment), plus the validation and negative cases below.

### 1. MCA configure — `INTERNAL_GATEWAY` tokenization

#### Request

```json
{
  "connector_type": "payment_processor",
  "connector_name": "worldpayxml",
  "connector_label": "wpg_gpay_juspay",
  "connector_account_details": {
    "auth_type": "SignatureKey",
    "api_key": "BA***************JP",
    "key1": "BA******************************5!",
    "api_secret": "BA***************JP"
  },
  "payment_methods_enabled": [
    {
      "payment_method": "wallet",
      "payment_method_types": [
        {
          "payment_method_type": "google_pay",
          "payment_experience": "invoke_sdk_client",
          "recurring_enabled": true,
          "installment_payment_enabled": false
        }
      ]
    }
  ],
  "metadata": {
    "issuer_id": "62971bc290eda8063b9e2e2a",
    "google_pay": {
      "support_predecrypted_token": true
    },
    "jwt_mac_key": "2a5350bf-0ba2-49dc-a4cc-521a4892aab7",
    "organizational_unit_id": "62971bc29905261be9e5a808"
  },
  "test_mode": true,
  "connector_wallets_details": {
    "google_pay": {
      "provider_details": {
        "merchant_info": {
          "merchant_name": "Contoso Retail",
          "merchant_id": "TESTMERCHNATID",
          "tokenization_specification": {
            "type": "INTERNAL_GATEWAY"
          }
        }
      },
      "cards": {
        "allowed_auth_methods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
        "allowed_card_networks": ["AMEX", "DISCOVER", "JCB", "MASTERCARD", "VISA"]
      },
      "support_predecrypted_token": true
    }
  }
}
```

#### Response — `200 OK`, MCA created with the same `connector_wallets_details` echoed back

```json
{
  "connector_type": "payment_processor",
  "connector_name": "worldpayxml",
  "connector_label": "wpg_gpay_juspay",
  "merchant_connector_id": "mca_TxRu2hmp573AU2GPvCRc",
  "profile_id": "pro_HYFzKcNO1Td0bGmfCzOK",
  "status": "active",
  "metadata": {
    "issuer_id": "62971bc290eda8063b9e2e2a",
    "google_pay": {
      "support_predecrypted_token": true
    },
    "jwt_mac_key": "2a5350bf-0ba2-49dc-a4cc-521a4892aab7",
    "organizational_unit_id": "62971bc29905261be9e5a808"
  },
  "connector_wallets_details": {
    "google_pay": {
      "provider_details": {
        "merchant_info": {
          "merchant_name": "Contoso Retail",
          "merchant_id": "TESTMERCHNATID",
          "tokenization_specification": {
            "type": "INTERNAL_GATEWAY"
          }
        }
      },
      "cards": {
        "allowed_auth_methods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
        "allowed_card_networks": ["AMEX", "DISCOVER", "JCB", "MASTERCARD", "VISA"]
      },
      "support_predecrypted_token": true
    }
  }
}
```

### 2. Create payment intent

```json
{
  "amount": 123,
  "customer_id": "{{customer_id}}",
  "currency": "EUR",
  "connector": ["worldpayxml"],
  "confirm": false,
  "capture_method": "automatic",
  "description": "hellow world",
  "email": "guest@example.com",
  "name": "fsad",
  "billing": {
    "address": {
      "zip": "560095",
      "country": "AF",
      "first_name": "Sakil",
      "last_name": "Mostak",
      "line1": "Fasdf",
      "line2": "Fasdf",
      "city": "Fasdf"
    }
  },
  "browser_info": {
    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
    "ip_address": "192.168.1.1",
    "java_enabled": false,
    "java_script_enabled": true,
    "language": "en-US",
    "color_depth": 24,
    "screen_height": 1080,
    "screen_width": 1920,
    "time_zone": 330,
    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
  }
}
```

### 3. Session token — `INTERNAL_GATEWAY` resolved to `PAYMENT_GATEWAY`

The SDK receives `type: "PAYMENT_GATEWAY"` with `gateway: "juspay"` (from env config) and `gateway_merchant_id` = the Hyperswitch merchant id — never the literal `INTERNAL_GATEWAY`:

```json
{
    "payment_id": "pay_6j7NVELPVNZhqSRvFAdw",
    "client_secret": "pay_6j7NVELPVNZhqSRvFAdw_secret_6ZBnQbCdInOpXQS4IkhW",
    "session_token": [
        {
            "wallet_name": "google_pay",
            "merchant_info": {
                "merchant_id": "TESTMERCHNATID",
                "merchant_name": "Contoso Retail"
            },
            "shipping_address_required": false,
            "email_required": false,
            "shipping_address_parameters": {
                "phone_number_required": false
            },
            "allowed_payment_methods": [
                {
                    "type": "CARD",
                    "parameters": {
                        "allowed_auth_methods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
                        "allowed_card_networks": ["AMEX", "DISCOVER", "JCB", "MASTERCARD", "VISA"],
                        "billing_address_required": false
                    },
                    "tokenization_specification": {
                        "type": "PAYMENT_GATEWAY",
                        "parameters": {
                            "gateway": "juspay",
                            "gateway_merchant_id": "merchant_1789023090" // merchant id of hyperswitch
                        }
                    }
                }
            ],
            "transaction_info": {
                "country_code": "AF",
                "currency_code": "EUR",
                "total_price_status": "Final",
                "total_price": "1.23"
            },
            "delayed_session_token": false,
            "connector": "worldpayxml",
            "sdk_next_action": {
                "next_action": "confirm",
                "should_block_confirm": null
            },
            "secrets": null
        }
    ],
    "vault_details": null
}
```

Note there is **no** `public_key` and **no** `protocol_version` — correct for a gateway specification.

### 4. Payment confirm with a real Google Pay token — success

Token minted from the Google Pay sheet (TEST environment) with this configuration:

| Field | Value |
|---|---|
| Tokenization | `PAYMENT_GATEWAY` |
| `recipient_id` | `gateway:juspay` |
| `gateway` | `juspay` |
| `gatewayMerchantId` | `merchant_1789023090` (the Hyperswitch merchant id) |

#### Request

```json
{
    "amount": 123,
    "customer_id": "{{customer_id}}",
    "currency": "EUR",
    "connector": ["worldpayxml"],
    "confirm": true,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_type": "google_pay",
    "description": "hellow world",
    "authentication_type": "no_three_ds",
    "email": "guest@example.com",
    "name": "fsad",
    "billing": {
        "address": {
            "zip": "560095",
            "country": "US",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf"
        }
    },
    "payment_method_data": {
        "wallet": {
            "google_pay": {
                "description": "Test Card: Visa  •••• 1111",
                "info": {
                    "assurance_details": {
                        "account_verified": true,
                        "card_holder_authenticated": true
                    },
                    "card_details": "1111",
                    "card_funding_source": "CREDIT",
                    "card_network": "VISA"
                },
                "tokenization_data": {
                    "token": "{\"signature\":\"MEUCIQCV8mLG/LFwENmHwEFXfYvRihEciiNI6bY+mkMPeOfjoAIgcglLUhjEtPE6tJMRYm3we1AS5jUWWiBvUZIufTFn42s\\u003d\",\"intermediateSigningKey\":{\"signedKey\":\"{\\\"keyValue\\\":\\\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQBmm7C/X3a4gFozrd/ygvHE/y87Q0LFVzN+say7mOM6swT2slfqVTKSQeSZHKYtl2rlLF0TaQXseb+eqWGc7Ww\\\\u003d\\\\u003d\\\",\\\"keyExpiration\\\":\\\"1789682658674\\\"}\",\"signatures\":[\"MEQCIGgr77CsbAPuvkCkRJXGPdyJBDTsq9CvOykuOyzS0pxSAiAE0PAaedWDZgTtNDaVHfX6S1kSbXFj6jb4fJc1IaTvrw\\u003d\\u003d\"]},\"protocolVersion\":\"ECv2\",\"signedMessage\":\"{\\\"encryptedMessage\\\":\\\"H2GGRONh8KsMW8BF0vz6DLnsi/mIqQNTtVC+IFofCx32J/BCkodZP7yK9YNEtZ84Ur7ztm4gtRNZMvEWqaewPGYcHLQV66sigaeJEIGG5GC/W3c7Fw31L6/ROY056jD7hEhOwNlSEa4ofPSr711gb8o6/tA1d45Cq/qllmkbtMsRpG5g+jEyvdcvgYhb8yv4ioKQq8OeVWb/O3Vt2WQjz+3kvPCipVyUE0X8nxDsFwBmKb7AOB1Il3Tj0FHQVOpAioxJCfpCHj0XVJq6aBsnwBg5+8NreO9RAE2gn7+5yYg9EPw7vFSCq83gy9Jhj+83GJBt5N5EAuKLK/dSZKqVRXFvkR0IxqaEg6c4BhsnTJx88JfsexC+U6ZwMKzN+TgrXr79Xtj3xW1xYpePxqljy3o+GlWSljY3WJJLP9ZuJGWMek4n9wXwSzCw6IuKJwXW32enNyb43MFhYBathZNUVCUoUoDoSBx3m7htgk6OFIU7+8UqihyMEtQ82Nfsn6+irdtNFJQ5AC83X1Jy+5fXlrtx5hxlH/6xHyKUmKNcK8Vamy6Kybi/WymCPeqJWiZEVigAA7O7yX6qIprI4b8FhYKP5Jn/ddw6hEA\\\\u003d\\\",\\\"ephemeralPublicKey\\\":\\\"BOq+DMS7UjZahRMbjhSkcuQJRhp9P6nPB2llSAaG+b1WZK+VfyDcyAD3BcXUpULfz97WzlIHQQfZTb7AHyYVk2s\\\\u003d\\\",\\\"tag\\\":\\\"L8VHoD8sLP0mE4eLcH/AV8iEJjLuNusiE47W2+6i2kE\\\\u003d\\\"}\"}",
                    "type": "DIRECT"
                },
                "type": "CARD"
            }
        }
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    }
}
```

#### Response — `status: "succeeded"` (trimmed to relevant fields)

```json
{
    "payment_id": "pay_NiYEFtxfD8VtczLHGLmO",
    "merchant_id": "merchant_1789023090",
    "status": "succeeded",
    "amount": 123,
    "net_amount": 123,
    "amount_received": 123,
    "connector": "worldpayxml",
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_type": "google_pay",
    "authentication_type": "no_three_ds",
    "currency": "EUR",
    "connector_transaction_id": "pay_NiYEFtxfD8VtczLHGLmO_1",
    "payment_method_data": {
        "wallet": {
            "google_pay": {
                "last4": "1111",
                "card_network": "VISA",
                "type": "CARD",
                "card_exp_month": "12",
                "card_exp_year": "2028",
                "auth_code": "755365",
                "email": null
            }
        },
        "billing": null
    }
}
```

The token was decrypted server-side with `google_pay_private_key` from env config, and the decrypted card data was forwarded to the connector — raw connector request:

```
Object {"@version": String("1.4"), "@merchantCode": String("*** alloc::string::String ***"), "submit": Object {"order": Object {"@orderCode": String("pay_NiYEFtxfD8VtczLHGLmO_1"), "@captureDelay": String("0"), "description": String("hellow world"), "amount": Object {"@value": String("123"), "@currencyCode": String("EUR"), "@exponent": String("2")}, "paymentDetails": Object {"@action": String("SALE"), "CARD-SSL": Object {"cardNumber": String("411111**********"), "expiryDate": Object {"date": Object {"@month": String("*** alloc::string::String ***"), "@year": String("*** alloc::string::String ***")}}, "cardHolderName": String("*** alloc::string::String ***")}}, "shopper": Object {"shopperEmailAddress": String("*****@example.com"), "authenticatedShopperID": String("*** alloc::string::String ***"), "browser": Object {"acceptHeader": String("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"), "userAgentHeader": String("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"), "timeZone": Number(330), "browserLanguage": String("en-US"), "browserJavaEnabled": Bool(false), "browserJavaScriptEnabled": Bool(true), "browserColourDepth": Number(24), "browserScreenHeight": Number(1080), "browserScreenWidth": Number(1920)}}, "billingAddress": Object {"address": Object {"firstName": String("*** alloc::string::String ***"), "lastName": String("*** alloc::string::String ***"), "address1": String("*** alloc::string::String ***"), "address2": String("*** alloc::string::String ***"), "address3": String("*** alloc::string::String ***"), "postalCode": String("*** alloc::string::String ***"), "city": String("Fasdf"), "countryCode": String("US")}}}}}
```

### 5. Validation — a token minted for a different `gatewayMerchantId` is rejected

Same sheet, but the Google Pay token was generated with `gatewayMerchantId: "merchant_XXXXXXX"` instead of the merchant being paid (`merchant_1789023090`). Origin-of-merchant validation kicks in:

```json
{
    "error": {
        "type": "invalid_request",
        "message": "Failed to decrypt the Google Pay token: gateway merchant id in the token does not match the gateway merchant id configured for the merchant",
        "code": "IR_06"
    }
}
```

### 6. Config validation — the router refuses to boot on a half-configured gateway

`google_pay_private_key` set without `google_pay_gateway_id` / `google_pay_common_merchant_id`:

```
thread 'main' panicked at crates/router/src/bin/router.rs:28:10:
Failed to validate router configuration: Invalid configuration value provided: google_pay_private_key, google_pay_gateway_id and google_pay_common_merchant_id must either all be set or all be unset; missing: google_pay_gateway_id, google_pay_common_merchant_id
╰╴at crates/router/src/configs/settings.rs:1599:9
```

### 7. `merchant_id` is not mandatory on the MCA

MCA created with `merchant_info.merchant_id` omitted (only `merchant_name` + `tokenization_specification.type = "INTERNAL_GATEWAY"`) is accepted. The session response then substitutes the common merchant id from env config (`google_pay_common_merchant_id`) into `merchant_info.merchant_id`, while `gateway_merchant_id` remains the Hyperswitch merchant id:

```json
{
    "wallet_name": "google_pay",
    "merchant_info": {
        "merchant_id": "testMerchantid", // common gateway merchant id from env
        "merchant_name": "Contoso Retail"
    },
    "allowed_payment_methods": [
        {
            "type": "CARD",
            "tokenization_specification": {
                "type": "PAYMENT_GATEWAY",
                "parameters": {
                    "gateway": "juspay",
                    "gateway_merchant_id": "merchant_1789023090"
                }
            }
        }
    ],
    "connector": "worldpayxml"
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
