### PR TITLE
docs(openapi): document X-Integration-Type and the server-integration response on payment create and update

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -31,6 +31,19 @@
         "summary": "Payments - Create",
         "description": "Creates a payment resource, which represents a customer's intent to pay.\nThis endpoint is the starting point for various payment flows:\n",
         "operationId": "Create a Payment",
+        "parameters": [
+          {
+            "name": "X-Integration-Type",
+            "in": "header",
+            "description": "Selects the response shape. `server` returns the payment together with `payment_method_list` and `session_tokens`, so a server-to-server integration can render its checkout from one call; it is honoured only with merchant API key authentication. `client`, or no header, returns the payment response unchanged.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "example": "server"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -627,6 +640,90 @@
                       "profile_id": "pro_pzzzzzzzzzzz",
                       "status": "succeeded"
                     }
+                  },
+                  "12. Server integration response": {
+                    "value": {
+                      "amount": 6540,
+                      "attempt_count": 1,
+                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                      "currency": "USD",
+                      "customer_id": "cus_abcdefgh",
+                      "merchant_id": "merchant_1668273825",
+                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                      "payment_method_list": {
+                        "customer_payment_methods": [],
+                        "intent_data": {
+                          "amount": 6540,
+                          "attempt_count": 1,
+                          "currency": "USD",
+                          "customer_id": "cus_abcdefgh",
+                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                          "profile_id": "pro_pzzzzzzzzzzz",
+                          "status": "requires_payment_method"
+                        },
+                        "payment_methods_enabled": [
+                          {
+                            "card_networks": [
+                              "Visa",
+                              "Mastercard"
+                            ],
+                            "customer_acceptance_support": "supported",
+                            "payment_method": "card",
+                            "payment_method_type": "credit"
+                          }
+                        ],
+                        "sdk_next_action": {
+                          "next_action": "confirm"
+                        }
+                      },
+                      "profile_id": "pro_pzzzzzzzzzzz",
+                      "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
+                      "session_tokens": {
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "session_token": [],
+                        "vault_details": {
+                          "vault_data": {
+                            "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM="
+                          },
+                          "vault_type": "hyperswitch"
+                        }
+                      },
+                      "status": "requires_payment_method"
+                    }
+                  },
+                  "13. Server integration, one section failed": {
+                    "value": {
+                      "amount": 6540,
+                      "attempt_count": 1,
+                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                      "currency": "USD",
+                      "merchant_id": "merchant_1668273825",
+                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                      "payment_method_list": {
+                        "customer_payment_methods": [],
+                        "intent_data": {
+                          "amount": 6540,
+                          "attempt_count": 1,
+                          "currency": "USD",
+                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                          "status": "requires_payment_method"
+                        },
+                        "payment_methods_enabled": [],
+                        "sdk_next_action": {
+                          "next_action": "confirm"
+                        }
+                      },
+                      "profile_id": "pro_pzzzzzzzzzzz",
+                      "session_tokens": {
+                        "error": {
+                          "code": "HE_00",
+                          "message": "Something went wrong",
+                          "type": "api"
+                        }
+                      },
+                      "status": "requires_payment_method"
+                    }
                   }
                 }
               }
