### PR TITLE
feat(payments): keep the vault session and combined PML stable per payment

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -3017,7 +3017,7 @@ pub struct PaymentMethodListIntentDataInput {
 }
 
 /// Intent-only payment details returned as part of the Payment Method List response
-#[derive(Debug, Clone, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct PaymentMethodListIntentData {
     /// Unique identifier for the payment
     #[schema(value_type = String)]
@@ -3119,7 +3119,7 @@ pub struct PaymentMethodListIntentData {
 /// Payment experience entry in the client PM list.
 /// Subtype-specific data for each payment method entry in the client list
 #[cfg(feature = "v1")]
-#[derive(Debug, Clone, serde::Serialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq)]
 #[serde(untagged)]
 pub enum PaymentMethodSubtypeSpecificDataForClient {
     /// Card payment method — contains card network info
@@ -3136,7 +3136,7 @@ pub enum PaymentMethodSubtypeSpecificDataForClient {
 
 /// A single flat entry in the client payment method list — one per (payment_method_type × payment_method_subtype)
 #[cfg(feature = "v1")]
-#[derive(Debug, Clone, serde::Serialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq)]
 pub struct ResponsePaymentMethodsEnabledForClient {
     /// The top-level payment method type (e.g. "card", "wallet")
     #[schema(value_type = PaymentMethod)]
@@ -3179,7 +3179,7 @@ pub struct ResponsePaymentMethodsEnabledForClient {
 /// `CustomerPaymentMethodForClient` is `None`.
 /// Wallet payment method data returned in the client-facing PM list.
 #[cfg(feature = "v1")]
-#[derive(Debug, Clone, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WalletPaymentMethodDataForClient {
     ApplePay(Box<PaymentMethodDataWalletInfo>),
@@ -3191,7 +3191,7 @@ pub enum WalletPaymentMethodDataForClient {
 /// Bank debit payment method data returned in the client-facing PM list.
 /// Field names use `_last4_digits` to match the modular service response.
 #[cfg(feature = "v1")]
-#[derive(Debug, Clone, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BankDebitDataForClient {
     AchBankDebit {
@@ -3209,7 +3209,7 @@ pub enum BankDebitDataForClient {
 }
 
 #[cfg(feature = "v1")]
-#[derive(Debug, Clone, serde::Serialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum CustomerPaymentMethodDataForClient {
     /// Masked card details from the card locker.
@@ -3229,7 +3229,7 @@ pub enum CustomerPaymentMethodDataForClient {
 /// Only the fields needed by the SDK are included; server-side fields
 /// (e.g. `surcharge_details`, `metadata`) are omitted.
 #[cfg(feature = "v1")]
-#[derive(Debug, Clone, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct CustomerPaymentMethodForClient {
     /// Token for payment method in temporary card locker which gets refreshed often.
     /// The SDK passes this back when submitting the payment.
@@ -3273,7 +3273,7 @@ pub struct CustomerPaymentMethodForClient {
 
 /// Response for the GET /payments/{payment_id}/payment-methods/client endpoint
 #[cfg(feature = "v1")]
-#[derive(Debug, Clone, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct ClientPaymentMethodsListResponse {
     /// Flat list of enabled payment methods — one entry per (payment_method_type × payment_method_subtype)
     pub payment_methods_enabled: Vec<ResponsePaymentMethodsEnabledForClient>,
@@ -3310,7 +3310,7 @@ pub enum PaymentMethodListResult {
 }
 
 /// Installment options for a payment method, as returned in the payment method list response
-#[derive(Debug, Clone, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct PaymentMethodListInstallmentOption {
     /// The payment method these plans apply to
     #[schema(value_type = PaymentMethod)]
@@ -3320,7 +3320,7 @@ pub struct PaymentMethodListInstallmentOption {
 }
 
 /// A single installment plan with pre-computed amount breakdown
-#[derive(Debug, Clone, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct PaymentMethodListInstallmentPlan {
     /// Number of installments for this plan
     #[schema(value_type = u8)]
@@ -3336,7 +3336,7 @@ pub struct PaymentMethodListInstallmentPlan {
 }
 
 /// Amount breakdown for a single installment plan
-#[derive(Debug, Clone, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct PaymentMethodListInstallmentAmountDetails {
     /// Amount charged per installment in major units
     #[schema(value_type = f64)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -10782,7 +10782,7 @@ pub enum SessionToken {
 /// Top-level vault details returned in the session-tokens response.
 /// For v1: contains both internal vault (SDK authorization) and external vault details.
 /// For v2: contains only external vault details.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct VaultDetails {
     /// Internal vault details containing the SDK authorization token (v1 only)
     pub internal_vault: Option<InternalVaultSessionDetails>,
@@ -10791,20 +10791,20 @@ pub struct VaultDetails {
 }
 
 /// Internal vault details for SDK authorization
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct InternalVaultSessionDetails {
     /// Base64-encoded SDK authorization token for the internal vault session
     pub sdk_authorization: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum VaultSessionDetails {
     Vgs(VgsSessionDetails),
     HyperswitchVault(HyperswitchVaultSessionDetails),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct VgsSessionDetails {
     /// The identifier of the external vault
     #[schema(value_type = String)]
@@ -10813,7 +10813,7 @@ pub struct VgsSessionDetails {
     pub sdk_env: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct HyperswitchVaultSessionDetails {
     /// Base64-encoded SDK authorization token for the Hyperswitch Vault session
     #[schema(value_type = String)]

--- a/crates/common_utils/src/id_type/payment.rs
+++ b/crates/common_utils/src/id_type/payment.rs
@@ -63,6 +63,24 @@ impl PaymentId {
         )
     }
 
+    /// Get the Redis key under which the payment-method vault session for this payment is cached
+    pub fn get_pm_vault_session_redis_key(&self, merchant_id: &super::MerchantId) -> String {
+        format!(
+            "{}_{}_pm_vault_session",
+            merchant_id.get_string_repr(),
+            self.get_string_repr()
+        )
+    }
+
+    /// Get the Redis key under which the combined payment-method list for this payment is cached
+    pub fn get_combined_pm_list_redis_key(&self, merchant_id: &super::MerchantId) -> String {
+        format!(
+            "{}_{}_combined_pm_list",
+            merchant_id.get_string_repr(),
+            self.get_string_repr()
+        )
+    }
+
     /// Generate a test payment id with prefix test_
     pub fn generate_test_payment_id_for_sample_data() -> Self {
         let id = generate_id_with_default_len("test");

--- a/crates/payment_methods/src/client/session.rs
+++ b/crates/payment_methods/src/client/session.rs
@@ -84,6 +84,9 @@ pub struct ModularPMSessionCreateResponse {
     /// External vault session details returned by the PM service when an external vault is
     /// configured for the profile.
     pub external_vault_details: Option<VaultSessionDetailsResponse>,
+    /// When the session stops being usable on the PM service side.
+    #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
+    pub expires_at: Option<time::PrimitiveDateTime>,
 }
 
 /// V1-facing response (thin wrapper around the wire response).
@@ -94,6 +97,7 @@ pub struct CreatePaymentMethodSessionResponse {
     pub customer_id: Option<id_type::CustomerId>,
     pub sdk_authorization: Option<String>,
     pub external_vault_details: Option<api_models::payments::VaultSessionDetails>,
+    pub expires_at: Option<time::PrimitiveDateTime>,
 }
 
 // --- Conversions ---
@@ -119,6 +123,7 @@ impl TryFrom<ModularPMSessionCreateResponse> for CreatePaymentMethodSessionRespo
             customer_id: resp.customer_id,
             sdk_authorization: resp.sdk_authorization,
             external_vault_details: resp.external_vault_details.map(Into::into),
+            expires_at: resp.expires_at,
         })
     }
 }

--- a/crates/router/src/core/payment_methods/client.rs
+++ b/crates/router/src/core/payment_methods/client.rs
@@ -27,6 +27,7 @@ use crate::{
             cards, transformers::list_customer_payment_methods_from_modular_service,
         },
         payments::helpers,
+        utils as core_utils,
     },
     pii::PeekInterface,
     routes::{self, payment_methods::ParentPaymentMethodToken},
@@ -632,51 +633,67 @@ async fn fetch_customer_payment_methods(
 // list_payment_methods_client  — top-level orchestrator
 // ---------------------------------------------------------------------------
 
-#[instrument(skip_all, fields(flow = ?Flow::PaymentMethodsList))]
-pub async fn list_payment_methods_client(
-    state: routes::SessionState,
-    platform: domain::Platform,
-    payment_id: id_type::PaymentId,
-    client_secret: Option<String>,
-) -> errors::RouterResponse<ClientPaymentMethodsListResponse> {
-    // 1. Load payment intent + related context
-    let payment_intent_context =
-        load_payment_intent_context(&state, &platform, &payment_id).await?;
+/// The combined list cached per payment.
+///
+/// Every route that lists payment methods for a payment — the SDK's own list call and the
+/// server-integration enrichment of an intent update — comes through here, so all of them hand
+/// out the list, and the saved-payment-method tokens in it, that whichever ran first produced.
+/// The intent's `modified_at` travels with it so a payment update rebuilds the list instead of
+/// serving one computed for the previous state. The attempt's `modified_at` is deliberately not
+/// part of this: building the list itself writes routing results to the attempt, so keying on it
+/// would invalidate the entry on every build.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct CachedClientPaymentMethodsList {
+    intent_modified_at: time::PrimitiveDateTime,
+    response: ClientPaymentMethodsListResponse,
+}
 
-    if let Some(client_secret) = client_secret.as_ref() {
-        helpers::authenticate_client_secret(
-            Some(client_secret),
-            &payment_intent_context.payment_intent,
-        )?;
+impl CachedClientPaymentMethodsList {
+    const TYPE_NAME: &'static str = "CachedClientPaymentMethodsList";
+
+    fn is_for(&self, payment_intent_context: &PaymentIntentContext) -> bool {
+        self.intent_modified_at == payment_intent_context.payment_intent.modified_at
     }
+}
 
-    // 2. Fetch enabled payment methods (Gate 1 + Gate 2 + consolidation)
+/// Builds the combined list for the payment: enabled methods, the customer's saved methods
+/// (filtered to the enabled ones and past the blocklist) and the intent data.
+///
+/// The saved-method entries carry freshly minted payment tokens, valid for the profile's order
+/// fulfillment time; that is what makes two builds for the same payment differ, and why the
+/// result is cached by the caller for the same window.
+async fn build_client_payment_methods_list(
+    state: &routes::SessionState,
+    platform: &domain::Platform,
+    payment_intent_context: &PaymentIntentContext,
+) -> errors::RouterResult<ClientPaymentMethodsListResponse> {
+    // 1. Fetch enabled payment methods (Gate 1 + Gate 2 + consolidation)
     let EnabledPmsResult {
         payment_methods_enabled,
         sdk_next_action,
         connector_supports_installments,
-    } = fetch_enabled_payment_methods(&state, &platform, &payment_intent_context).await?;
+    } = fetch_enabled_payment_methods(state, platform, payment_intent_context).await?;
 
-    // 3. Fetch saved customer payment methods
+    // 2. Fetch saved customer payment methods
     let customer_payment_methods =
-        fetch_customer_payment_methods(&state, &platform, &payment_intent_context).await?;
+        fetch_customer_payment_methods(state, platform, payment_intent_context).await?;
 
-    // 4. Filter customer PMs to only those whose (payment_method, payment_method_type)
+    // 3. Filter customer PMs to only those whose (payment_method, payment_method_type)
     //    combination is present in the merchant-enabled list.
     let customer_payment_methods_filtered =
         filter_customer_pms_by_enabled(customer_payment_methods, &payment_methods_enabled);
 
-    // 5. Drop saved cards whose BIN is blocklisted for this merchant/profile (no-op unless
+    // 4. Drop saved cards whose BIN is blocklisted for this merchant/profile (no-op unless
     //    the merchant has the blocklist guard enabled).
     let customer_payment_methods_filtered = filter_customer_pms_by_blocklist(
-        &state,
-        &platform,
+        state,
+        platform,
         payment_intent_context.business_profile.get_id(),
         customer_payment_methods_filtered,
     )
     .await;
 
-    // 6. Build intent_data
+    // 5. Build intent_data
     let net_amount = payment_intent_context
         .payment_attempt
         .net_amount
@@ -716,12 +733,100 @@ pub async fn list_payment_methods_client(
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to build intent_data")?;
 
-    Ok(services::ApplicationResponse::Json(
-        ClientPaymentMethodsListResponse {
-            payment_methods_enabled,
-            customer_payment_methods: customer_payment_methods_filtered,
-            sdk_next_action,
-            intent_data,
-        },
-    ))
+    Ok(ClientPaymentMethodsListResponse {
+        payment_methods_enabled,
+        customer_payment_methods: customer_payment_methods_filtered,
+        sdk_next_action,
+        intent_data,
+    })
+}
+
+/// Returns the combined list for this payment, building it on first use.
+///
+/// The cache lives no longer than the payment tokens inside the list: those expire after the
+/// profile's order fulfillment time from the moment they were minted, so the entry gets that
+/// window less however long the build took. A cache miss or a cache write failure is never
+/// fatal; the worst case is a fresh list, which is what every call used to get.
+async fn get_or_build_client_payment_methods_list(
+    state: &routes::SessionState,
+    platform: &domain::Platform,
+    payment_intent_context: &PaymentIntentContext,
+) -> errors::RouterResult<ClientPaymentMethodsListResponse> {
+    let payment_intent = &payment_intent_context.payment_intent;
+    let redis_key = payment_intent
+        .payment_id
+        .get_combined_pm_list_redis_key(&payment_intent.merchant_id);
+
+    let cached = core_utils::read_cached_value::<CachedClientPaymentMethodsList>(
+        state,
+        &redis_key,
+        CachedClientPaymentMethodsList::TYPE_NAME,
+    )
+    .await
+    .filter(|cached| cached.is_for(payment_intent_context));
+
+    match cached {
+        Some(cached) => {
+            logger::info!(
+                payment_id = %payment_intent.payment_id.get_string_repr(),
+                "Reusing the cached combined payment-method list for this payment"
+            );
+            Ok(cached.response)
+        }
+        None => {
+            let started = std::time::Instant::now();
+            let response =
+                build_client_payment_methods_list(state, platform, payment_intent_context).await?;
+
+            let build_seconds = i64::try_from(started.elapsed().as_secs()).unwrap_or(i64::MAX);
+            let ttl_seconds = payment_intent_context
+                .business_profile
+                .get_order_fulfillment_time()
+                .unwrap_or(consts::DEFAULT_INTENT_FULFILLMENT_TIME)
+                .saturating_sub(build_seconds.saturating_add(1));
+
+            if ttl_seconds > 0 {
+                let entry = CachedClientPaymentMethodsList {
+                    intent_modified_at: payment_intent.modified_at,
+                    response,
+                };
+                core_utils::cache_value_with_expiry(
+                    state,
+                    &redis_key,
+                    CachedClientPaymentMethodsList::TYPE_NAME,
+                    &entry,
+                    ttl_seconds,
+                )
+                .await;
+                Ok(entry.response)
+            } else {
+                Ok(response)
+            }
+        }
+    }
+}
+
+#[instrument(skip_all, fields(flow = ?Flow::PaymentMethodsList))]
+pub async fn list_payment_methods_client(
+    state: routes::SessionState,
+    platform: domain::Platform,
+    payment_id: id_type::PaymentId,
+    client_secret: Option<String>,
+) -> errors::RouterResponse<ClientPaymentMethodsListResponse> {
+    // Load payment intent + related context
+    let payment_intent_context =
+        load_payment_intent_context(&state, &platform, &payment_id).await?;
+
+    if let Some(client_secret) = client_secret.as_ref() {
+        helpers::authenticate_client_secret(
+            Some(client_secret),
+            &payment_intent_context.payment_intent,
+        )?;
+    }
+
+    let response =
+        get_or_build_client_payment_methods_list(&state, &platform, &payment_intent_context)
+            .await?;
+
+    Ok(services::ApplicationResponse::Json(response))
 }

--- a/crates/router/src/core/payments/update_context.rs
+++ b/crates/router/src/core/payments/update_context.rs
@@ -234,7 +234,9 @@ async fn session_tokens(
     .await?;
 
     // Returned whole: the caller gets `session_token` and `vault_details` (the internal vault
-    // SDK authorization) exactly as the standalone endpoint would have returned them.
+    // SDK authorization) exactly as the standalone endpoint would have returned them. The vault
+    // session is the per-payment one shared with `/session_tokens`, so a server integration sees
+    // the same SDK authorization on every call for this payment.
     json_body(response, "session_tokens")
 }
 

--- a/crates/router/src/core/payments/vault_session.rs
+++ b/crates/router/src/core/payments/vault_session.rs
@@ -33,6 +33,8 @@ use crate::core::{
     payments::{customers, gateway::context as gateway_context},
     utils as core_utils,
 };
+#[cfg(feature = "v1")]
+use crate::{consts, core::utils as core_utils};
 use crate::{
     core::{
         errors::{self, RouterResult},
@@ -108,6 +110,131 @@ where
     Ok(())
 }
 
+/// What the internal PM service handed back for a freshly created session.
+#[cfg(feature = "v1")]
+struct CreatedPmVaultSession {
+    vault_details: Option<api::VaultDetails>,
+    expires_at: Option<time::PrimitiveDateTime>,
+}
+
+/// The vault session cached per payment, so every call for that payment hands the SDK the same
+/// authorization. `customer_id` and `storage_type` travel with it so an intent update that
+/// changes either mints a fresh session instead of reusing one created under different terms.
+#[cfg(feature = "v1")]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct CachedPmVaultSession {
+    customer_id: Option<id_type::CustomerId>,
+    storage_type: common_enums::StorageType,
+    vault_details: api::VaultDetails,
+}
+
+/// Storage intent for the PM vault session.
+///
+/// `setup_future_usage` on the intent carries the merchant's storage intent for the session: set
+/// (on_session/off_session) → persistent, absent → volatile. Persistent intent without a
+/// customer_id is rejected at payment create/confirm (`validate_customer_id_mandatory_cases`), so
+/// a persistent session always has a customer to attach to.
+#[cfg(feature = "v1")]
+pub fn resolve_vault_storage_type(
+    setup_future_usage: Option<common_enums::FutureUsage>,
+    customer_id: Option<&id_type::CustomerId>,
+) -> common_enums::StorageType {
+    match (setup_future_usage, customer_id) {
+        (Some(_), Some(_)) => common_enums::StorageType::Persistent,
+        _ => common_enums::StorageType::Volatile,
+    }
+}
+
+/// Returns the PM vault session for this payment, creating it on first use.
+///
+/// Every route that mints session tokens for a payment — the standalone session-tokens call and
+/// the server-integration enrichment of a payment create or intent update — comes through here,
+/// so all of them return the session minted by whichever ran first. The cache lives no longer
+/// than the PM service says the session does. A cache miss or a cache write failure is never
+/// fatal: the worst case is a fresh session, which is what every call used to get.
+#[cfg(feature = "v1")]
+pub async fn get_or_create_pm_vault_session(
+    state: &SessionState,
+    external_vault_profile: &domain::Profile,
+    merchant_id: &id_type::MerchantId,
+    payment_id: &id_type::PaymentId,
+    customer_id: Option<&id_type::CustomerId>,
+    storage_type: common_enums::StorageType,
+) -> RouterResult<Option<api::VaultDetails>> {
+    let redis_key = payment_id.get_pm_vault_session_redis_key(merchant_id);
+
+    let cached = core_utils::read_cached_value::<CachedPmVaultSession>(
+        state,
+        &redis_key,
+        "CachedPmVaultSession",
+    )
+    .await
+    .filter(|cached| {
+        cached.customer_id.as_ref() == customer_id && cached.storage_type == storage_type
+    });
+
+    match cached {
+        Some(cached) => {
+            router_env::logger::info!(
+                payment_id = %payment_id.get_string_repr(),
+                ?storage_type,
+                "Reusing the cached PM vault session for this payment"
+            );
+            Ok(Some(cached.vault_details))
+        }
+        None => {
+            let created = call_internal_pm_session_create_for_vault(
+                state,
+                external_vault_profile,
+                customer_id,
+                storage_type,
+            )
+            .await?;
+
+            let cache_entry = created
+                .vault_details
+                .clone()
+                .zip(cache_ttl_seconds(created.expires_at))
+                .map(|(vault_details, ttl_seconds)| {
+                    (
+                        CachedPmVaultSession {
+                            customer_id: customer_id.cloned(),
+                            storage_type,
+                            vault_details,
+                        },
+                        ttl_seconds,
+                    )
+                });
+
+            if let Some((entry, ttl_seconds)) = cache_entry {
+                core_utils::cache_value_with_expiry(
+                    state,
+                    &redis_key,
+                    "CachedPmVaultSession",
+                    &entry,
+                    ttl_seconds,
+                )
+                .await;
+            }
+
+            Ok(created.vault_details)
+        }
+    }
+}
+
+/// How long the cache entry may live: the remaining life of the PM session, capped at the
+/// default session expiry. `None` when the session has already expired, in which case caching
+/// would only hand out a dead authorization.
+#[cfg(feature = "v1")]
+fn cache_ttl_seconds(expires_at: Option<time::PrimitiveDateTime>) -> Option<i64> {
+    let default_ttl = i64::from(consts::DEFAULT_PAYMENT_METHOD_SESSION_EXPIRY);
+    expires_at
+        .map(|expires_at| (expires_at - common_utils::date_time::now()).whole_seconds())
+        .map_or(Some(default_ttl), |remaining| {
+            Some(remaining.min(default_ttl)).filter(|ttl| *ttl > 0)
+        })
+}
+
 /// Call the internal payment-methods service to create a PM session and extract both
 /// `internal_vault` (sdk_authorization) and `external_vault_details` from the response.
 #[cfg(feature = "v1")]
@@ -116,7 +243,7 @@ async fn call_internal_pm_session_create_for_vault(
     profile: &domain::Profile,
     customer_id: Option<&id_type::CustomerId>,
     storage_type: common_enums::StorageType,
-) -> RouterResult<Option<api::VaultDetails>> {
+) -> RouterResult<CreatedPmVaultSession> {
     use common_utils::request::Headers;
     use payment_methods::client::{
         CreatePaymentMethodSession, CreatePaymentMethodSessionV1Request, PaymentMethodClient,
@@ -179,32 +306,37 @@ async fn call_internal_pm_session_create_for_vault(
                 sdk_authorization: sdk_auth,
             });
 
-    let external_vault_details = response.external_vault_details;
+    // Only worth returning when at least one of the two parts is present.
+    let vault_details = match (internal_vault, response.external_vault_details) {
+        (None, None) => {
+            router_env::logger::warn!(
+                merchant_id=%merchant_id.get_string_repr(),
+                profile_id=%profile_id.get_string_repr(),
+                ?storage_type,
+                "Internal PM session create returned neither sdk_authorization nor external_vault_details"
+            );
+            None
+        }
+        (internal_vault, external_vault_details) => {
+            router_env::logger::info!(
+                merchant_id=%merchant_id.get_string_repr(),
+                profile_id=%profile_id.get_string_repr(),
+                ?storage_type,
+                has_internal_vault=internal_vault.is_some(),
+                has_external_vault_details=external_vault_details.is_some(),
+                "Internal PM session created for vault details"
+            );
+            Some(api::VaultDetails {
+                internal_vault,
+                external_vault_details,
+            })
+        }
+    };
 
-    // Only return Some if at least one of the two parts is present.
-    if internal_vault.is_none() && external_vault_details.is_none() {
-        router_env::logger::warn!(
-            merchant_id=%merchant_id.get_string_repr(),
-            profile_id=%profile_id.get_string_repr(),
-            ?storage_type,
-            "Internal PM session create returned neither sdk_authorization nor external_vault_details"
-        );
-        return Ok(None);
-    }
-
-    router_env::logger::info!(
-        merchant_id=%merchant_id.get_string_repr(),
-        profile_id=%profile_id.get_string_repr(),
-        ?storage_type,
-        has_internal_vault=internal_vault.is_some(),
-        has_external_vault_details=external_vault_details.is_some(),
-        "Internal PM session create for vault succeeded"
-    );
-
-    Ok(Some(api::VaultDetails {
-        internal_vault,
-        external_vault_details,
-    }))
+    Ok(CreatedPmVaultSession {
+        vault_details,
+        expires_at: response.expires_at,
+    })
 }
 
 #[cfg(feature = "v1")]
@@ -237,31 +369,27 @@ where
             helpers::resolve_provider_profile(state, platform, profile).await?;
         let customer_id = customer.as_ref().map(|c| c.get_id());
 
-        // `setup_future_usage` on the intent carries the merchant's storage intent for the
-        // session: set (on_session/off_session) → persistent, absent → volatile. Persistent
-        // intent without a customer_id is rejected at payment create/confirm
-        // (`validate_customer_id_mandatory_cases`), so a persistent session always has a
-        // customer to attach to.
-        let storage_type = match (
-            payment_data.get_payment_intent().setup_future_usage,
-            customer_id,
-        ) {
-            (Some(_), Some(_)) => common_enums::StorageType::Persistent,
-            _ => common_enums::StorageType::Volatile,
-        };
+        let payment_intent = payment_data.get_payment_intent();
+        let merchant_id = payment_intent.merchant_id.clone();
+        let payment_id = payment_intent.payment_id.clone();
+        let setup_future_usage = payment_intent.setup_future_usage;
+
+        let storage_type = resolve_vault_storage_type(setup_future_usage, customer_id);
         router_env::logger::info!(
             ?storage_type,
-            setup_future_usage=?payment_data.get_payment_intent().setup_future_usage,
-            has_customer=customer_id.is_some(),
+            ?setup_future_usage,
+            has_customer = customer_id.is_some(),
             "Resolved storage type for PM vault session create"
         );
 
         // Use the resolved external vault profile (the platform merchant's profile in platform
         // flows) so the PM service operates under the merchant that actually holds the external
         // vault configuration. For standard merchants this is the payment profile itself.
-        let vault_details = call_internal_pm_session_create_for_vault(
+        let vault_details = get_or_create_pm_vault_session(
             state,
             &external_vault_profile,
+            &merchant_id,
+            &payment_id,
             customer_id,
             storage_type,
         )

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -41,6 +41,7 @@ use hyperswitch_masking::Secret;
 #[cfg(feature = "payouts")]
 use hyperswitch_masking::{ExposeInterface, PeekInterface};
 use maud::{html, PreEscaped};
+use redis_interface::errors::RedisError;
 use regex::Regex;
 use router_env::{instrument, tracing};
 use storage_impl::StorageError;
@@ -3144,4 +3145,74 @@ where
     .attach_printable_lazy(|| format!("Unable to encrypt data for table: {}", table_name))?;
 
     Ok(encrypted_data)
+}
+
+/// Reads a value cached in Redis under `redis_key`.
+///
+/// Never fatal: a miss, an unreachable Redis, or an entry that no longer deserializes all read as
+/// "not cached", and the caller rebuilds what it would have built without the cache. Only the
+/// failures are logged; a miss is the normal first-call case.
+pub async fn read_cached_value<T>(
+    state: &SessionState,
+    redis_key: &str,
+    type_name: &'static str,
+) -> Option<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let lookup: CustomResult<T, RedisError> = async {
+        state
+            .store
+            .get_redis_conn()?
+            .get_and_deserialize_key::<T>(&redis_key.into(), type_name)
+            .await
+    }
+    .await;
+
+    match lookup {
+        Ok(cached) => Some(cached),
+        Err(err) if matches!(err.current_context(), RedisError::NotFound) => None,
+        Err(err) => {
+            router_env::logger::warn!(
+                ?err,
+                redis_key,
+                type_name,
+                "Failed to read the cached value; rebuilding it"
+            );
+            None
+        }
+    }
+}
+
+/// Caches `value` in Redis under `redis_key` for `ttl_seconds`.
+///
+/// Never fatal: a write failure only means later calls rebuild the value, so it is logged and
+/// otherwise ignored.
+pub async fn cache_value_with_expiry<T>(
+    state: &SessionState,
+    redis_key: &str,
+    type_name: &'static str,
+    value: &T,
+    ttl_seconds: i64,
+) where
+    T: serde::Serialize + std::fmt::Debug,
+{
+    let stored: CustomResult<(), RedisError> = async {
+        state
+            .store
+            .get_redis_conn()?
+            .serialize_and_set_key_with_expiry(&redis_key.into(), value, ttl_seconds)
+            .await
+    }
+    .await;
+
+    match stored {
+        Ok(()) => router_env::logger::info!(redis_key, type_name, ttl_seconds, "Cached the value"),
+        Err(err) => router_env::logger::warn!(
+            ?err,
+            redis_key,
+            type_name,
+            "Failed to cache the value; later calls will rebuild it"
+        ),
+    }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The server-integration enrichment of an intent update, the standalone session-token call and the SDK's own list call each minted a fresh PM vault session and a fresh combined payment-method list, so a server integration and its SDK saw different SDK authorizations and different saved-method tokens for the same payment.

Both are now cached in Redis per payment:

- The PM vault session is cached for as long as the PM service says the session lives, keyed on the customer and storage type it was created under, so an intent update that changes either mints a new one.
- The combined payment-method list is cached for the profile's order fulfillment time (the lifetime of the payment tokens inside it), keyed on the intent's `modified_at`, so an intent update rebuilds it. The attempt's `modified_at` is deliberately not part of the key: building the list writes routing results to the attempt.

A cache miss or a cache write failure is never fatal; the worst case is a fresh session or list, which is what every call used to get. The Redis read/write helpers are shared between the two.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

test cases are in the attached issue


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
