### PR TITLE
fix(api_models): keep `router_env` off the wasm32 target

### DIFF
--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -61,9 +61,14 @@ hyperswitch_masking = { version = "0.0.1", default-features = false, features = 
     "time",
 ] }
 router_derive = { version = "0.1.0", path = "../router_derive" }
-router_env = { version = "0.1.0", path = "../router_env" }
 smithy = { version = "0.1.0", path = "../smithy" }
 smithy-core = { version = "0.1.0", path = "../smithy-core" }
+
+# `router_env` depends on tokio and the OpenTelemetry exporters, neither of which builds for
+# wasm32 (tokio pulls `mio`, whose `sys` module is empty there). `euclid_wasm` depends on this
+# crate, so the logger is only wired up off that target.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+router_env = { version = "0.1.0", path = "../router_env" }
 
 [lints]
 workspace = true

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -20,6 +20,7 @@ use common_utils::{
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::PeekInterface;
+#[cfg(not(target_arch = "wasm32"))]
 use router_env::logger;
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},
@@ -1962,11 +1963,14 @@ impl TryFrom<PaymentMethodDataWalletInfo> for Box<payments::ApplepayPaymentMetho
                 .to_uppercase()
                 .parse::<api_enums::CardType>()
                 .inspect_err(|error| {
+                    #[cfg(not(target_arch = "wasm32"))]
                     logger::error!(
                         ?error,
                         unparsed_card_type = %card_type,
                         "Received an unrecognized card_type value from Apple Pay; defaulting to None"
-                    )
+                    );
+                    #[cfg(target_arch = "wasm32")]
+                    let _ = error;
                 })
                 .ok(),
             card_exp_month: item.card_exp_month,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

`Check wasm build` has been red on `main` since 2026-09-08. `make euclid-wasm` fails with 47 unresolved-import errors inside `mio`, whose `sys` module is empty on wasm32:

```
Compiling mio v1.0.3
error[E0432]: unresolved import `crate::sys::IoSourceState`
error[E0433]: cannot find `Selector` in `sys`
...
error: could not compile `mio` (lib) due to 47 previous errors
```

`mio` reaches the wasm32 tree through:

```
euclid_wasm → api_models → router_env → actix-web / opentelemetry-otlp → tokio → mio
```

#14055 added `router_env` to `crates/api_models/Cargo.toml` for one diagnostic `logger::error!` in `payment_methods.rs`. `router_env` depends on tokio and the OpenTelemetry exporters unconditionally, so *any* dependency on it pulls tokio in — `default-features = false` does not help, because the tokio path survives through `opentelemetry-otlp`, `opentelemetry_sdk` and `tracing-opentelemetry` even with `actix_web` off.

Since `euclid_wasm` depends on `api_models`, the dependency moves under a target gate and the single call site is gated to match:

```toml
[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
router_env = { version = "0.1.0", path = "../router_env" }
```

Server builds are unchanged. They already depend on `router_env` directly, and `api_models` takes its own actix-web through its `errors` and `control_center_theme` features rather than inheriting it from `router_env`'s defaults — so nothing outside wasm32 loses anything.

`ring` is also in the wasm32 tree, via `common_utils`, but that is pre-existing and unchanged by this PR — it built fine before #14055 and is not part of this failure.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes #14176.

`euclid_wasm` is the routing DSL bundle the dashboard loads, so this is a shipping artifact and not only a CI check. While it is red, the job is also useless as a signal — a genuine wasm regression would be indistinguishable from the current failure.

## How did you test it?

- `cargo tree -p euclid_wasm --target wasm32-unknown-unknown --features dummy_connector,v1 -i mio` reports `nothing to print` after the change; before it, it prints the `tokio → mio` chain rooted at `router_env`.
- The same query for `ring` is byte-identical before and after, confirming this PR does not disturb that path.
- `RUSTFLAGS="-D warnings" just clippy` passes, so the non-wasm build is unaffected by the target gate and the gated `use`.

`make euclid-wasm` could not be run to completion locally: Apple's bundled clang has no wasm32 target (`unable to create target: 'No available targets are compatible with triple "wasm32-unknown-unknown"'`), which stops `ring`'s build script well after `mio` would have failed. CI has a wasm-capable clang, so the job here is the real verification of the full build.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
