### PR TITLE
fix(wasm): remove router_env dependency from api_models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,6 @@ dependencies = [
  "nutype",
  "reqwest 0.11.27",
  "router_derive",
- "router_env",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -484,6 +483,7 @@ dependencies = [
  "superposition_types",
  "tempfile",
  "time 0.3.41",
+ "tracing",
  "url 2.5.4",
  "utoipa",
 ]

--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -61,9 +61,9 @@ hyperswitch_masking = { version = "0.0.1", default-features = false, features = 
     "time",
 ] }
 router_derive = { version = "0.1.0", path = "../router_derive" }
-router_env = { version = "0.1.0", path = "../router_env" }
 smithy = { version = "0.1.0", path = "../smithy" }
 smithy-core = { version = "0.1.0", path = "../smithy-core" }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -20,7 +20,6 @@ use common_utils::{
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
-use router_env::logger;
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},
     Decimal,
@@ -1962,7 +1961,7 @@ impl TryFrom<PaymentMethodDataWalletInfo> for Box<payments::ApplepayPaymentMetho
                 .to_uppercase()
                 .parse::<api_enums::CardType>()
                 .inspect_err(|error| {
-                    logger::error!(
+                    tracing::warn!(
                         ?error,
                         unparsed_card_type = %card_type,
                         "Received an unrecognized card_type value from Apple Pay; defaulting to None"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Wasm build was failing because router_env was added as a dependency of api_models. router_env was imported for using the logger.  In this PR we replace the logger with  tracing. 

router_env was introduced in the apu_models by a recent PR https://github.com/juspay/hyperswitch/pull/14055


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Build wasm 

```
[INFO]: ✨   Done in 0.70s
[INFO]: 📦   Your wasm pkg is ready to publish at /Users/akshaya.shankar/hyperswitch/wasm.
```

Cargo Build :  Successful

Create a tesuro off_session applepay payment, with wrong applepay.payment_method.type

```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_GShEH47kaciwR9u8lFOIrGdv63vjWL6Tk31K8xdlUYVirZMy9Ha51p0dIsIPjuki' \
--data-raw '{
    "amount": 100,
    "currency": "USD",
    "confirm": true,
    
    
    "capture_method": "automatic",
    "description": "vantiv payment",
    "customer_id": "234389",
    "email": "hello@123.com",
    
    "return_url": "https://google.com",
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "online",
        "accepted_at": "2025-12-30T04:43:34.149Z",
        "online": {
            "ip_address": "10.**.**.**",
            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
        }
    },
    "payment_method": "wallet",
    "payment_method_type": "apple_pay",
    "payment_method_data": {
        "wallet": {
            "apple_pay": {
                "payment_data": {
                    "application_primary_account_number": "4830269090274605",
                    "application_expiration_month": "01",
                    "application_expiration_year": "30",
                    "application_brand": "VISA",
                    "payment_data": {
                        "online_payment_cryptogram": "A+dJ4lIABTuuy82tKyShMAABAAA=",
                        "eci_indicator": "7"
                    }
                },
                "payment_method": {
                    "display_name": "Discover 9319",
                    "network": "Visa",
                    "type": "debitt"
                },
                "transaction_identifier": "c635c5b3af900d7bd81fecd7028f1262f9d030754ee65ec7afd988a678194751"
            }
        }
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    }

    
}'
```

Response

```
{
    "payment_id": "pay_Mqy83EkRo9M7emmb3Sst",
    "merchant_id": "4ce400bc-b6b3-4468-9c00-bfe6051ba747",
    "status": "succeeded",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 100,
    "processor_merchant_id": "4ce400bc-b6b3-4468-9c00-bfe6051ba747",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9faE9GbmQ4NGdzUm9zemxqc1VLRmYscHVibGlzaGFibGVfa2V5PXBrX2Rldl9iN2I2ZDk4YzRiOGQ0MjE3YTY5ZTRmNzhmMzZjNDcyZCxjbGllbnRfc2VjcmV0PXBheV9NcXk4M0VrUm85TTdlbW1iM1NzdF9zZWNyZXRfN1V5WlhpZlV1SzFVTGhwTTlpYTEsY3VzdG9tZXJfaWQ9MjM0Mzg5LGNsaWVudF9zZXNzaW9uX2lkPWNsaWVudF9zZXNzX1R2d0x4dnlXanJjaUN6TmZoV1YyLHBheW1lbnRfaWQ9cGF5X01xeTgzRWtSbzlNN2VtbWIzU3N0",
    "connector": "tesouro",
    "state_metadata": null,
    "client_secret": "pay_Mqy83EkRo9M7emmb3Sst_secret_7UyZXifUuK1ULhpM9ia1",
    "created": "2026-09-10T12:23:19.040Z",
    "modified_at": "2026-09-10T12:23:20.149Z",
    "connector_customer_id": null,
    "currency": "USD",
    "customer_id": "234389",
    "customer": {
        "id": "234389",
        "name": null,
        "email": "hello@123.com",
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": "vantiv payment",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {
            "apple_pay": {
                "type": "debitt",
                "card_network": "Visa",
                "card_type": null,
                "card_subtype": null,
                "card_segment_type": null,
                "funding_source": null,
                "last4": "9319",
                "card_bin": null,
                "device_pan_bin": "483026",
                "card_exp_month": "01",
                "card_exp_year": "30",
                "issuer_name": null,
                "issuer_country": null,
                "auth_code": null,
                "email": null
            }
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "hello@123.com",
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "apple_pay",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "689de47a-ad12-11f1-9709-3bd2017d584c",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_hOFnd84gsRoszljsUKFf",
    "surcharge_details": null,
    "applied_offer": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_JNwFUDQIBBuy8fPVfKaZ",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-09-10T12:38:19.040Z",
    "fingerprint": null,
    "fingerprint_type": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_dxgsclRPAXx3e3AOLwxu",
    "network_transaction_id": null,
    "payment_account_reference": null,
    "network_transaction_link_id": null,
    "payment_method_status": "active",
    "updated": "2026-09-10T12:23:20.149Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "d438328e-b54d-418e-8f04-0fb7bc9d1746",
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "is_account_funded_transaction": null,
    "recipient_details": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_dxgsclRPAXx3e3AOLwxu",
        "payment_method_status": "active",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": null,
        "network_transaction_link_id": null,
        "is_eligible_for_mit_payment": false
    },
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

Then do a MIT

```
{
    "payment_id": "pay_XK5rBYEkh77p662lFJ2y",
    "merchant_id": "4ce400bc-b6b3-4468-9c00-bfe6051ba747",
    "status": "succeeded",
    "amount": 107000,
    "net_amount": 107000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 107000,
    "processor_merchant_id": "4ce400bc-b6b3-4468-9c00-bfe6051ba747",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9faE9GbmQ4NGdzUm9zemxqc1VLRmYscHVibGlzaGFibGVfa2V5PXBrX2Rldl9iN2I2ZDk4YzRiOGQ0MjE3YTY5ZTRmNzhmMzZjNDcyZCxjbGllbnRfc2VjcmV0PXBheV9YSzVyQllFa2g3N3A2NjJsRkoyeV9zZWNyZXRfdEdGVEFVa3F0dVE2RW01elFYREksY3VzdG9tZXJfaWQ9MjM0Mzg5LGNsaWVudF9zZXNzaW9uX2lkPWNsaWVudF9zZXNzX0REdE14d0Q5N01WNW9mcnVnd2xKLHBheW1lbnRfaWQ9cGF5X1hLNXJCWUVraDc3cDY2MmxGSjJ5",
    "connector": "tesouro",
    "state_metadata": null,
    "client_secret": "pay_XK5rBYEkh77p662lFJ2y_secret_tGFTAUkqtuQ6Em5zQXDI",
    "created": "2026-09-10T12:24:23.213Z",
    "modified_at": "2026-09-10T12:24:24.386Z",
    "connector_customer_id": null,
    "currency": "USD",
    "customer_id": "234389",
    "customer": {
        "id": "234389",
        "name": null,
        "email": "hello@123.com",
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": true,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {
            "apple_pay": {
                "type": "debitt",
                "card_network": "Visa",
                "card_type": null,
                "card_subtype": null,
                "card_segment_type": null,
                "funding_source": null,
                "last4": "9319",
                "card_bin": null,
                "device_pan_bin": null,
                "card_exp_month": "01",
                "card_exp_year": "30",
                "issuer_name": null,
                "issuer_country": null,
                "auth_code": null,
                "email": null
            }
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "hello@123.com",
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "apple_pay",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "8eea9c06-ad12-11f1-b55f-3bf51da001dc",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_hOFnd84gsRoszljsUKFf",
    "surcharge_details": null,
    "applied_offer": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_JNwFUDQIBBuy8fPVfKaZ",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-09-10T12:39:23.213Z",
    "fingerprint": null,
    "fingerprint_type": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "13.232.74.226",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_dxgsclRPAXx3e3AOLwxu",
    "network_transaction_id": null,
    "payment_account_reference": null,
    "network_transaction_link_id": null,
    "payment_method_status": "active",
    "updated": "2026-09-10T12:24:24.386Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "d438328e-b54d-418e-8f04-0fb7bc9d1746",
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": true,
    "mit_category": null,
    "billing_descriptor": null,
    "is_account_funded_transaction": null,
    "recipient_details": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_dxgsclRPAXx3e3AOLwxu",
        "payment_method_status": "active",
        "psp_tokenization": true,
        "network_tokenization": false,
        "network_transaction_id": null,
        "network_transaction_link_id": null,
        "is_eligible_for_mit_payment": true
    },
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

Now log returns 

<img width="1444" height="31" alt="Screenshot 2026-09-10 at 5 54 37 PM" src="https://github.com/user-attachments/assets/bd6a2000-6295-48c1-bb38-3f8cb6744d8d" />





## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
