### PR TITLE
feat(observability): evaluate CloudWatch metric alarms and announce transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6542,6 +6542,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "thiserror 1.0.69",
+ "time 0.3.41",
  "tokio 1.48.0",
 ]
 

--- a/config/observability.toml
+++ b/config/observability.toml
@@ -109,3 +109,556 @@ aws_region = ""
 # nowhere.
 [email.destinations.smoke]
 to = "alerts@example.com"
+
+# ---------------------------------------------------------------------------------------------
+# CloudWatch metric alarms.
+#
+# This service evaluates these against CloudWatch every time `POST /alerts/cloudwatch/evaluate` is
+# called, and announces each state transition to the destination its severity maps to. An empty
+# `[cloudwatch.alarms]` turns the whole thing off, and a deployment that only forwards alerts needs
+# no `[cloudwatch]` section at all.
+#
+# **The infrastructure repository owns this catalogue.** Terraform knows the resource identifiers
+# and expands the templated classifications; it renders these definitions and Helm delivers them.
+# Nothing here is discovered, parsed or expanded at runtime — a definition arrives with its
+# dimensions already resolved, and this service's job is to check that what arrived is usable and
+# then evaluate it.
+[cloudwatch]
+region = "ap-south-1"
+
+# Where a failed *evaluation* is reported. Separate from the severity destinations below, because
+# "CloudWatch did not answer" is a fact about this service, not an alert about the database.
+failure_destination = "smoke"
+
+# Where these definitions came from. `temporary = true` makes the service log a warning at every
+# boot, so a hand-checked snapshot announces itself for as long as it is one. The renderer that
+# replaces it fills in the same three fields.
+[cloudwatch.source]
+origin = "hyperswitch-infra.git observability-plane/terraform/aws/live/sandbox/ap-south-1/cloudwatch-alarms/terragrunt.hcl (classification `rds-alerts`)"
+revision = "2851b3d6e6dc2fb09c8bd97caf209d3470f7c273"
+temporary = true
+
+# Three severity ids, all naming one sandbox destination. Routing lives here so that splitting
+# them later is a configuration change rather than a code change.
+#
+# `smoke` accepts messages and delivers nothing (`type = "log"` above), which is what a developer
+# machine should be pointed at. A deployment overrides these with a real destination id:
+#
+#   OBSERVABILITY__CLOUDWATCH__SEVERITY_DESTINATIONS__SEV1=infra_alerts
+[cloudwatch.severity_destinations]
+sev1 = "smoke"
+sev2 = "smoke"
+sev3 = "smoke"
+
+# --- The catalogue -----------------------------------------------------------------------------
+#
+# Twenty definitions, fifty-three severities, twenty distinct CloudWatch queries — severities of
+# one definition differ only by threshold, and a threshold is not part of a query.
+#
+# Field names and defaults are `classified_metric_alarms`' own, so an entry can be checked against
+# its source by eye. What is omitted means what the Terraform module fills in: `statistic` is
+# `Average`, `comparison_operator` is `GreaterThanThreshold`, `treat_missing_data` is
+# `notBreaching`, and `datapoints_to_alarm` defaults to `evaluation_periods`. Note that the
+# module's missing-data default is *not* AWS's (`missing`); it is the module's value that the
+# deployed alarms actually carry.
+#
+# Dimensions come from `dimension_map` in the same source file, resolved:
+#   rds          -> DBClusterIdentifier  = hyperswitchdb-cluster  (database module output)
+#   rds-primary  -> DBInstanceIdentifier = hyperswitchdb-primary  (literal)
+#   rds-failover -> DBInstanceIdentifier = failover-replica-1     (literal)
+#   rds-writer   -> DBClusterIdentifier + Role = WRITER
+#   rds-reader   -> DBClusterIdentifier + Role = READER
+
+[cloudwatch.alarms.rds-primary-cpu]
+classification = "rds-alerts"
+metric_name = "CPUUtilization"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "hyperswitchdb-primary" }]
+
+[cloudwatch.alarms.rds-primary-cpu.severities.sev1]
+threshold = 90.0
+comparison_operator = "GreaterThanOrEqualToThreshold"
+evaluation_periods = 1
+treat_missing_data = "breaching"
+description = "SEV1: RDS primary database CPU utilization is above 90% (Sev0 limit) for 5 minutes. Immediate scaling or database resource optimization is required."
+
+[cloudwatch.alarms.rds-primary-cpu.severities.sev2]
+threshold = 85.0
+comparison_operator = "GreaterThanOrEqualToThreshold"
+evaluation_periods = 1
+description = "SEV2: RDS primary database CPU utilization is above 85% (Critical limit) for 5 minutes. Review slow queries and active database metrics."
+
+[cloudwatch.alarms.rds-primary-cpu.severities.sev3]
+threshold = 65.0
+comparison_operator = "GreaterThanOrEqualToThreshold"
+evaluation_periods = 1
+description = "SEV3: RDS primary database CPU utilization is above 65% (Warning limit) for 5 minutes. Monitor connection patterns and slow queries."
+
+[cloudwatch.alarms.rds-failover-cpu]
+classification = "rds-alerts"
+metric_name = "CPUUtilization"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "failover-replica-1" }]
+
+[cloudwatch.alarms.rds-failover-cpu.severities.sev1]
+threshold = 90.0
+comparison_operator = "GreaterThanOrEqualToThreshold"
+evaluation_periods = 1
+treat_missing_data = "breaching"
+description = "SEV1: RDS failover database CPU utilization is above 90% (Sev0 limit) for 5 minutes. Review replica performance."
+
+[cloudwatch.alarms.rds-failover-cpu.severities.sev2]
+threshold = 85.0
+comparison_operator = "GreaterThanOrEqualToThreshold"
+evaluation_periods = 1
+description = "SEV2: RDS failover database CPU utilization is above 85% (Critical limit) for 5 minutes. High read traffic load detected."
+
+[cloudwatch.alarms.rds-failover-cpu.severities.sev3]
+threshold = 65.0
+comparison_operator = "GreaterThanOrEqualToThreshold"
+evaluation_periods = 1
+description = "SEV3: RDS failover database CPU utilization is above 65% (Warning limit) for 5 minutes. Monitor read query load."
+
+[cloudwatch.alarms.rds-primary-connections]
+classification = "rds-alerts"
+metric_name = "DatabaseConnections"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "hyperswitchdb-primary" }]
+
+[cloudwatch.alarms.rds-primary-connections.severities.sev1]
+threshold = 1620.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS primary database has reached 90% (Sev0 limit) of max backend connections (1,800). Active connections are dangerously high - immediate connection pool review required."
+
+[cloudwatch.alarms.rds-primary-connections.severities.sev2]
+threshold = 1530.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS primary database has reached 85% (Critical limit) of max backend connections (1,800). Check for query locks or connection leaks."
+
+[cloudwatch.alarms.rds-primary-connections.severities.sev3]
+threshold = 1170.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS primary database has reached 65% (Warning limit) of max backend connections (1,800). Monitor connection trends."
+
+[cloudwatch.alarms.rds-failover-connections]
+classification = "rds-alerts"
+metric_name = "DatabaseConnections"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "failover-replica-1" }]
+
+[cloudwatch.alarms.rds-failover-connections.severities.sev1]
+threshold = 3240.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS failover database has reached 90% (Sev0 limit) of max backend connections (3,600). Active connections are dangerously high."
+
+[cloudwatch.alarms.rds-failover-connections.severities.sev2]
+threshold = 3060.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS failover database has reached 85% (Critical limit) of max backend connections (3,600). High connection workload."
+
+[cloudwatch.alarms.rds-failover-connections.severities.sev3]
+threshold = 2340.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS failover database has reached 65% (Warning limit) of max backend connections (3,600). Monitor read scaling performance."
+
+[cloudwatch.alarms.rds-replica-lag]
+classification = "rds-alerts"
+metric_name = "AuroraReplicaLag"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBClusterIdentifier", value = "hyperswitchdb-cluster" }]
+
+[cloudwatch.alarms.rds-replica-lag.severities.sev1]
+threshold = 10000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: Aurora replica lag is above 10 seconds (Sev0 limit). Critical lag detected on read replicas - major read consistency issue."
+
+[cloudwatch.alarms.rds-replica-lag.severities.sev2]
+threshold = 5000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: Aurora replica lag is above 5 seconds (Critical limit). Read replica lag is growing significantly."
+
+[cloudwatch.alarms.rds-replica-lag.severities.sev3]
+threshold = 1000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: Aurora replica lag is above 1 second (Warning limit). Replica sync delay detected."
+
+[cloudwatch.alarms.rds-write-latency]
+classification = "rds-alerts"
+metric_name = "WriteLatency"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBClusterIdentifier", value = "hyperswitchdb-cluster" }]
+
+[cloudwatch.alarms.rds-write-latency.severities.sev1]
+threshold = 0.2
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS write latency is above 200ms. Critical IOPS issues detected."
+
+[cloudwatch.alarms.rds-write-latency.severities.sev2]
+threshold = 0.1
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS write latency is above 100ms. Storage bottlenecks detected."
+
+[cloudwatch.alarms.rds-read-latency]
+classification = "rds-alerts"
+metric_name = "ReadLatency"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBClusterIdentifier", value = "hyperswitchdb-cluster" }]
+
+[cloudwatch.alarms.rds-read-latency.severities.sev1]
+threshold = 0.2
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS read latency is above 200ms. Critical IOPS issues detected."
+
+[cloudwatch.alarms.rds-read-latency.severities.sev2]
+threshold = 0.1
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS read latency is above 100ms. Query optimization required."
+
+[cloudwatch.alarms.rds-deadlocks]
+classification = "rds-alerts"
+metric_name = "Deadlocks"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Sum"
+dimensions = [{ name = "DBClusterIdentifier", value = "hyperswitchdb-cluster" }]
+
+[cloudwatch.alarms.rds-deadlocks.severities.sev1]
+threshold = 50.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 2
+description = "SEV1: RDS cluster has critical deadlock rate. Immediate investigation required."
+
+[cloudwatch.alarms.rds-deadlocks.severities.sev2]
+threshold = 20.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 2
+description = "SEV2: RDS cluster is experiencing high deadlock rate. Review transaction patterns."
+
+[cloudwatch.alarms.rds-primary-freeable-memory]
+classification = "rds-alerts"
+metric_name = "FreeableMemory"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "hyperswitchdb-primary" }]
+
+[cloudwatch.alarms.rds-primary-freeable-memory.severities.sev1]
+threshold = 858993459.0
+comparison_operator = "LessThanOrEqualToThreshold"
+evaluation_periods = 1
+description = "SEV1: RDS primary database freeable memory is below 5% (Sev0 limit) of total memory (16GB). Critical OOM risk."
+
+[cloudwatch.alarms.rds-primary-freeable-memory.severities.sev2]
+threshold = 1717986918.0
+comparison_operator = "LessThanOrEqualToThreshold"
+evaluation_periods = 1
+description = "SEV2: RDS primary database freeable memory is below 10% (Critical limit) of total memory (16GB). Severe memory pressure."
+
+[cloudwatch.alarms.rds-primary-freeable-memory.severities.sev3]
+threshold = 2576980377.0
+comparison_operator = "LessThanOrEqualToThreshold"
+evaluation_periods = 1
+description = "SEV3: RDS primary database freeable memory is below 15% (Warning limit) of total memory (16GB). Monitor memory usage."
+
+[cloudwatch.alarms.rds-failover-freeable-memory]
+classification = "rds-alerts"
+metric_name = "FreeableMemory"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "failover-replica-1" }]
+
+[cloudwatch.alarms.rds-failover-freeable-memory.severities.sev1]
+threshold = 1717986918.0
+comparison_operator = "LessThanOrEqualToThreshold"
+evaluation_periods = 5
+description = "SEV1: RDS failover database freeable memory is below 5% (Sev0 limit) of total memory (32GB). Critical OOM risk."
+
+[cloudwatch.alarms.rds-failover-freeable-memory.severities.sev2]
+threshold = 3435973836.0
+comparison_operator = "LessThanOrEqualToThreshold"
+evaluation_periods = 5
+description = "SEV2: RDS failover database freeable memory is below 10% (Critical limit) of total memory (32GB). Severe memory pressure."
+
+[cloudwatch.alarms.rds-failover-freeable-memory.severities.sev3]
+threshold = 5153960755.0
+comparison_operator = "LessThanOrEqualToThreshold"
+evaluation_periods = 5
+description = "SEV3: RDS failover database freeable memory is below 15% (Warning limit) of total memory (32GB). Monitor memory usage."
+
+[cloudwatch.alarms.rds-primary-read-iops]
+classification = "rds-alerts"
+metric_name = "ReadIOPS"
+namespace = "AWS/RDS"
+period = 300
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "hyperswitchdb-primary" }]
+
+[cloudwatch.alarms.rds-primary-read-iops.severities.sev1]
+threshold = 18000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS primary database Read IOPS is above 18,000 (Sev0 limit). Disk read capacity is saturated."
+
+[cloudwatch.alarms.rds-primary-read-iops.severities.sev2]
+threshold = 17000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS primary database Read IOPS is above 17,000 (Critical limit). Heavy read I/O pressure."
+
+[cloudwatch.alarms.rds-primary-read-iops.severities.sev3]
+threshold = 15000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS primary database Read IOPS is above 15,000 (Warning limit). Elevated read IOPS."
+
+[cloudwatch.alarms.rds-failover-read-iops]
+classification = "rds-alerts"
+metric_name = "ReadIOPS"
+namespace = "AWS/RDS"
+period = 300
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "failover-replica-1" }]
+
+[cloudwatch.alarms.rds-failover-read-iops.severities.sev1]
+threshold = 18000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS failover database Read IOPS is above 18,000 (Sev0 limit). Disk read capacity is saturated."
+
+[cloudwatch.alarms.rds-failover-read-iops.severities.sev2]
+threshold = 17000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS failover database Read IOPS is above 17,000 (Critical limit). Heavy read I/O pressure."
+
+[cloudwatch.alarms.rds-failover-read-iops.severities.sev3]
+threshold = 15000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS failover database Read IOPS is above 15,000 (Warning limit). Elevated read IOPS."
+
+[cloudwatch.alarms.rds-primary-write-iops]
+classification = "rds-alerts"
+metric_name = "WriteIOPS"
+namespace = "AWS/RDS"
+period = 300
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "hyperswitchdb-primary" }]
+
+[cloudwatch.alarms.rds-primary-write-iops.severities.sev1]
+threshold = 18000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS primary database Write IOPS is above 18,000 (Sev0 limit). Disk write capacity is saturated."
+
+[cloudwatch.alarms.rds-primary-write-iops.severities.sev2]
+threshold = 17000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS primary database Write IOPS is above 17,000 (Critical limit). Heavy write I/O pressure."
+
+[cloudwatch.alarms.rds-primary-write-iops.severities.sev3]
+threshold = 15000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS primary database Write IOPS is above 15,000 (Warning limit). Elevated write IOPS."
+
+[cloudwatch.alarms.rds-failover-write-iops]
+classification = "rds-alerts"
+metric_name = "WriteIOPS"
+namespace = "AWS/RDS"
+period = 300
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "failover-replica-1" }]
+
+[cloudwatch.alarms.rds-failover-write-iops.severities.sev1]
+threshold = 18000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS failover database Write IOPS is above 18,000 (Sev0 limit). Disk write capacity is saturated."
+
+[cloudwatch.alarms.rds-failover-write-iops.severities.sev2]
+threshold = 17000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS failover database Write IOPS is above 17,000 (Critical limit). Heavy write I/O pressure."
+
+[cloudwatch.alarms.rds-failover-write-iops.severities.sev3]
+threshold = 15000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS failover database Write IOPS is above 15,000 (Warning limit). Elevated write IOPS."
+
+[cloudwatch.alarms.rds-primary-network-receive]
+classification = "rds-alerts"
+metric_name = "NetworkReceiveThroughput"
+namespace = "AWS/RDS"
+period = 300
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "hyperswitchdb-primary" }]
+
+[cloudwatch.alarms.rds-primary-network-receive.severities.sev1]
+threshold = 140625000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS primary database Network Receive is above 90% (Sev0 limit) of baseline limit (1.25 Gbps). Network RX is saturated."
+
+[cloudwatch.alarms.rds-primary-network-receive.severities.sev2]
+threshold = 132812500.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS primary database Network Receive is above 85% (Critical limit) of baseline limit (1.25 Gbps). High RX network utilization."
+
+[cloudwatch.alarms.rds-primary-network-receive.severities.sev3]
+threshold = 101562500.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS primary database Network Receive is above 65% (Warning limit) of baseline limit (1.25 Gbps). Network RX is elevated."
+
+[cloudwatch.alarms.rds-failover-network-receive]
+classification = "rds-alerts"
+metric_name = "NetworkReceiveThroughput"
+namespace = "AWS/RDS"
+period = 300
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "failover-replica-1" }]
+
+[cloudwatch.alarms.rds-failover-network-receive.severities.sev1]
+threshold = 281250000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS failover database Network Receive is above 90% (Sev0 limit) of baseline limit (2.5 Gbps). Network RX is saturated."
+
+[cloudwatch.alarms.rds-failover-network-receive.severities.sev2]
+threshold = 265625000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS failover database Network Receive is above 85% (Critical limit) of baseline limit (2.5 Gbps). High RX network utilization."
+
+[cloudwatch.alarms.rds-failover-network-receive.severities.sev3]
+threshold = 203125000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS failover database Network Receive is above 65% (Warning limit) of baseline limit (2.5 Gbps). Network RX is elevated."
+
+[cloudwatch.alarms.rds-primary-network-transmit]
+classification = "rds-alerts"
+metric_name = "NetworkTransmitThroughput"
+namespace = "AWS/RDS"
+period = 300
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "hyperswitchdb-primary" }]
+
+[cloudwatch.alarms.rds-primary-network-transmit.severities.sev1]
+threshold = 140625000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS primary database Network Transmit is above 90% (Sev0 limit) of baseline limit (1.25 Gbps). Network TX is saturated."
+
+[cloudwatch.alarms.rds-primary-network-transmit.severities.sev2]
+threshold = 132812500.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS primary database Network Transmit is above 85% (Critical limit) of baseline limit (1.25 Gbps). High TX network utilization."
+
+[cloudwatch.alarms.rds-primary-network-transmit.severities.sev3]
+threshold = 101562500.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS primary database Network Transmit is above 65% (Warning limit) of baseline limit (1.25 Gbps). Network TX is elevated."
+
+[cloudwatch.alarms.rds-failover-network-transmit]
+classification = "rds-alerts"
+metric_name = "NetworkTransmitThroughput"
+namespace = "AWS/RDS"
+period = 300
+statistic = "Average"
+dimensions = [{ name = "DBInstanceIdentifier", value = "failover-replica-1" }]
+
+[cloudwatch.alarms.rds-failover-network-transmit.severities.sev1]
+threshold = 281250000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV1: RDS failover database Network Transmit is above 90% (Sev0 limit) of baseline limit (2.5 Gbps). Network TX is saturated."
+
+[cloudwatch.alarms.rds-failover-network-transmit.severities.sev2]
+threshold = 265625000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV2: RDS failover database Network Transmit is above 85% (Critical limit) of baseline limit (2.5 Gbps). High TX network utilization."
+
+[cloudwatch.alarms.rds-failover-network-transmit.severities.sev3]
+threshold = 203125000.0
+comparison_operator = "GreaterThanThreshold"
+evaluation_periods = 3
+description = "SEV3: RDS failover database Network Transmit is above 65% (Warning limit) of baseline limit (2.5 Gbps). Network TX is elevated."
+
+# Failover detection: Aurora restarts the promoted instance during failover, so EngineUptime on the
+# WRITER role drops to ~0 whenever a failover (or writer restart) occurs. Fires within a minute and
+# auto-resolves once the new writer has been up for 2 minutes, re-arming quickly so back-to-back
+# failovers each produce a fresh alert.
+[cloudwatch.alarms.rds-writer-failover]
+classification = "rds-alerts"
+metric_name = "EngineUptime"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Minimum"
+dimensions = [
+  { name = "DBClusterIdentifier", value = "hyperswitchdb-cluster" },
+  { name = "Role", value = "WRITER" },
+]
+
+[cloudwatch.alarms.rds-writer-failover.severities.sev1]
+threshold = 120.0
+comparison_operator = "LessThanThreshold"
+evaluation_periods = 1
+treat_missing_data = "notBreaching"
+description = "SEV1: RDS writer engine uptime is below 2 minutes - a failover or writer restart just occurred. Verify application connectivity and investigate the cause of the failover."
+
+# Reader counterpart: also fires when the old writer restarts as a reader after a failover, or when
+# a reader instance is restarted or newly added.
+[cloudwatch.alarms.rds-reader-failover]
+classification = "rds-alerts"
+metric_name = "EngineUptime"
+namespace = "AWS/RDS"
+period = 60
+statistic = "Minimum"
+dimensions = [
+  { name = "DBClusterIdentifier", value = "hyperswitchdb-cluster" },
+  { name = "Role", value = "READER" },
+]
+
+[cloudwatch.alarms.rds-reader-failover.severities.sev1]
+threshold = 120.0
+comparison_operator = "LessThanThreshold"
+evaluation_periods = 1
+treat_missing_data = "notBreaching"
+description = "SEV1: RDS reader engine uptime is below 2 minutes - a reader restart or failover just occurred. Verify read traffic health and investigate the cause."

--- a/crates/external_services/src/metrics_service/response.rs
+++ b/crates/external_services/src/metrics_service/response.rs
@@ -9,6 +9,12 @@
 //! the window that was asked for, `None` where there was no datapoint. Providers do that placement
 //! themselves, using the range and period from the request rather than asking the caller to repeat
 //! them.
+//!
+//! The constructors are public rather than crate-private, because
+//! [`MetricsProvider`](super::MetricsProvider) is object-safe and provider-neutral on purpose — a
+//! trait no other crate can produce a value for is one no other crate can implement, which would
+//! quietly make "provider-neutral" mean "the providers in this module". It is also what lets a
+//! caller stand a stub provider up in its own tests instead of reaching for a live account.
 
 /// A provider's opaque marker for "there is more after this page".
 ///
