### PR TITLE
fix(ucs): record request rejections as payment failures

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -162,6 +162,10 @@ pub enum UnifiedConnectorServiceError {
     #[error("This step has not been implemented for: {0}")]
     NotImplemented(String),
 
+    /// The connector does not support this operation.
+    #[error("This operation is not supported: {0}")]
+    NotSupported(String),
+
     /// Parsing of some value or input failed.
     #[error("Parsing failed")]
     ParsingFailed,
@@ -1979,6 +1983,7 @@ impl UnifiedConnectorServiceError {
             | Self::RequestEncodingFailedWithReason(_)
             | Self::InvalidConnectorName
             | Self::MissingConnectorName
+            | Self::NotSupported(_)
             | Self::FailedToObtainAuthType => 400,
             Self::NotImplemented(_) => 501,
             _ => 500,
@@ -2166,12 +2171,13 @@ impl UnifiedConnectorServiceError {
             | Code::InvalidConnectorConfig
             | Code::NoConnectorMetaData
             | Code::ConfigurationError => Self::FailedToObtainAuthType,
-            // Unsupported flow / feature → IR_00
-            Code::NotImplemented
-            | Code::NotSupported
+            // Not implemented → IR_00
+            Code::NotImplemented => Self::NotImplemented(ie.error_message.clone()),
+            // Unsupported flow / method / currency → IR_19
+            Code::NotSupported
             | Code::FlowNotSupported
             | Code::CaptureMethodNotSupported
-            | Code::CurrencyNotSupported => Self::NotImplemented(ie.error_message.clone()),
+            | Code::CurrencyNotSupported => Self::NotSupported(ie.error_message.clone()),
             // UCS internal failures → HE_00
             Code::RequestEncodingFailed
             | Code::HeaderMapConstructionFailed
@@ -2217,6 +2223,23 @@ impl ErrorSwitch<ApiErrorResponse> for UnifiedConnectorServiceError {
                 connector: inner.connector.clone(),
                 status_code: inner.status_code,
                 reason: inner.reason.clone(),
+            },
+            Self::NotSupported(message) => ApiErrorResponse::NotSupported {
+                message: message.clone(),
+            },
+            Self::NotImplemented(message) => ApiErrorResponse::NotImplemented {
+                message: NotImplementedMessage::Reason(message.clone()),
+            },
+            Self::MissingRequiredField { field_name } => ApiErrorResponse::MissingRequiredField {
+                field_name: field_name.clone(),
+            },
+            Self::MissingRequiredFields { field_names } => {
+                ApiErrorResponse::MissingRequiredFields {
+                    field_names: field_names.clone(),
+                }
+            }
+            Self::InvalidDataFormat { field_name } => ApiErrorResponse::InvalidRequestData {
+                message: format!("Invalid data format: {field_name}"),
             },
             _ => ApiErrorResponse::InternalServerError,
         }
@@ -2279,6 +2302,11 @@ impl ErrorSwitch<ConnectorError> for UnifiedConnectorServiceError {
             Self::FailedToObtainAuthType => ConnectorError::FailedToObtainAuthType,
             // Not implemented
             Self::NotImplemented(msg) => ConnectorError::NotImplemented(msg.clone()),
+            // Not supported
+            Self::NotSupported(msg) => ConnectorError::NotSupported {
+                message: msg.clone(),
+                connector: "unified_connector_service",
+            },
             // Invalid connector name
             Self::InvalidConnectorName | Self::MissingConnectorName => {
                 ConnectorError::InvalidConnectorName
@@ -2380,6 +2408,9 @@ impl UnifiedConnectorServiceError {
 
             // Raised by Hyperswitch, but it reports a flow UCS cannot serve.
             Self::NotImplemented(_) => Some(UcsKillSwitchReason::UcsFlowUnsupported),
+
+            // UCS rejected a request it does not support.
+            Self::NotSupported(_) => Some(UcsKillSwitchReason::UcsRejectedRequest),
 
             // UCS-side by construction: `from_grpc_error` extracts connector errors first.
             Self::TonicStatus { code, .. } => match code {

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -1093,7 +1093,10 @@ where
                         )
                         .await?;
 
-                    let (router_data, mca) = Box::pin(complete_connector_service(
+                    let failed_attempt_router_data =
+                        call_connector_service_response.router_data.clone();
+
+                    let (router_data, mca) = match Box::pin(complete_connector_service(
                         &updated_state,
                         platform.get_processor(),
                         &operation,
@@ -1112,7 +1115,48 @@ where
                         call_connector_service_response,
                         &dimensions.without_profile_id(),
                     ))
-                    .await?;
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(api_error) => {
+                            // Record the rejected attempt, then return the mapped error so the
+                            // API returns the error response instead of a payment object.
+                            let status_code = {
+                                use actix_web::ResponseError;
+                                api_error.current_context().status_code().as_u16()
+                            };
+                            let mut error_response: hyperswitch_domain_models::router_data::ErrorResponse =
+                                api_error.current_context().clone().into();
+                            error_response.status_code = status_code;
+                            let mut failed_router_data = failed_attempt_router_data;
+                            failed_router_data.response = Err(error_response);
+                            failed_router_data.connector_http_status_code = Some(status_code);
+                            // Record through the same tracker the normal path uses.
+                            let operation = Box::new(PaymentResponse);
+                            if let Err(tracker_error) = operation
+                                .to_post_update_tracker()?
+                                .update_tracker(
+                                    state,
+                                    platform.get_processor(),
+                                    payment_data,
+                                    failed_router_data,
+                                    &locale,
+                                    #[cfg(all(feature = "dynamic_routing", feature = "v1"))]
+                                    routable_connectors,
+                                    #[cfg(all(feature = "dynamic_routing", feature = "v1"))]
+                                    &business_profile,
+                                    &dimensions.without_profile_id(),
+                                )
+                                .await
+                            {
+                                logger::error!(
+                                    ?tracker_error,
+                                    "failed to record the rejected attempt"
+                                );
+                            }
+                            return Err(api_error);
+                        }
+                    };
 
                     let op_ref = &operation;
                     let should_trigger_post_processing_flows = is_operation_confirm(&operation);
@@ -1281,7 +1325,10 @@ where
                         )
                         .await?;
 
-                    let (router_data, mca) = Box::pin(complete_connector_service(
+                    let failed_attempt_router_data =
+                        call_connector_service_response.router_data.clone();
+
+                    let (router_data, mca) = match Box::pin(complete_connector_service(
                         &updated_state,
                         platform.get_processor(),
                         &operation,
@@ -1300,7 +1347,48 @@ where
                         call_connector_service_response,
                         &dimensions.without_profile_id(),
                     ))
-                    .await?;
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(api_error) => {
+                            // Record the rejected attempt, then return the mapped error so the
+                            // API returns the error response instead of a payment object.
+                            let status_code = {
+                                use actix_web::ResponseError;
+                                api_error.current_context().status_code().as_u16()
+                            };
+                            let mut error_response: hyperswitch_domain_models::router_data::ErrorResponse =
+                                api_error.current_context().clone().into();
+                            error_response.status_code = status_code;
+                            let mut failed_router_data = failed_attempt_router_data;
+                            failed_router_data.response = Err(error_response);
+                            failed_router_data.connector_http_status_code = Some(status_code);
+                            // Record through the same tracker the normal path uses.
+                            let operation = Box::new(PaymentResponse);
+                            if let Err(tracker_error) = operation
+                                .to_post_update_tracker()?
+                                .update_tracker(
+                                    state,
+                                    platform.get_processor(),
+                                    payment_data,
+                                    failed_router_data,
+                                    &locale,
+                                    #[cfg(all(feature = "dynamic_routing", feature = "v1"))]
+                                    routable_connectors,
+                                    #[cfg(all(feature = "dynamic_routing", feature = "v1"))]
+                                    &business_profile,
+                                    &dimensions.without_profile_id(),
+                                )
+                                .await
+                            {
+                                logger::error!(
+                                    ?tracker_error,
+                                    "failed to record the rejected attempt"
+                                );
+                            }
+                            return Err(api_error);
+                        }
+                    };
 
                     #[cfg(all(feature = "retry", feature = "v1"))]
                     let mut router_data = router_data;

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -3284,6 +3284,31 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
     offer_engine::schedule_payment_notification_for_attempt(state, &payment_data.payment_attempt)
         .await;
 
+    // A pre-call UCS rejection is recorded as a payment outcome above. For these refusals
+    // the API contract stays the error response, so return the mapped error after the
+    // attempt has been written instead of the payment object.
+    if let Err(error_response) = &router_data.response {
+        match error_response.code.as_str() {
+            "IR_19" => {
+                return Err(error_stack::Report::new(
+                    errors::ApiErrorResponse::NotSupported {
+                        message: error_response.message.clone(),
+                    },
+                ));
+            }
+            "IR_00" => {
+                return Err(error_stack::Report::new(
+                    errors::ApiErrorResponse::NotImplemented {
+                        message: errors::NotImplementedMessage::Reason(
+                            error_response.message.clone(),
+                        ),
+                    },
+                ));
+            }
+            _ => {}
+        }
+    }
+
     match router_data.integrity_check {
         Ok(()) => Ok(payment_data),
         Err(err) => {

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -3284,31 +3284,6 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
     offer_engine::schedule_payment_notification_for_attempt(state, &payment_data.payment_attempt)
         .await;
 
-    // A pre-call UCS rejection is recorded as a payment outcome above. For these refusals
-    // the API contract stays the error response, so return the mapped error after the
-    // attempt has been written instead of the payment object.
-    if let Err(error_response) = &router_data.response {
-        match error_response.code.as_str() {
-            "IR_19" => {
-                return Err(error_stack::Report::new(
-                    errors::ApiErrorResponse::NotSupported {
-                        message: error_response.message.clone(),
-                    },
-                ));
-            }
-            "IR_00" => {
-                return Err(error_stack::Report::new(
-                    errors::ApiErrorResponse::NotImplemented {
-                        message: errors::NotImplementedMessage::Reason(
-                            error_response.message.clone(),
-                        ),
-                    },
-                ));
-            }
-            _ => {}
-        }
-    }
-
     match router_data.integrity_check {
         Ok(()) => Ok(payment_data),
         Err(err) => {

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -25,7 +25,6 @@ use hyperswitch_connectors::utils::CardData;
 #[cfg(feature = "v2")]
 use hyperswitch_domain_models::merchant_connector_account::MerchantConnectorAccountTypeDetails;
 use hyperswitch_domain_models::{
-    errors::api_error_response::ApiErrorResponse,
     merchant_connector_account::ExternalVaultConnectorMetadata,
     payment_method_data as domain_pm,
     platform::Processor,
@@ -4081,7 +4080,7 @@ where
                 // error's own status decides whether the attempt fails (4xx) or stays
                 // pending (5xx) under the shared status rule.
                 let status_code = error.current_context().http_status();
-                let api_error: ApiErrorResponse = error.current_context().switch();
+                let api_error: errors::ApiErrorResponse = error.current_context().switch();
                 let mut router_data = router_data_clone;
                 let mut error_response: ErrorResponse = api_error.into();
                 error_response.status_code = status_code;

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -4074,22 +4074,10 @@ where
                     "error": error.to_string(),
                     "error_type": "ucs_call_failed"
                 });
-
-                // Turn the typed UCS error into a payment outcome so the normal response
-                // handling records it, rather than aborting with nothing persisted. The
-                // error's own status decides whether the attempt fails (4xx) or stays
-                // pending (5xx) under the shared status rule.
-                let status_code = error.current_context().http_status();
-                let api_error: errors::ApiErrorResponse = error.current_context().switch();
-                let mut router_data = router_data_clone;
-                let mut error_response: ErrorResponse = api_error.into();
-                error_response.status_code = status_code;
-                router_data.response = Err(error_response);
-                router_data.connector_http_status_code = Some(status_code);
                 (
-                    status_code,
+                    error.current_context().http_status(),
                     Some(error_body),
-                    Ok((router_data, FlowOutput::default())),
+                    Err(error),
                 )
             }
         }

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -25,6 +25,7 @@ use hyperswitch_connectors::utils::CardData;
 #[cfg(feature = "v2")]
 use hyperswitch_domain_models::merchant_connector_account::MerchantConnectorAccountTypeDetails;
 use hyperswitch_domain_models::{
+    errors::api_error_response::ApiErrorResponse,
     merchant_connector_account::ExternalVaultConnectorMetadata,
     payment_method_data as domain_pm,
     platform::Processor,
@@ -4074,10 +4075,22 @@ where
                     "error": error.to_string(),
                     "error_type": "ucs_call_failed"
                 });
+
+                // Turn the typed UCS error into a payment outcome so the normal response
+                // handling records it, rather than aborting with nothing persisted. The
+                // error's own status decides whether the attempt fails (4xx) or stays
+                // pending (5xx) under the shared status rule.
+                let status_code = error.current_context().http_status();
+                let api_error: ApiErrorResponse = error.current_context().switch();
+                let mut router_data = router_data_clone;
+                let mut error_response: ErrorResponse = api_error.into();
+                error_response.status_code = status_code;
+                router_data.response = Err(error_response);
+                router_data.connector_http_status_code = Some(status_code);
                 (
-                    error.current_context().http_status(),
+                    status_code,
                     Some(error_body),
-                    Err(error),
+                    Ok((router_data, FlowOutput::default())),
                 )
             }
         }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

When UCS rejected a request before calling the connector, Hyperswitch returned the error to the caller and recorded nothing on the payment. The attempt kept its previous status and the intent stayed in `processing`.

This PR records that rejection as a payment outcome and then returns the mapped error response, so the payment state moves and the API contract stays the error response:

- On the connector service path, the mapped API error is written to the attempt through the normal `PaymentResponse` post-update tracker, then the API error is returned. No hardcoded error codes.
- **Only a request-phase rejection is recorded.** A response-phase failure (for example the connector answered but UCS could not deserialize the response) leaves the outcome unknown — the payment may have succeeded at the connector — so it keeps its existing behavior and is left for sync/reconcile. The predicate lives on `ConnectorError::is_request_phase_rejection`, the enum both paths already share: native connectors raise it from their transformers, and UCS errors are switched into it. No UCS-specific downcast.
- `NotSupported` is split from `NotImplemented`. Not-supported codes (`NOT_SUPPORTED`, `FLOW_NOT_SUPPORTED`, `CAPTURE_METHOD_NOT_SUPPORTED`, `CURRENCY_NOT_SUPPORTED`) map to `IR_19` / HTTP 400; `NOT_IMPLEMENTED` maps to `IR_00` / 501. Either way the recorded attempt is marked `Failure` explicitly on the `ErrorResponse` rather than derived from the status code, so the payment does not sit in flight and the recorded state does not drift if that derivation changes.
- Other decoded classes carry their documented codes: missing required field `IR_04`, missing required fields `IR_21`, invalid data format `IR_05`.
- The rejection reason no longer names the connector twice. UCS already sends a complete, attributed message (`... is not supported by worldpayxml`), so the router surfaces it verbatim instead of re-appending `is not supported by unified_connector_service`, which `ConnectorError::NotSupported`'s `&'static str` connector field could never populate correctly.

The direct path is unchanged and needs no equivalent: it builds its connector request *before* the trackers move the payment to `processing` and aborts there, so it commits nothing and never reaches this call site. The recording is positional — anything failing after the commit point is classified by the shared predicate.

No UCS-side change is required for this fix. The router classifies on the decoded `IntegrationError` proto `error_code`, not on the gRPC status code (`decode_integration_error` never reads `status.code()`), so the wire code is only consulted in the `TonicStatus` fallback.

### Additional Changes

- [x] This PR modifies the API contract - a request rejection over UCS now records the failed attempt and returns the mapped error response (HTTP 400 for not-supported codes, HTTP 501 for not-implemented) instead of leaving the payment untouched.

## Motivation and Context

A merchant running worldpayxml over UCS reported that a request rejection leaves the payment intent in `processing` with no attempt recorded while the router answers `501 IR_00`. They reconcile on the intent state, so the payment looked in flight and their fallback never ran. This applies to any UCS connector that refuses during request construction, not only worldpayxml.

## How did you test it?

Local stack, router built from this branch, UCS `2026.09.11.1-2-g94c1ad158c75` on `:8000`, worldpayxml and stripe both routed through UCS. The direct runs were produced by flipping `rollout_percent` 1 → 0 on `*_card_Authorize` and restoring afterwards (config diffed byte-identical to the backup); every direct payment was verified absent from the UCS log.

### Matrix — both services

| case | http | code | intent | attempt | service |
|---|---|---|---|---|---|
| worldpayxml no-CVC (the reported case) | 400 | `IR_19` | `failed` | `failure` | ucs |
| worldpayxml no-CVC | 501 | - | `requires_payment_method` | `payment_method_awaited` | direct |
| stripe no-CVC | 501 | `IR_00` | `failed` | `failure` | ucs |
| stripe no-CVC | 501 | - | `requires_payment_method` | `payment_method_awaited` | direct |
| worldpayxml card (happy path) | 200 | - | `succeeded` | `charged` | ucs |
| worldpayxml card (happy path) | 200 | - | `succeeded` | `charged` | direct |
| stripe decline (connector 4xx) | 200 | `card_declined` | `failed` | `failure` | ucs |
| stripe decline (connector 4xx) | 200 | `card_declined` | `failed` | `failure` | direct |

The first row is the fix: the reported case now ends terminal instead of stranding in `processing` with nothing recorded. Rows 5–8 are the regression guard — the happy path and connector declines are untouched on both paths, and declines still return a payment object with the connector's own error code rather than an error envelope.

### What UCS sent, and what Hyperswitch made of it

| case | UCS sent | Hyperswitch rendered |
|---|---|---|
| worldpayxml no-CVC | gRPC `3 InvalidArgument`, `error_code: NOT_SUPPORTED`, `http_status_code: null`, `"Selected payment method is not supported by worldpayxml"` | `IR_19` / 400, reason = message verbatim, attempt recorded `failure` |
| stripe no-CVC | gRPC `12 Unimplemented`, `error_code: NOT_IMPLEMENTED`, `http_status_code: null` | `IR_00` / 501, attempt recorded `failure` |
| worldpayxml happy path | status 200, no gRPC error | 200 payment object, `charged` |
| stripe decline | gRPC `3 InvalidArgument`, `error_code: CONNECTOR_ERROR_RESPONSE`, `http_status_code: 402`, `"Your card was declined."` | 200 payment object, `card_declined`, attempt `failure` |

`http_status_code` `null` vs `402` is the phase marker: `null` means the connector was never called, `402` means it answered. Both arrive as gRPC `3`, which is why the classification is driven by the proto `error_code` rather than the gRPC status.

<details><summary><b>worldpayxml no-CVC over UCS — before and after</b></summary>

```sh
curl -X POST 'http://localhost:8080/payments' -H 'Content-Type: application/json' -H 'api-key: ****' \
  -d '{"amount":1000,"currency":"USD","confirm":true,"capture_method":"automatic","authentication_type":"no_three_ds","connector":["worldpayxml"],"customer_id":"...","payment_method":"card","payment_method_type":"credit","payment_method_data":{"card_with_no_cvc":{"card_number":"4242424242424242","card_exp_month":"12","card_exp_year":"30","card_holder_name":"John Doe"}}}'
```

Before — HTTP 501, nothing recorded, intent left in flight:

```json
{"error":{"type":"invalid_request","message":"Selected payment method is not supported by worldpayxml is not implemented","code":"IR_00"}}
```

```
payment_attempt: status = pending, error_code = NULL
payment_intent:  status = processing
```

After — HTTP 400, recorded, terminal, and the connector named once:

```json
{
  "error": {
    "type": "invalid_request",
    "message": "Payment method type not supported",
    "code": "IR_19",
    "reason": "Selected payment method is not supported by worldpayxml"
  }
}
```

```
payment_attempt: status = failure, error_code = IR_19, error_message = Selected payment method is not supported by worldpayxml
payment_intent:  status = failed
```

</details>

<details><summary><b>Regression guard — happy path and connector decline (UCS)</b></summary>

Happy path, worldpayxml card with CVC:

```json
{"status":"succeeded","payment_id":"pay_zoLmEJelKAaIbtz3PU5q"}
```
```
payment_attempt: charged   payment_intent: succeeded
```

Connector decline, stripe `4000000000000002` — still a payment object with the connector's code, not an error envelope:

```json
{"status":"failed","payment_id":"pay_5L3k7OpHYzomvy0AjbJr","error_code":"card_declined","error_message":"message - Your card was declined., decline_code - generic_decline"}
```
```
payment_attempt: failure / card_declined   payment_intent: failed
```

</details>

### Checks

- `cargo check -p router` passes.
- `cargo +nightly fmt --all -- --check` passes.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