@@ -667,6 +764,17 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "X-Integration-Type",
+            "in": "header",
+            "description": "Selects the response shape. `server` returns the payment together with `payment_method_list` and `session_tokens`, so a server-to-server integration can render its checkout from one call; it is honoured only with merchant API key authentication. `client`, or no header, returns the payment response unchanged.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "example": "server"
           }
         ],
         "requestBody": {
@@ -714,6 +822,92 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PaymentsCreateResponseOpenApi"
+                },
+                "examples": {
+                  "Server integration response": {
+                    "value": {
+                      "amount": 6540,
+                      "attempt_count": 1,
+                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                      "currency": "USD",
+                      "customer_id": "cus_abcdefgh",
+                      "merchant_id": "merchant_1668273825",
+                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                      "payment_method_list": {
+                        "customer_payment_methods": [],
+                        "intent_data": {
+                          "amount": 6540,
+                          "attempt_count": 1,
+                          "currency": "USD",
+                          "customer_id": "cus_abcdefgh",
+                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                          "profile_id": "pro_pzzzzzzzzzzz",
+                          "status": "requires_payment_method"
+                        },
+                        "payment_methods_enabled": [
+                          {
+                            "card_networks": [
+                              "Visa",
+                              "Mastercard"
+                            ],
+                            "customer_acceptance_support": "supported",
+                            "payment_method": "card",
+                            "payment_method_type": "credit"
+                          }
+                        ],
+                        "sdk_next_action": {
+                          "next_action": "confirm"
+                        }
+                      },
+                      "profile_id": "pro_pzzzzzzzzzzz",
+                      "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
+                      "session_tokens": {
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "session_token": [],
+                        "vault_details": {
+                          "vault_data": {
+                            "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM="
+                          },
+                          "vault_type": "hyperswitch"
+                        }
+                      },
+                      "status": "requires_payment_method"
+                    }
+                  },
+                  "Server integration, one section failed": {
+                    "value": {
+                      "amount": 6540,
+                      "attempt_count": 1,
+                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                      "currency": "USD",
+                      "merchant_id": "merchant_1668273825",
+                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                      "payment_method_list": {
+                        "customer_payment_methods": [],
+                        "intent_data": {
+                          "amount": 6540,
+                          "attempt_count": 1,
+                          "currency": "USD",
+                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                          "status": "requires_payment_method"
+                        },
+                        "payment_methods_enabled": [],
+                        "sdk_next_action": {
+                          "next_action": "confirm"
+                        }
+                      },
+                      "profile_id": "pro_pzzzzzzzzzzz",
+                      "session_tokens": {
+                        "error": {
+                          "code": "HE_00",
+                          "message": "Something went wrong",
+                          "type": "api"
+                        }
+                      },
+                      "status": "requires_payment_method"
+                    }
+                  }
                 }
               }
             }

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -645,11 +645,11 @@
                     "value": {
                       "amount": 6540,
                       "attempt_count": 1,
-                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                      "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                       "currency": "USD",
                       "customer_id": "cus_abcdefgh",
-                      "merchant_id": "merchant_1668273825",
-                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                      "merchant_id": "merchant_myyyyyyyyyyyy",
+                      "payment_id": "pay_serverint_xxxxxxxxxxxx",
                       "payment_method_list": {
                         "customer_payment_methods": [],
                         "intent_data": {
@@ -657,7 +657,7 @@
                           "attempt_count": 1,
                           "currency": "USD",
                           "customer_id": "cus_abcdefgh",
-                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                          "payment_id": "pay_serverint_xxxxxxxxxxxx",
                           "profile_id": "pro_pzzzzzzzzzzz",
                           "status": "requires_payment_method"
                         },
@@ -679,8 +679,8 @@
                       "profile_id": "pro_pzzzzzzzzzzz",
                       "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                       "session_tokens": {
-                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
-                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
                         "session_token": [],
                         "vault_details": {
                           "vault_data": {
@@ -696,17 +696,17 @@
                     "value": {
                       "amount": 6540,
                       "attempt_count": 1,
-                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                      "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                       "currency": "USD",
-                      "merchant_id": "merchant_1668273825",
-                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                      "merchant_id": "merchant_myyyyyyyyyyyy",
+                      "payment_id": "pay_serverint_xxxxxxxxxxxx",
                       "payment_method_list": {
                         "customer_payment_methods": [],
                         "intent_data": {
                           "amount": 6540,
                           "attempt_count": 1,
                           "currency": "USD",
-                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                          "payment_id": "pay_serverint_xxxxxxxxxxxx",
                           "status": "requires_payment_method"
                         },
                         "payment_methods_enabled": [],
@@ -828,11 +828,11 @@
                     "value": {
                       "amount": 6540,
                       "attempt_count": 1,
-                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                      "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                       "currency": "USD",
                       "customer_id": "cus_abcdefgh",
-                      "merchant_id": "merchant_1668273825",
-                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                      "merchant_id": "merchant_myyyyyyyyyyyy",
+                      "payment_id": "pay_serverint_xxxxxxxxxxxx",
                       "payment_method_list": {
                         "customer_payment_methods": [],
                         "intent_data": {
@@ -840,7 +840,7 @@
                           "attempt_count": 1,
                           "currency": "USD",
                           "customer_id": "cus_abcdefgh",
-                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                          "payment_id": "pay_serverint_xxxxxxxxxxxx",
                           "profile_id": "pro_pzzzzzzzzzzz",
                           "status": "requires_payment_method"
                         },
@@ -862,8 +862,8 @@
                       "profile_id": "pro_pzzzzzzzzzzz",
                       "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                       "session_tokens": {
-                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
-                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
                         "session_token": [],
                         "vault_details": {
                           "vault_data": {
@@ -879,17 +879,17 @@
                     "value": {
                       "amount": 6540,
                       "attempt_count": 1,
-                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                      "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                       "currency": "USD",
-                      "merchant_id": "merchant_1668273825",
-                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                      "merchant_id": "merchant_myyyyyyyyyyyy",
+                      "payment_id": "pay_serverint_xxxxxxxxxxxx",
                       "payment_method_list": {
                         "customer_payment_methods": [],
                         "intent_data": {
                           "amount": 6540,
                           "attempt_count": 1,
                           "currency": "USD",
-                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                          "payment_id": "pay_serverint_xxxxxxxxxxxx",
                           "status": "requires_payment_method"
                         },
                         "payment_methods_enabled": [],

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -645,11 +645,11 @@
                     "value": {
                       "amount": 6540,
                       "attempt_count": 1,
-                      "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                       "currency": "USD",
                       "customer_id": "cus_abcdefgh",
-                      "merchant_id": "merchant_myyyyyyyyyyyy",
-                      "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                      "merchant_id": "merchant_1668273825",
+                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                       "payment_method_list": {
                         "customer_payment_methods": [],
                         "intent_data": {
@@ -657,7 +657,7 @@
                           "attempt_count": 1,
                           "currency": "USD",
                           "customer_id": "cus_abcdefgh",
-                          "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                           "profile_id": "pro_pzzzzzzzzzzz",
                           "status": "requires_payment_method"
                         },
@@ -679,8 +679,8 @@
                       "profile_id": "pro_pzzzzzzzzzzz",
                       "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                       "session_tokens": {
-                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
-                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                         "session_token": [],
                         "vault_details": {
                           "vault_data": {
@@ -696,17 +696,17 @@
                     "value": {
                       "amount": 6540,
                       "attempt_count": 1,
-                      "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                       "currency": "USD",
-                      "merchant_id": "merchant_myyyyyyyyyyyy",
-                      "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                      "merchant_id": "merchant_1668273825",
+                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                       "payment_method_list": {
                         "customer_payment_methods": [],
                         "intent_data": {
                           "amount": 6540,
                           "attempt_count": 1,
                           "currency": "USD",
-                          "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                           "status": "requires_payment_method"
                         },
                         "payment_methods_enabled": [],
@@ -828,11 +828,11 @@
                     "value": {
                       "amount": 6540,
                       "attempt_count": 1,
-                      "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                       "currency": "USD",
                       "customer_id": "cus_abcdefgh",
-                      "merchant_id": "merchant_myyyyyyyyyyyy",
-                      "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                      "merchant_id": "merchant_1668273825",
+                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                       "payment_method_list": {
                         "customer_payment_methods": [],
                         "intent_data": {
@@ -840,7 +840,7 @@
                           "attempt_count": 1,
                           "currency": "USD",
                           "customer_id": "cus_abcdefgh",
-                          "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                           "profile_id": "pro_pzzzzzzzzzzz",
                           "status": "requires_payment_method"
                         },
@@ -862,8 +862,8 @@
                       "profile_id": "pro_pzzzzzzzzzzz",
                       "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                       "session_tokens": {
-                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
-                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                         "session_token": [],
                         "vault_details": {
                           "vault_data": {
@@ -879,17 +879,17 @@
                     "value": {
                       "amount": 6540,
                       "attempt_count": 1,
-                      "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                      "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                       "currency": "USD",
-                      "merchant_id": "merchant_myyyyyyyyyyyy",
-                      "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                      "merchant_id": "merchant_1668273825",
+                      "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                       "payment_method_list": {
                         "customer_payment_methods": [],
                         "intent_data": {
                           "amount": 6540,
                           "attempt_count": 1,
                           "currency": "USD",
-                          "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                          "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                           "status": "requires_payment_method"
                         },
                         "payment_methods_enabled": [],

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -658,7 +658,7 @@
                           "currency": "USD",
                           "customer_id": "cus_abcdefgh",
                           "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
-                          "profile_id": "pro_pzzzzzzzzzzz",
+                          "profile_id": "pro_abcdefghijklmnop",
                           "status": "requires_payment_method"
                         },
                         "payment_methods_enabled": [
@@ -676,7 +676,7 @@
                           "next_action": "confirm"
                         }
                       },
-                      "profile_id": "pro_pzzzzzzzzzzz",
+                      "profile_id": "pro_abcdefghijklmnop",
                       "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                       "session_tokens": {
                         "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
@@ -714,7 +714,7 @@
                           "next_action": "confirm"
                         }
                       },
-                      "profile_id": "pro_pzzzzzzzzzzz",
+                      "profile_id": "pro_abcdefghijklmnop",
                       "session_tokens": {
                         "error": {
                           "code": "HE_00",
@@ -841,7 +841,7 @@
                           "currency": "USD",
                           "customer_id": "cus_abcdefgh",
                           "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
-                          "profile_id": "pro_pzzzzzzzzzzz",
+                          "profile_id": "pro_abcdefghijklmnop",
                           "status": "requires_payment_method"
                         },
                         "payment_methods_enabled": [
@@ -859,7 +859,7 @@
                           "next_action": "confirm"
                         }
                       },
-                      "profile_id": "pro_pzzzzzzzzzzz",
+                      "profile_id": "pro_abcdefghijklmnop",
                       "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                       "session_tokens": {
                         "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
@@ -897,7 +897,7 @@
                           "next_action": "confirm"
                         }
                       },
-                      "profile_id": "pro_pzzzzzzzzzzz",
+                      "profile_id": "pro_abcdefghijklmnop",
                       "session_tokens": {
                         "error": {
                           "code": "HE_00",

--- a/crates/openapi/src/routes/payments.rs
+++ b/crates/openapi/src/routes/payments.rs
@@ -564,7 +564,7 @@
                     "customer_id": "cus_abcdefgh",
                     "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                     "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
-                    "profile_id": "pro_pzzzzzzzzzzz",
+                    "profile_id": "pro_abcdefghijklmnop",
                     "attempt_count": 1,
                     "payment_method_list": {
                         "payment_methods_enabled": [
@@ -583,7 +583,7 @@
                             "amount": 6540,
                             "currency": "USD",
                             "customer_id": "cus_abcdefgh",
-                            "profile_id": "pro_pzzzzzzzzzzz",
+                            "profile_id": "pro_abcdefghijklmnop",
                             "attempt_count": 1
                         }
                     },
@@ -608,7 +608,7 @@
                     "amount": 6540,
                     "currency": "USD",
                     "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
-                    "profile_id": "pro_pzzzzzzzzzzz",
+                    "profile_id": "pro_abcdefghijklmnop",
                     "attempt_count": 1,
                     "payment_method_list": {
                         "payment_methods_enabled": [],
@@ -734,7 +734,7 @@ pub fn payments_retrieve() {}
                         "customer_id": "cus_abcdefgh",
                         "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                         "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
-                        "profile_id": "pro_pzzzzzzzzzzz",
+                        "profile_id": "pro_abcdefghijklmnop",
                         "attempt_count": 1,
                         "payment_method_list": {
                             "payment_methods_enabled": [
@@ -753,7 +753,7 @@ pub fn payments_retrieve() {}
                                 "amount": 6540,
                                 "currency": "USD",
                                 "customer_id": "cus_abcdefgh",
-                                "profile_id": "pro_pzzzzzzzzzzz",
+                                "profile_id": "pro_abcdefghijklmnop",
                                 "attempt_count": 1
                             }
                         },
@@ -778,7 +778,7 @@ pub fn payments_retrieve() {}
                         "amount": 6540,
                         "currency": "USD",
                         "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
-                        "profile_id": "pro_pzzzzzzzzzzz",
+                        "profile_id": "pro_abcdefghijklmnop",
                         "attempt_count": 1,
                         "payment_method_list": {
                             "payment_methods_enabled": [],

--- a/crates/openapi/src/routes/payments.rs
+++ b/crates/openapi/src/routes/payments.rs
@@ -556,13 +556,13 @@
             )),
             ("12. Server integration response" = (
                 value = json!({
-                    "payment_id": "pay_serverint_xxxxxxxxxxxx",
-                    "merchant_id": "merchant_myyyyyyyyyyyy",
+                    "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                    "merchant_id": "merchant_1668273825",
                     "status": "requires_payment_method",
                     "amount": 6540,
                     "currency": "USD",
                     "customer_id": "cus_abcdefgh",
-                    "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                    "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                     "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                     "profile_id": "pro_pzzzzzzzzzzz",
                     "attempt_count": 1,
@@ -578,7 +578,7 @@
                         "customer_payment_methods": [],
                         "sdk_next_action": { "next_action": "confirm" },
                         "intent_data": {
-                            "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                             "status": "requires_payment_method",
                             "amount": 6540,
                             "currency": "USD",
@@ -588,8 +588,8 @@
                         }
                     },
                     "session_tokens": {
-                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
-                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                         "session_token": [],
                         "vault_details": {
                             "vault_type": "hyperswitch",
@@ -602,12 +602,12 @@
             )),
             ("13. Server integration, one section failed" = (
                 value = json!({
-                    "payment_id": "pay_serverint_xxxxxxxxxxxx",
-                    "merchant_id": "merchant_myyyyyyyyyyyy",
+                    "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                    "merchant_id": "merchant_1668273825",
                     "status": "requires_payment_method",
                     "amount": 6540,
                     "currency": "USD",
-                    "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                    "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                     "profile_id": "pro_pzzzzzzzzzzz",
                     "attempt_count": 1,
                     "payment_method_list": {
@@ -615,7 +615,7 @@
                         "customer_payment_methods": [],
                         "sdk_next_action": { "next_action": "confirm" },
                         "intent_data": {
-                            "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                             "status": "requires_payment_method",
                             "amount": 6540,
                             "currency": "USD",
@@ -726,13 +726,13 @@ pub fn payments_retrieve() {}
             examples(
                 ("Server integration response" = (
                     value = json!({
-                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
-                        "merchant_id": "merchant_myyyyyyyyyyyy",
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "merchant_id": "merchant_1668273825",
                         "status": "requires_payment_method",
                         "amount": 6540,
                         "currency": "USD",
                         "customer_id": "cus_abcdefgh",
-                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                         "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                         "profile_id": "pro_pzzzzzzzzzzz",
                         "attempt_count": 1,
@@ -748,7 +748,7 @@ pub fn payments_retrieve() {}
                             "customer_payment_methods": [],
                             "sdk_next_action": { "next_action": "confirm" },
                             "intent_data": {
-                                "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                                "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                                 "status": "requires_payment_method",
                                 "amount": 6540,
                                 "currency": "USD",
@@ -758,8 +758,8 @@ pub fn payments_retrieve() {}
                             }
                         },
                         "session_tokens": {
-                            "payment_id": "pay_serverint_xxxxxxxxxxxx",
-                            "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                            "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                             "session_token": [],
                             "vault_details": {
                                 "vault_type": "hyperswitch",
@@ -772,12 +772,12 @@ pub fn payments_retrieve() {}
                 )),
                 ("Server integration, one section failed" = (
                     value = json!({
-                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
-                        "merchant_id": "merchant_myyyyyyyyyyyy",
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "merchant_id": "merchant_1668273825",
                         "status": "requires_payment_method",
                         "amount": 6540,
                         "currency": "USD",
-                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
                         "profile_id": "pro_pzzzzzzzzzzz",
                         "attempt_count": 1,
                         "payment_method_list": {
@@ -785,7 +785,7 @@ pub fn payments_retrieve() {}
                             "customer_payment_methods": [],
                             "sdk_next_action": { "next_action": "confirm" },
                             "intent_data": {
-                                "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                                "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
                                 "status": "requires_payment_method",
                                 "amount": 6540,
                                 "currency": "USD",

--- a/crates/openapi/src/routes/payments.rs
+++ b/crates/openapi/src/routes/payments.rs
@@ -556,13 +556,13 @@
             )),
             ("12. Server integration response" = (
                 value = json!({
-                    "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
-                    "merchant_id": "merchant_1668273825",
+                    "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                    "merchant_id": "merchant_myyyyyyyyyyyy",
                     "status": "requires_payment_method",
                     "amount": 6540,
                     "currency": "USD",
                     "customer_id": "cus_abcdefgh",
-                    "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                    "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                     "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                     "profile_id": "pro_pzzzzzzzzzzz",
                     "attempt_count": 1,
@@ -578,7 +578,7 @@
                         "customer_payment_methods": [],
                         "sdk_next_action": { "next_action": "confirm" },
                         "intent_data": {
-                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                            "payment_id": "pay_serverint_xxxxxxxxxxxx",
                             "status": "requires_payment_method",
                             "amount": 6540,
                             "currency": "USD",
@@ -588,8 +588,8 @@
                         }
                     },
                     "session_tokens": {
-                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
-                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                         "session_token": [],
                         "vault_details": {
                             "vault_type": "hyperswitch",
@@ -602,12 +602,12 @@
             )),
             ("13. Server integration, one section failed" = (
                 value = json!({
-                    "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
-                    "merchant_id": "merchant_1668273825",
+                    "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                    "merchant_id": "merchant_myyyyyyyyyyyy",
                     "status": "requires_payment_method",
                     "amount": 6540,
                     "currency": "USD",
-                    "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                    "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                     "profile_id": "pro_pzzzzzzzzzzz",
                     "attempt_count": 1,
                     "payment_method_list": {
@@ -615,7 +615,7 @@
                         "customer_payment_methods": [],
                         "sdk_next_action": { "next_action": "confirm" },
                         "intent_data": {
-                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                            "payment_id": "pay_serverint_xxxxxxxxxxxx",
                             "status": "requires_payment_method",
                             "amount": 6540,
                             "currency": "USD",
@@ -726,13 +726,13 @@ pub fn payments_retrieve() {}
             examples(
                 ("Server integration response" = (
                     value = json!({
-                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
-                        "merchant_id": "merchant_1668273825",
+                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                        "merchant_id": "merchant_myyyyyyyyyyyy",
                         "status": "requires_payment_method",
                         "amount": 6540,
                         "currency": "USD",
                         "customer_id": "cus_abcdefgh",
-                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                         "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
                         "profile_id": "pro_pzzzzzzzzzzz",
                         "attempt_count": 1,
@@ -748,7 +748,7 @@ pub fn payments_retrieve() {}
                             "customer_payment_methods": [],
                             "sdk_next_action": { "next_action": "confirm" },
                             "intent_data": {
-                                "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                                "payment_id": "pay_serverint_xxxxxxxxxxxx",
                                 "status": "requires_payment_method",
                                 "amount": 6540,
                                 "currency": "USD",
@@ -758,8 +758,8 @@ pub fn payments_retrieve() {}
                             }
                         },
                         "session_tokens": {
-                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
-                            "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                            "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                            "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                             "session_token": [],
                             "vault_details": {
                                 "vault_type": "hyperswitch",
@@ -772,12 +772,12 @@ pub fn payments_retrieve() {}
                 )),
                 ("Server integration, one section failed" = (
                     value = json!({
-                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
-                        "merchant_id": "merchant_1668273825",
+                        "payment_id": "pay_serverint_xxxxxxxxxxxx",
+                        "merchant_id": "merchant_myyyyyyyyyyyy",
                         "status": "requires_payment_method",
                         "amount": 6540,
                         "currency": "USD",
-                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "client_secret": "pay_serverint_xxxxxxxxxxxx_secret_szzzzzzzzzzz",
                         "profile_id": "pro_pzzzzzzzzzzz",
                         "attempt_count": 1,
                         "payment_method_list": {
@@ -785,7 +785,7 @@ pub fn payments_retrieve() {}
                             "customer_payment_methods": [],
                             "sdk_next_action": { "next_action": "confirm" },
                             "intent_data": {
-                                "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                                "payment_id": "pay_serverint_xxxxxxxxxxxx",
                                 "status": "requires_payment_method",
                                 "amount": 6540,
                                 "currency": "USD",

--- a/crates/openapi/src/routes/payments.rs
+++ b/crates/openapi/src/routes/payments.rs
@@ -553,10 +553,93 @@
                     "attempt_count": 1,
                     "expires_on": "2023-10-26T10:45:00Z"
                 })
+            )),
+            ("12. Server integration response" = (
+                value = json!({
+                    "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                    "merchant_id": "merchant_1668273825",
+                    "status": "requires_payment_method",
+                    "amount": 6540,
+                    "currency": "USD",
+                    "customer_id": "cus_abcdefgh",
+                    "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
+                    "profile_id": "pro_pzzzzzzzzzzz",
+                    "attempt_count": 1,
+                    "payment_method_list": {
+                        "payment_methods_enabled": [
+                            {
+                                "payment_method": "card",
+                                "payment_method_type": "credit",
+                                "card_networks": ["Visa", "Mastercard"],
+                                "customer_acceptance_support": "supported"
+                            }
+                        ],
+                        "customer_payment_methods": [],
+                        "sdk_next_action": { "next_action": "confirm" },
+                        "intent_data": {
+                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                            "status": "requires_payment_method",
+                            "amount": 6540,
+                            "currency": "USD",
+                            "customer_id": "cus_abcdefgh",
+                            "profile_id": "pro_pzzzzzzzzzzz",
+                            "attempt_count": 1
+                        }
+                    },
+                    "session_tokens": {
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "session_token": [],
+                        "vault_details": {
+                            "vault_type": "hyperswitch",
+                            "vault_data": {
+                                "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM="
+                            }
+                        }
+                    }
+                })
+            )),
+            ("13. Server integration, one section failed" = (
+                value = json!({
+                    "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                    "merchant_id": "merchant_1668273825",
+                    "status": "requires_payment_method",
+                    "amount": 6540,
+                    "currency": "USD",
+                    "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                    "profile_id": "pro_pzzzzzzzzzzz",
+                    "attempt_count": 1,
+                    "payment_method_list": {
+                        "payment_methods_enabled": [],
+                        "customer_payment_methods": [],
+                        "sdk_next_action": { "next_action": "confirm" },
+                        "intent_data": {
+                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                            "status": "requires_payment_method",
+                            "amount": 6540,
+                            "currency": "USD",
+                            "attempt_count": 1
+                        }
+                    },
+                    "session_tokens": {
+                        "error": {
+                            "type": "api",
+                            "message": "Something went wrong",
+                            "code": "HE_00"
+                        }
+                    }
+                })
             ))
             )
         ),
         (status = 400, description = "Missing Mandatory fields", body = GenericErrorResponseOpenApi),
+    ),
+    params(
+        ("X-Integration-Type" = Option<String>, Header, description = "Selects the response shape. `server` returns the payment together with \
+            `payment_method_list` and `session_tokens`, so a server-to-server integration can render \
+            its checkout from one call; it is honoured only with merchant API key authentication. \
+            `client`, or no header, returns the payment response unchanged.", example = "server")
     ),
     tag = "Payments",
     operation_id = "Create a Payment",
@@ -594,7 +677,11 @@ pub fn payments_retrieve() {}
     post,
     path = "/payments/{payment_id}",
     params(
-        ("payment_id" = String, Path, description = "The identifier for payment")
+        ("payment_id" = String, Path, description = "The identifier for payment"),
+        ("X-Integration-Type" = Option<String>, Header, description = "Selects the response shape. `server` returns the payment together with \
+            `payment_method_list` and `session_tokens`, so a server-to-server integration can render \
+            its checkout from one call; it is honoured only with merchant API key authentication. \
+            `client`, or no header, returns the payment response unchanged.", example = "server")
     ),
    request_body(
      content = PaymentsUpdateRequest,
@@ -635,7 +722,87 @@ pub fn payments_retrieve() {}
      )
     ),
     responses(
-        (status = 200, description = "Payment updated", body = PaymentsCreateResponseOpenApi),
+        (status = 200, description = "Payment updated", body = PaymentsCreateResponseOpenApi,
+            examples(
+                ("Server integration response" = (
+                    value = json!({
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "merchant_id": "merchant_1668273825",
+                        "status": "requires_payment_method",
+                        "amount": 6540,
+                        "currency": "USD",
+                        "customer_id": "cus_abcdefgh",
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM=",
+                        "profile_id": "pro_pzzzzzzzzzzz",
+                        "attempt_count": 1,
+                        "payment_method_list": {
+                            "payment_methods_enabled": [
+                                {
+                                    "payment_method": "card",
+                                    "payment_method_type": "credit",
+                                    "card_networks": ["Visa", "Mastercard"],
+                                    "customer_acceptance_support": "supported"
+                                }
+                            ],
+                            "customer_payment_methods": [],
+                            "sdk_next_action": { "next_action": "confirm" },
+                            "intent_data": {
+                                "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                                "status": "requires_payment_method",
+                                "amount": 6540,
+                                "currency": "USD",
+                                "customer_id": "cus_abcdefgh",
+                                "profile_id": "pro_pzzzzzzzzzzz",
+                                "attempt_count": 1
+                            }
+                        },
+                        "session_tokens": {
+                            "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                            "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                            "session_token": [],
+                            "vault_details": {
+                                "vault_type": "hyperswitch",
+                                "vault_data": {
+                                    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9mXzEyMyxwdWJsaXNoYWJsZV9rZXk9cGtfbGl2ZV8xMjM="
+                                }
+                            }
+                        }
+                    })
+                )),
+                ("Server integration, one section failed" = (
+                    value = json!({
+                        "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                        "merchant_id": "merchant_1668273825",
+                        "status": "requires_payment_method",
+                        "amount": 6540,
+                        "currency": "USD",
+                        "client_secret": "pay_mbabizu24mvu3mela5njyhpit4_secret_el9ksDkiB8hi6j9N78yo",
+                        "profile_id": "pro_pzzzzzzzzzzz",
+                        "attempt_count": 1,
+                        "payment_method_list": {
+                            "payment_methods_enabled": [],
+                            "customer_payment_methods": [],
+                            "sdk_next_action": { "next_action": "confirm" },
+                            "intent_data": {
+                                "payment_id": "pay_mbabizu24mvu3mela5njyhpit4",
+                                "status": "requires_payment_method",
+                                "amount": 6540,
+                                "currency": "USD",
+                                "attempt_count": 1
+                            }
+                        },
+                        "session_tokens": {
+                            "error": {
+                                "type": "api",
+                                "message": "Something went wrong",
+                                "code": "HE_00"
+                            }
+                        }
+                    })
+                ))
+            )
+        ),
         (status = 400, description = "Missing mandatory fields", body = GenericErrorResponseOpenApi)
     ),
     tag = "Payments",


### PR DESCRIPTION
## Type of Change

- [x] Documentation

## Description

`POST /payments` and `POST /payments/{payment_id}` read the `X-Integration-Type` header, and their response schema already lists the `payment_method_list` and `session_tokens` sections it unlocks, but the header itself was missing from the OpenAPI spec. A merchant reading the API reference could not discover how to get the server-integration response shape.

This adds, on both routes:

- the `X-Integration-Type` header parameter, with its description and a `server` example;
- a response example showing the enriched shape (payment plus `payment_method_list` and `session_tokens`);
- a response example showing a section that could not be built carrying its error inline.

Spec regenerated with `cargo run -p openapi --features v1`. Docs only; no runtime change. The update-intent behaviour is on main (#14050); the create-intent behaviour is in #14172.

## How did you test it?

Regenerated the spec and checked the `parameters` and `examples` of both operations in `api-reference/v1/openapi_spec_v1.json`.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9FTBBUR5H33h1h67EDB5a