@@ -19,7 +25,7 @@ pub struct Cursor(String);
 
 impl Cursor {
     /// Wrap a provider's continuation marker.
-    pub(crate) fn new(token: impl Into<String>) -> Self {
+    pub fn new(token: impl Into<String>) -> Self {
         Self(token.into())
     }
 
@@ -53,7 +59,7 @@ pub struct MetricSeries {
 
 impl MetricSeries {
     /// Build a series, for providers translating a response.
-    pub(crate) fn new(index: usize, status: SeriesStatus, values: Vec<Option<f64>>) -> Self {
+    pub fn new(index: usize, status: SeriesStatus, values: Vec<Option<f64>>) -> Self {
         Self {
             index,
             status,
@@ -97,7 +103,7 @@ pub struct MetricPage {
 
 impl MetricPage {
     /// Build a page, for providers translating a response.
-    pub(crate) fn new(series: Vec<MetricSeries>, cursor: Option<Cursor>) -> Self {
+    pub fn new(series: Vec<MetricSeries>, cursor: Option<Cursor>) -> Self {
         Self { series, cursor }
     }
 

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_path_to_error = "0.1.17"
 thiserror = "1.0.69"
+time = { version = "0.3.41", features = ["serde", "serde-well-known", "std"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
 
 # First Party Crates
@@ -52,3 +53,4 @@ workspace = true
 
 [dev-dependencies]
 external_services = { version = "0.1.0", path = "../external_services", features = ["email"] }
+time = { version = "0.3.41", features = ["macros"] }

--- a/crates/observability/src/core.rs
+++ b/crates/observability/src/core.rs
@@ -6,4 +6,5 @@
 //! Distinct from [`crate::domain`], which holds the traits and the types they exchange: `domain`
 //! says what delivering an alert *is*, `core` says what one HTTP request does about it.
 
+pub mod alarm;
 pub mod notifier;

--- a/crates/observability/src/core/alarm.rs
+++ b/crates/observability/src/core/alarm.rs
@@ -1,0 +1,668 @@
+//! One evaluation run: read the metrics, decide, announce, report what happened.
+//!
+//! This is the only module in the crate that has a clock, a metrics provider and a notifier at
+//! once. Everything it decides is decided by [`crate::domain::alarm`]; what lives here is the
+//! order of operations and the answer to "what should happen when part of this fails".
+//!
+//! ## The clock
+//!
+//! A run evaluates through the **latest completed minute** and compares against the evaluation
+//! ending one minute earlier — not one period earlier. CloudWatch evaluates every minute for any
+//! period of a minute or longer, so two consecutive evaluations of a five-minute metric are two
+//! overlapping five-minute windows, and the trigger that eventually drives this should run every
+//! minute regardless of the periods in the catalogue.
+//!
+//! ## Nothing is remembered
+//!
+//! Both windows are reconstructed from CloudWatch on every request, and no state is written
+//! anywhere. Two consequences are accepted rather than worked around:
+//!
+//! * Two requests in the same minute announce the same transition twice. There is no
+//!   exactly-once delivery guarantee here, and adding one would mean the alert *management* store
+//!   this ticket is explicitly not building.
+//! * A transition that happens while a query is failing, or that is only visible in a datapoint
+//!   that arrives late, is not announced at all — the next run compares two windows that both
+//!   already contain it. See the delivery-hardening ticket.
+//!
+//! ## Failure is not missing data
+//!
+//! The distinction this module exists to protect: a metric that stopped reporting and a CloudWatch
+//! call that did not work look identical if you flatten them, and one of them is an alarm while
+//! the other is an outage. A reading whose series came back `Failed` or `Partial`, or that did not
+//! come back at all, is **not evaluated** — it does not become a window of gaps for the
+//! missing-data policy to turn into a breach. It is reported, and every other reading in the run
+//! is evaluated normally.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use common_utils::date_time;
+use error_stack::report;
+use external_services::metrics_service::{Cursor, MetricRequest, MetricsProvider, SeriesStatus};
+use hyperswitch_masking::Secret;
+
+use crate::{
+    domain::{
+        alarm::{
+            self,
+            catalogue::{AlarmTarget, Catalogue, FetchPlan, Reading},
+            message, AlarmState, Evaluation, Transition,
+        },
+        notifier::{chat::ChatNotification, Outcome},
+    },
+    errors::{ObservabilityApiResult, ObservabilityError},
+    logger,
+    state::AppState,
+};
+
+/// How many pages one request is followed for before the run gives up on it.
+///
+/// A page holds up to 100,800 datapoints and a run asks for tens, so the first page is always the
+/// last. The cap is here because a provider that kept handing back a cursor would otherwise be an
+/// unbounded loop inside a request handler.
+const MAX_PAGES: usize = 8;
+
+/// What a caller asked of one run.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EvaluationOptions {
+    /// Evaluate and render, but send nothing at all — not even a failure summary.
+    ///
+    /// A dry run is the same evaluation, so its proposed messages are the messages a real run
+    /// would have sent rather than a separately built preview of them.
+    pub dry_run: bool,
+}
+
+/// Evaluate every configured definition and announce what changed.
+///
+/// Never returns an error for a metric that could not be read or a message that could not be sent:
+/// both are reported in the run's own result, because a run that read nineteen of twenty metrics
+/// did nineteen twentieths of its job and saying so is more useful than a 502.
+pub async fn evaluate(
+    state: AppState,
+    options: EvaluationOptions,
+) -> ObservabilityApiResult<RunReport> {
+    let catalogue = Arc::clone(&state.alarms);
+    let evaluated_at = evaluation_instant(date_time::now(), catalogue.evaluation_delay_seconds);
+
+    let mut report = RunReport {
+        evaluated_at,
+        previous_evaluated_at: evaluated_at
+            - time::Duration::seconds(alarm::catalogue::EVALUATION_INTERVAL_SECONDS),
+        dry_run: options.dry_run,
+        definitions: catalogue.definitions(),
+        readings: catalogue.readings.len(),
+        targets: Vec::with_capacity(catalogue.targets.len()),
+        failure: None,
+    };
+
+    if catalogue.is_empty() {
+        logger::debug!("No CloudWatch alarms are configured; nothing to evaluate");
+        return Ok(report);
+    }
+
+    let provider = state.metrics.as_ref().ok_or_else(|| {
+        // Unreachable through the boot path, which builds a provider whenever the catalogue is
+        // non-empty. It is an error rather than an assumption so that a future wiring mistake is a
+        // 500 with a log line instead of a silent run that evaluates nothing.
+        report!(ObservabilityError::InternalServerError)
+            .attach_printable("Alarms are configured but no metrics provider was built")
+    })?;
+
+    let plan = FetchPlan::build(&catalogue, evaluated_at);
+    let answers = fetch_all(&**provider, &plan.requests).await;
+
+    // One report per target, in catalogue order and never skipping one, so that the announcement
+    // pass can walk the two lists side by side instead of searching.
+    for target in &catalogue.targets {
+        report.targets.push(
+            match (
+                catalogue.readings.get(target.reading),
+                windows_for(&catalogue, &plan, &answers, target),
+            ) {
+                (Some(reading), Ok((current, previous))) => {
+                    decide(target, reading, &current, &previous)
+                }
+                (Some(reading), Err(reason)) => TargetReport::unevaluated(target, reading, reason),
+                (None, _) => TargetReport::unevaluated(
+                    target,
+                    &Reading::unknown(),
+                    "the catalogue resolved this severity against no metric".to_owned(),
+                ),
+            },
+        );
+    }
+
+    announce(&state, &catalogue, &mut report).await;
+
+    Ok(report)
+}
+
+/// The instant a run evaluates through: the latest completed minute, less any configured delay.
+///
+/// Flooring to the minute is what makes two runs inside the same minute compare the same two
+/// windows, and it is also what aligns the request with CloudWatch's own rounding — it rounds a
+/// start time down to the whole minute for data less than fifteen days old, so an unaligned
+/// request would silently be answered as an aligned one anyway.
+///
+/// A naive [`PrimitiveDateTime`](time::PrimitiveDateTime), holding UTC by discipline, matching
+/// `common_utils::date_time` and the rest of the repository. It is turned into an offset instant
+/// only where the metrics client's window type demands one.
+fn evaluation_instant(now: time::PrimitiveDateTime, delay_seconds: i64) -> time::PrimitiveDateTime {
+    let instant = now.assume_utc() - time::Duration::seconds(delay_seconds);
+    let seconds = instant.unix_timestamp();
+
+    date_time::convert_to_pdt(
+        time::OffsetDateTime::from_unix_timestamp(seconds - seconds.rem_euclid(60))
+            .unwrap_or(instant),
+    )
+}
+
+/// Evaluate both windows and work out whether the state moved.
+fn decide(
+    target: &AlarmTarget,
+    reading: &Reading,
+    current: &[Option<f64>],
+    previous: &[Option<f64>],
+) -> TargetReport {
+    let now = target.rule.evaluate(current);
+    let before = target.rule.evaluate(previous);
+
+    TargetReport {
+        definition: target.definition.clone(),
+        classification: target.classification.clone(),
+        severity: target.severity.clone(),
+        metric: reading.describe(),
+        dimensions: reading.dimensions(),
+        state: Some(now.state),
+        previous_state: Some(before.state),
+        transition: Transition::between(before.state, now.state),
+        observed: now.observed,
+        threshold: target.rule.threshold,
+        breaching_datapoints: now.breaching,
+        evaluation_periods: target.rule.evaluation_periods,
+        datapoints_to_alarm: target.rule.datapoints_to_alarm,
+        evaluation: Some(now),
+        error: None,
+        message: None,
+        delivery: None,
+    }
+}
+
+/// Send what the run decided, best effort.
+///
+/// Every send is attempted even when an earlier one failed: a chat outage that silenced the first
+/// announcement has no bearing on the second, and stopping at the first failure would turn one
+/// broken destination into a silent run.
+async fn announce(state: &AppState, catalogue: &Catalogue, report: &mut RunReport) {
+    let evaluated_at = report.evaluated_at;
+    let dry_run = report.dry_run;
+
+    for (outcome, source) in report.targets.iter_mut().zip(&catalogue.targets) {
+        let (Some(transition), Some(evaluation)) =
+            (outcome.transition, outcome.evaluation.as_ref())
+        else {
+            continue;
+        };
+        let Some(reading) = catalogue.readings.get(source.reading) else {
+            continue;
+        };
+
+        let text = message::announcement(source, reading, transition, evaluation, evaluated_at);
+
+        logger::info!(
+            definition = %source.definition,
+            severity = %source.severity,
+            from = %transition.from.label(),
+            to = %transition.to.label(),
+            dry_run,
+            "Alarm state transition detected"
+        );
+
+        outcome.delivery = Some(deliver(state, &source.destination, &text, dry_run).await);
+        outcome.message = Some(text);
+    }
+
+    // Named by definition rather than by severity: three severities of one metric share a reading,
+    // so a failed query is one thing that went wrong, not three.
+    let mut failed = Vec::new();
+    let mut reasons = Vec::new();
+    for outcome in &report.targets {
+        let Some(reason) = outcome.error.as_ref() else {
+            continue;
+        };
+        if !failed.contains(&outcome.definition) {
+            failed.push(outcome.definition.clone());
+        }
+        if !reasons.contains(reason) {
+            reasons.push(reason.clone());
+        }
+    }
+
+    if failed.is_empty() {
+        return;
+    }
+
+    // A single reason shared by everything is worth quoting — it is usually the one sentence that
+    // explains the whole run. Several different ones are a list nobody reads in a chat message,
+    // and they are already in the response and the log.
+    let reason = match reasons.as_slice() {
+        [only] => Some(only.clone()),
+        _ => None,
+    };
+
+    let text =
+        message::failure_summary(report.definitions, &failed, reason.as_deref(), evaluated_at);
+
+    logger::error!(
+        failed_definitions = failed.len(),
+        definitions = report.definitions,
+        dry_run,
+        "CloudWatch readings could not be retrieved"
+    );
+
+    let delivery = deliver(state, &catalogue.failure_destination, &text, dry_run).await;
+    report.failure = Some(FailureReport {
+        definitions: failed,
+        reason,
+        message: text,
+        delivery,
+    });
+}
+
+/// One delivery attempt, reported rather than raised.
+async fn deliver(state: &AppState, destination: &str, text: &str, dry_run: bool) -> DeliveryReport {
+    if dry_run {
+        return DeliveryReport::SkippedDryRun {
+            destination: destination.to_owned(),
+        };
+    }
+
+    let Some(notifier) = state.chat.get(destination) else {
+        // Boot validation makes this unreachable; reporting it beats a panic and beats silence.
+        return DeliveryReport::Failed {
+            destination: destination.to_owned(),
+            error: "no chat destination is configured under this id".to_owned(),
+        };
+    };
+
+    let notification = ChatNotification {
+        text: Secret::new(text.to_owned()),
+        reply_to: None,
+    };
+
+    match notifier.notify(notification).await {
+        Ok(Outcome::Delivered(receipt)) => DeliveryReport::Delivered {
+            destination: destination.to_owned(),
+            message_id: receipt.message_id,
+        },
+        Ok(Outcome::Refused(refusal)) => {
+            logger::warn!(
+                destination = %destination,
+                code = %refusal.code,
+                "Chat destination refused an alarm announcement"
+            );
+            DeliveryReport::Refused {
+                destination: destination.to_owned(),
+                code: refusal.code,
+            }
+        }
+        Err(error) => {
+            logger::error!(
+                destination = %destination,
+                error = ?error,
+                "Chat destination could not be reached for an alarm announcement"
+            );
+            DeliveryReport::Failed {
+                destination: destination.to_owned(),
+                error: error.current_context().to_string(),
+            }
+        }
+    }
+}
+
+/// One window's readings, laid on its period grid, `None` where a period had no datapoint.
+type Window = Vec<Option<f64>>;
+
+/// A window, or the sentence explaining why there is not one.
+///
+/// The failure side is a `String` rather than an error type on purpose: it is not handled, it is
+/// *reported* — into the response, the log and the operational summary — and every producer of one
+/// is a different flavour of "CloudWatch did not give us this".
+type WindowResult = Result<Window, String>;
+
+/// The two windows one target is evaluated over, or why it cannot be evaluated.
+fn windows_for(
+    catalogue: &Catalogue,
+    plan: &FetchPlan,
+    answers: &[RequestAnswer],
+    target: &AlarmTarget,
+) -> Result<(Window, Window), String> {
+    let entry = plan
+        .readings
+        .iter()
+        .find(|entry| entry.reading == target.reading)
+        .ok_or_else(|| "the run planned no request for this metric".to_owned())?;
+
+    let span = target
+        .rule
+        .evaluation_range(catalogue.missing_data_lookback);
+
+    let grid = |reference: alarm::catalogue::GridRef| -> WindowResult {
+        let position = plan
+            .position_of(reference.request, target.reading)
+            .ok_or_else(|| "the run planned no query for this metric".to_owned())?;
+
+        let series = answers
+            .get(reference.request)
+            .ok_or_else(|| "the run made no such request".to_owned())?
+            .series
+            .get(position)
+            .ok_or_else(|| "CloudWatch answered nothing for this query".to_owned())?
+            .as_ref()
+            .map_err(Clone::clone)?;
+
+        alarm::window(series, span, reference.back)
+            .map(<[Option<f64>]>::to_vec)
+            .ok_or_else(|| {
+                format!("CloudWatch returned fewer than the {span} datapoints the window needs")
+            })
+    };
+
+    Ok((grid(entry.current)?, grid(entry.previous)?))
+}
+
+/// What one `GetMetricData` request produced, per query position.
+struct RequestAnswer {
+    series: Vec<WindowResult>,
+}
+
+/// Issue every planned request.
+///
+/// Sequential: a run makes a handful of calls, and running them concurrently would trade a
+/// readable failure attribution for latency nobody is waiting on.
+async fn fetch_all(
+    provider: &dyn MetricsProvider,
+    requests: &[MetricRequest],
+) -> Vec<RequestAnswer> {
+    let mut answers = Vec::with_capacity(requests.len());
+
+    for request in requests {
+        answers.push(fetch(provider, request).await);
+    }
+
+    answers
+}
+
+/// Fetch one request, following its pages, and report each query's series separately.
+///
+/// A whole-request failure becomes the same failure for every query in it, so one broken call does
+/// not have to be distinguished from many at the point where a definition asks what happened.
+async fn fetch(provider: &dyn MetricsProvider, request: &MetricRequest) -> RequestAnswer {
+    let mut merged: Vec<Option<(SeriesStatus, Vec<Option<f64>>)>> =
+        vec![None; request.queries.len()];
+    let mut cursor: Option<Cursor> = None;
+
+    for page_number in 0..MAX_PAGES {
+        let page = match provider.fetch(request, cursor.as_ref()).await {
+            Ok(page) => page,
+            Err(error) => {
+                let reason = error.current_context().to_string();
+                logger::error!(
+                    error = ?error,
+                    page = page_number,
+                    queries = request.queries.len(),
+                    "A CloudWatch request failed"
+                );
+
+                return RequestAnswer {
+                    series: vec![Err(reason); request.queries.len()],
+                };
+            }
+        };
+
+        for series in page.series() {
+            let Some(slot) = merged.get_mut(series.index()) else {
+                continue;
+            };
+
+            match slot {
+                // Every page lays its datapoints on the *whole* window's grid, filling only the
+                // slots it carries, so pages are merged slot-wise rather than concatenated.
+                Some((status, values)) => {
+                    *status = coarsest(*status, series.status());
+                    for (existing, arriving) in values.iter_mut().zip(series.values()) {
+                        if existing.is_none() {
+                            *existing = *arriving;
+                        }
+                    }
+                }
+                None => *slot = Some((series.status(), series.values().to_vec())),
+            }
+        }
+
+        cursor = page.cursor().cloned();
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    if cursor.is_some() {
+        logger::warn!(
+            pages = MAX_PAGES,
+            "A CloudWatch request still had pages after the page limit; treating it as incomplete"
+        );
+
+        return RequestAnswer {
+            series: vec![
+                Err("the response did not finish paginating".to_owned());
+                request.queries.len()
+            ],
+        };
+    }
+
+    RequestAnswer {
+        series: merged
+            .into_iter()
+            .map(|slot| match slot {
+                Some((SeriesStatus::Complete, values)) => Ok(values),
+                // Neither of these is a metric that stopped reporting. `Partial` is a window we
+                // only half received and `Failed` is one we did not receive; evaluating either
+                // would let a CloudWatch problem be announced as a database problem.
+                Some((SeriesStatus::Partial, _)) => {
+                    Err("CloudWatch returned only part of this series".to_owned())
+                }
+                Some((SeriesStatus::Failed, _)) => {
+                    Err("CloudWatch could not produce this series".to_owned())
+                }
+                None => Err("CloudWatch reported nothing for this query".to_owned()),
+            })
+            .collect(),
+    }
+}
+
+/// The less complete of two statuses, for a series spread over pages.
+fn coarsest(one: SeriesStatus, other: SeriesStatus) -> SeriesStatus {
+    match (one, other) {
+        (SeriesStatus::Failed, _) | (_, SeriesStatus::Failed) => SeriesStatus::Failed,
+        (SeriesStatus::Partial, _) | (_, SeriesStatus::Partial) => SeriesStatus::Partial,
+        _ => SeriesStatus::Complete,
+    }
+}
+
+/// Everything one run found and did.
+#[derive(Debug)]
+pub struct RunReport {
+    /// The instant the current evaluation ends at, in UTC.
+    pub evaluated_at: time::PrimitiveDateTime,
+    /// The instant the evaluation it was compared against ends at — one minute earlier.
+    pub previous_evaluated_at: time::PrimitiveDateTime,
+    /// Whether every send was skipped.
+    pub dry_run: bool,
+    /// How many catalogue entries the run covered.
+    pub definitions: usize,
+    /// How many distinct metric readings those entries needed. Fewer, because severities and
+    /// definitions watching one metric share a query.
+    pub readings: usize,
+    /// One entry per severity, in catalogue order.
+    pub targets: Vec<TargetReport>,
+    /// The operational summary, when anything failed to read.
+    pub failure: Option<FailureReport>,
+}
+
+/// What happened to one severity.
+#[derive(Debug)]
+pub struct TargetReport {
+    /// The catalogue entry's name.
+    pub definition: String,
+    /// The group it belongs to.
+    pub classification: String,
+    /// The severity id.
+    pub severity: String,
+    /// Namespace and metric name.
+    pub metric: String,
+    /// The dimensions it read.
+    pub dimensions: BTreeMap<String, String>,
+    /// The state the current window puts it in, absent if it could not be evaluated.
+    pub state: Option<AlarmState>,
+    /// The state the previous window puts it in.
+    pub previous_state: Option<AlarmState>,
+    /// The change between them, if any.
+    pub transition: Option<Transition>,
+    /// The most recent real reading in the current window.
+    pub observed: Option<f64>,
+    /// What it was compared against.
+    pub threshold: f64,
+    /// How many of the window's readings breached.
+    pub breaching_datapoints: usize,
+    /// N.
+    pub evaluation_periods: u32,
+    /// M.
+    pub datapoints_to_alarm: u32,
+    /// The full evaluation, kept so the announcement and the response agree.
+    pub evaluation: Option<Evaluation>,
+    /// Why it could not be evaluated, when it could not.
+    pub error: Option<String>,
+    /// The message that was sent, or that a dry run would have sent.
+    pub message: Option<String>,
+    /// What came of sending it.
+    pub delivery: Option<DeliveryReport>,
+}
+
+impl TargetReport {
+    fn unevaluated(target: &AlarmTarget, reading: &Reading, error: String) -> Self {
+        Self {
+            definition: target.definition.clone(),
+            classification: target.classification.clone(),
+            severity: target.severity.clone(),
+            metric: reading.describe(),
+            dimensions: reading.dimensions(),
+            state: None,
+            previous_state: None,
+            transition: None,
+            observed: None,
+            threshold: target.rule.threshold,
+            breaching_datapoints: 0,
+            evaluation_periods: target.rule.evaluation_periods,
+            datapoints_to_alarm: target.rule.datapoints_to_alarm,
+            evaluation: None,
+            error: Some(error),
+            message: None,
+            delivery: None,
+        }
+    }
+}
+
+/// The operational summary a run sends when it could not read everything.
+#[derive(Debug)]
+pub struct FailureReport {
+    /// The definitions that went unevaluated.
+    pub definitions: Vec<String>,
+    /// The one reason behind all of them, when there was only one.
+    pub reason: Option<String>,
+    /// The message that was sent, or that a dry run would have sent.
+    pub message: String,
+    /// What came of sending it.
+    pub delivery: DeliveryReport,
+}
+
+/// What came of one attempt to send a message.
+#[derive(Debug)]
+pub enum DeliveryReport {
+    /// The provider accepted it.
+    Delivered {
+        /// The destination it went to.
+        destination: String,
+        /// The provider's id for the message, when it named one.
+        message_id: Option<String>,
+    },
+    /// The provider was reached and refused it.
+    Refused {
+        /// The destination that refused.
+        destination: String,
+        /// The stable code it refused with.
+        code: String,
+    },
+    /// The provider could not be reached, so whether it arrived is unknown.
+    Failed {
+        /// The destination that could not be reached.
+        destination: String,
+        /// What went wrong.
+        error: String,
+    },
+    /// Nothing was sent, because this was a dry run.
+    SkippedDryRun {
+        /// Where it would have gone.
+        destination: String,
+    },
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use time::macros::datetime;
+
+    use super::*;
+
+    /// A run evaluates through the last minute that finished, so two runs inside one minute
+    /// compare the same two windows rather than two slightly different ones.
+    #[test]
+    fn a_run_evaluates_through_the_latest_completed_minute() {
+        assert_eq!(
+            evaluation_instant(datetime!(2026-09-10 12:34:56.789), 0),
+            datetime!(2026-09-10 12:34:00)
+        );
+        assert_eq!(
+            evaluation_instant(datetime!(2026-09-10 12:34:00), 0),
+            datetime!(2026-09-10 12:34:00)
+        );
+    }
+
+    /// The knob for a metric whose readings are known to land late. Still floored, so the two
+    /// windows stay a whole minute apart.
+    #[test]
+    fn a_configured_delay_moves_the_instant_back_whole_minutes() {
+        assert_eq!(
+            evaluation_instant(datetime!(2026-09-10 12:34:56), 120),
+            datetime!(2026-09-10 12:32:00)
+        );
+        assert_eq!(
+            evaluation_instant(datetime!(2026-09-10 12:34:56), 30),
+            datetime!(2026-09-10 12:34:00)
+        );
+    }
+
+    #[test]
+    fn a_partial_page_makes_the_whole_series_incomplete() {
+        assert_eq!(
+            coarsest(SeriesStatus::Complete, SeriesStatus::Partial),
+            SeriesStatus::Partial
+        );
+        assert_eq!(
+            coarsest(SeriesStatus::Partial, SeriesStatus::Failed),
+            SeriesStatus::Failed
+        );
+        assert_eq!(
+            coarsest(SeriesStatus::Complete, SeriesStatus::Complete),
+            SeriesStatus::Complete
+        );
+    }
+}

--- a/crates/observability/src/domain.rs
+++ b/crates/observability/src/domain.rs
@@ -5,4 +5,5 @@
 //! into `core`, and serializes what comes back; `core` resolves a destination and asks the domain
 //! to deliver. Nothing here knows that HTTP exists.
 
+pub mod alarm;
 pub mod notifier;

--- a/crates/observability/src/domain/alarm.rs
+++ b/crates/observability/src/domain/alarm.rs
@@ -1,0 +1,555 @@
+//! Deciding whether a run of metric readings is alarming.
+//!
+//! Everything in here is pure: readings in, a state out. No clock, no provider, no chat. That is
+//! what makes the parity claims below testable against AWS's own published tables rather than
+//! against a live account, and it is why [`crate::core::alarm`] — which has all three — holds no
+//! evaluation logic of its own.
+//!
+//! ## What is being reproduced
+//!
+//! CloudWatch's own alarm evaluation, closely enough that porting the `rds-alerts` catalogue does
+//! not change when it fires. Four properties matter and each is implemented here:
+//!
+//! * **A window of N periods, M of which must breach.** `evaluation_periods` is N,
+//!   `datapoints_to_alarm` is M, and the breaching datapoints need not be consecutive.
+//! * **A wider *evaluation range* than the window.** CloudWatch retrieves more datapoints than N
+//!   so that gaps in the recent ones can be covered by real readings from further back. See
+//!   [`AlarmRule::evaluate`].
+//! * **A missing-data policy**, consulted only when the range cannot supply N real readings.
+//! * **Evaluation every minute**, with the window sliding by a minute rather than by a period.
+//!   That one lives in [`crate::core::alarm`], because it is about clocks.
+//!
+//! ## Where parity stops, deliberately
+//!
+//! Two divergences, both named rather than hidden:
+//!
+//! 1. **`ignore` is not implementable here.** It means "keep the state the alarm already had",
+//!    which is a memory of a previous decision. This service reconstructs both windows from
+//!    CloudWatch on every request and remembers nothing, so it cannot honour `ignore`. Rather than
+//!    approximate it, [`MissingDataPolicy`] has no such variant and
+//!    [`settings::cloudwatch`](crate::settings::cloudwatch) refuses a catalogue that asks for it.
+//!    No `rds-alerts` definition does.
+//! 2. **The *premature alarm state* rule is not implemented.** AWS documents a special case that
+//!    forces `ALARM` when the oldest breaching datapoint in the window is at least as old as M and
+//!    everything more recent is breaching or missing. Its published examples are not consistent
+//!    enough to reimplement from — two rows of the tables in
+//!    <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/alarms-and-missing-data.html>
+//!    satisfy the stated condition and disagree on the outcome — and it only ever changes the
+//!    result under `missing` or `ignore`. Neither is used by `rds-alerts`. The tests below encode
+//!    all twenty cells of both AWS tables, including the two this divergence gets wrong, so the
+//!    gap is visible rather than assumed away.
+
+pub mod catalogue;
+pub mod message;
+
+/// What state a set of readings puts an alarm in.
+///
+/// Three, not two. `INSUFFICIENT_DATA` is not "we had a problem fetching" — a retrieval failure
+/// never reaches this module at all, precisely so that a CloudWatch outage cannot be rendered as a
+/// metric that stopped reporting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlarmState {
+    /// Every reading the window needed was within the threshold.
+    Ok,
+    /// At least `datapoints_to_alarm` of the window's readings breached.
+    Alarm,
+    /// The evaluation range held no real reading at all, under a policy that says so.
+    InsufficientData,
+}
+
+impl AlarmState {
+    /// The name this state is announced under, matching CloudWatch's own spelling.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::Alarm => "ALARM",
+            Self::InsufficientData => "INSUFFICIENT_DATA",
+        }
+    }
+}
+
+/// What to do with the periods of a window that carry no reading.
+///
+/// CloudWatch's four minus `ignore`; see the module docs for why that one cannot exist here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissingDataPolicy {
+    /// A gap counts as a breach.
+    Breaching,
+    /// A gap counts as within the threshold.
+    NotBreaching,
+    /// A window of nothing but gaps is [`AlarmState::InsufficientData`].
+    Missing,
+}
+
+/// Which side of the threshold breaches.
+///
+/// The four static comparisons the catalogue uses. CloudWatch's anomaly-detection operators
+/// (`LessThanLowerOrGreaterThanUpperThreshold` and friends) compare against a band rather than a
+/// number and would need a second metric to fetch, so they are not modelled as if they were more
+/// of the same.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComparisonOperator {
+    /// Breaches above the threshold.
+    GreaterThanThreshold,
+    /// Breaches at or above the threshold.
+    GreaterThanOrEqualToThreshold,
+    /// Breaches below the threshold.
+    LessThanThreshold,
+    /// Breaches at or below the threshold.
+    LessThanOrEqualToThreshold,
+}
+
+impl ComparisonOperator {
+    /// Whether `value` is on the breaching side.
+    ///
+    /// A `NaN` reading breaches nothing, which falls out of IEEE comparison rather than being
+    /// special-cased: every one of these is false against `NaN`, and treating an unrepresentable
+    /// aggregate as a breach would page someone over a provider's arithmetic.
+    fn breaches(self, value: f64, threshold: f64) -> bool {
+        match self {
+            Self::GreaterThanThreshold => value > threshold,
+            Self::GreaterThanOrEqualToThreshold => value >= threshold,
+            Self::LessThanThreshold => value < threshold,
+            Self::LessThanOrEqualToThreshold => value <= threshold,
+        }
+    }
+
+    /// How the comparison reads in an announcement, next to the threshold.
+    pub fn symbol(self) -> &'static str {
+        match self {
+            Self::GreaterThanThreshold => ">",
+            Self::GreaterThanOrEqualToThreshold => ">=",
+            Self::LessThanThreshold => "<",
+            Self::LessThanOrEqualToThreshold => "<=",
+        }
+    }
+}
+
+/// One severity's threshold and window: everything needed to turn readings into a state.
+///
+/// A severity rather than a definition, because the catalogue's severities are independent
+/// generation rules that happen to share a metric. Two severities of one definition differ only in
+/// their threshold and are evaluated separately against the same readings.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AlarmRule {
+    /// Which side of [`Self::threshold`] breaches.
+    pub comparison_operator: ComparisonOperator,
+    /// The number a reading is compared against.
+    pub threshold: f64,
+    /// N — how many of the most recent periods form the window.
+    pub evaluation_periods: u32,
+    /// M — how many of the window's readings must breach. Equal to N unless the catalogue says
+    /// otherwise, which is how CloudWatch itself defaults it.
+    pub datapoints_to_alarm: u32,
+    /// What a period with no reading counts as.
+    pub treat_missing_data: MissingDataPolicy,
+}
+
+impl AlarmRule {
+    /// How many datapoints this rule wants fetched — CloudWatch's *evaluation range*.
+    ///
+    /// Wider than the window on purpose: when recent periods have no reading, CloudWatch prefers a
+    /// real reading from further back over a fabricated one, and only fills what it still cannot
+    /// cover. `lookback` is how much further back to reach.
+    ///
+    /// **The size of that widening is not documented.** AWS says only that it "depends on the
+    /// length of the alarm period and whether it is based on a metric with standard resolution or
+    /// high resolution", and publishes no formula. Both of its worked examples use a
+    /// standard-resolution five-minute metric with N = 3 and an evaluation range of 5, so N + 2 is
+    /// the only figure it has ever put a number to — which is why `lookback` is configuration with
+    /// that default rather than a constant compiled in here. Getting it wrong changes the outcome
+    /// only for a window that has some readings but not N of them.
+    pub fn evaluation_range(&self, lookback: u32) -> usize {
+        usize::try_from(self.evaluation_periods.saturating_add(lookback)).unwrap_or(usize::MAX)
+    }
+
+    /// Evaluate `range`, oldest reading first, `None` where a period had no datapoint.
+    ///
+    /// `range` is the evaluation range, not the window: it is expected to be
+    /// [`Self::evaluation_range`] long, and the window is the most recent N *readings* within it.
+    ///
+    /// The three-branch shape is CloudWatch's, and the order matters:
+    ///
+    /// 1. **N real readings are available.** The most recent N of them decide, the gaps between
+    ///    them are simply stepped over, and the missing-data policy is never consulted. This is
+    ///    the branch the wider range exists to reach.
+    /// 2. **Some real readings, but fewer than N.** Every one of them counts, and only the
+    ///    shortfall is filled according to the policy — "as few times as possible", as AWS puts it.
+    /// 3. **None at all.** The policy alone decides, and it is the only branch that can produce
+    ///    [`AlarmState::InsufficientData`].
+    pub fn evaluate(&self, range: &[Option<f64>]) -> Evaluation {
+        let window = usize::try_from(self.evaluation_periods).unwrap_or(usize::MAX);
+        let to_alarm = usize::try_from(self.datapoints_to_alarm).unwrap_or(usize::MAX);
+
+        // Flattening away the gaps is the whole trick: what CloudWatch calls "the most recent data
+        // points collected" is a count of readings, not a span of periods.
+        let readings = range.iter().flatten().copied().collect::<Vec<_>>();
+        let observed = readings.last().copied();
+
+        if readings.len() >= window {
+            let breaching = readings
+                .iter()
+                .rev()
+                .take(window)
+                .filter(|value| self.breaches(**value))
+                .count();
+
+            return Evaluation {
+                state: self.state_for(breaching, to_alarm),
+                breaching,
+                real: window,
+                filled: 0,
+                observed,
+            };
+        }
+
+        let breaching = readings
+            .iter()
+            .filter(|value| self.breaches(**value))
+            .count();
+        let filled = window.saturating_sub(readings.len());
+
+        let state = match self.treat_missing_data {
+            MissingDataPolicy::Breaching => {
+                self.state_for(breaching.saturating_add(filled), to_alarm)
+            }
+            MissingDataPolicy::NotBreaching => self.state_for(breaching, to_alarm),
+            MissingDataPolicy::Missing if readings.is_empty() => AlarmState::InsufficientData,
+            MissingDataPolicy::Missing => self.state_for(breaching, to_alarm),
+        };
+
+        Evaluation {
+            state,
+            breaching,
+            real: readings.len(),
+            filled,
+            observed,
+        }
+    }
+
+    fn breaches(&self, value: f64) -> bool {
+        self.comparison_operator.breaches(value, self.threshold)
+    }
+
+    fn state_for(&self, breaching: usize, to_alarm: usize) -> AlarmState {
+        if breaching >= to_alarm {
+            AlarmState::Alarm
+        } else {
+            AlarmState::Ok
+        }
+    }
+}
+
+/// What one evaluation found, beyond the state itself.
+///
+/// The extra counts exist for the announcement and for the response body: "3 of 3 breaching" and
+/// "2 of 3 readings were missing" are the two sentences an operator asks for first, and neither is
+/// recoverable from [`AlarmState`] alone.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Evaluation {
+    /// The state these readings put the alarm in.
+    pub state: AlarmState,
+    /// How many of the evaluated readings breached.
+    pub breaching: usize,
+    /// How many real readings the window was decided on.
+    pub real: usize,
+    /// How many periods the missing-data policy had to stand in for.
+    pub filled: usize,
+    /// The most recent real reading in the range, if there was one.
+    ///
+    /// The number that goes in the message. `None` means the range held nothing real — in which
+    /// case the state came entirely from the policy and there is no observed value to quote.
+    pub observed: Option<f64>,
+}
+
+/// A change of state between two consecutive evaluations.
+///
+/// Announcing is driven by this and nothing else: an alarm that stays breaching produces no
+/// transition and therefore no second message, which is what makes a stateless evaluator quiet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Transition {
+    /// Where the previous evaluation left it.
+    pub from: AlarmState,
+    /// Where this evaluation puts it.
+    pub to: AlarmState,
+}
+
+impl Transition {
+    /// The transition between two evaluations, or `None` if the state did not move.
+    pub fn between(previous: AlarmState, current: AlarmState) -> Option<Self> {
+        (previous != current).then_some(Self {
+            from: previous,
+            to: current,
+        })
+    }
+}
+
+/// The `count` readings of `grid` ending `back` slots before its end.
+///
+/// `None` when the grid is too short to supply them, which a caller must treat as "cannot
+/// evaluate" rather than as a window of gaps: a short grid means we did not fetch what we meant
+/// to, and inventing missing readings from it would put the fabrication this module refuses back
+/// in through the other side.
+pub fn window(grid: &[Option<f64>], count: usize, back: usize) -> Option<&[Option<f64>]> {
+    let end = grid.len().checked_sub(back)?;
+    let start = end.checked_sub(count)?;
+
+    grid.get(start..end)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    /// Read AWS's own notation: `0` a reading within the threshold, `X` a breaching one, `-` a
+    /// period with no reading. Thresholded at 1.0 with `>`, so `X` is 2.0 and `0` is 0.0.
+    fn readings(pattern: &str) -> Vec<Option<f64>> {
+        pattern
+            .chars()
+            .filter(|character| !character.is_whitespace())
+            .map(|character| match character {
+                'X' => Some(2.0),
+                '0' => Some(0.0),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn rule(window: u32, to_alarm: u32, policy: MissingDataPolicy) -> AlarmRule {
+        AlarmRule {
+            comparison_operator: ComparisonOperator::GreaterThanThreshold,
+            threshold: 1.0,
+            evaluation_periods: window,
+            datapoints_to_alarm: to_alarm,
+            treat_missing_data: policy,
+        }
+    }
+
+    fn state(pattern: &str, window: u32, to_alarm: u32, policy: MissingDataPolicy) -> AlarmState {
+        rule(window, to_alarm, policy)
+            .evaluate(&readings(pattern))
+            .state
+    }
+
+    /// The first table from AWS's missing-data documentation: N = 3, M = 3, evaluation range 5.
+    ///
+    /// Every cell of the `breaching` and `notBreaching` columns, which are the only two policies
+    /// `rds-alerts` uses, plus the `missing` column so the one divergence stays visible.
+    #[test]
+    fn the_published_three_of_three_table_is_reproduced() {
+        use MissingDataPolicy::{Breaching, Missing, NotBreaching};
+
+        for (pattern, breaching, not_breaching, missing) in [
+            ("0 - X - X", AlarmState::Ok, AlarmState::Ok, AlarmState::Ok),
+            ("0 - - - -", AlarmState::Ok, AlarmState::Ok, AlarmState::Ok),
+            (
+                "- - - - -",
+                AlarmState::Alarm,
+                AlarmState::Ok,
+                AlarmState::InsufficientData,
+            ),
+            (
+                "0 X X - X",
+                AlarmState::Alarm,
+                AlarmState::Alarm,
+                AlarmState::Alarm,
+            ),
+            // Row 5 is AWS's "premature alarm state" case. It publishes `ALARM` for `missing`;
+            // this evaluator says `OK`, which is the divergence the module docs name. The
+            // `breaching` and `notBreaching` cells still match, and they are the ones in use.
+            (
+                "- - X - -",
+                AlarmState::Alarm,
+                AlarmState::Ok,
+                AlarmState::Ok,
+            ),
+        ] {
+            assert_eq!(
+                state(pattern, 3, 3, Breaching),
+                breaching,
+                "{pattern} breaching"
+            );
+            assert_eq!(
+                state(pattern, 3, 3, NotBreaching),
+                not_breaching,
+                "{pattern} notBreaching"
+            );
+            assert_eq!(state(pattern, 3, 3, Missing), missing, "{pattern} missing");
+        }
+    }
+
+    /// The second published table: N = 3, M = 2, evaluation range 5 — an M-out-of-N alarm.
+    #[test]
+    fn the_published_two_of_three_table_is_reproduced() {
+        use MissingDataPolicy::{Breaching, Missing, NotBreaching};
+
+        for (pattern, breaching, not_breaching, missing) in [
+            (
+                "0 - X - X",
+                AlarmState::Alarm,
+                AlarmState::Alarm,
+                AlarmState::Alarm,
+            ),
+            (
+                "0 0 X 0 X",
+                AlarmState::Alarm,
+                AlarmState::Alarm,
+                AlarmState::Alarm,
+            ),
+            (
+                "0 - X - -",
+                AlarmState::Alarm,
+                AlarmState::Ok,
+                AlarmState::Ok,
+            ),
+            (
+                "- - - - 0",
+                AlarmState::Alarm,
+                AlarmState::Ok,
+                AlarmState::Ok,
+            ),
+            // The M-out-of-N premature alarm case; same divergence as the table above.
+            (
+                "- - - X -",
+                AlarmState::Alarm,
+                AlarmState::Ok,
+                AlarmState::Ok,
+            ),
+        ] {
+            assert_eq!(
+                state(pattern, 3, 2, Breaching),
+                breaching,
+                "{pattern} breaching"
+            );
+            assert_eq!(
+                state(pattern, 3, 2, NotBreaching),
+                not_breaching,
+                "{pattern} notBreaching"
+            );
+            assert_eq!(state(pattern, 3, 2, Missing), missing, "{pattern} missing");
+        }
+    }
+
+    /// The reason the range is wider than the window: a real reading from further back is used in
+    /// preference to a fabricated one, and the policy never gets a say.
+    #[test]
+    fn real_readings_from_the_back_of_the_range_beat_the_missing_data_policy() {
+        // Three real readings exist in the range, so the window is full and `breaching` — which
+        // would otherwise turn the two gaps into breaches — changes nothing.
+        for policy in [
+            MissingDataPolicy::Breaching,
+            MissingDataPolicy::NotBreaching,
+            MissingDataPolicy::Missing,
+        ] {
+            assert_eq!(
+                state("0 0 - 0 -", 3, 3, policy),
+                AlarmState::Ok,
+                "{policy:?}"
+            );
+        }
+    }
+
+    /// Breaching datapoints do not have to be consecutive, which is the whole point of M-out-of-N.
+    #[test]
+    fn breaching_readings_need_not_be_adjacent() {
+        assert_eq!(
+            state("X 0 X", 3, 2, MissingDataPolicy::NotBreaching),
+            AlarmState::Alarm
+        );
+        assert_eq!(
+            state("X 0 0", 3, 2, MissingDataPolicy::NotBreaching),
+            AlarmState::Ok
+        );
+    }
+
+    #[test]
+    fn each_operator_breaches_on_its_own_side_of_the_threshold() {
+        use ComparisonOperator::{
+            GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanOrEqualToThreshold,
+            LessThanThreshold,
+        };
+
+        assert!(!GreaterThanThreshold.breaches(90.0, 90.0));
+        assert!(GreaterThanThreshold.breaches(90.1, 90.0));
+        assert!(GreaterThanOrEqualToThreshold.breaches(90.0, 90.0));
+        assert!(!LessThanThreshold.breaches(120.0, 120.0));
+        assert!(LessThanThreshold.breaches(119.0, 120.0));
+        assert!(LessThanOrEqualToThreshold.breaches(120.0, 120.0));
+    }
+
+    /// A metric that aggregated to `NaN` must not page anyone.
+    #[test]
+    fn a_nan_reading_breaches_nothing() {
+        for operator in [
+            ComparisonOperator::GreaterThanThreshold,
+            ComparisonOperator::GreaterThanOrEqualToThreshold,
+            ComparisonOperator::LessThanThreshold,
+            ComparisonOperator::LessThanOrEqualToThreshold,
+        ] {
+            assert!(!operator.breaches(f64::NAN, 1.0), "{operator:?}");
+        }
+    }
+
+    /// The value an announcement quotes is the latest real one, not the latest slot.
+    #[test]
+    fn the_observed_value_skips_a_trailing_gap() {
+        let evaluation =
+            rule(3, 3, MissingDataPolicy::NotBreaching).evaluate(&[Some(1.0), Some(7.0), None]);
+
+        assert_eq!(evaluation.observed, Some(7.0));
+        assert_eq!(evaluation.real, 2);
+        assert_eq!(evaluation.filled, 1);
+    }
+
+    #[test]
+    fn an_evaluation_of_nothing_has_no_observed_value() {
+        let evaluation = rule(1, 1, MissingDataPolicy::Breaching).evaluate(&[None, None]);
+
+        assert_eq!(evaluation.state, AlarmState::Alarm);
+        assert_eq!(evaluation.observed, None);
+    }
+
+    #[test]
+    fn a_state_that_does_not_move_is_not_a_transition() {
+        assert_eq!(Transition::between(AlarmState::Ok, AlarmState::Ok), None);
+        assert_eq!(
+            Transition::between(AlarmState::Ok, AlarmState::Alarm),
+            Some(Transition {
+                from: AlarmState::Ok,
+                to: AlarmState::Alarm,
+            })
+        );
+        // Recovery and insufficient data are transitions like any other, and are announced.
+        assert!(Transition::between(AlarmState::Alarm, AlarmState::Ok).is_some());
+        assert!(Transition::between(AlarmState::Ok, AlarmState::InsufficientData).is_some());
+    }
+
+    #[test]
+    fn a_window_is_taken_from_the_end_of_the_grid() {
+        let grid = [Some(1.0), Some(2.0), Some(3.0), Some(4.0)];
+
+        assert_eq!(window(&grid, 2, 0), Some(&grid[2..4]));
+        assert_eq!(window(&grid, 2, 1), Some(&grid[1..3]));
+        assert_eq!(window(&grid, 4, 0), Some(&grid[..]));
+    }
+
+    /// A grid too short to hold the window is refused rather than padded, so a truncated fetch
+    /// cannot be evaluated as a metric that stopped reporting.
+    #[test]
+    fn a_grid_too_short_for_the_window_yields_nothing() {
+        let grid = [Some(1.0), Some(2.0)];
+
+        assert_eq!(window(&grid, 3, 0), None);
+        assert_eq!(window(&grid, 2, 1), None);
+    }
+
+    #[test]
+    fn the_evaluation_range_is_the_window_plus_the_configured_lookback() {
+        let rule = rule(3, 3, MissingDataPolicy::NotBreaching);
+
+        assert_eq!(rule.evaluation_range(2), 5);
+        assert_eq!(rule.evaluation_range(0), 3);
+    }
+}

--- a/crates/observability/src/domain/alarm/catalogue.rs
+++ b/crates/observability/src/domain/alarm/catalogue.rs
@@ -1,0 +1,710 @@
+//! The catalogue, prepared: configuration turned into readings to fetch and rules to apply.
+//!
+//! *Prepared*, not resolved — the dimensions arrive already resolved, because the infrastructure
+//! side renders them. What happens here is once, at boot, and it is an **inversion**.
+//! Configuration is organised the way a person writes it, one entry per alarm with its severities
+//! nested inside. This is organised the way a request needs it: a deduplicated list of **readings**
+//! to ask CloudWatch for, and a flat list of **targets** — one per severity — each pointing at the
+//! reading it is evaluated against.
+//!
+//! That inversion is the whole reason the module exists. The three severities of one definition
+//! share a metric, dimensions, period and statistic; only their thresholds differ, and a threshold
+//! is not part of a CloudWatch query. The twenty `rds-alerts` definitions carry fifty-three
+//! severities between them and need **twenty** queries, not fifty-three.
+//!
+//! ## The two windows
+//!
+//! A transition is the difference between two consecutive evaluations, and CloudWatch's
+//! consecutive evaluations are **one minute apart, whatever the period**. Its documentation is
+//! explicit: *"if the Period is 5 minutes (300 seconds) and Evaluation Periods is 1, then at the
+//! end of minute 5 the alarm evaluates based on data from minutes 1 to 5. Then at the end of
+//! minute 6, the alarm is evaluated based on the data from minutes 2 to 6."* Two 300-second
+//! aggregates one minute apart are not two adjacent datapoints on a five-minute grid; they are two
+//! overlapping windows, and CloudWatch computes both.
+//!
+//! So a reading needs a grid for each. Whether one request can carry both comes down to one
+//! question — does the minute the window slides by divide the period? — and
+//! [`FetchPlan::build`] answers it per period rather than assuming either way:
+//!
+//! * **A 60-second metric**: yes. One request for `range + 1` datapoints holds both windows, one
+//!   slot apart. This is the `N + 1` fetch the design started from, and it is correct *here*.
+//! * **A 300-second metric**: no. The two windows sit on grids offset by a minute, and CloudWatch
+//!   lays a returned datapoint on the grid the request's own start time defines. Two requests.
+//!
+//! Twelve of the twenty `rds-alerts` definitions are 60-second and eight are 300-second, so a run
+//! is three `GetMetricData` calls.
+
+use std::collections::BTreeMap;
+
+use external_services::metrics_service::{
+    Aggregation, Labels, MetricQuery, MetricRequest, Period, TimeRange,
+};
+
+use crate::{
+    domain::alarm::{AlarmRule, ComparisonOperator, MissingDataPolicy},
+    errors::ConfigurationError,
+    settings::cloudwatch::{self, CloudWatchSettings},
+};
+
+/// How far apart two consecutive CloudWatch evaluations are, for any period of a minute or longer.
+///
+/// Not the period. AWS: *"For any period of one minute or longer, an alarm is evaluated every
+/// minute"*, and the sliding window advances by a minute each time.
+pub const EVALUATION_INTERVAL_SECONDS: i64 = 60;
+
+/// One thing to ask CloudWatch for: a metric, narrowed and reduced.
+///
+/// Carries no threshold, because a threshold is not part of a query — which is exactly why
+/// severities can share one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reading {
+    /// The namespace the metric is published under.
+    pub namespace: String,
+    /// The metric's name.
+    pub metric_name: String,
+    /// The dimensions narrowing it to one reporting stream.
+    pub labels: Labels,
+    /// How long one datapoint covers.
+    pub period: Period,
+    /// How the values inside a period are reduced.
+    pub aggregation: Aggregation,
+}
+
+impl Reading {
+    /// The identity two definitions must share to be answered by one query.
+    ///
+    /// A string rather than a derived `Hash`, because [`Labels`] is deliberately ordered rather
+    /// than hashed; its iteration order is stable, so this is too.
+    fn identity(&self) -> String {
+        let labels = self
+            .labels
+            .iter()
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>()
+            .join(",");
+
+        format!(
+            "{}|{}|{}|{:?}|{labels}",
+            self.namespace,
+            self.metric_name,
+            self.period.seconds(),
+            self.aggregation
+        )
+    }
+
+    /// The query that fetches it.
+    pub fn query(&self) -> MetricQuery {
+        MetricQuery {
+            namespace: Some(self.namespace.clone()),
+            name: self.metric_name.clone(),
+            labels: self.labels.clone(),
+            period: self.period,
+            aggregation: self.aggregation,
+        }
+    }
+
+    /// How the metric reads in an announcement.
+    pub fn describe(&self) -> String {
+        format!("{} {}", self.namespace, self.metric_name)
+    }
+
+    /// The dimensions, as an ordered map for the response body.
+    pub fn dimensions(&self) -> BTreeMap<String, String> {
+        self.labels
+            .iter()
+            .map(|(name, value)| (name.to_owned(), value.to_owned()))
+            .collect()
+    }
+
+    /// A stand-in for a reading a target points at but the catalogue does not hold.
+    ///
+    /// Resolution cannot produce that — a reading is pushed before anything indexes it — but the
+    /// evaluator still has to report *something* for such a target rather than dropping it, and a
+    /// dropped severity is the kind of silence this service exists to prevent.
+    pub fn unknown() -> Self {
+        Self {
+            namespace: String::new(),
+            metric_name: String::new(),
+            labels: Labels::default(),
+            period: Period::ONE_MINUTE,
+            aggregation: Aggregation::Average,
+        }
+    }
+}
+
+/// One severity of one definition: a rule, the reading it applies to, and where it announces.
+#[derive(Debug, Clone)]
+pub struct AlarmTarget {
+    /// The catalogue entry's name.
+    pub definition: String,
+    /// The group it belongs to, carried through from the HCL.
+    pub classification: String,
+    /// The severity id.
+    pub severity: String,
+    /// The hand-written message this severity announces.
+    pub description: String,
+    /// Which entry of [`Catalogue::readings`] it is evaluated against.
+    pub reading: usize,
+    /// The threshold and window.
+    pub rule: AlarmRule,
+    /// The chat destination its announcements go to.
+    pub destination: String,
+}
+
+impl AlarmTarget {
+    /// How this target is named in logs and in the response.
+    pub fn name(&self) -> String {
+        format!("{}/{}", self.definition, self.severity)
+    }
+}
+
+/// The whole catalogue, ready to evaluate.
+#[derive(Debug, Clone, Default)]
+pub struct Catalogue {
+    /// Every distinct reading, deduplicated.
+    pub readings: Vec<Reading>,
+    /// Every severity, pointing into [`Self::readings`].
+    pub targets: Vec<AlarmTarget>,
+    /// How many datapoints beyond each window to fetch.
+    pub missing_data_lookback: u32,
+    /// How far back from the latest completed minute a run evaluates.
+    pub evaluation_delay_seconds: i64,
+    /// Where a failed evaluation is reported.
+    pub failure_destination: String,
+}
+
+impl Catalogue {
+    /// Turn validated configuration into readings and targets.
+    ///
+    /// # Errors
+    ///
+    /// Only for what [`CloudWatchSettings::validate`] would already have refused — a definition
+    /// with no dimensions, a severity with no destination, `treat_missing_data = "ignore"`. It is
+    /// re-run here rather than assumed, so the two cannot drift into a state where a catalogue
+    /// prepares into something validation would not have allowed.
+    pub fn resolve(settings: &CloudWatchSettings) -> Result<Self, ConfigurationError> {
+        let mut catalogue = Self {
+            missing_data_lookback: settings.missing_data_lookback,
+            evaluation_delay_seconds: i64::from(settings.evaluation_delay_seconds),
+            failure_destination: settings.failure_destination.clone().unwrap_or_default(),
+            ..Self::default()
+        };
+
+        if !settings.is_enabled() {
+            return Ok(catalogue);
+        }
+
+        settings.validate()?;
+
+        // Positions of readings already seen, so the second definition watching a metric reuses
+        // the first's query rather than adding a duplicate to the batch.
+        let mut seen: BTreeMap<String, usize> = BTreeMap::new();
+
+        for (name, definition) in &settings.alarms {
+            // Dimensions arrive resolved, so there is nothing to look up and nothing to expand.
+            // The check that they are *there* stays, because an entry that lost its dimensions in
+            // rendering would query the undimensioned metric and simply never fire.
+            if definition.dimensions.is_empty() {
+                Err(ConfigurationError::ConfigParsingError(format!(
+                    "alarm `{name}` has no dimensions, which would read the undimensioned metric \
+                     rather than the stream it names"
+                )))?
+            }
+            let labels: Labels = definition
+                .dimensions
+                .iter()
+                .map(|dimension| (dimension.name.clone(), dimension.value.clone()))
+                .collect();
+
+            let reading = Reading {
+                namespace: definition.namespace.clone(),
+                metric_name: definition.metric_name.clone(),
+                labels,
+                period: Period::from_seconds(i32::try_from(definition.period).unwrap_or(i32::MAX)),
+                aggregation: aggregation_of(definition.statistic),
+            };
+
+            let index = match seen.get(&reading.identity()) {
+                Some(index) => *index,
+                None => {
+                    let index = catalogue.readings.len();
+                    seen.insert(reading.identity(), index);
+                    catalogue.readings.push(reading);
+                    index
+                }
+            };
+
+            for (severity, rule) in &definition.severities {
+                let destination = settings
+                    .severity_destinations
+                    .get(severity)
+                    .ok_or_else(|| {
+                        ConfigurationError::ConfigParsingError(format!(
+                            "alarm `{name}` uses severity `{severity}`, which has no entry in \
+                             cloudwatch.severity_destinations"
+                        ))
+                    })?
+                    .clone();
+
+                catalogue.targets.push(AlarmTarget {
+                    definition: name.clone(),
+                    classification: definition.classification.clone(),
+                    severity: severity.clone(),
+                    description: rule.description.clone(),
+                    reading: index,
+                    rule: AlarmRule {
+                        comparison_operator: operator_of(rule.comparison_operator),
+                        threshold: rule.threshold,
+                        evaluation_periods: rule.evaluation_periods,
+                        datapoints_to_alarm: rule.datapoints_to_alarm(),
+                        treat_missing_data: policy_of(rule.treat_missing_data, name, severity)?,
+                    },
+                    destination,
+                });
+            }
+        }
+
+        Ok(catalogue)
+    }
+
+    /// Whether there is anything to evaluate.
+    pub fn is_empty(&self) -> bool {
+        self.targets.is_empty()
+    }
+
+    /// How many catalogue entries the targets came from.
+    ///
+    /// Counted rather than stored, because the flat list of targets is the authority on what a run
+    /// actually covers and a second field could disagree with it.
+    pub fn definitions(&self) -> usize {
+        let mut names = self
+            .targets
+            .iter()
+            .map(|target| target.definition.as_str())
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        names.dedup();
+
+        names.len()
+    }
+
+    /// The widest evaluation range any target reads `index` over.
+    fn range_for(&self, index: usize) -> usize {
+        self.targets
+            .iter()
+            .filter(|target| target.reading == index)
+            .map(|target| target.rule.evaluation_range(self.missing_data_lookback))
+            .max()
+            .unwrap_or_default()
+    }
+}
+
+/// Where one reading's two windows are to be found once the requests come back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GridRef {
+    /// Which of [`FetchPlan::requests`] holds it.
+    pub request: usize,
+    /// How many slots before the grid's end the window ends.
+    pub back: usize,
+}
+
+/// One reading's place in the plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadingPlan {
+    /// Which of [`Catalogue::readings`] this is for.
+    pub reading: usize,
+    /// The evaluation ending at the run's instant.
+    pub current: GridRef,
+    /// The evaluation ending one minute earlier.
+    pub previous: GridRef,
+}
+
+/// Every request a run makes, and where each reading's windows land in the answers.
+#[derive(Debug, Clone, Default)]
+pub struct FetchPlan {
+    /// The requests to issue, in order. Each carries the queries for one period and one alignment.
+    pub requests: Vec<MetricRequest>,
+    /// Which query position inside each request answers which reading.
+    ///
+    /// Indexed as `positions[request][query] = reading`, mirroring the provider's promise that a
+    /// series comes back keyed by its query's position.
+    pub positions: Vec<Vec<usize>>,
+    /// One entry per reading.
+    pub readings: Vec<ReadingPlan>,
+}
+
+impl FetchPlan {
+    /// Plan the requests for an evaluation ending at `end`.
+    ///
+    /// Readings are grouped by period, because one `GetMetricData` call covers one time range and
+    /// a range is only meaningful against a period. Within a period, whether the two windows share
+    /// a grid is decided by whether the minute the window slides by divides that period — see the
+    /// module docs.
+    pub fn build(catalogue: &Catalogue, end: time::PrimitiveDateTime) -> Self {
+        // The one place a naive UTC instant becomes an offset one: `TimeRange` is the metrics
+        // client's type and it takes an `OffsetDateTime`. Everything on this side of that call
+        // stays naive, as `common_utils::date_time` and the rest of the repository do.
+        let end = end.assume_utc();
+        let mut plan = Self::default();
+
+        let mut by_period: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+        for (index, reading) in catalogue.readings.iter().enumerate() {
+            by_period
+                .entry(reading.period.seconds())
+                .or_default()
+                .push(index);
+        }
+
+        for (seconds, readings) in by_period {
+            let period = Period::from_seconds(seconds);
+            let range = readings
+                .iter()
+                .map(|index| catalogue.range_for(*index))
+                .max()
+                .unwrap_or_default();
+
+            // How many whole periods the window slides by between two evaluations. `None` means
+            // the slide is shorter than a period, so the two windows do not share a grid.
+            let stride = (period.seconds_i64() > 0
+                && EVALUATION_INTERVAL_SECONDS % period.seconds_i64() == 0)
+                .then(|| EVALUATION_INTERVAL_SECONDS / period.seconds_i64())
+                .and_then(|stride| usize::try_from(stride).ok());
+
+            // A rejected batch takes every metric in it down, so the cap is respected here rather
+            // than discovered by the provider on a catalogue that has grown past it.
+            for chunk in readings.chunks(MAX_QUERIES_PER_REQUEST) {
+                match stride {
+                    // One grid holds both windows: the previous evaluation is the same grid read
+                    // `stride` slots further back.
+                    Some(stride) => {
+                        let slots = range.saturating_add(stride);
+                        let request = plan.push(
+                            catalogue,
+                            TimeRange::ending_at(end, period, slot_count(slots)),
+                            chunk,
+                        );
+
+                        plan.readings.extend(chunk.iter().map(|index| ReadingPlan {
+                            reading: *index,
+                            current: GridRef { request, back: 0 },
+                            previous: GridRef {
+                                request,
+                                back: stride,
+                            },
+                        }));
+                    }
+
+                    // Two grids, a minute apart. Asking for one and reading it twice would compare
+                    // a window against itself shifted by a whole period, which is a different
+                    // question from the one CloudWatch asks.
+                    None => {
+                        let shift = time::Duration::seconds(EVALUATION_INTERVAL_SECONDS);
+                        let current = plan.push(
+                            catalogue,
+                            TimeRange::ending_at(end, period, slot_count(range)),
+                            chunk,
+                        );
+                        let previous = plan.push(
+                            catalogue,
+                            TimeRange::ending_at(end - shift, period, slot_count(range)),
+                            chunk,
+                        );
+
+                        plan.readings.extend(chunk.iter().map(|index| ReadingPlan {
+                            reading: *index,
+                            current: GridRef {
+                                request: current,
+                                back: 0,
+                            },
+                            previous: GridRef {
+                                request: previous,
+                                back: 0,
+                            },
+                        }));
+                    }
+                }
+            }
+        }
+
+        plan
+    }
+
+    /// Which query position inside `request` answers `reading`, if it is in that request at all.
+    pub fn position_of(&self, request: usize, reading: usize) -> Option<usize> {
+        self.positions
+            .get(request)?
+            .iter()
+            .position(|candidate| *candidate == reading)
+    }
+
+    fn push(&mut self, catalogue: &Catalogue, range: TimeRange, readings: &[usize]) -> usize {
+        let queries = readings
+            .iter()
+            .filter_map(|index| catalogue.readings.get(*index))
+            .map(Reading::query)
+            .collect::<Vec<_>>();
+
+        let index = self.requests.len();
+        self.requests.push(MetricRequest { range, queries });
+        self.positions.push(readings.to_vec());
+        index
+    }
+}
+
+/// The most queries one `GetMetricData` call takes. The provider enforces the same number; naming
+/// it here is what keeps a grown catalogue from ever reaching that check.
+const MAX_QUERIES_PER_REQUEST: usize = 500;
+
+fn slot_count(slots: usize) -> u32 {
+    u32::try_from(slots).unwrap_or(u32::MAX)
+}
+
+fn aggregation_of(statistic: cloudwatch::Statistic) -> Aggregation {
+    match statistic {
+        cloudwatch::Statistic::Average => Aggregation::Average,
+        cloudwatch::Statistic::Maximum => Aggregation::Maximum,
+        cloudwatch::Statistic::Minimum => Aggregation::Minimum,
+        cloudwatch::Statistic::Sum => Aggregation::Sum,
+    }
+}
+
+fn operator_of(operator: cloudwatch::ComparisonOperator) -> ComparisonOperator {
+    match operator {
+        cloudwatch::ComparisonOperator::GreaterThanThreshold => {
+            ComparisonOperator::GreaterThanThreshold
+        }
+        cloudwatch::ComparisonOperator::GreaterThanOrEqualToThreshold => {
+            ComparisonOperator::GreaterThanOrEqualToThreshold
+        }
+        cloudwatch::ComparisonOperator::LessThanThreshold => ComparisonOperator::LessThanThreshold,
+        cloudwatch::ComparisonOperator::LessThanOrEqualToThreshold => {
+            ComparisonOperator::LessThanOrEqualToThreshold
+        }
+    }
+}
+
+fn policy_of(
+    treatment: cloudwatch::TreatMissingData,
+    alarm: &str,
+    severity: &str,
+) -> Result<MissingDataPolicy, ConfigurationError> {
+    match treatment {
+        cloudwatch::TreatMissingData::Breaching => Ok(MissingDataPolicy::Breaching),
+        cloudwatch::TreatMissingData::NotBreaching => Ok(MissingDataPolicy::NotBreaching),
+        cloudwatch::TreatMissingData::Missing => Ok(MissingDataPolicy::Missing),
+        cloudwatch::TreatMissingData::Ignore => {
+            Err(ConfigurationError::ConfigParsingError(format!(
+                "alarm `{alarm}` severity `{severity}` asks for treat_missing_data `ignore`, \
+                 which this evaluator cannot reproduce without a memory of the previous state"
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use time::macros::datetime;
+
+    use super::*;
+
+    fn settings(alarms: serde_json::Value) -> CloudWatchSettings {
+        serde_json::from_value(serde_json::json!({
+            "region": "ap-south-1",
+            "failure_destination": "smoke",
+            "severity_destinations": { "sev1": "smoke", "sev2": "smoke", "sev3": "smoke" },
+            "alarms": alarms,
+        }))
+        .unwrap()
+    }
+
+    fn definition(
+        metric: &str,
+        instance: &str,
+        period: u32,
+        severities: serde_json::Value,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "classification": "rds-alerts",
+            "metric_name": metric,
+            "namespace": "AWS/RDS",
+            "dimensions": [{ "name": "DBInstanceIdentifier", "value": instance }],
+            "period": period,
+            "statistic": "Average",
+            "severities": severities,
+        })
+    }
+
+    fn severity(threshold: f64, evaluation_periods: u32) -> serde_json::Value {
+        serde_json::json!({
+            "threshold": threshold,
+            "description": "d",
+            "evaluation_periods": evaluation_periods,
+        })
+    }
+
+    /// The inversion this module exists for: severities differ only by threshold, and a threshold
+    /// is not part of a CloudWatch query.
+    #[test]
+    fn severities_of_one_definition_share_a_single_reading() {
+        let catalogue = Catalogue::resolve(&settings(serde_json::json!({
+            "cpu": definition("CPUUtilization", "rds-primary", 60, serde_json::json!({
+                "sev1": severity(90.0, 1),
+                "sev2": severity(85.0, 1),
+                "sev3": severity(65.0, 1),
+            })),
+        })))
+        .unwrap();
+
+        assert_eq!(catalogue.readings.len(), 1);
+        assert_eq!(catalogue.targets.len(), 3);
+        assert!(catalogue.targets.iter().all(|target| target.reading == 0));
+    }
+
+    /// The same metric on two instances is two readings, because the dimensions identify it.
+    #[test]
+    fn the_same_metric_on_different_dimensions_is_a_second_reading() {
+        let catalogue = Catalogue::resolve(&settings(serde_json::json!({
+            "primary": definition("CPUUtilization", "rds-primary", 60, serde_json::json!({
+                "sev1": severity(90.0, 1),
+            })),
+            "failover": definition("CPUUtilization", "rds-failover", 60, serde_json::json!({
+                "sev1": severity(90.0, 1),
+            })),
+        })))
+        .unwrap();
+
+        assert_eq!(catalogue.readings.len(), 2);
+    }
+
+    /// A 60-second metric slides by exactly one slot, so one grid holds both evaluations — the
+    /// `N + 1` fetch, and the only case where it is correct.
+    #[test]
+    fn a_one_minute_metric_needs_one_request_for_both_windows() {
+        let catalogue = Catalogue::resolve(&settings(serde_json::json!({
+            "cpu": definition("CPUUtilization", "rds-primary", 60, serde_json::json!({
+                "sev1": severity(90.0, 3),
+            })),
+        })))
+        .unwrap();
+
+        let plan = FetchPlan::build(&catalogue, datetime!(2026-09-10 12:00:00));
+
+        assert_eq!(plan.requests.len(), 1);
+        // Evaluation range 3 + 2 lookback, plus the one slot the window slides by.
+        assert_eq!(
+            plan.requests[0].range.start,
+            datetime!(2026-09-10 11:54:00 UTC)
+        );
+        assert_eq!(
+            plan.readings[0].current,
+            GridRef {
+                request: 0,
+                back: 0
+            }
+        );
+        assert_eq!(
+            plan.readings[0].previous,
+            GridRef {
+                request: 0,
+                back: 1
+            }
+        );
+    }
+
+    /// A 300-second metric does not. Its two windows sit on grids a minute apart, and one
+    /// response cannot represent both — reading one grid twice would compare windows a whole
+    /// period apart, which is not what CloudWatch compares.
+    #[test]
+    fn a_five_minute_metric_needs_two_differently_aligned_requests() {
+        let catalogue = Catalogue::resolve(&settings(serde_json::json!({
+            "iops": definition("ReadIOPS", "rds-primary", 300, serde_json::json!({
+                "sev1": severity(18000.0, 3),
+            })),
+        })))
+        .unwrap();
+
+        let plan = FetchPlan::build(&catalogue, datetime!(2026-09-10 12:00:00));
+
+        assert_eq!(plan.requests.len(), 2);
+        assert_eq!(
+            plan.requests[0].range.end,
+            datetime!(2026-09-10 12:00:00 UTC)
+        );
+        // Exactly one minute earlier, not one period earlier.
+        assert_eq!(
+            plan.requests[1].range.end,
+            datetime!(2026-09-10 11:59:00 UTC)
+        );
+        assert_eq!(
+            plan.requests[0].range.start,
+            datetime!(2026-09-10 11:35:00 UTC)
+        );
+        assert_eq!(
+            plan.readings[0].current,
+            GridRef {
+                request: 0,
+                back: 0
+            }
+        );
+        assert_eq!(
+            plan.readings[0].previous,
+            GridRef {
+                request: 1,
+                back: 0
+            }
+        );
+    }
+
+    /// Readings of one period travel in one request, and the request is sized by the widest window
+    /// any of them needs.
+    #[test]
+    fn one_request_per_period_carries_every_reading_of_that_period() {
+        let catalogue = Catalogue::resolve(&settings(serde_json::json!({
+            "cpu": definition("CPUUtilization", "rds-primary", 60, serde_json::json!({
+                "sev1": severity(90.0, 1),
+            })),
+            "memory": definition("FreeableMemory", "rds-failover", 60, serde_json::json!({
+                "sev1": severity(1.0, 5),
+            })),
+            "iops": definition("ReadIOPS", "rds-primary", 300, serde_json::json!({
+                "sev1": severity(18000.0, 3),
+            })),
+        })))
+        .unwrap();
+
+        let plan = FetchPlan::build(&catalogue, datetime!(2026-09-10 12:00:00));
+
+        // One for the minute metrics, two for the five-minute one.
+        assert_eq!(plan.requests.len(), 3);
+        assert_eq!(plan.requests[0].queries.len(), 2);
+        // Sized by the widest: 5 evaluation periods + 2 lookback + 1 slide = 8 minutes.
+        assert_eq!(
+            plan.requests[0].range.start,
+            datetime!(2026-09-10 11:52:00 UTC)
+        );
+    }
+
+    #[test]
+    fn an_empty_catalogue_plans_nothing() {
+        let catalogue = Catalogue::resolve(&CloudWatchSettings::default()).unwrap();
+
+        assert!(catalogue.is_empty());
+        assert!(FetchPlan::build(&catalogue, datetime!(2026-09-10 12:00:00))
+            .requests
+            .is_empty());
+    }
+
+    #[test]
+    fn a_target_carries_the_destination_its_severity_maps_to() {
+        let catalogue = Catalogue::resolve(&settings(serde_json::json!({
+            "cpu": definition("CPUUtilization", "rds-primary", 60, serde_json::json!({
+                "sev2": severity(85.0, 1),
+            })),
+        })))
+        .unwrap();
+
+        assert_eq!(catalogue.targets[0].destination, "smoke");
+        assert_eq!(catalogue.targets[0].name(), "cpu/sev2");
+    }
+}

--- a/crates/observability/src/domain/alarm/message.rs
+++ b/crates/observability/src/domain/alarm/message.rs
@@ -1,0 +1,368 @@
+//! Turning an evaluation into the message an operator reads.
+//!
+//! The catalogue's per-severity `description` fields were written for people on call, and they are
+//! reproduced verbatim: this module frames them, it does not paraphrase them. Everything added
+//! around a description is there because it is the next thing asked after "what fired" — which
+//! instance, what the number actually was, and what it was compared against.
+//!
+//! Rendering is separated from delivery so that a dry run can produce exactly the message a real
+//! run would send. If a dry run built its preview differently, it would be a preview of something
+//! else.
+
+use std::fmt::Write;
+
+use crate::domain::alarm::{
+    catalogue::{AlarmTarget, Reading},
+    Evaluation, MissingDataPolicy, Transition,
+};
+
+/// The message announcing one state transition.
+pub fn announcement(
+    target: &AlarmTarget,
+    reading: &Reading,
+    transition: Transition,
+    evaluation: &Evaluation,
+    evaluated_at: time::PrimitiveDateTime,
+) -> String {
+    let severity = target.severity.to_uppercase();
+    let mut message = format!(
+        "*{severity} · {} · {} → {}*\n{}\n",
+        target.definition,
+        transition.from.label(),
+        transition.to.label(),
+        target.description.trim(),
+    );
+
+    let period = reading.period.seconds();
+    let _ = writeln!(
+        message,
+        "• Metric: {} ({:?} over {period}s)",
+        reading.describe(),
+        reading.aggregation,
+    );
+    let _ = writeln!(message, "• Dimensions: {}", dimensions(reading));
+    let _ = writeln!(message, "• {}", observation(target, evaluation));
+    let _ = writeln!(message, "• {}", window(target, evaluation));
+
+    if evaluation.filled > 0 {
+        let _ = writeln!(message, "• {}", gaps(target, evaluation));
+    }
+
+    let _ = write!(message, "• Evaluated through {}", timestamp(evaluated_at));
+
+    message
+}
+
+/// The message reporting that a run could not read some or all of its metrics.
+///
+/// Separate from an alarm announcement on purpose. A CloudWatch outage is a fact about this
+/// service, not about the database, and rendering it as an alarm would put an estate-shaped
+/// message in front of someone about something that is not happening to the estate.
+pub fn failure_summary(
+    total: usize,
+    failed: &[String],
+    reason: Option<&str>,
+    evaluated_at: time::PrimitiveDateTime,
+) -> String {
+    let at = timestamp(evaluated_at);
+    let mut message = if failed.len() >= total {
+        format!(
+            "*Observability · CloudWatch evaluation failed*\nNo metric readings could be \
+             retrieved for the evaluation ending {at}, so no alarm was evaluated this run.\n"
+        )
+    } else {
+        format!(
+            "*Observability · CloudWatch evaluation degraded*\n{} of {total} metric readings \
+             could not be retrieved for the evaluation ending {at}. Everything else was evaluated \
+             normally.\n",
+            failed.len(),
+        )
+    };
+
+    if let Some(reason) = reason {
+        let _ = writeln!(message, "• Reason: {reason}");
+    }
+
+    for name in failed.iter().take(MAX_LISTED_FAILURES) {
+        let _ = writeln!(message, "• Not evaluated: {name}");
+    }
+
+    if let Some(remaining) = failed.len().checked_sub(MAX_LISTED_FAILURES) {
+        if remaining > 0 {
+            let _ = writeln!(message, "• …and {remaining} more");
+        }
+    }
+
+    let _ = write!(
+        message,
+        "This run is not retried; the next evaluation covers the same ground."
+    );
+
+    message
+}
+
+/// How many affected definitions a summary names before it starts counting instead.
+///
+/// A summary is read on a phone. Naming all seventy-six would be a wall that nobody reads, and the
+/// count is the actionable part once the list is long enough to be an outage rather than a metric.
+const MAX_LISTED_FAILURES: usize = 12;
+
+fn dimensions(reading: &Reading) -> String {
+    let pairs = reading
+        .labels
+        .iter()
+        .map(|(name, value)| format!("{name}={value}"))
+        .collect::<Vec<_>>();
+
+    pairs.join(", ")
+}
+
+fn observation(target: &AlarmTarget, evaluation: &Evaluation) -> String {
+    let comparison = format!(
+        "threshold {} {}",
+        target.rule.comparison_operator.symbol(),
+        number(target.rule.threshold),
+    );
+
+    match evaluation.observed {
+        Some(value) => format!("Observed: {} ({comparison})", number(value)),
+        // The state came entirely from the missing-data policy, so quoting a value would be
+        // quoting one this run never saw.
+        None => format!("Observed: no reading in the evaluation range ({comparison})"),
+    }
+}
+
+fn window(target: &AlarmTarget, evaluation: &Evaluation) -> String {
+    format!(
+        "Window: {} of the last {} datapoints breaching, {} needed",
+        evaluation.breaching, target.rule.evaluation_periods, target.rule.datapoints_to_alarm,
+    )
+}
+
+fn gaps(target: &AlarmTarget, evaluation: &Evaluation) -> String {
+    let treatment = match target.rule.treat_missing_data {
+        MissingDataPolicy::Breaching => "counted as breaching",
+        MissingDataPolicy::NotBreaching => "counted as within the threshold",
+        MissingDataPolicy::Missing => "not enough data to decide on",
+    };
+
+    format!(
+        "Missing: only {} real datapoints were available, so {} were {treatment}",
+        evaluation.real, evaluation.filled,
+    )
+}
+
+/// A number as an operator wrote it in the catalogue.
+///
+/// `f64`'s own formatting already drops a trailing `.0` and never reaches for scientific notation
+/// at these magnitudes, so a threshold of `858993459` reads back as itself rather than as
+/// `8.58993459e8`.
+fn number(value: f64) -> String {
+    format!("{value}")
+}
+
+/// A UTC instant, to the second.
+///
+/// Infallible on purpose. `time`'s well-known formatters return a `Result`, and there is nothing
+/// sensible to do with an error while building an alert — a timestamp rendered as an error string
+/// is worse than one rendered plainly. Every instant reaching here is minute-aligned, so no
+/// subsecond is dropped; the response body carries the same instant through
+/// `common_utils::custom_serde::iso8601`, which renders milliseconds as well.
+pub fn timestamp(instant: time::PrimitiveDateTime) -> String {
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        instant.year(),
+        u8::from(instant.month()),
+        instant.day(),
+        instant.hour(),
+        instant.minute(),
+        instant.second(),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use external_services::metrics_service::{Aggregation, Period};
+    use time::macros::datetime;
+
+    use super::*;
+    use crate::domain::alarm::{AlarmRule, AlarmState, ComparisonOperator};
+
+    fn reading() -> Reading {
+        Reading {
+            namespace: "AWS/RDS".to_owned(),
+            metric_name: "CPUUtilization".to_owned(),
+            labels: [("DBInstanceIdentifier", "hyperswitchdb-primary")]
+                .into_iter()
+                .collect(),
+            period: Period::ONE_MINUTE,
+            aggregation: Aggregation::Average,
+        }
+    }
+
+    fn target(policy: MissingDataPolicy) -> AlarmTarget {
+        AlarmTarget {
+            definition: "rds-primary-cpu".to_owned(),
+            classification: "rds-alerts".to_owned(),
+            severity: "sev1".to_owned(),
+            description: "SEV1: RDS primary database CPU utilization is above 90% (Sev0 limit) \
+                          for 5 minutes."
+                .to_owned(),
+            reading: 0,
+            rule: AlarmRule {
+                comparison_operator: ComparisonOperator::GreaterThanOrEqualToThreshold,
+                threshold: 90.0,
+                evaluation_periods: 3,
+                datapoints_to_alarm: 3,
+                treat_missing_data: policy,
+            },
+            destination: "smoke".to_owned(),
+        }
+    }
+
+    fn evaluation(
+        state: AlarmState,
+        observed: Option<f64>,
+        real: usize,
+        filled: usize,
+    ) -> Evaluation {
+        Evaluation {
+            state,
+            breaching: 3,
+            real,
+            filled,
+            observed,
+        }
+    }
+
+    fn render(policy: MissingDataPolicy, evaluation: &Evaluation) -> String {
+        announcement(
+            &target(policy),
+            &reading(),
+            Transition {
+                from: AlarmState::Ok,
+                to: AlarmState::Alarm,
+            },
+            evaluation,
+            datetime!(2026-09-10 12:00:00),
+        )
+    }
+
+    /// Everything the ticket asks a message to carry: the description as written, the metric, the
+    /// value, the threshold, and the dimension it fired on.
+    #[test]
+    fn an_announcement_carries_the_description_metric_value_threshold_and_dimension() {
+        let message = render(
+            MissingDataPolicy::NotBreaching,
+            &evaluation(AlarmState::Alarm, Some(93.25), 3, 0),
+        );
+
+        assert!(message.contains("SEV1"), "{message}");
+        assert!(message.contains("rds-primary-cpu"), "{message}");
+        assert!(message.contains("OK → ALARM"), "{message}");
+        assert!(
+            message.contains("CPU utilization is above 90% (Sev0 limit)"),
+            "{message}"
+        );
+        assert!(message.contains("AWS/RDS CPUUtilization"), "{message}");
+        assert!(
+            message.contains("DBInstanceIdentifier=hyperswitchdb-primary"),
+            "{message}"
+        );
+        assert!(message.contains("Observed: 93.25"), "{message}");
+        assert!(message.contains("threshold >= 90"), "{message}");
+        assert!(message.contains("2026-09-10T12:00:00Z"), "{message}");
+    }
+
+    /// Recovery is announced the same way, so an operator who saw the alarm sees it close.
+    #[test]
+    fn a_recovery_reads_as_a_transition_back() {
+        let message = announcement(
+            &target(MissingDataPolicy::NotBreaching),
+            &reading(),
+            Transition {
+                from: AlarmState::Alarm,
+                to: AlarmState::Ok,
+            },
+            &evaluation(AlarmState::Ok, Some(12.0), 3, 0),
+            datetime!(2026-09-10 12:00:00),
+        );
+
+        assert!(message.contains("ALARM → OK"), "{message}");
+    }
+
+    /// A state the policy decided has no observed value, and says so instead of quoting one.
+    #[test]
+    fn an_evaluation_with_no_readings_says_so_rather_than_inventing_a_value() {
+        let message = render(
+            MissingDataPolicy::Breaching,
+            &evaluation(AlarmState::Alarm, None, 0, 3),
+        );
+
+        assert!(
+            message.contains("no reading in the evaluation range"),
+            "{message}"
+        );
+        assert!(message.contains("counted as breaching"), "{message}");
+    }
+
+    /// A window that was complete says nothing about gaps, rather than a line of zeroes.
+    #[test]
+    fn a_complete_window_mentions_no_gaps() {
+        let message = render(
+            MissingDataPolicy::NotBreaching,
+            &evaluation(AlarmState::Alarm, Some(93.0), 3, 0),
+        );
+
+        assert!(!message.contains("Missing:"), "{message}");
+    }
+
+    /// Large thresholds come back as they were written, not in scientific notation.
+    #[test]
+    fn a_large_threshold_reads_as_the_catalogue_wrote_it() {
+        assert_eq!(number(858993459.0), "858993459");
+        assert_eq!(number(0.2), "0.2");
+        assert_eq!(number(140625000.0), "140625000");
+    }
+
+    #[test]
+    fn a_total_failure_and_a_partial_one_read_differently() {
+        let total = failure_summary(
+            3,
+            &["a".to_owned(), "b".to_owned(), "c".to_owned()],
+            Some("the credentials were rejected"),
+            datetime!(2026-09-10 12:00:00),
+        );
+        assert!(total.contains("evaluation failed"), "{total}");
+        assert!(total.contains("no alarm was evaluated"), "{total}");
+        assert!(total.contains("credentials were rejected"), "{total}");
+
+        let partial = failure_summary(
+            20,
+            &["rds-primary-cpu".to_owned()],
+            None,
+            datetime!(2026-09-10 12:00:00),
+        );
+        assert!(partial.contains("evaluation degraded"), "{partial}");
+        assert!(partial.contains("1 of 20"), "{partial}");
+        assert!(partial.contains("rds-primary-cpu"), "{partial}");
+    }
+
+    /// A long list becomes a count, because a summary is read on a phone.
+    #[test]
+    fn a_long_failure_list_is_truncated_with_a_count() {
+        let failed = (0..20).map(|index| format!("d{index}")).collect::<Vec<_>>();
+        let message = failure_summary(40, &failed, None, datetime!(2026-09-10 12:00:00));
+
+        assert!(message.contains("…and 8 more"), "{message}");
+    }
+
+    #[test]
+    fn a_timestamp_is_utc_to_the_second() {
+        assert_eq!(
+            timestamp(datetime!(2026-09-10 12:34:56)),
+            "2026-09-10T12:34:56Z"
+        );
+    }
+}

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -1,8 +1,17 @@
 //! The observability plane for Hyperswitch.
 //!
-//! `observability` delivers alerts. Deciding what is alert-worthy happens elsewhere; alerts
-//! arrive here already decided. Its first concern is [`core::notifier`], and further alerting
-//! concerns are expected to live alongside it.
+//! `observability` decides what is alert-worthy and delivers the result. Both, now — the crate
+//! began as delivery only, with alerts arriving already decided, and [`core::alarm`] added the
+//! other half by evaluating CloudWatch metric alarms in this process and handing them to
+//! [`core::notifier`] without a hop.
+//!
+//! The two halves stay distinguishable. An alert that arrives on a notify route was decided by its
+//! caller and is forwarded unchanged; one that leaves the evaluate route was decided here, from
+//! thresholds in [`settings::cloudwatch`] and readings from a metrics provider. What the crate
+//! deliberately does **not** do is remember anything about an alert after it has been sent — no
+//! mute, no acknowledgement, no history. Deciding from a source is generation and belongs here;
+//! remembering things about an alert is management and belongs to a separate effort, source
+//! agnostic, or it ends up covering infrastructure alerts and nothing else.
 //!
 //! Laid out on the router's lines: [`core`] decides, [`routes`] exposes, and the whole route tree
 //! is visible in [`routes::app`].

--- a/crates/observability/src/routes.rs
+++ b/crates/observability/src/routes.rs
@@ -1,6 +1,7 @@
 //! HTTP surface, laid out as the router lays its own out: [`app`] holds the route tree, and one
 //! module per area holds the handlers.
 
+pub mod alarm;
 pub mod app;
 pub mod health_check;
 pub mod notify;

--- a/crates/observability/src/routes/alarm.rs
+++ b/crates/observability/src/routes/alarm.rs
@@ -1,0 +1,85 @@
+//! Handler for the alarm evaluation route. The route tree that mounts it is in
+//! [`crate::routes::app`].
+
+use actix_web::{web, HttpRequest, HttpResponse};
+use error_stack::report;
+
+use crate::{
+    auth, core,
+    core::alarm::EvaluationOptions,
+    errors::ObservabilityError,
+    logger, services,
+    state::AppState,
+    types::{EvaluateAlarmsRequest, EvaluateAlarmsResponse},
+};
+
+/// `POST /alerts/cloudwatch/evaluate`.
+///
+/// The body is optional — a trigger that posts nothing gets a normal evaluation — but a body that
+/// is *present and malformed* is rejected rather than defaulted. The difference matters because of
+/// exactly one field: silently defaulting a body that said `{"dry_run": true}` but misspelled it
+/// would send real announcements to a real channel in answer to a request that asked for none.
+pub async fn evaluate(
+    state: web::Data<AppState>,
+    request: HttpRequest,
+    body: web::Bytes,
+) -> HttpResponse {
+    services::server_wrap(
+        state.get_ref().clone(),
+        &request,
+        body,
+        |state, body| async move {
+            let options = parse(&body)?;
+
+            core::alarm::evaluate(state, options)
+                .await
+                .map(EvaluateAlarmsResponse::from)
+        },
+        &auth::InternalApiKeyAuth,
+    )
+    .await
+}
+
+/// Read the options out of a body that may not be there.
+fn parse(body: &[u8]) -> error_stack::Result<EvaluationOptions, ObservabilityError> {
+    let request = if body.iter().all(u8::is_ascii_whitespace) {
+        EvaluateAlarmsRequest::default()
+    } else {
+        serde_json::from_slice::<EvaluateAlarmsRequest>(body).map_err(|error| {
+            // The parse failure goes to the log rather than to the caller, matching
+            // `routes::app::json_config`: serde quotes the offending part of the body.
+            logger::warn!(error = %error, "Evaluation request rejected: the body could not be parsed");
+            report!(ObservabilityError::InvalidRequest)
+        })?
+    };
+
+    Ok(EvaluationOptions {
+        dry_run: request.dry_run,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_absent_body_is_a_normal_evaluation() {
+        assert!(!parse(b"").unwrap().dry_run);
+        assert!(!parse(b"  \n").unwrap().dry_run);
+        assert!(!parse(b"{}").unwrap().dry_run);
+    }
+
+    #[test]
+    fn a_dry_run_is_read_from_the_body() {
+        assert!(parse(br#"{"dry_run": true}"#).unwrap().dry_run);
+    }
+
+    /// The failure this refuses to have: a misspelled `dry_run` that defaults to `false` would
+    /// answer "please send nothing" by sending everything.
+    #[test]
+    fn a_body_that_does_not_parse_is_refused_rather_than_defaulted() {
+        assert!(parse(br#"{"dryrun": true}"#).is_err());
+        assert!(parse(b"not json").is_err());
+    }
+}

--- a/crates/observability/src/routes/app.rs
+++ b/crates/observability/src/routes/app.rs
@@ -14,7 +14,7 @@ use actix_web::{web, Scope};
 use crate::{
     errors::types::{ApiError, ApiErrorResponse},
     logger,
-    routes::{health_check, notify},
+    routes::{alarm, health_check, notify},
     state::AppState,
 };
 
@@ -51,6 +51,13 @@ impl Alerts {
             .service(web::scope("/email").service(
                 web::resource("/notify/{destination}").route(web::post().to(notify::email)),
             ))
+            // The one route that decides rather than forwards. It names no destination, because
+            // the catalogue's severities already map to them — a caller cannot redirect an
+            // infrastructure alert by asking.
+            .service(
+                web::scope("/cloudwatch")
+                    .service(web::resource("/evaluate").route(web::post().to(alarm::evaluate))),
+            )
     }
 }
 

--- a/crates/observability/src/secrets_transformers.rs
+++ b/crates/observability/src/secrets_transformers.rs
@@ -116,5 +116,9 @@ pub async fn fetch_raw_secrets(
         proxy: conf.proxy,
         chat,
         email: conf.email,
+        // Carried across unchanged: the alarm catalogue holds thresholds, metric names and
+        // resource identifiers, and no credential. What it needs to reach CloudWatch comes from
+        // the pod's role, not from a secret in this file.
+        cloudwatch: conf.cloudwatch,
     }
 }

--- a/crates/observability/src/settings.rs
+++ b/crates/observability/src/settings.rs
@@ -9,6 +9,8 @@
 //! configuration can be used to serve requests, so "did we remember to decrypt this?" is answered
 //! by the type checker rather than by review.
 
+pub mod cloudwatch;
+
 use std::{collections::HashMap, path::PathBuf};
 
 use common_utils::{ext_traits::ConfigExt, pii};
@@ -62,6 +64,9 @@ pub struct Settings<S: SecretState> {
     pub chat: SecretStateContainer<ChatSettings, S>,
     /// Email destinations this service can deliver to.
     pub email: EmailSettings,
+    /// The CloudWatch metric alarms this service evaluates. Empty means it evaluates nothing and
+    /// only forwards what it is sent.
+    pub cloudwatch: cloudwatch::CloudWatchSettings,
 }
 
 const DEFAULT_MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
@@ -349,11 +354,50 @@ impl Settings<SecuredSecret> {
         self.auth.get_inner().validate()?;
         self.chat.get_inner().validate()?;
         self.email.validate()?;
+        self.cloudwatch.validate()?;
+        validate_alarm_destinations(&self.cloudwatch, self.chat.get_inner())?;
         self.secrets_management
             .validate()
             .map_err(|error| errors::ConfigurationError::ConfigParsingError(error.into()))?;
         Ok(())
     }
+}
+
+/// Every destination the alarm catalogue announces to has to be a chat destination that exists.
+///
+/// Checked here rather than inside [`cloudwatch::CloudWatchSettings::validate`] because it is the
+/// only rule that spans two sections, and it is worth spanning them: an alarm pointed at a
+/// destination id nobody configured would evaluate perfectly and deliver nothing, which is
+/// indistinguishable from an estate that is healthy.
+fn validate_alarm_destinations(
+    alarms: &cloudwatch::CloudWatchSettings,
+    chat: &ChatSettings,
+) -> Result<(), errors::ConfigurationError> {
+    if !alarms.is_enabled() {
+        return Ok(());
+    }
+
+    let referenced = alarms
+        .severity_destinations
+        .iter()
+        .map(|(severity, destination)| (format!("severity `{severity}`"), destination))
+        .chain(
+            alarms
+                .failure_destination
+                .iter()
+                .map(|destination| ("failure_destination".to_owned(), destination)),
+        );
+
+    for (what, destination) in referenced {
+        if !chat.destinations.contains_key(destination) {
+            Err(errors::ConfigurationError::ConfigParsingError(format!(
+                "cloudwatch {what} names chat destination `{destination}`, which is not in \
+                 chat.destinations"
+            )))?
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/observability/src/settings/cloudwatch.rs
+++ b/crates/observability/src/settings/cloudwatch.rs
@@ -1,0 +1,673 @@
+//! The metric alarm catalogue, as configuration.
+//!
+//! ## Who owns this
+//!
+//! **The infrastructure repository does.** Terraform already knows every resource identifier and
+//! already expands the templated classifications; it renders the catalogue and Helm delivers it as
+//! configuration, and this service validates and evaluates what arrives. There is deliberately no
+//! Terraform parsing, no resource discovery and no group expansion in Rust, because a second
+//! implementation of "which cache nodes exist" would drift from the first the day a node is added.
+//!
+//! That decision is what shapes the schema below. A definition carries **its dimensions, resolved**
+//! — `[{ name = "DBInstanceIdentifier", value = "hyperswitchdb-primary" }]`, not a key naming a map
+//! somewhere else and not a group to expand. A CloudWatch metric is identified by its dimension
+//! combination, so the producer that knows the identifiers is the right place for them to be named,
+//! and the consumer's job is to check that what arrived is usable. See [`Dimension`] for why they
+//! are name/value pairs rather than the map they look like they should be.
+//!
+//! ## Field names are the catalogue's own
+//!
+//! Everything a severity carries — `threshold`, `comparison_operator`, `description`,
+//! `evaluation_periods`, `datapoints_to_alarm`, `treat_missing_data` — keeps the name and the
+//! spelling `classified_metric_alarms` gives it, and so do the **defaults**. A severity that omits
+//! `evaluation_periods`, `statistic`, `comparison_operator` or `treat_missing_data` in the HCL may
+//! omit it here and mean the same thing, so a rendered entry is checkable against its source by
+//! eye. Those defaults are the Terraform module's rather than AWS's, and the two differ where it
+//! matters most: AWS defaults `treat_missing_data` to `missing`, `classified_metric_alarms`
+//! defaults it to `notBreaching`, and it is the module's value the deployed alarms actually have.
+//!
+//! ## Snapshots say so
+//!
+//! Until the rendering is automated, the catalogue in `config/observability.toml` is a hand-checked
+//! snapshot. [`CatalogueSource`] is how it says that: an origin, the revision it was taken from,
+//! and a `temporary` flag that makes the service log a warning at every boot. A comment would have
+//! done the same job until someone deleted it.
+//!
+//! ## Why the section can be absent
+//!
+//! `[cloudwatch]` with no alarms is off, and validated as such. A deployment that only forwards
+//! alerts — everything before this ticket — must not have to name an AWS region to boot.
+
+use std::collections::BTreeMap;
+
+pub use external_services::metrics_service::aws_cloudwatch::CloudWatchConfig;
+use serde::Deserialize;
+
+use crate::errors::ConfigurationError;
+
+/// CloudWatch periods are one of the five high-resolution values or any positive multiple of a
+/// minute. Checked at boot rather than left to the provider, which would reject the whole batch on
+/// the first evaluation and take every other metric down with it.
+const HIGH_RESOLUTION_PERIODS: [u32; 5] = [1, 5, 10, 20, 30];
+
+/// The default number of extra datapoints fetched beyond the evaluation window.
+///
+/// See [`AlarmRule::evaluation_range`](crate::domain::alarm::AlarmRule::evaluation_range) for why
+/// this is configuration with a default rather than a constant: AWS documents that its own widening
+/// varies with the period and publishes no formula, and 2 is the only number its worked examples
+/// put to a standard-resolution metric.
+const DEFAULT_MISSING_DATA_LOOKBACK: u32 = 2;
+
+/// The Terraform module's default evaluation window, reproduced so an omission ports faithfully.
+const DEFAULT_EVALUATION_PERIODS: u32 = 5;
+
+/// The Terraform module's default period, likewise.
+const DEFAULT_PERIOD: u32 = 60;
+
+fn default_missing_data_lookback() -> u32 {
+    DEFAULT_MISSING_DATA_LOOKBACK
+}
+
+fn default_evaluation_periods() -> u32 {
+    DEFAULT_EVALUATION_PERIODS
+}
+
+fn default_period() -> u32 {
+    DEFAULT_PERIOD
+}
+
+/// Everything the evaluator reads from configuration.
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct CloudWatchSettings {
+    /// How to reach CloudWatch. `external_services`' own type, so the region is validated exactly
+    /// where the client validates it and cannot drift into a second spelling.
+    #[serde(flatten)]
+    pub client: CloudWatchConfig,
+
+    /// How many datapoints beyond the window to retrieve, so that gaps in the recent periods can
+    /// be covered by real readings from further back.
+    #[serde(default = "default_missing_data_lookback")]
+    pub missing_data_lookback: u32,
+
+    /// How far to hold back from the latest completed minute before evaluating.
+    ///
+    /// Zero matches CloudWatch, which evaluates through the last completed minute and does not
+    /// wait for stragglers. Raise it where a metric's ingestion lag is known to exceed a minute:
+    /// a datapoint that lands after its window was evaluated cannot retroactively produce the
+    /// transition it would have caused, because nothing here remembers the decision.
+    pub evaluation_delay_seconds: u32,
+
+    /// The chat destination each severity's announcements go to, by severity id.
+    ///
+    /// Three ids all naming one channel in sandbox. Routing is configuration precisely so that
+    /// splitting them later is not a code change.
+    pub severity_destinations: BTreeMap<String, String>,
+
+    /// Where a failed *evaluation* is reported — a CloudWatch outage rather than a breached
+    /// threshold. Kept separate from the severity destinations because it is an operational
+    /// message about this service, not an alert about the estate.
+    pub failure_destination: Option<String>,
+
+    /// Where the catalogue below came from, and whether it is a hand-made snapshot.
+    pub source: CatalogueSource,
+
+    /// The catalogue, by definition name. Empty means the evaluator is off.
+    ///
+    /// A `BTreeMap` rather than a `HashMap` so that a run's results come back in a stable order —
+    /// the endpoint's first caller is a human comparing two curl outputs.
+    pub alarms: BTreeMap<String, AlarmDefinition>,
+}
+
+/// The provenance of the catalogue, carried in the configuration that carries the catalogue.
+///
+/// Renders as a boot log line, and `temporary` renders as a warning. The point is that a snapshot
+/// announces itself for as long as it exists: a hand-checked copy of somebody else's source of
+/// truth is fine to develop against and dangerous to forget about, and the version that replaces it
+/// fills in the same three fields from the generator rather than needing a new shape.
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct CatalogueSource {
+    /// Where the definitions came from — a repository and path, or the renderer that produced them.
+    pub origin: String,
+
+    /// The revision of that source, so an entry can be checked against the thing it was copied
+    /// from rather than against whatever that file says today.
+    pub revision: String,
+
+    /// Whether this is a hand-made snapshot rather than rendered output.
+    pub temporary: bool,
+}
+
+/// One catalogue entry: a metric, and the severities watching it.
+#[derive(Debug, Deserialize, Clone)]
+pub struct AlarmDefinition {
+    /// The group this definition belongs to, carried through from the HCL. Not used to decide
+    /// anything here; it is what says which Terraform-side ticket owns the entry.
+    pub classification: String,
+
+    /// The metric's name, as CloudWatch publishes it.
+    pub metric_name: String,
+
+    /// The namespace it is published under.
+    pub namespace: String,
+
+    /// The dimensions narrowing it to one reporting stream, already resolved.
+    ///
+    /// **Resolved, and never empty.** A CloudWatch metric is *identified* by its dimension
+    /// combination: a query carrying the wrong ones — or none — reads a different metric, one that
+    /// reports nothing and therefore never fires. The producer resolves them because it is the
+    /// side that knows the identifiers; this side refuses an entry that arrived without any.
+    pub dimensions: Vec<Dimension>,
+
+    /// How long one datapoint covers, in seconds.
+    #[serde(default = "default_period")]
+    pub period: u32,
+
+    /// How the values inside a period are reduced.
+    #[serde(default)]
+    pub statistic: Statistic,
+
+    /// The severities, by id. Each is an independent generation rule: they share readings and
+    /// neither suppresses the other.
+    pub severities: BTreeMap<String, SeverityRule>,
+}
+
+/// One severity's threshold, window and message.
+#[derive(Debug, Deserialize, Clone)]
+pub struct SeverityRule {
+    /// The number readings are compared against.
+    pub threshold: f64,
+
+    /// Which side of the threshold breaches.
+    #[serde(default)]
+    pub comparison_operator: ComparisonOperator,
+
+    /// The message an operator reads. Hand-written in the catalogue and reproduced verbatim — it
+    /// is the alert, not a label for it.
+    pub description: String,
+
+    /// N: how many of the most recent periods form the window.
+    #[serde(default = "default_evaluation_periods")]
+    pub evaluation_periods: u32,
+
+    /// M: how many of the window's readings must breach. Defaults to N, as CloudWatch does.
+    pub datapoints_to_alarm: Option<u32>,
+
+    /// What a period with no reading counts as.
+    #[serde(default)]
+    pub treat_missing_data: TreatMissingData,
+}
+
+/// One CloudWatch dimension: a name and a value.
+///
+/// **A pair, not a map entry, and that is not a style preference.** The `config` crate lowercases
+/// every key it reads — from files as well as from the environment — so a dimension written as
+/// `{ DBInstanceIdentifier = "…" }` arrives as `dbinstanceidentifier`. CloudWatch dimension names
+/// are case-sensitive, and a query carrying the wrong case names a metric that does not exist:
+/// it returns no datapoints, so under this catalogue's `notBreaching` default every alarm on it
+/// evaluates perfectly and never fires. Silence is the one failure mode an alarm cannot afford.
+///
+/// [`ChatSettings::destinations`](super::ChatSettings::destinations) meets the same lowercasing
+/// and answers it by refusing ids that would not survive the round trip. A dimension name cannot
+/// be spelled to survive it, so it moves out of the key instead — values keep their case. This
+/// also happens to be the shape CloudWatch itself uses on the wire.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct Dimension {
+    /// The dimension's name, case preserved — `DBInstanceIdentifier`, `Role`.
+    pub name: String,
+    /// The value identifying one reporting stream.
+    pub value: String,
+}
+
+/// How the values inside one period are reduced, spelled as CloudWatch spells it.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Statistic {
+    /// Arithmetic mean.
+    #[default]
+    Average,
+    /// Largest value in the period.
+    Maximum,
+    /// Smallest value in the period.
+    Minimum,
+    /// Every value in the period added together.
+    Sum,
+}
+
+/// Which side of the threshold breaches, spelled as CloudWatch spells it.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ComparisonOperator {
+    /// Breaches above the threshold. The Terraform module's default.
+    #[default]
+    GreaterThanThreshold,
+    /// Breaches at or above the threshold.
+    GreaterThanOrEqualToThreshold,
+    /// Breaches below the threshold.
+    LessThanThreshold,
+    /// Breaches at or below the threshold.
+    LessThanOrEqualToThreshold,
+}
+
+/// What a period with no reading counts as, spelled as the HCL spells it.
+///
+/// All four of CloudWatch's, including the one this service cannot honour, so that a catalogue
+/// asking for it is *refused* rather than quietly evaluated as something else. See
+/// [`crate::domain::alarm`].
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum TreatMissingData {
+    /// A gap counts as a breach.
+    Breaching,
+    /// A gap counts as within the threshold. The Terraform module's default.
+    #[default]
+    NotBreaching,
+    /// A window of nothing but gaps is `INSUFFICIENT_DATA`.
+    Missing,
+    /// Keep whatever state the alarm already had. Rejected at boot: this evaluator has no memory
+    /// of a previous state to keep.
+    Ignore,
+}
+
+impl CloudWatchSettings {
+    /// Whether any definition is configured.
+    ///
+    /// The off switch, and there is no separate flag: a catalogue with nothing in it has nothing
+    /// to evaluate, so neither a region nor a destination is demanded of a deployment that only
+    /// forwards alerts.
+    pub fn is_enabled(&self) -> bool {
+        !self.alarms.is_empty()
+    }
+
+    /// Every severity id any definition uses.
+    pub fn severities_in_use(&self) -> impl Iterator<Item = &str> {
+        self.alarms
+            .values()
+            .flat_map(|definition| definition.severities.keys().map(String::as_str))
+    }
+
+    /// Reject a catalogue that cannot be evaluated.
+    ///
+    /// Everything checkable without a network call is checked here, because the alternative is
+    /// discovering it on the first evaluation — by which time the failure is a chat message about
+    /// a metric nobody can find rather than a service that refused to start.
+    pub fn validate(&self) -> Result<(), ConfigurationError> {
+        if !self.is_enabled() {
+            return Ok(());
+        }
+
+        self.client
+            .validate()
+            .map_err(|reason| ConfigurationError::ConfigParsingError(reason.to_owned()))?;
+
+        if self.failure_destination.is_none() {
+            Err(ConfigurationError::ConfigParsingError(
+                "cloudwatch.failure_destination must name a chat destination when alarms are \
+                 configured, so a CloudWatch outage is reported somewhere"
+                    .into(),
+            ))?
+        }
+
+        for (name, definition) in &self.alarms {
+            definition.validate(name)?;
+
+            for severity in definition.severities.keys() {
+                if !self.severity_destinations.contains_key(severity) {
+                    Err(ConfigurationError::ConfigParsingError(format!(
+                        "alarm `{name}` uses severity `{severity}`, which has no entry in \
+                         cloudwatch.severity_destinations"
+                    )))?
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl AlarmDefinition {
+    fn validate(&self, name: &str) -> Result<(), ConfigurationError> {
+        let reject = |reason: String| ConfigurationError::ConfigParsingError(reason);
+
+        if !is_cloudwatch_period(self.period) {
+            Err(reject(format!(
+                "alarm `{name}` has period {}, which is not a CloudWatch period: use 1, 5, 10, \
+                 20, 30, or a multiple of 60",
+                self.period
+            )))?
+        }
+
+        // An empty dimension set does not mean "every stream" — it names the metric published with
+        // no dimensions at all, which for every metric in this catalogue reports nothing. An entry
+        // that arrived without dimensions is a rendering that went wrong upstream, and it would
+        // otherwise present as an alarm that simply never fires.
+        if self.dimensions.is_empty() {
+            Err(reject(format!(
+                "alarm `{name}` has no dimensions, which would read the undimensioned metric \
+                 rather than the stream it names"
+            )))?
+        }
+
+        if self
+            .dimensions
+            .iter()
+            .any(|dimension| dimension.name.trim().is_empty() || dimension.value.trim().is_empty())
+        {
+            Err(reject(format!(
+                "alarm `{name}` has a dimension with an empty name or value, which usually means \
+                 an unresolved reference reached the rendered catalogue"
+            )))?
+        }
+
+        // Two entries for one dimension name is a rendering that went wrong; one of them would win
+        // silently and select a stream nobody asked for.
+        let mut names = self
+            .dimensions
+            .iter()
+            .map(|dimension| dimension.name.as_str())
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        let total = names.len();
+        names.dedup();
+        if names.len() != total {
+            Err(reject(format!(
+                "alarm `{name}` names the same dimension twice"
+            )))?
+        }
+
+        if self.severities.is_empty() {
+            Err(reject(format!("alarm `{name}` has no severities")))?
+        }
+
+        for (severity, rule) in &self.severities {
+            rule.validate(name, severity)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl SeverityRule {
+    /// M, defaulted to N the way CloudWatch defaults it.
+    pub fn datapoints_to_alarm(&self) -> u32 {
+        self.datapoints_to_alarm.unwrap_or(self.evaluation_periods)
+    }
+
+    fn validate(&self, alarm: &str, severity: &str) -> Result<(), ConfigurationError> {
+        let reject = |reason: String| ConfigurationError::ConfigParsingError(reason);
+        let where_ = format!("alarm `{alarm}` severity `{severity}`");
+
+        if self.evaluation_periods == 0 {
+            Err(reject(format!("{where_} has evaluation_periods 0")))?
+        }
+
+        // M above N can never be satisfied, and M of zero is satisfied by nothing at all: both are
+        // an alarm that silently never fires, which is the worst way for a threshold to be wrong.
+        let to_alarm = self.datapoints_to_alarm();
+        if to_alarm == 0 || to_alarm > self.evaluation_periods {
+            Err(reject(format!(
+                "{where_} has datapoints_to_alarm {to_alarm}, which must be between 1 and its \
+                 evaluation_periods {}",
+                self.evaluation_periods
+            )))?
+        }
+
+        if self.description.trim().is_empty() {
+            Err(reject(format!("{where_} has no description to announce")))?
+        }
+
+        if self.treat_missing_data == TreatMissingData::Ignore {
+            Err(reject(format!(
+                "{where_} asks for treat_missing_data `ignore`, which keeps the alarm's previous \
+                 state. This evaluator reconstructs both windows from CloudWatch on every request \
+                 and remembers no previous state, so it cannot reproduce it — use `missing`, \
+                 `breaching` or `notBreaching`"
+            )))?
+        }
+
+        Ok(())
+    }
+}
+
+fn is_cloudwatch_period(seconds: u32) -> bool {
+    HIGH_RESOLUTION_PERIODS.contains(&seconds) || (seconds > 0 && seconds % 60 == 0)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    fn settings_from(value: serde_json::Value) -> CloudWatchSettings {
+        serde_json::from_value(value).unwrap()
+    }
+
+    /// The shape a rendered catalogue produces: dimensions resolved, everything else spelled as
+    /// the HCL spells it.
+    fn minimal() -> serde_json::Value {
+        serde_json::json!({
+            "region": "ap-south-1",
+            "failure_destination": "smoke",
+            "severity_destinations": { "sev1": "smoke" },
+            "alarms": {
+                "rds-primary-cpu": {
+                    "classification": "rds-alerts",
+                    "metric_name": "CPUUtilization",
+                    "namespace": "AWS/RDS",
+                    "dimensions": [{ "name": "DBInstanceIdentifier", "value": "hyperswitchdb-primary" }],
+                    "period": 60,
+                    "statistic": "Average",
+                    "severities": {
+                        "sev1": {
+                            "threshold": 90.0,
+                            "comparison_operator": "GreaterThanOrEqualToThreshold",
+                            "description": "SEV1: CPU is high",
+                            "evaluation_periods": 1,
+                            "treat_missing_data": "breaching",
+                        },
+                    },
+                },
+            },
+        })
+    }
+
+    /// The property that keeps a rendered entry checkable by eye: what the HCL leaves out, this
+    /// may leave out, and the values that appear are the Terraform module's own defaults.
+    #[test]
+    fn omitted_fields_take_the_terraform_modules_defaults() {
+        let settings = settings_from(serde_json::json!({
+            "region": "ap-south-1",
+            "failure_destination": "smoke",
+            "severity_destinations": { "sev1": "smoke" },
+            "alarms": {
+                "bare": {
+                    "classification": "rds-alerts",
+                    "metric_name": "CPUUtilization",
+                    "namespace": "AWS/RDS",
+                    "dimensions": [{ "name": "DBClusterIdentifier", "value": "cluster" }],
+                    "severities": {
+                        "sev1": { "threshold": 1.0, "description": "d" },
+                    },
+                },
+            },
+        }));
+
+        let definition = &settings.alarms["bare"];
+        assert_eq!(definition.period, 60);
+        assert_eq!(definition.statistic, Statistic::Average);
+
+        let rule = &definition.severities["sev1"];
+        assert_eq!(rule.evaluation_periods, 5);
+        assert_eq!(
+            rule.comparison_operator,
+            ComparisonOperator::GreaterThanThreshold
+        );
+        // Not AWS's `missing`. The deployed alarms have what the module put there.
+        assert_eq!(rule.treat_missing_data, TreatMissingData::NotBreaching);
+        // CloudWatch's own default for M, which the module leaves to AWS by sending nothing.
+        assert_eq!(rule.datapoints_to_alarm(), 5);
+
+        settings.validate().unwrap();
+    }
+
+    #[test]
+    fn a_catalogue_with_no_alarms_needs_no_region_or_destination() {
+        CloudWatchSettings::default().validate().unwrap();
+        assert!(!CloudWatchSettings::default().is_enabled());
+    }
+
+    #[test]
+    fn a_configured_catalogue_needs_a_region() {
+        let mut settings = settings_from(minimal());
+        settings.client.region = String::new();
+
+        assert!(settings.validate().is_err());
+    }
+
+    /// A definition with no dimensions would read the undimensioned stream — a different metric,
+    /// which reports nothing and would never fire.
+    #[test]
+    fn a_definition_without_dimensions_fails_the_boot() {
+        let mut settings = settings_from(minimal());
+        settings
+            .alarms
+            .get_mut("rds-primary-cpu")
+            .unwrap()
+            .dimensions
+            .clear();
+
+        let error = settings.validate().unwrap_err().to_string();
+        assert!(error.contains("rds-primary-cpu"), "{error}");
+    }
+
+    /// The shape an unresolved Terraform reference arrives in once it has been rendered to a
+    /// string: present, and empty.
+    #[test]
+    fn a_dimension_with_an_empty_value_fails_the_boot() {
+        let mut settings = settings_from(minimal());
+        settings
+            .alarms
+            .get_mut("rds-primary-cpu")
+            .unwrap()
+            .dimensions
+            .push(Dimension {
+                name: "Role".to_owned(),
+                value: String::new(),
+            });
+
+        assert!(settings.validate().is_err());
+    }
+
+    #[test]
+    fn the_same_dimension_named_twice_fails_the_boot() {
+        let mut settings = settings_from(minimal());
+        let definition = settings.alarms.get_mut("rds-primary-cpu").unwrap();
+        definition.dimensions.push(Dimension {
+            name: "DBInstanceIdentifier".to_owned(),
+            value: "somewhere-else".to_owned(),
+        });
+
+        assert!(settings.validate().is_err());
+    }
+
+    /// The bug this shape exists to prevent. `config` lowercases every key it reads, so a
+    /// dimension written as a map arrives as `dbinstanceidentifier` — a case CloudWatch does not
+    /// know, naming a metric that reports nothing, so every alarm on it would evaluate cleanly and
+    /// never fire. Carried as a value, the name survives.
+    #[test]
+    fn a_dimension_name_keeps_its_case_through_configuration() {
+        let settings = settings_from(minimal());
+        let dimensions = &settings.alarms["rds-primary-cpu"].dimensions;
+
+        assert_eq!(dimensions.len(), 1);
+        assert_eq!(dimensions[0].name, "DBInstanceIdentifier");
+        assert_eq!(dimensions[0].value, "hyperswitchdb-primary");
+    }
+
+    #[test]
+    fn a_severity_with_nowhere_to_go_fails_the_boot() {
+        let mut settings = settings_from(minimal());
+        settings.severity_destinations.clear();
+
+        let error = settings.validate().unwrap_err().to_string();
+        assert!(error.contains("sev1"), "{error}");
+    }
+
+    #[test]
+    fn a_catalogue_with_no_failure_destination_fails_the_boot() {
+        let mut settings = settings_from(minimal());
+        settings.failure_destination = None;
+
+        assert!(settings.validate().is_err());
+    }
+
+    /// The parity limitation, made loud. `ignore` needs a memory of the previous state, and there
+    /// is none — so it is refused rather than silently evaluated as something else.
+    #[test]
+    fn treat_missing_data_ignore_is_refused_with_its_reason() {
+        let mut settings = settings_from(minimal());
+        settings
+            .alarms
+            .get_mut("rds-primary-cpu")
+            .unwrap()
+            .severities
+            .get_mut("sev1")
+            .unwrap()
+            .treat_missing_data = TreatMissingData::Ignore;
+
+        let error = settings.validate().unwrap_err().to_string();
+        assert!(error.contains("previous state"), "{error}");
+    }
+
+    /// Both of these are an alarm that can never fire, which is worse than one that fires wrongly.
+    #[test]
+    fn an_unsatisfiable_m_out_of_n_fails_the_boot() {
+        for (window, to_alarm) in [(3_u32, 4_u32), (3, 0)] {
+            let mut settings = settings_from(minimal());
+            let rule = settings
+                .alarms
+                .get_mut("rds-primary-cpu")
+                .unwrap()
+                .severities
+                .get_mut("sev1")
+                .unwrap();
+            rule.evaluation_periods = window;
+            rule.datapoints_to_alarm = Some(to_alarm);
+
+            assert!(
+                settings.validate().is_err(),
+                "{to_alarm} of {window} should be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn only_periods_cloudwatch_accepts_are_allowed() {
+        for seconds in [1, 5, 10, 20, 30, 60, 300, 3600] {
+            assert!(is_cloudwatch_period(seconds), "{seconds}");
+        }
+        for seconds in [0, 2, 45, 61, 359] {
+            assert!(!is_cloudwatch_period(seconds), "{seconds}");
+        }
+    }
+
+    /// The HCL spells these in camelCase and PascalCase respectively; a port that has to translate
+    /// them is a port with a bug in it.
+    #[test]
+    fn the_catalogues_own_spellings_deserialize() {
+        assert_eq!(
+            serde_json::from_value::<TreatMissingData>(serde_json::json!("notBreaching")).unwrap(),
+            TreatMissingData::NotBreaching
+        );
+        assert_eq!(
+            serde_json::from_value::<Statistic>(serde_json::json!("Sum")).unwrap(),
+            Statistic::Sum
+        );
+        assert_eq!(
+            serde_json::from_value::<ComparisonOperator>(serde_json::json!(
+                "LessThanOrEqualToThreshold"
+            ))
+            .unwrap(),
+            ComparisonOperator::LessThanOrEqualToThreshold
+        );
+    }
+}

--- a/crates/observability/src/state.rs
+++ b/crates/observability/src/state.rs
@@ -8,6 +8,7 @@ use external_services::{
         no_email::NoEmailClient, ses::AwsSes, smtp::SmtpServer, EmailClientConfigs, EmailService,
         EmailSettings as EmailClientSettings,
     },
+    metrics_service::{aws_cloudwatch::CloudWatchMetrics, MetricsProvider},
 };
 use hyperswitch_interfaces::{
     secrets_interface::secret_state::{RawSecret, SecuredSecret},
@@ -15,14 +16,19 @@ use hyperswitch_interfaces::{
 };
 
 use crate::{
-    domain::notifier::{
-        chat::{ChatClientNotifier, ChatNotifier, LogChatNotifier},
-        email::{EmailNotifier, EmailServiceNotifier},
-        Registry,
+    domain::{
+        alarm::catalogue::Catalogue,
+        notifier::{
+            chat::{ChatClientNotifier, ChatNotifier, LogChatNotifier},
+            email::{EmailNotifier, EmailServiceNotifier},
+            Registry,
+        },
     },
     errors::ConfigurationError,
     logger, secrets_transformers,
-    settings::{ChatDestination, ChatSettings, EmailSettings, Settings},
+    settings::{
+        cloudwatch::CloudWatchSettings, ChatDestination, ChatSettings, EmailSettings, Settings,
+    },
 };
 
 /// Everything a request handler needs, cloned per worker.
@@ -39,6 +45,11 @@ pub struct AppState {
     pub chat: Arc<Registry<dyn ChatNotifier>>,
     /// Email destinations, by the id a request names.
     pub email: Arc<Registry<dyn EmailNotifier>>,
+    /// The alarm catalogue, resolved once. Empty when nothing is configured to evaluate.
+    pub alarms: Arc<Catalogue>,
+    /// Where metric readings come from. `Some` exactly when [`Self::alarms`] has something in it,
+    /// so a deployment that only forwards alerts never builds an AWS client it will not use.
+    pub metrics: Option<Arc<dyn MetricsProvider>>,
 }
 
 impl AppState {
@@ -85,12 +96,66 @@ impl AppState {
             );
         }
 
+        #[allow(clippy::expect_used)]
+        let alarms = Catalogue::resolve(&raw_conf.cloudwatch)
+            .expect("Failed to resolve the alarm catalogue");
+        let metrics = build_metrics_provider(&raw_conf.cloudwatch).await;
+
+        if alarms.is_empty() {
+            logger::info!("No CloudWatch alarms are configured; the evaluator will find nothing");
+        } else {
+            let source = &raw_conf.cloudwatch.source;
+
+            logger::info!(
+                definitions = alarms.definitions(),
+                severities = alarms.targets.len(),
+                readings = alarms.readings.len(),
+                origin = %source.origin,
+                revision = %source.revision,
+                "Alarm catalogue resolved"
+            );
+
+            // Loud, and on every boot. A hand-checked copy of somebody else's source of truth is
+            // fine to develop against and dangerous to forget about; a comment in the config file
+            // would say the same thing right up until someone deleted it.
+            if source.temporary {
+                logger::warn!(
+                    origin = %source.origin,
+                    revision = %source.revision,
+                    "The alarm catalogue is a temporary snapshot rather than rendered output; it \
+                     does not follow changes to the infrastructure it was copied from"
+                );
+            }
+        }
+
         Self {
             conf: Arc::new(raw_conf),
             chat: Arc::new(chat),
             email: Arc::new(email),
+            alarms: Arc::new(alarms),
+            metrics,
         }
     }
+}
+
+/// Build the metrics client, but only for a deployment that has alarms to evaluate.
+///
+/// # Panics
+///
+/// Panics if the client cannot be built. Same reasoning as the destinations above: a service that
+/// starts without a usable metrics client would answer every evaluation with a failure summary,
+/// and discovering that from a chat message is worse than discovering it from a boot log.
+async fn build_metrics_provider(settings: &CloudWatchSettings) -> Option<Arc<dyn MetricsProvider>> {
+    if !settings.is_enabled() {
+        return None;
+    }
+
+    #[allow(clippy::expect_used)]
+    let client = CloudWatchMetrics::create(&settings.client)
+        .await
+        .expect("Failed to build the CloudWatch metrics client");
+
+    Some(Arc::new(client))
 }
 
 /// Turn configured chat destinations into the notifiers that serve them.

--- a/crates/observability/src/types.rs
+++ b/crates/observability/src/types.rs
@@ -47,14 +47,22 @@
 //! message looks like, in whatever markup its destination reads. `body` is HTML, because both email
 //! backends in `external_services` hardcode an HTML body and there is no plain-text path to reach.
 
+use std::collections::BTreeMap;
+
 use actix_multipart::form::{bytes::Bytes, text::Text, MultipartForm};
 use hyperswitch_masking::Secret;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::notifier::{
-    chat::{ChatFileOutcome, ChatFileReceipt, ChatOutcome, ChatReceipt},
-    email::EmailOutcome,
-    Outcome, Refusal,
+use crate::{
+    core::alarm as run,
+    domain::{
+        alarm::AlarmState,
+        notifier::{
+            chat::{ChatFileOutcome, ChatFileReceipt, ChatOutcome, ChatReceipt},
+            email::EmailOutcome,
+            Outcome, Refusal,
+        },
+    },
 };
 
 /// The body of `POST /alerts/chat/notify/{destination}`.
@@ -227,6 +235,279 @@ impl From<EmailOutcome> for EmailNotifyResponse {
                 error_code: Some(code),
                 retry_after_seconds,
             },
+        }
+    }
+}
+
+/// The body of `POST /alerts/cloudwatch/evaluate`.
+///
+/// Every field is optional, so an empty body is a normal evaluation — the shape a cron trigger or
+/// a bare `curl -XPOST` sends.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct EvaluateAlarmsRequest {
+    /// Evaluate and render, but send nothing at all.
+    ///
+    /// Nothing, including the failure summary: a dry run that announced a CloudWatch outage would
+    /// not be a dry run. The messages a real run would have sent come back in the response, built
+    /// by the same code that would have sent them.
+    pub dry_run: bool,
+}
+
+/// What `POST /alerts/cloudwatch/evaluate` returns.
+///
+/// Verbose on purpose. For a while the only caller is a person with `curl` asking why an alert did
+/// or did not fire, and the questions they will have — what did CloudWatch say, what state did
+/// that put each severity in, what changed, what was sent, what could not be read — are all
+/// answered here rather than only in the logs.
+///
+/// The rendered messages are included in full. They carry metric names, thresholds and instance
+/// identifiers, which are infrastructure facts rather than the merchant data the notify routes
+/// treat as [`hyperswitch_masking::Secret`].
+#[derive(Debug, Serialize)]
+pub struct EvaluateAlarmsResponse {
+    /// The instant this evaluation ends at: the latest completed minute, less any configured
+    /// delay.
+    ///
+    /// Rendered by `common_utils`' ISO 8601 serializer, so it reads the same as every other
+    /// timestamp this repository puts on the wire.
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub evaluated_at: time::PrimitiveDateTime,
+
+    /// The instant the evaluation it was compared against ends at. One minute earlier, whatever
+    /// the metrics' periods — that is CloudWatch's own evaluation cadence.
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub compared_with: time::PrimitiveDateTime,
+
+    /// Whether every send was skipped.
+    pub dry_run: bool,
+
+    /// How many catalogue entries the run covered.
+    pub definitions: usize,
+
+    /// How many distinct CloudWatch queries those entries needed. Fewer than the severities,
+    /// because a threshold is not part of a query.
+    pub readings: usize,
+
+    /// The counts worth reading before the list.
+    pub summary: AlarmRunSummary,
+
+    /// One entry per severity, in catalogue order.
+    pub evaluations: Vec<AlarmEvaluation>,
+
+    /// The operational summary, present only when something could not be read.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<AlarmRunFailure>,
+}
+
+/// The headline counts of one run.
+#[derive(Debug, Serialize)]
+pub struct AlarmRunSummary {
+    /// Severities that produced a state.
+    pub evaluated: usize,
+    /// Severities whose metric could not be read.
+    pub unevaluated: usize,
+    /// Severities whose state moved.
+    pub transitions: usize,
+    /// Announcements the provider accepted.
+    pub delivered: usize,
+    /// Announcements that were refused or could not be sent. Non-zero here with a `200` overall is
+    /// the case the delivery-hardening work exists for.
+    pub undelivered: usize,
+}
+
+/// What one severity's evaluation found.
+#[derive(Debug, Serialize)]
+pub struct AlarmEvaluation {
+    /// The catalogue entry's name.
+    pub definition: String,
+    /// The group it belongs to.
+    pub classification: String,
+    /// The severity id.
+    pub severity: String,
+    /// Namespace and metric name.
+    pub metric: String,
+    /// The dimensions it read. What actually identifies the CloudWatch metric, so this is the
+    /// field to compare against the AWS console when an alarm disagrees with its counterpart.
+    pub dimensions: BTreeMap<String, String>,
+
+    /// The state the current window puts it in. `null` when it could not be evaluated, which is
+    /// deliberately different from any of the three states.
+    pub state: Option<&'static str>,
+    /// The state the previous window puts it in.
+    pub previous_state: Option<&'static str>,
+    /// Whether the two differ. The only thing that causes an announcement.
+    pub transitioned: bool,
+
+    /// The most recent real reading in the current window. `null` when the window held none, in
+    /// which case the state came from the missing-data policy alone.
+    pub observed: Option<f64>,
+    /// What readings were compared against.
+    pub threshold: f64,
+    /// How many of the window's readings breached.
+    pub breaching_datapoints: usize,
+    /// How many periods the missing-data policy had to stand in for.
+    pub missing_datapoints: usize,
+    /// N.
+    pub evaluation_periods: u32,
+    /// M.
+    pub datapoints_to_alarm: u32,
+
+    /// Why it could not be evaluated. Present exactly when `state` is `null`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+
+    /// The message that was sent, or that a dry run would have sent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// What came of sending it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<AlarmDelivery>,
+}
+
+/// The run's own failure, when CloudWatch did not answer for some or all of it.
+#[derive(Debug, Serialize)]
+pub struct AlarmRunFailure {
+    /// The definitions that went unevaluated.
+    pub definitions: Vec<String>,
+    /// The one reason behind all of them, when there was only one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// The summary that was sent, or that a dry run would have sent.
+    pub message: String,
+    /// What came of sending it.
+    pub delivery: AlarmDelivery,
+}
+
+/// What came of one attempt to send a message.
+///
+/// Tagged, and the tag is required, for the reason [`NotifyStatus`] is: a caller cannot read this
+/// without confronting whether the message actually arrived.
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum AlarmDelivery {
+    /// The provider accepted it.
+    Delivered {
+        /// The destination it went to.
+        destination: String,
+        /// The provider's id for the message, when it named one.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message_id: Option<String>,
+    },
+    /// The provider was reached and refused it.
+    Refused {
+        /// The destination that refused.
+        destination: String,
+        /// The stable snake_case code it refused with.
+        code: String,
+    },
+    /// The provider could not be reached, so whether it arrived is unknown.
+    Failed {
+        /// The destination that could not be reached.
+        destination: String,
+        /// What went wrong.
+        error: String,
+    },
+    /// Nothing was sent, because this was a dry run.
+    SkippedDryRun {
+        /// Where it would have gone.
+        destination: String,
+    },
+}
+
+impl From<run::RunReport> for EvaluateAlarmsResponse {
+    fn from(report: run::RunReport) -> Self {
+        let evaluated = report
+            .targets
+            .iter()
+            .filter(|target| target.state.is_some())
+            .count();
+        let transitions = report
+            .targets
+            .iter()
+            .filter(|target| target.transition.is_some())
+            .count();
+        let delivered = report
+            .targets
+            .iter()
+            .filter(|target| matches!(target.delivery, Some(run::DeliveryReport::Delivered { .. })))
+            .count();
+
+        Self {
+            evaluated_at: report.evaluated_at,
+            compared_with: report.previous_evaluated_at,
+            dry_run: report.dry_run,
+            definitions: report.definitions,
+            readings: report.readings,
+            summary: AlarmRunSummary {
+                evaluated,
+                unevaluated: report.targets.len().saturating_sub(evaluated),
+                transitions,
+                delivered,
+                undelivered: transitions.saturating_sub(delivered),
+            },
+            failure: report.failure.map(|failure| AlarmRunFailure {
+                definitions: failure.definitions,
+                reason: failure.reason,
+                message: failure.message,
+                delivery: failure.delivery.into(),
+            }),
+            evaluations: report
+                .targets
+                .into_iter()
+                .map(AlarmEvaluation::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<run::TargetReport> for AlarmEvaluation {
+    fn from(target: run::TargetReport) -> Self {
+        Self {
+            definition: target.definition,
+            classification: target.classification,
+            severity: target.severity,
+            metric: target.metric,
+            dimensions: target.dimensions,
+            state: target.state.map(AlarmState::label),
+            previous_state: target.previous_state.map(AlarmState::label),
+            transitioned: target.transition.is_some(),
+            observed: target.observed,
+            threshold: target.threshold,
+            breaching_datapoints: target.breaching_datapoints,
+            missing_datapoints: target
+                .evaluation
+                .map(|evaluation| evaluation.filled)
+                .unwrap_or_default(),
+            evaluation_periods: target.evaluation_periods,
+            datapoints_to_alarm: target.datapoints_to_alarm,
+            error: target.error,
+            message: target.message,
+            delivery: target.delivery.map(AlarmDelivery::from),
+        }
+    }
+}
+
+impl From<run::DeliveryReport> for AlarmDelivery {
+    fn from(delivery: run::DeliveryReport) -> Self {
+        match delivery {
+            run::DeliveryReport::Delivered {
+                destination,
+                message_id,
+            } => Self::Delivered {
+                destination,
+                message_id,
+            },
+            run::DeliveryReport::Refused { destination, code } => {
+                Self::Refused { destination, code }
+            }
+            run::DeliveryReport::Failed { destination, error } => {
+                Self::Failed { destination, error }
+            }
+            run::DeliveryReport::SkippedDryRun { destination } => {
+                Self::SkippedDryRun { destination }
+            }
         }
     }
 }

--- a/crates/observability/tests/alarm_catalogue.rs
+++ b/crates/observability/tests/alarm_catalogue.rs
@@ -1,0 +1,231 @@
+//! The shipped catalogue, loaded the way the service loads it.
+//!
+//! Every other test builds its own definitions. This one reads `config/observability.toml` — the
+//! file a deployment actually runs — and checks that it deserializes, validates, and resolves into
+//! the shape the port was supposed to produce.
+//!
+//! That matters more than it looks. The catalogue is a hand-checked snapshot of somebody else's
+//! source of truth, and the ways it can go wrong are all silent: a threshold that lost a digit
+//! still evaluates, a definition whose dimensions did not survive the copy queries a metric that
+//! reports nothing and simply never fires, and a severity pointing at an unconfigured destination
+//! evaluates perfectly and delivers nowhere. None of those is a compile error. The counts and
+//! spot-checks below are what turn them into a failing test.
+//!
+//! When the rendering is automated and this file stops being a snapshot, these assertions are the
+//! ones the generator has to keep satisfying.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+
+use std::path::PathBuf;
+
+use observability::{
+    domain::alarm::{catalogue::Catalogue, MissingDataPolicy},
+    settings::Settings,
+};
+
+/// The config directory, from the crate this test lives in.
+fn config_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../config")
+        .join("observability.toml")
+}
+
+fn catalogue() -> Catalogue {
+    let settings = Settings::with_config_path(Some(config_path()))
+        .expect("config/observability.toml should deserialize");
+
+    // The whole boot check, not just the CloudWatch section: this is also what proves every
+    // severity's destination and the failure destination exist in `chat.destinations`.
+    settings
+        .validate()
+        .expect("config/observability.toml should validate");
+
+    Catalogue::resolve(&settings.cloudwatch).expect("the catalogue should resolve")
+}
+
+/// The port's headline shape: twenty `rds-alerts` definitions carrying fifty-three severities, and
+/// twenty CloudWatch queries rather than fifty-three — severities of one definition differ only by
+/// threshold, and a threshold is not part of a query.
+#[test]
+fn the_shipped_catalogue_is_the_twenty_rds_definitions() {
+    let catalogue = catalogue();
+
+    assert_eq!(catalogue.definitions(), 20, "definitions");
+    assert_eq!(catalogue.targets.len(), 53, "severities");
+    assert_eq!(catalogue.readings.len(), 20, "distinct queries");
+
+    assert!(
+        catalogue
+            .targets
+            .iter()
+            .all(|target| target.classification == "rds-alerts"),
+        "this ticket ships `rds-alerts` only"
+    );
+}
+
+/// Both periods the subset uses, in the proportion it uses them. The split is what decides how
+/// many requests a run makes: the twelve minute metrics share one grid for both windows, the eight
+/// five-minute ones need two.
+#[test]
+fn the_catalogue_carries_both_periods() {
+    let catalogue = catalogue();
+
+    let seconds = catalogue
+        .readings
+        .iter()
+        .map(|reading| reading.period.seconds())
+        .collect::<Vec<_>>();
+
+    assert_eq!(seconds.iter().filter(|period| **period == 60).count(), 12);
+    assert_eq!(seconds.iter().filter(|period| **period == 300).count(), 8);
+}
+
+/// Every definition names a stream. A definition that lost its dimensions in the copy would query
+/// the undimensioned metric, which reports nothing — an alarm that never fires and never says why.
+#[test]
+fn every_reading_names_a_dimensioned_stream() {
+    for reading in catalogue().readings {
+        assert!(
+            !reading.labels.is_empty(),
+            "{} has no dimensions",
+            reading.describe()
+        );
+        assert_eq!(reading.namespace, "AWS/RDS");
+    }
+}
+
+/// The dimension values the snapshot resolved, checked against the infrastructure they were copied
+/// from. These are the identifiers that decide *which database* is being watched, so a typo here
+/// is a catalogue that watches nothing.
+#[test]
+fn the_resolved_dimension_values_are_the_ones_terraform_publishes() {
+    let catalogue = catalogue();
+
+    let values = catalogue
+        .readings
+        .iter()
+        .flat_map(|reading| {
+            reading
+                .labels
+                .iter()
+                .map(|(name, value)| format!("{name}={value}"))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    for expected in [
+        "DBInstanceIdentifier=hyperswitchdb-primary",
+        "DBInstanceIdentifier=failover-replica-1",
+        "DBClusterIdentifier=hyperswitchdb-cluster",
+        "Role=WRITER",
+        "Role=READER",
+    ] {
+        assert!(
+            values.iter().any(|value| value == expected),
+            "expected {expected} among {values:?}"
+        );
+    }
+}
+
+/// The missing-data policies the subset actually uses, which is the fact the ticket got wrong.
+///
+/// Only the two CPU `sev1` entries treat a gap as breaching; every other severity treats it as
+/// within the threshold, because that is the Terraform module's default rather than AWS's
+/// `missing`. Neither `missing` nor `ignore` appears — so `INSUFFICIENT_DATA` is unreachable for
+/// this catalogue, and nothing here needs the previous state that `ignore` would demand.
+#[test]
+fn only_two_severities_treat_missing_data_as_breaching() {
+    let catalogue = catalogue();
+
+    let breaching = catalogue
+        .targets
+        .iter()
+        .filter(|target| target.rule.treat_missing_data == MissingDataPolicy::Breaching)
+        .map(|target| target.name())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        breaching,
+        vec!["rds-failover-cpu/sev1", "rds-primary-cpu/sev1"]
+    );
+
+    assert!(
+        !catalogue
+            .targets
+            .iter()
+            .any(|target| target.rule.treat_missing_data == MissingDataPolicy::Missing),
+        "no rds definition uses `missing`, so INSUFFICIENT_DATA cannot arise from the policy"
+    );
+}
+
+/// `datapoints_to_alarm` is used seven times in the full seventy-six-definition catalogue and not
+/// once in `rds-alerts`, so every severity here is N-out-of-N. M-out-of-N is implemented and
+/// tested, but nothing shipped exercises it — worth asserting so the day a rendered catalogue does
+/// start using it, this test is what notices.
+#[test]
+fn no_shipped_severity_uses_m_out_of_n() {
+    for target in catalogue().targets {
+        assert_eq!(
+            target.rule.datapoints_to_alarm,
+            target.rule.evaluation_periods,
+            "{}",
+            target.name()
+        );
+    }
+}
+
+/// The evaluation windows in use, spot-checked. Values outside this set mean a transcription slip.
+#[test]
+fn the_evaluation_windows_are_the_ones_the_subset_uses() {
+    for target in catalogue().targets {
+        assert!(
+            [1, 2, 3, 5].contains(&target.rule.evaluation_periods),
+            "{} has an unexpected evaluation_periods {}",
+            target.name(),
+            target.rule.evaluation_periods
+        );
+    }
+}
+
+/// One definition, end to end, against the HCL it was copied from. A threshold that lost a digit
+/// deserializes and evaluates perfectly well; only comparing it to the source catches it.
+#[test]
+fn a_spot_checked_definition_matches_its_source() {
+    let catalogue = catalogue();
+
+    let target = catalogue
+        .targets
+        .iter()
+        .find(|target| target.name() == "rds-failover-freeable-memory/sev1")
+        .expect("the definition should be in the catalogue");
+
+    // `threshold = 1717986918`, `LessThanOrEqualToThreshold`, `evaluation_periods = 5`, and no
+    // `treat_missing_data` — so the module's `notBreaching` default applies.
+    assert_eq!(target.rule.threshold, 1_717_986_918.0);
+    assert_eq!(target.rule.evaluation_periods, 5);
+    assert_eq!(
+        target.rule.treat_missing_data,
+        MissingDataPolicy::NotBreaching
+    );
+    assert!(target
+        .description
+        .starts_with("SEV1: RDS failover database freeable memory"));
+
+    let reading = &catalogue.readings[target.reading];
+    assert_eq!(reading.metric_name, "FreeableMemory");
+    assert_eq!(reading.period.seconds(), 60);
+}
+
+/// The snapshot has to say it is one. The flag is what makes the service warn at every boot, and a
+/// rendered catalogue is what clears it — so this assertion is expected to be inverted, not
+/// deleted, when [#23444] lands.
+#[test]
+fn the_shipped_catalogue_declares_itself_a_snapshot() {
+    let settings = Settings::with_config_path(Some(config_path()))
+        .expect("config/observability.toml should deserialize");
+    let source = &settings.cloudwatch.source;
+
+    assert!(source.temporary, "the snapshot must declare itself");
+    assert!(!source.origin.is_empty(), "a snapshot must say where from");
+    assert_eq!(source.revision.len(), 40, "a full git revision");
+}

--- a/crates/observability/tests/alarm_evaluation.rs
+++ b/crates/observability/tests/alarm_evaluation.rs
@@ -1,0 +1,713 @@
+//! One evaluation run, end to end, against a stub metrics provider.
+//!
+//! Everything else tests a piece: the evaluator against AWS's published tables, the planner against
+//! its request shapes, the catalogue against the config file. This tests the thing those pieces are
+//! assembled into — `core::alarm::evaluate` — because the properties that decide whether this
+//! service is *useful* only exist once a clock, a provider and a notifier are in the same room:
+//!
+//! * a breach that persists announces **once**, not once a minute;
+//! * a query that failed is not a metric that stopped reporting;
+//! * a chat destination that is down does not silence the destinations that are up.
+//!
+//! ## The stub is a metric history, not a canned response
+//!
+//! [`StubMetrics`] holds one value per minute and aggregates on demand, exactly as CloudWatch
+//! would: for a request covering `[start, end)` with period P it produces `(end - start) / P` slots
+//! and reduces the minutes falling in each. That matters, because the one thing this branch could
+//! not check against a live account is whether two 300-second windows a minute apart really are
+//! different aggregates. A stub that replayed a fixed `Vec` per call would assert that the code
+//! does what it does; a stub that aggregates makes the question real.
+//!
+//! Announcements are observed rather than inferred — [`RecordingChat`] keeps every message it was
+//! given, so "announces exactly once" is a length assertion rather than a state assertion.
+
+// `as_conversions` is allowed here rather than worked around: most of the warnings come out of the
+// `#[tokio::test]` expansion rather than from anything written below, and the one that is ours is a
+// mean over a handful of readings.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::as_conversions
+)]
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use external_services::metrics_service::{
+    Aggregation, Cursor, MetricPage, MetricRequest, MetricSeries, MetricsProvider, MetricsResult,
+    SeriesStatus,
+};
+use observability::{
+    core::alarm::{self, DeliveryReport, EvaluationOptions},
+    domain::{
+        alarm::catalogue::Catalogue,
+        notifier::{
+            chat::{
+                ChatFileOutcome, ChatFileReceipt, ChatFileUpload, ChatNotification, ChatNotifier,
+                ChatOutcome, ChatReceipt,
+            },
+            Outcome, Refusal, Registry,
+        },
+    },
+    errors::{ObservabilityApiResult, ObservabilityError},
+    settings::cloudwatch::CloudWatchSettings,
+    state::AppState,
+};
+use serde_json::json;
+
+const DESTINATION: &str = "smoke";
+
+// ---------------------------------------------------------------------------------------------
+// A metrics provider backed by a minute-resolution history.
+// ---------------------------------------------------------------------------------------------
+
+/// A stub CloudWatch: one reading per minute, aggregated into whatever window is asked for.
+///
+/// `minutes` is oldest-first and its **last entry is the minute ending at the run's evaluation
+/// instant**, so a test writes the recent past directly — `[.., Some(95.0), Some(95.0)]` is "the
+/// last two minutes both breached".
+///
+/// That instant is discovered rather than declared. `evaluate` reads the real clock, so a stub
+/// anchored to a literal timestamp would answer every request with gaps, and one anchored to
+/// `now()` computed in the test would be a coin-flip whenever a run straddled a minute boundary.
+/// Instead the first request's `range.end` becomes the anchor: the planner always asks for the
+/// current window before the one a minute behind it, so the first end it sees is the instant the
+/// run is evaluating through, whatever the clock happened to say.
+#[derive(Debug)]
+struct StubMetrics {
+    minutes: Vec<Option<f64>>,
+    /// The instant the newest minute ends at, taken from the first request.
+    anchor: Mutex<Option<time::OffsetDateTime>>,
+    /// What to report for each query's series, by query position. Absent means `Complete`.
+    statuses: HashMap<usize, SeriesStatus>,
+    /// Whether the first call should hand back a cursor and only half the datapoints.
+    paginate: bool,
+    calls: Mutex<usize>,
+}
+
+impl StubMetrics {
+    fn new(minutes: Vec<Option<f64>>) -> Self {
+        Self {
+            minutes,
+            anchor: Mutex::new(None),
+            statuses: HashMap::new(),
+            paginate: false,
+            calls: Mutex::new(0),
+        }
+    }
+
+    fn with_status(mut self, query: usize, status: SeriesStatus) -> Self {
+        self.statuses.insert(query, status);
+        self
+    }
+
+    fn paginated(mut self) -> Self {
+        self.paginate = true;
+        self
+    }
+
+    /// The reading for the minute ending at `ends_at`, if the history covers it.
+    fn minute_at(&self, ends_at: i64) -> Option<f64> {
+        let anchor = (*self.anchor.lock().unwrap())?.unix_timestamp();
+        let behind = (anchor - ends_at) / 60;
+        let index = usize::try_from(i64::try_from(self.minutes.len()).ok()? - 1 - behind).ok()?;
+
+        self.minutes.get(index).copied().flatten()
+    }
+
+    /// Reduce the minutes covered by `[from, to)` the way the query asks.
+    fn aggregate(&self, from: i64, to: i64, aggregation: Aggregation) -> Option<f64> {
+        let readings = (from..to)
+            .step_by(60)
+            .filter_map(|second| self.minute_at(second + 60))
+            .collect::<Vec<_>>();
+
+        if readings.is_empty() {
+            return None;
+        }
+
+        Some(match aggregation {
+            Aggregation::Average => readings.iter().sum::<f64>() / readings.len() as f64,
+            Aggregation::Sum => readings.iter().sum(),
+            Aggregation::Maximum => readings.iter().copied().fold(f64::MIN, f64::max),
+            Aggregation::Minimum => readings.iter().copied().fold(f64::MAX, f64::min),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl MetricsProvider for StubMetrics {
+    async fn fetch(
+        &self,
+        request: &MetricRequest,
+        cursor: Option<&Cursor>,
+    ) -> MetricsResult<MetricPage> {
+        let is_first_page = cursor.is_none();
+        *self.calls.lock().unwrap() += 1;
+        self.anchor.lock().unwrap().get_or_insert(request.range.end);
+
+        let series = request
+            .queries
+            .iter()
+            .enumerate()
+            .map(|(index, query)| {
+                let period = query.period.seconds_i64();
+                let start = request.range.start.unix_timestamp();
+                let slots = (request.range.end.unix_timestamp() - start) / period;
+
+                let values = (0..slots)
+                    .map(|slot| {
+                        // A paginated response splits the grid down the middle: the first page
+                        // carries the older half and the second the newer. Neither page is a
+                        // usable window on its own, so the slot-wise merge in `core::alarm::fetch`
+                        // is the only thing that can put them back together.
+                        let withheld = self.paginate
+                            && if is_first_page {
+                                slot >= slots / 2
+                            } else {
+                                slot < slots / 2
+                            };
+
+                        let from = start + slot * period;
+                        (!withheld)
+                            .then(|| self.aggregate(from, from + period, query.aggregation))
+                            .flatten()
+                    })
+                    .collect();
+
+                MetricSeries::new(
+                    index,
+                    self.statuses
+                        .get(&index)
+                        .copied()
+                        .unwrap_or(SeriesStatus::Complete),
+                    values,
+                )
+            })
+            .collect();
+
+        Ok(MetricPage::new(
+            series,
+            (self.paginate && is_first_page).then(|| Cursor::new("more")),
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Chat destinations that record, refuse, or fail.
+// ---------------------------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct RecordingChat {
+    sent: Mutex<Vec<String>>,
+}
+
+impl RecordingChat {
+    fn sent(&self) -> Vec<String> {
+        self.sent.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl ChatNotifier for RecordingChat {
+    async fn notify(&self, notification: ChatNotification) -> ObservabilityApiResult<ChatOutcome> {
+        use hyperswitch_masking::ExposeInterface;
+
+        self.sent.lock().unwrap().push(notification.text.expose());
+
+        Ok(Outcome::Delivered(ChatReceipt {
+            message_id: Some("1.0".to_owned()),
+        }))
+    }
+
+    async fn upload_file(
+        &self,
+        _upload: ChatFileUpload,
+    ) -> ObservabilityApiResult<ChatFileOutcome> {
+        Ok(Outcome::Delivered(ChatFileReceipt { file_id: None }))
+    }
+}
+
+/// Reached, and said no. A refusal is an outcome, not an error.
+#[derive(Debug)]
+struct RefusingChat;
+
+#[async_trait::async_trait]
+impl ChatNotifier for RefusingChat {
+    async fn notify(&self, _notification: ChatNotification) -> ObservabilityApiResult<ChatOutcome> {
+        Ok(Outcome::Refused(Refusal::new("channel_not_found")))
+    }
+
+    async fn upload_file(
+        &self,
+        _upload: ChatFileUpload,
+    ) -> ObservabilityApiResult<ChatFileOutcome> {
+        Ok(Outcome::Refused(Refusal::new("channel_not_found")))
+    }
+}
+
+/// Could not be reached at all, so whether the message arrived is unknown.
+#[derive(Debug)]
+struct FailingChat;
+
+#[async_trait::async_trait]
+impl ChatNotifier for FailingChat {
+    async fn notify(&self, _notification: ChatNotification) -> ObservabilityApiResult<ChatOutcome> {
+        Err(error_stack::report!(
+            ObservabilityError::ProviderUnavailable {
+                destination: DESTINATION.to_owned(),
+            }
+        ))
+    }
+
+    async fn upload_file(
+        &self,
+        _upload: ChatFileUpload,
+    ) -> ObservabilityApiResult<ChatFileOutcome> {
+        Err(error_stack::report!(
+            ObservabilityError::ProviderUnavailable {
+                destination: DESTINATION.to_owned(),
+            }
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Building a run.
+// ---------------------------------------------------------------------------------------------
+
+/// A catalogue of one definition and one severity, breaching above `threshold`.
+fn catalogue_of(period: u32, evaluation_periods: u32, threshold: f64) -> Catalogue {
+    catalogue_from(json!({
+        "cpu": {
+            "classification": "rds-alerts",
+            "metric_name": "CPUUtilization",
+            "namespace": "AWS/RDS",
+            "dimensions": [{ "name": "DBInstanceIdentifier", "value": "hyperswitchdb-primary" }],
+            "period": period,
+            "statistic": "Average",
+            "severities": {
+                "sev1": {
+                    "threshold": threshold,
+                    "comparison_operator": "GreaterThanThreshold",
+                    "description": "SEV1: CPU is high",
+                    "evaluation_periods": evaluation_periods,
+                },
+            },
+        },
+    }))
+}
+
+fn catalogue_from(alarms: serde_json::Value) -> Catalogue {
+    let settings: CloudWatchSettings = serde_json::from_value(json!({
+        "region": "ap-south-1",
+        "failure_destination": DESTINATION,
+        "severity_destinations": { "sev1": DESTINATION },
+        "alarms": alarms,
+    }))
+    .expect("the test catalogue should deserialize");
+
+    Catalogue::resolve(&settings).expect("the test catalogue should resolve")
+}
+
+fn state_with(
+    catalogue: Catalogue,
+    metrics: Arc<dyn MetricsProvider>,
+    chat: Arc<dyn ChatNotifier>,
+) -> AppState {
+    AppState {
+        conf: Arc::new(
+            serde_json::from_value(json!({ "auth": { "internal_api_key": "k" } }))
+                .expect("the test configuration should deserialize"),
+        ),
+        chat: Arc::new(Registry::new(HashMap::from([(
+            DESTINATION.to_owned(),
+            chat,
+        )]))),
+        email: Arc::new(Registry::default()),
+        alarms: Arc::new(catalogue),
+        metrics: Some(metrics),
+    }
+}
+
+async fn run(state: &AppState) -> alarm::RunReport {
+    alarm::evaluate(state.clone(), EvaluationOptions::default())
+        .await
+        .expect("a run should not fail as a whole")
+}
+
+// ---------------------------------------------------------------------------------------------
+// The properties.
+// ---------------------------------------------------------------------------------------------
+
+/// **The ticket's acceptance criterion.** A condition that stays breaching across two consecutive
+/// evaluations announces exactly once.
+///
+/// This is the whole justification for reconstructing both windows instead of remembering the last
+/// state: the previous window is already breaching, so there is no transition and nothing to say. A
+/// regression here turns a single alert into one alert per minute for as long as the incident
+/// lasts, which is how an on-call channel becomes unreadable.
+#[tokio::test]
+async fn a_breach_that_persists_across_two_evaluations_announces_once() {
+    // Four minutes of breach: both the current window and the one ending a minute earlier are
+    // fully breaching, so the state was already ALARM before this run.
+    let metrics = Arc::new(StubMetrics::new(vec![
+        Some(95.0),
+        Some(95.0),
+        Some(95.0),
+        Some(95.0),
+        Some(95.0),
+    ]));
+    let chat = Arc::new(RecordingChat::default());
+    let state = state_with(
+        catalogue_of(60, 1, 90.0),
+        metrics,
+        Arc::clone(&chat) as Arc<dyn ChatNotifier>,
+    );
+
+    let report = run(&state).await;
+
+    assert_eq!(report.targets[0].state.map(|s| s.label()), Some("ALARM"));
+    assert_eq!(
+        report.targets[0].previous_state.map(|s| s.label()),
+        Some("ALARM")
+    );
+    assert!(report.targets[0].transition.is_none());
+    assert!(chat.sent().is_empty(), "{:?}", chat.sent());
+
+    // Evaluating again changes nothing, because nothing is remembered *and* nothing moved.
+    let second = run(&state).await;
+    assert!(second.targets[0].transition.is_none());
+    assert!(chat.sent().is_empty(), "{:?}", chat.sent());
+}
+
+/// The other half: a breach that has just started *is* a transition, and it says so.
+#[tokio::test]
+async fn a_new_breach_announces_with_the_value_that_caused_it() {
+    // The previous window was fine; only the latest minute breached.
+    let metrics = Arc::new(StubMetrics::new(vec![
+        Some(10.0),
+        Some(10.0),
+        Some(10.0),
+        Some(95.5),
+    ]));
+    let chat = Arc::new(RecordingChat::default());
+    let state = state_with(
+        catalogue_of(60, 1, 90.0),
+        metrics,
+        Arc::clone(&chat) as Arc<dyn ChatNotifier>,
+    );
+
+    let report = run(&state).await;
+
+    assert_eq!(report.targets[0].state.map(|s| s.label()), Some("ALARM"));
+    assert_eq!(
+        report.targets[0].previous_state.map(|s| s.label()),
+        Some("OK")
+    );
+
+    let sent = chat.sent();
+    assert_eq!(sent.len(), 1, "{sent:?}");
+    assert!(sent[0].contains("OK → ALARM"), "{}", sent[0]);
+    assert!(sent[0].contains("Observed: 95.5"), "{}", sent[0]);
+    assert!(matches!(
+        report.targets[0].delivery,
+        Some(DeliveryReport::Delivered { .. })
+    ));
+}
+
+/// Recovery is a transition like any other and is announced, so an alert that opened also closes.
+#[tokio::test]
+async fn a_recovery_announces() {
+    let metrics = Arc::new(StubMetrics::new(vec![
+        Some(95.0),
+        Some(95.0),
+        Some(95.0),
+        Some(4.0),
+    ]));
+    let chat = Arc::new(RecordingChat::default());
+    let state = state_with(
+        catalogue_of(60, 1, 90.0),
+        metrics,
+        Arc::clone(&chat) as Arc<dyn ChatNotifier>,
+    );
+
+    run(&state).await;
+
+    let sent = chat.sent();
+    assert_eq!(sent.len(), 1, "{sent:?}");
+    assert!(sent[0].contains("ALARM → OK"), "{}", sent[0]);
+}
+
+/// The claim this branch could not check against a live account: for a 300-second metric the two
+/// evaluations are two *overlapping* aggregates a minute apart, not two adjacent datapoints.
+///
+/// The history is built so the distinction is the whole answer. The five minutes ending at 12:00
+/// average above the threshold; the five ending at 11:59 do not. Comparing adjacent five-minute
+/// datapoints instead would compare 11:55–12:00 with 11:50–11:55 and reach a different conclusion.
+#[tokio::test]
+async fn a_five_minute_alarm_compares_windows_one_minute_apart() {
+    // minutes ending 11:52 .. 12:00
+    let metrics = Arc::new(StubMetrics::new(vec![
+        Some(0.0),   // 11:52
+        Some(0.0),   // 11:53
+        Some(0.0),   // 11:54
+        Some(0.0),   // 11:55  <- in the previous window, not the current one
+        Some(100.0), // 11:56
+        Some(100.0), // 11:57
+        Some(100.0), // 11:58
+        Some(100.0), // 11:59
+        Some(100.0), // 12:00
+    ]));
+    let chat = Arc::new(RecordingChat::default());
+    let state = state_with(
+        catalogue_of(300, 1, 90.0),
+        metrics,
+        Arc::clone(&chat) as Arc<dyn ChatNotifier>,
+    );
+
+    let report = run(&state).await;
+
+    // Current window 11:55–12:00 averages 100; previous window 11:54–11:59 averages 80.
+    assert_eq!(report.targets[0].state.map(|s| s.label()), Some("ALARM"));
+    assert_eq!(
+        report.targets[0].previous_state.map(|s| s.label()),
+        Some("OK")
+    );
+    assert_eq!(chat.sent().len(), 1);
+}
+
+/// A query that failed is not a metric that stopped reporting.
+///
+/// The alarm's policy is `notBreaching`, so treating the failure as a window of gaps would report a
+/// confident OK about a database nobody actually looked at. It must report *nothing* about the
+/// state, and say why.
+#[tokio::test]
+async fn a_failed_series_is_not_evaluated_as_missing_data() {
+    let metrics = Arc::new(
+        StubMetrics::new(vec![Some(95.0), Some(95.0)]).with_status(0, SeriesStatus::Failed),
+    );
+    let chat = Arc::new(RecordingChat::default());
+    let state = state_with(
+        catalogue_of(60, 1, 90.0),
+        metrics,
+        Arc::clone(&chat) as Arc<dyn ChatNotifier>,
+    );
+
+    let report = run(&state).await;
+
+    assert!(report.targets[0].state.is_none());
+    assert!(report.targets[0].transition.is_none());
+    assert!(report.targets[0].error.is_some());
+
+    // One operational summary, and it is not dressed up as an alarm about the estate.
+    let failure = report.failure.expect("a failed reading should be reported");
+    assert_eq!(failure.definitions, vec!["cpu"]);
+    assert_eq!(chat.sent().len(), 1);
+    assert!(
+        chat.sent()[0].contains("CloudWatch evaluation"),
+        "{:?}",
+        chat.sent()
+    );
+}
+
+/// A partially incomplete series is treated the same way, because half a window evaluated as if it
+/// were whole is a confident answer about data that was never received.
+#[tokio::test]
+async fn a_partial_series_is_refused_like_a_failed_one() {
+    let metrics = Arc::new(
+        StubMetrics::new(vec![Some(95.0), Some(95.0)]).with_status(0, SeriesStatus::Partial),
+    );
+    let state = state_with(
+        catalogue_of(60, 1, 90.0),
+        metrics,
+        Arc::new(RecordingChat::default()),
+    );
+
+    assert!(run(&state).await.targets[0].error.is_some());
+}
+
+/// Best-effort progress: one broken reading does not blind the run to the others. Only the total
+/// failure path was ever exercised by hand, and it is the *partial* one that has to keep working.
+#[tokio::test]
+async fn one_failed_reading_does_not_stop_the_others_being_evaluated() {
+    let catalogue = catalogue_from(json!({
+        "broken": {
+            "classification": "rds-alerts",
+            "metric_name": "CPUUtilization",
+            "namespace": "AWS/RDS",
+            "dimensions": [{ "name": "DBInstanceIdentifier", "value": "one" }],
+            "period": 60,
+            "statistic": "Average",
+            "severities": { "sev1": {
+                "threshold": 90.0, "comparison_operator": "GreaterThanThreshold",
+                "description": "d", "evaluation_periods": 1,
+            }},
+        },
+        "healthy": {
+            "classification": "rds-alerts",
+            "metric_name": "CPUUtilization",
+            "namespace": "AWS/RDS",
+            "dimensions": [{ "name": "DBInstanceIdentifier", "value": "two" }],
+            "period": 60,
+            "statistic": "Average",
+            "severities": { "sev1": {
+                "threshold": 90.0, "comparison_operator": "GreaterThanThreshold",
+                "description": "d", "evaluation_periods": 1,
+            }},
+        },
+    }));
+
+    // Query 0 is `broken`; the catalogue is ordered by definition name.
+    let metrics = Arc::new(
+        StubMetrics::new(vec![Some(10.0), Some(10.0), Some(95.0)])
+            .with_status(0, SeriesStatus::Failed),
+    );
+    let chat = Arc::new(RecordingChat::default());
+    let state = state_with(
+        catalogue,
+        metrics,
+        Arc::clone(&chat) as Arc<dyn ChatNotifier>,
+    );
+
+    let report = run(&state).await;
+
+    let broken = &report.targets[0];
+    let healthy = &report.targets[1];
+    assert_eq!(broken.definition, "broken");
+    assert!(broken.error.is_some());
+
+    assert_eq!(healthy.definition, "healthy");
+    assert_eq!(healthy.state.map(|s| s.label()), Some("ALARM"));
+    assert!(healthy.transition.is_some());
+
+    // The announcement for `healthy` and the summary naming `broken` — not one instead of the
+    // other.
+    let failure = report
+        .failure
+        .expect("the partial failure should be summarised");
+    assert_eq!(failure.definitions, vec!["broken"]);
+    assert_eq!(chat.sent().len(), 2, "{:?}", chat.sent());
+}
+
+/// A dry run performs the same evaluation and returns the messages it *would* have sent, including
+/// the failure summary. Nothing reaches chat — a dry run that announced a CloudWatch outage would
+/// not be a dry run.
+#[tokio::test]
+async fn a_dry_run_returns_the_messages_and_sends_none_of_them() {
+    let metrics = Arc::new(StubMetrics::new(vec![Some(10.0), Some(10.0), Some(95.0)]));
+    let chat = Arc::new(RecordingChat::default());
+    let state = state_with(
+        catalogue_of(60, 1, 90.0),
+        metrics,
+        Arc::clone(&chat) as Arc<dyn ChatNotifier>,
+    );
+
+    let report = alarm::evaluate(state, EvaluationOptions { dry_run: true })
+        .await
+        .unwrap();
+
+    assert!(report.dry_run);
+    assert!(report.targets[0].transition.is_some());
+    // The message is built by the code that would have sent it, not a separate preview.
+    assert!(report.targets[0]
+        .message
+        .as_ref()
+        .is_some_and(|message| message.contains("OK → ALARM")));
+    assert!(matches!(
+        report.targets[0].delivery,
+        Some(DeliveryReport::SkippedDryRun { .. })
+    ));
+    assert!(chat.sent().is_empty());
+}
+
+/// A destination that refuses, and one that cannot be reached, are both reported rather than
+/// raised — the run still returns its evaluation, and the response says the alert did not arrive.
+#[tokio::test]
+async fn a_refusal_and_an_unreachable_destination_are_reported_not_raised() {
+    let history = vec![Some(10.0), Some(10.0), Some(95.0)];
+
+    let refused = run(&state_with(
+        catalogue_of(60, 1, 90.0),
+        Arc::new(StubMetrics::new(history.clone())),
+        Arc::new(RefusingChat),
+    ))
+    .await;
+    assert!(matches!(
+        refused.targets[0].delivery,
+        Some(DeliveryReport::Refused { ref code, .. }) if code == "channel_not_found"
+    ));
+
+    let failed = run(&state_with(
+        catalogue_of(60, 1, 90.0),
+        Arc::new(StubMetrics::new(history)),
+        Arc::new(FailingChat),
+    ))
+    .await;
+    assert!(matches!(
+        failed.targets[0].delivery,
+        Some(DeliveryReport::Failed { .. })
+    ));
+    // The evaluation itself still succeeded; only the delivery did not.
+    assert_eq!(failed.targets[0].state.map(|s| s.label()), Some("ALARM"));
+}
+
+/// A series spread over pages is merged slot-wise rather than concatenated.
+///
+/// Each page lays its datapoints on the *whole* window's grid and fills only the slots it carries,
+/// so appending one page to the next would produce a grid twice the right length with the readings
+/// in the wrong periods — and the window would then be sliced out of the wrong end of it.
+#[tokio::test]
+async fn a_series_split_across_pages_is_merged_into_one_grid() {
+    let metrics = Arc::new(
+        StubMetrics::new(vec![
+            Some(95.0),
+            Some(95.0),
+            Some(95.0),
+            Some(95.0),
+            Some(95.0),
+        ])
+        .paginated(),
+    );
+    let state = state_with(
+        catalogue_of(60, 3, 90.0),
+        Arc::clone(&metrics) as Arc<dyn MetricsProvider>,
+        Arc::new(RecordingChat::default()),
+    );
+
+    let report = run(&state).await;
+
+    assert!(
+        *metrics.calls.lock().unwrap() >= 2,
+        "the stub should paginate"
+    );
+    assert!(
+        report.targets[0].error.is_none(),
+        "{:?}",
+        report.targets[0].error
+    );
+    assert_eq!(report.targets[0].state.map(|s| s.label()), Some("ALARM"));
+}
+
+/// An empty catalogue is a normal, successful run that touches nothing.
+#[tokio::test]
+async fn an_empty_catalogue_evaluates_nothing_and_succeeds() {
+    let state = AppState {
+        conf: Arc::new(
+            serde_json::from_value(json!({ "auth": { "internal_api_key": "k" } })).unwrap(),
+        ),
+        chat: Arc::new(Registry::default()),
+        email: Arc::new(Registry::default()),
+        alarms: Arc::new(Catalogue::default()),
+        metrics: None,
+    };
+
+    let report = run(&state).await;
+
+    assert!(report.targets.is_empty());
+    assert!(report.failure.is_none());
+    assert_eq!(report.definitions, 0);
+}

--- a/crates/observability/tests/notify.rs
+++ b/crates/observability/tests/notify.rs
@@ -18,10 +18,13 @@ use actix_web::{
 use external_services::email::no_email::NoEmailClient;
 use observability::{
     auth::X_INTERNAL_API_KEY,
-    domain::notifier::{
-        chat::{ChatNotifier, LogChatNotifier},
-        email::{EmailNotifier, EmailServiceNotifier},
-        Registry,
+    domain::{
+        alarm::catalogue::Catalogue,
+        notifier::{
+            chat::{ChatNotifier, LogChatNotifier},
+            email::{EmailNotifier, EmailServiceNotifier},
+            Registry,
+        },
     },
     routes::Alerts,
     state::AppState,
@@ -57,6 +60,10 @@ async fn state_with_max(max_upload_bytes: usize) -> AppState {
         conf: Arc::new(conf),
         chat: Arc::new(Registry::new(HashMap::from([(CHAT.to_owned(), chat)]))),
         email: Arc::new(Registry::new(HashMap::from([(EMAIL.to_owned(), email)]))),
+        // No alarms, and therefore no metrics provider — these tests exercise the notify routes,
+        // which forward alerts somebody else decided. The evaluator has its own tests.
+        alarms: Arc::new(Catalogue::default()),
+        metrics: None,
     }
 }
 


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Stacked on #14150, which is this branch's base — review that one first; this PR's diff is the evaluator alone.

The observability plane now decides as well as delivers. `POST /alerts/cloudwatch/evaluate`, behind the existing `X-Internal-Api-Key` guard, reads the twenty `rds-alerts` definitions from configuration, evaluates them against CloudWatch through the metrics client added in #14150, and hands each state transition to the in-process notifier. Closes [#23445](https://github.com/juspay/hyperswitch-cloud/issues/23445).

### Reproducing CloudWatch

Three things decide whether a port changes when an alarm fires, and all three are easy to get wrong:

**Evaluations are a minute apart, not a period apart.** AWS evaluates every metric alarm every minute for any period of a minute or longer, and the sliding window advances by a minute — *"at the end of minute 5 the alarm evaluates on minutes 1–5. Then at the end of minute 6, on minutes 2–6."* So two consecutive evaluations of a 300-second metric are two overlapping 300-second windows, not two adjacent datapoints. The twelve 60-second definitions get both windows out of a single `range + 1` request, one slot apart; the eight 300-second ones need two differently aligned requests, because a returned datapoint lands on the grid the request's own start time defines. A run is three `GetMetricData` calls.

**The evaluation range is wider than the window.** A gap in a recent period is covered by a real reading from further back before the missing-data policy is consulted at all. AWS documents that the size of this widening *"depends on the length of the alarm period and whether it is based on a metric with standard resolution or high resolution"* and publishes no formula, so `missing_data_lookback` is configuration defaulting to 2 — the only figure its worked examples put to a standard-resolution metric — rather than a constant presented as parity.

**A failed query is not a metric that stopped reporting.** A series that came back `Failed` or `Partial`, or did not come back, is not evaluated. It never becomes a window of gaps for a `breaching` policy to turn into an alarm about a database that is perfectly healthy. Everything else in the run evaluates normally, and the affected definitions get one operational summary.

### Two divergences, named rather than approximated

`treat_missing_data = "ignore"` keeps the alarm's previous state — a memory that stateless window reconstruction does not have. A catalogue asking for it is **refused at boot** with that reason rather than quietly evaluated as something else.

AWS's *premature alarm state* rule is not implemented. Its two published tables contain rows that satisfy the stated condition and disagree on the outcome, and it only ever changes the result under `missing` or `ignore`. All twenty cells of both tables are encoded as tests, including the two cells this diverges on, so the gap is visible rather than assumed away.

Neither policy appears in `rds-alerts`. Worth flagging against the ticket text: the Terraform module defaults `treat_missing_data` to `notBreaching`, **not** AWS's `missing`, so across the 20 definitions it is `breaching` on 2 severities and `notBreaching` on the other 51 — which means `INSUFFICIENT_DATA` is unreachable for this catalogue, and the ticket's "a transition to INSUFFICIENT_DATA on a `breaching` alarm is worth announcing" cannot occur (`breaching` + all-missing is ALARM). The state still exists for `missing`. Likewise `datapoints_to_alarm` is used 7 times in the full 76-definition catalogue and **zero** times in `rds-alerts`; M-out-of-N is implemented and tested, but nothing shipped exercises it, and a test asserts that so the day a rendered catalogue starts using it, something notices.

### Nothing is remembered

Both windows are reconstructed from CloudWatch on every request. No `HashMap`, no Redis, no table — and no mute, acknowledgement, history or delivery state, because that is alert *management*, it is source-agnostic, and building it here would produce a second mechanism covering infrastructure alerts and nothing else. The accepted costs, stated plainly: repeated requests announce the same transition twice, and a transition hidden by a failed query or a late-arriving datapoint is not announced at all. Delivery retries are [#23485](https://github.com/juspay/hyperswitch-cloud/issues/23485).

### The catalogue belongs to Terraform

The infrastructure repository knows the resource identifiers and already expands the templated classifications, so it renders the catalogue and Helm delivers it; definitions arrive with **dimensions already resolved** and this service validates and evaluates them. No Terraform parsing, no resource discovery, no group expansion in Rust. `config/observability.toml` carries a hand-checked snapshot until that rendering lands ([#23444](https://github.com/juspay/hyperswitch-cloud/issues/23444)) and says so — `[cloudwatch.source]` records origin and revision and sets `temporary`, which makes the service log a warning at **every** boot. A comment would have done the same job right up until someone deleted it.

One thing worth a look in review: **dimensions are name/value pairs, not a map.** The `config` crate lowercases every key it reads, so `DBInstanceIdentifier` written as a map key arrives as `dbinstanceidentifier` — a case CloudWatch does not know. It would name a metric that reports nothing, so under this catalogue's `notBreaching` default all twenty alarms would evaluate cleanly and never fire. This was a real bug in an earlier revision of this branch, caught by the catalogue test; carrying the name as a *value* is what preserves its case.

## Additional Changes

- [x] Configuration file changes

`MetricSeries::new`, `MetricPage::new` and `Cursor::new` in `external_services` become public. They were crate-private, which meant `MetricsProvider` — object-safe and provider-neutral on purpose — could not be implemented outside `external_services`: a trait no other crate can produce a value for is one no other crate can implement, so "provider-neutral" quietly meant "the two providers in this module". It is also what lets this crate stand a stub provider up instead of reaching for a live account.

`crates/observability/src/lib.rs` documented the crate as delivery-only — *"Deciding what is alert-worthy happens elsewhere"* — which is no longer true, so it now says what the crate actually does and where the line between generation and management falls.

## Motivation and Context

The keystone of [the CloudWatch-sourced infrastructure alerts map](https://github.com/juspay/hyperswitch-cloud/issues/23440). `rds-alerts` ships first because its dimensions are stable names rather than generated ids, so it does not wait on the Terraform work, and because at 20 definitions it is the largest classification — the config shape gets stressed rather than validated against a toy.

## How did you test it?

`cargo test -p observability --features v1` — **116 passing**, plus `clippy` and `fmt` clean.

Worth knowing what the tests actually pin down:

- **The run itself** (`tests/alarm_evaluation.rs`), against a stub provider. This is the one that matters: it covers the ticket's acceptance criterion — a condition that stays breaching across two consecutive evaluations announces **exactly once** — plus recovery, dry run, partial failure, page merging, and delivery refusals. The stub is a minute-resolution metric history that aggregates on demand rather than a canned response, which is what makes the five-minute test meaningful: it fails if the two windows a minute apart are ever collapsed into one. Both key properties were checked by mutation, not assumed — making `Transition::between` always fire failed exactly the announce-once test, and treating a `Failed` series as data failed exactly the two tests about query failure not being missing data.
- **Both AWS missing-data tables**, all twenty cells, as the parity contract.
- **The shipped catalogue itself** (`tests/alarm_catalogue.rs`) loaded exactly as the service loads it, through `Settings::with_config_path` and full `validate()`. This is the guard that matters most, because every way a hand-checked snapshot goes wrong is silent: a threshold that lost a digit still evaluates, a definition that lost its dimensions queries a metric that reports nothing, and a severity pointing at an unconfigured destination evaluates perfectly and delivers nowhere. It asserts 20 definitions / 53 severities / 20 queries, the 12–8 period split, the resolved dimension values against the infrastructure they were copied from, and the missing-data policies in use.
- **Window planning**: that a 60-second metric needs one request and a 300-second metric needs two, one minute apart.

Exercised end to end against a running server, with CloudWatch deliberately failing (see below):

```
evaluated_at   2026-09-10T18:13:00.000Z
compared_with  2026-09-10T18:12:00.000Z     ← one minute, not one period
definitions 20 · readings 20 · severities 53
```

- all 53 severities came back `state: null` with an `error` — not one fabricated breach
- one total-failure summary naming the affected definitions, truncated at 12 with `…and 8 more`
- `"delivery":{"status":"skipped_dry_run"}` — the dry run skipped the failure notification too, not just the announcements
- `401` unauthenticated; `400` on `{"dryrun": true}`, the misspelling that would otherwise have silently sent real messages

### Not yet verified — flagging honestly

- **No live CloudWatch data.** The IAM identity available to me is denied `cloudwatch:GetMetricData` on the sandbox account, which is what produced the failure path above. The ticket's "all 20 definitions evaluate against real sandbox CloudWatch data" needs that grant, and so does empirically confirming the 300-second window alignment — that is documented from the AWS API reference and the client's own grid placement, not measured.
- **No synthetic breach delivered to a real channel.** Everything is pointed at the `log` destination; a sandbox destination id is needed for that check. Per the handoff, that must be the sandbox destination and never a production channel.

I would keep the build ticket open until both are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FoL6nSZvJnajbpScxLrEP
