### PR TITLE
perf(merchant_connector_account): cache MCA list queries via scope supersets

### DIFF
--- a/crates/diesel_models/src/merchant_connector_account.rs
+++ b/crates/diesel_models/src/merchant_connector_account.rs
@@ -63,6 +63,17 @@ impl MerchantConnectorAccount {
     pub fn get_id(&self) -> id_type::MerchantConnectorAccountId {
         self.merchant_connector_id.clone()
     }
+
+    /// Whether this account counts as enabled, mirroring the SQL `disabled = false` that
+    /// the merchant connector account list queries filter on.
+    ///
+    /// Deliberately `== Some(false)` rather than `!= Some(true)`: `disabled` is nullable,
+    /// and a SQL equality comparison never matches NULL, so a row with no `disabled` value
+    /// is not one those queries return. Callers filtering in memory rather than in SQL
+    /// must not start including it.
+    pub fn is_enabled(&self) -> bool {
+        self.disabled == Some(false)
+    }
 }
 
 #[cfg(feature = "v2")]
@@ -114,6 +125,17 @@ pub struct MerchantConnectorAccount {
 impl MerchantConnectorAccount {
     pub fn get_id(&self) -> id_type::MerchantConnectorAccountId {
         self.id.clone()
+    }
+
+    /// Whether this account counts as enabled, mirroring the SQL `disabled = false` that
+    /// the merchant connector account list queries filter on.
+    ///
+    /// Deliberately `== Some(false)` rather than `!= Some(true)`: `disabled` is nullable,
+    /// and a SQL equality comparison never matches NULL, so a row with no `disabled` value
+    /// is not one those queries return. Callers filtering in memory rather than in SQL
+    /// must not start including it.
+    pub fn is_enabled(&self) -> bool {
+        self.disabled == Some(false)
     }
 }
 

--- a/crates/diesel_models/src/query/merchant_connector_account.rs
+++ b/crates/diesel_models/src/query/merchant_connector_account.rs
@@ -1,4 +1,4 @@
-use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods, Table};
+use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods};
 
 use super::generics;
 #[cfg(feature = "v1")]
@@ -87,28 +87,6 @@ impl MerchantConnectorAccount {
         .await
     }
 
-    pub async fn find_by_merchant_id_connector_name(
-        conn: &DatabaseConnectionWithContext<'_>,
-        merchant_id: &common_utils::id_type::MerchantId,
-        connector_name: &str,
-    ) -> StorageResult<Vec<Self>> {
-        generics::generic_filter::<
-            <Self as HasTable>::Table,
-            _,
-            <<Self as HasTable>::Table as Table>::PrimaryKey,
-            _,
-        >(
-            conn,
-            dsl::merchant_id
-                .eq(merchant_id.to_owned())
-                .and(dsl::connector_name.eq(connector_name.to_owned())),
-            None,
-            None,
-            None,
-        )
-        .await
-    }
-
     pub async fn find_by_merchant_id_merchant_connector_id(
         conn: &DatabaseConnectionWithContext<'_>,
         merchant_id: &common_utils::id_type::MerchantId,
@@ -123,50 +101,16 @@ impl MerchantConnectorAccount {
         .await
     }
 
-    pub async fn find_by_merchant_id(
+    /// Every merchant connector account of a merchant, including disabled ones, ordered by
+    /// `created_at` ascending. The other merchant-scoped list queries are row-subsets of
+    /// this one, so it doubles as the cached superset they project from.
+    pub async fn list_by_merchant_id(
         conn: &DatabaseConnectionWithContext<'_>,
         merchant_id: &common_utils::id_type::MerchantId,
-        get_disabled: bool,
-    ) -> StorageResult<Vec<Self>> {
-        if get_disabled {
-            generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
-                conn,
-                dsl::merchant_id.eq(merchant_id.to_owned()),
-                None,
-                None,
-                Some(dsl::created_at.asc()),
-            )
-            .await
-        } else {
-            generics::generic_filter::<
-                <Self as HasTable>::Table,
-                _,
-                <<Self as HasTable>::Table as Table>::PrimaryKey,
-                _,
-            >(
-                conn,
-                dsl::merchant_id
-                    .eq(merchant_id.to_owned())
-                    .and(dsl::disabled.eq(false)),
-                None,
-                None,
-                None,
-            )
-            .await
-        }
-    }
-
-    pub async fn list_enabled_by_profile_id(
-        conn: &DatabaseConnectionWithContext<'_>,
-        profile_id: &common_utils::id_type::ProfileId,
-        connector_type: common_enums::ConnectorType,
     ) -> StorageResult<Vec<Self>> {
         generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
             conn,
-            dsl::profile_id
-                .eq(profile_id.to_owned())
-                .and(dsl::disabled.eq(false))
-                .and(dsl::connector_type.eq(connector_type)),
+            dsl::merchant_id.eq(merchant_id.to_owned()),
             None,
             None,
             Some(dsl::created_at.asc()),
@@ -174,47 +118,27 @@ impl MerchantConnectorAccount {
         .await
     }
 
-    pub async fn list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id(
+    /// Every merchant connector account of a merchant's profile, including disabled ones,
+    /// ordered by `created_at` ascending. The other profile-scoped list queries are
+    /// row-subsets of this one, so it doubles as the cached superset they project from.
+    ///
+    /// Scoped by merchant as well as profile so the cached superset can be keyed by both.
+    /// Profile ids are globally unique, so the extra predicate does not change the rows
+    /// returned; it keeps one merchant's cache entries from ever being addressable by
+    /// another's key.
+    pub async fn list_by_merchant_id_profile_id(
         conn: &DatabaseConnectionWithContext<'_>,
         merchant_id: &common_utils::id_type::MerchantId,
         profile_id: &common_utils::id_type::ProfileId,
     ) -> StorageResult<Vec<Self>> {
-        generics::generic_filter::<
-            <Self as HasTable>::Table,
-            _,
-            <<Self as HasTable>::Table as Table>::PrimaryKey,
-            _,
-        >(
+        generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
             conn,
             dsl::merchant_id
                 .eq(merchant_id.to_owned())
                 .and(dsl::profile_id.eq(profile_id.to_owned())),
             None,
             None,
-            None,
-        )
-        .await
-    }
-
-    pub async fn list_enabled_merchant_connector_accounts_without_encrypted_by_merchant_id_profile_id(
-        conn: &DatabaseConnectionWithContext<'_>,
-        merchant_id: &common_utils::id_type::MerchantId,
-        profile_id: &common_utils::id_type::ProfileId,
-    ) -> StorageResult<Vec<Self>> {
-        generics::generic_filter::<
-            <Self as HasTable>::Table,
-            _,
-            <<Self as HasTable>::Table as Table>::PrimaryKey,
-            _,
-        >(
-            conn,
-            dsl::merchant_id
-                .eq(merchant_id.to_owned())
-                .and(dsl::profile_id.eq(profile_id.to_owned()))
-                .and(dsl::disabled.eq(false)),
-            None,
-            None,
-            None,
+            Some(dsl::created_at.asc()),
         )
         .await
     }
@@ -261,46 +185,16 @@ impl MerchantConnectorAccount {
         .await
     }
 
-    pub async fn find_by_merchant_id(
+    /// Every merchant connector account of a merchant, including disabled ones, ordered by
+    /// `created_at` ascending. The other merchant-scoped list queries are row-subsets of
+    /// this one, so it doubles as the cached superset they project from.
+    pub async fn list_by_merchant_id(
         conn: &DatabaseConnectionWithContext<'_>,
         merchant_id: &common_utils::id_type::MerchantId,
-        get_disabled: bool,
-    ) -> StorageResult<Vec<Self>> {
-        if get_disabled {
-            generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
-                conn,
-                dsl::merchant_id.eq(merchant_id.to_owned()),
-                None,
-                None,
-                Some(dsl::created_at.asc()),
-            )
-            .await
-        } else {
-            generics::generic_filter::<
-                <Self as HasTable>::Table,
-                _,
-                <<Self as HasTable>::Table as Table>::PrimaryKey,
-                _,
-            >(
-                conn,
-                dsl::merchant_id
-                    .eq(merchant_id.to_owned())
-                    .and(dsl::disabled.eq(false)),
-                None,
-                None,
-                None,
-            )
-            .await
-        }
-    }
-
-    pub async fn list_by_profile_id(
-        conn: &DatabaseConnectionWithContext<'_>,
-        profile_id: &common_utils::id_type::ProfileId,
     ) -> StorageResult<Vec<Self>> {
         generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
             conn,
-            dsl::profile_id.eq(profile_id.to_owned()),
+            dsl::merchant_id.eq(merchant_id.to_owned()),
             None,
             None,
             Some(dsl::created_at.asc()),
@@ -308,62 +202,24 @@ impl MerchantConnectorAccount {
         .await
     }
 
-    pub async fn list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id(
+    /// Every merchant connector account of a merchant's profile, including disabled ones,
+    /// ordered by `created_at` ascending. The other profile-scoped list queries are
+    /// row-subsets of this one, so it doubles as the cached superset they project from.
+    ///
+    /// Scoped by merchant as well as profile so the cached superset can be keyed by both.
+    /// Profile ids are globally unique, so the extra predicate does not change the rows
+    /// returned; it keeps one merchant's cache entries from ever being addressable by
+    /// another's key.
+    pub async fn list_by_merchant_id_profile_id(
         conn: &DatabaseConnectionWithContext<'_>,
         merchant_id: &common_utils::id_type::MerchantId,
         profile_id: &common_utils::id_type::ProfileId,
     ) -> StorageResult<Vec<Self>> {
-        generics::generic_filter::<
-            <Self as HasTable>::Table,
-            _,
-            <<Self as HasTable>::Table as Table>::PrimaryKey,
-            _,
-        >(
+        generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
             conn,
             dsl::merchant_id
                 .eq(merchant_id.to_owned())
                 .and(dsl::profile_id.eq(profile_id.to_owned())),
-            None,
-            None,
-            None,
-        )
-        .await
-    }
-
-    pub async fn list_enabled_merchant_connector_accounts_without_encrypted_by_merchant_id_profile_id(
-        conn: &DatabaseConnectionWithContext<'_>,
-        merchant_id: &common_utils::id_type::MerchantId,
-        profile_id: &common_utils::id_type::ProfileId,
-    ) -> StorageResult<Vec<Self>> {
-        generics::generic_filter::<
-            <Self as HasTable>::Table,
-            _,
-            <<Self as HasTable>::Table as Table>::PrimaryKey,
-            _,
-        >(
-            conn,
-            dsl::merchant_id
-                .eq(merchant_id.to_owned())
-                .and(dsl::profile_id.eq(profile_id.to_owned()))
-                .and(dsl::disabled.eq(false)),
-            None,
-            None,
-            None,
-        )
-        .await
-    }
-
-    pub async fn list_enabled_by_profile_id(
-        conn: &DatabaseConnectionWithContext<'_>,
-        profile_id: &common_utils::id_type::ProfileId,
-        connector_type: common_enums::ConnectorType,
-    ) -> StorageResult<Vec<Self>> {
-        generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
-            conn,
-            dsl::profile_id
-                .eq(profile_id.to_owned())
-                .and(dsl::disabled.eq(false))
-                .and(dsl::connector_type.eq(connector_type)),
             None,
             None,
             Some(dsl::created_at.asc()),

--- a/crates/router/src/routes/metrics/bg_metrics_collector.rs
+++ b/crates/router/src/routes/metrics/bg_metrics_collector.rs
@@ -9,6 +9,7 @@ pub fn spawn_metrics_collector(metrics_collection_interval_in_secs: Option<u16>)
     let cache_instances = [
         &cache::CONFIG_CACHE,
         &cache::ACCOUNTS_CACHE,
+        &cache::MCA_LIST_CACHE,
         &cache::ROUTING_CACHE,
         &cache::CGRAPH_CACHE,
         &cache::PM_FILTERS_CGRAPH_CACHE,

--- a/crates/storage_impl/src/merchant_connector_account.rs
+++ b/crates/storage_impl/src/merchant_connector_account.rs
@@ -17,6 +17,166 @@ use crate::{
     CustomResult, DatabaseStore, MockDb, RouterStore, StorageError,
 };
 
+/// Cache keys and invalidation for the merchant connector account list caches.
+///
+/// Every list query in this module is a row-subset of one of two supersets — all accounts
+/// of a merchant, or all accounts of a profile — so those are the only two things ever
+/// cached. A write touching a single account therefore invalidates every list entry that
+/// could contain it by redacting exactly two keys, both derivable from the account alone.
+///
+/// This is the only place list cache keys are constructed. Adding a new list query means
+/// adding a projection over one of the supersets; no write path needs to change for it.
+#[cfg(feature = "accounts_cache")]
+mod list_cache {
+    use common_utils::id_type;
+
+    use crate::redis::cache::CacheKind;
+
+    /// Key of the superset holding every account of a merchant, disabled included.
+    pub(super) fn merchant_scope_key(merchant_id: &id_type::MerchantId) -> String {
+        format!("mca_list_m_{}", merchant_id.get_string_repr())
+    }
+
+    /// Key of the superset holding every account of a merchant's profile, disabled
+    /// included. Scoped by merchant as well as profile so that one merchant's entries are
+    /// never addressable by another merchant's key.
+    pub(super) fn merchant_profile_scope_key(
+        merchant_id: &id_type::MerchantId,
+        profile_id: &id_type::ProfileId,
+    ) -> String {
+        format!(
+            "mca_list_mp_{}_{}",
+            merchant_id.get_string_repr(),
+            profile_id.get_string_repr()
+        )
+    }
+
+    /// The complete set of list cache entries a single account belongs to.
+    ///
+    /// `profile_id` is deliberately required rather than optional. An `Option` here would
+    /// conflate two different things — "this account has no profile", where there is no
+    /// profile superset to drop, and "the caller does not know this account's profile",
+    /// where one must be dropped but no key can be built for it. The second silently
+    /// leaves `mca_list_mp_*` serving pre-write rows, so a caller that lacks the profile
+    /// id has to go and fetch it (as the delete paths do) rather than pass `None`.
+    ///
+    /// Returning a fixed-size array keeps "always exactly these two" a property of the
+    /// type rather than of the body.
+    pub(super) fn invalidation_kinds<'a>(
+        merchant_id: &id_type::MerchantId,
+        profile_id: &id_type::ProfileId,
+    ) -> [CacheKind<'a>; 2] {
+        [
+            CacheKind::MerchantConnectorAccountList(merchant_scope_key(merchant_id).into()),
+            CacheKind::MerchantConnectorAccountList(
+                merchant_profile_scope_key(merchant_id, profile_id).into(),
+            ),
+        ]
+    }
+}
+
+/// Every merchant connector account of a merchant, disabled included, ordered by
+/// `created_at` ascending.
+///
+/// The merchant-scoped list queries are row-subsets of this and project from it, so this
+/// is the only place they touch the database or the cache.
+async fn list_all_by_merchant_id<T: DatabaseStore>(
+    store: &RouterStore<T>,
+    merchant_id: &common_utils::id_type::MerchantId,
+) -> CustomResult<Vec<storage::MerchantConnectorAccount>, StorageError> {
+    let find_call = || async {
+        let conn = pg_accounts_connection_read(store).await?;
+        storage::MerchantConnectorAccount::list_by_merchant_id(&conn, merchant_id)
+            .await
+            .map_err(|error| report!(StorageError::from(error)))
+    };
+
+    #[cfg(not(feature = "accounts_cache"))]
+    {
+        find_call().await
+    }
+
+    #[cfg(feature = "accounts_cache")]
+    {
+        cache::get_or_populate_in_memory(
+            store,
+            &list_cache::merchant_scope_key(merchant_id),
+            find_call,
+            &cache::MCA_LIST_CACHE,
+        )
+        .await
+    }
+}
+
+/// Every merchant connector account of a merchant's profile, disabled included, ordered
+/// by `created_at` ascending.
+///
+/// The profile-scoped list queries are row-subsets of this and project from it, so this
+/// is the only place they touch the database or the cache.
+async fn list_all_by_merchant_id_profile_id<T: DatabaseStore>(
+    store: &RouterStore<T>,
+    merchant_id: &common_utils::id_type::MerchantId,
+    profile_id: &common_utils::id_type::ProfileId,
+) -> CustomResult<Vec<storage::MerchantConnectorAccount>, StorageError> {
+    let find_call = || async {
+        let conn = pg_accounts_connection_read(store).await?;
+        storage::MerchantConnectorAccount::list_by_merchant_id_profile_id(
+            &conn,
+            merchant_id,
+            profile_id,
+        )
+        .await
+        .map_err(|error| report!(StorageError::from(error)))
+    };
+
+    #[cfg(not(feature = "accounts_cache"))]
+    {
+        find_call().await
+    }
+
+    #[cfg(feature = "accounts_cache")]
+    {
+        cache::get_or_populate_in_memory(
+            store,
+            &list_cache::merchant_profile_scope_key(merchant_id, profile_id),
+            find_call,
+            &cache::MCA_LIST_CACHE,
+        )
+        .await
+    }
+}
+
+/// Decrypt a batch of account rows into domain accounts, concurrently.
+///
+/// Each conversion is a `BatchDecrypt` which, when the encryption service is enabled, is
+/// its own HTTP round-trip to the keymanager — so decrypting a list of N accounts
+/// sequentially costs N round-trips. Falling back to application-local AES this is
+/// CPU-bound and merely interleaves, which costs nothing either way.
+///
+/// `try_join_all` preserves input order, which matters: the supersets these rows come
+/// from are ordered by `created_at`, and the queries projecting them rely on it.
+async fn decrypt_all<T: DatabaseStore>(
+    store: &RouterStore<T>,
+    accounts: Vec<storage::MerchantConnectorAccount>,
+    key_store: &MerchantKeyStore,
+) -> CustomResult<Vec<domain::MerchantConnectorAccount>, StorageError> {
+    let keymanager_state = store
+        .get_keymanager_state()
+        .attach_printable("Missing KeyManagerState")?;
+
+    futures::future::try_join_all(accounts.into_iter().map(|account| async move {
+        account
+            .convert(
+                keymanager_state,
+                key_store.key.get_inner(),
+                key_store.merchant_id.clone().into(),
+            )
+            .await
+            .change_context(StorageError::DecryptionError)
+    }))
+    .await
+}
+
 #[async_trait::async_trait]
 impl<T: DatabaseStore> MerchantConnectorAccountInterface for kv_router_store::KVRouterStore<T> {
     type Error = StorageError;
@@ -378,31 +538,13 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
         connector_name: &str,
         key_store: &MerchantKeyStore,
     ) -> CustomResult<Vec<domain::MerchantConnectorAccount>, Self::Error> {
-        let conn = pg_accounts_connection_read(self).await?;
-        storage::MerchantConnectorAccount::find_by_merchant_id_connector_name(
-            &conn,
-            merchant_id,
-            connector_name,
-        )
-        .await
-        .map_err(|error| report!(Self::Error::from(error)))
-        .async_and_then(|items| async {
-            let mut output = Vec::with_capacity(items.len());
-            for item in items.into_iter() {
-                output.push(
-                    item.convert(
-                        self.get_keymanager_state()
-                            .attach_printable("Missing KeyManagerState")?,
-                        key_store.key.get_inner(),
-                        key_store.merchant_id.clone().into(),
-                    )
-                    .await
-                    .change_context(Self::Error::DecryptionError)?,
-                )
-            }
-            Ok(output)
-        })
-        .await
+        let accounts = list_all_by_merchant_id(self, merchant_id)
+            .await?
+            .into_iter()
+            .filter(|account| account.connector_name == connector_name)
+            .collect();
+
+        decrypt_all(self, accounts, key_store).await
     }
 
     #[instrument(skip_all)]
@@ -518,24 +660,46 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
         t: domain::MerchantConnectorAccount,
         key_store: &MerchantKeyStore,
     ) -> CustomResult<domain::MerchantConnectorAccount, Self::Error> {
-        let conn = pg_accounts_connection_write(self).await?;
-        t.construct_new()
-            .await
-            .change_context(Self::Error::EncryptionError)?
-            .insert(&conn)
-            .await
-            .map_err(|error| report!(Self::Error::from(error)))
-            .async_and_then(|item| async {
-                item.convert(
-                    self.get_keymanager_state()
-                        .attach_printable("Missing KeyManagerState")?,
-                    key_store.key.get_inner(),
-                    key_store.merchant_id.clone().into(),
-                )
+        let _merchant_id = t.merchant_id.clone();
+        let _profile_id = t.profile_id.clone();
+
+        let insert_call = || async {
+            let conn = pg_accounts_connection_write(self).await?;
+            t.construct_new()
                 .await
-                .change_context(Self::Error::DecryptionError)
-            })
+                .change_context(Self::Error::EncryptionError)?
+                .insert(&conn)
+                .await
+                .map_err(|error| report!(Self::Error::from(error)))
+                .async_and_then(|item| async {
+                    item.convert(
+                        self.get_keymanager_state()
+                            .attach_printable("Missing KeyManagerState")?,
+                        key_store.key.get_inner(),
+                        key_store.merchant_id.clone().into(),
+                    )
+                    .await
+                    .change_context(Self::Error::DecryptionError)
+                })
+                .await
+        };
+
+        #[cfg(feature = "accounts_cache")]
+        {
+            // A newly created account belongs to both list supersets, so any cached list
+            // that should now contain it has to go.
+            Box::pin(cache::publish_and_redact_multiple(
+                self,
+                list_cache::invalidation_kinds(&_merchant_id, &_profile_id),
+                insert_call,
+            ))
             .await
+        }
+
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            insert_call().await
+        }
     }
 
     async fn list_enabled_connector_accounts_by_profile_id(
@@ -544,32 +708,13 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
         key_store: &MerchantKeyStore,
         connector_type: common_enums::ConnectorType,
     ) -> CustomResult<Vec<domain::MerchantConnectorAccount>, Self::Error> {
-        let conn = pg_accounts_connection_read(self).await?;
+        let accounts = list_all_by_merchant_id_profile_id(self, &key_store.merchant_id, profile_id)
+            .await?
+            .into_iter()
+            .filter(|account| account.is_enabled() && account.connector_type == connector_type)
+            .collect();
 
-        storage::MerchantConnectorAccount::list_enabled_by_profile_id(
-            &conn,
-            profile_id,
-            connector_type,
-        )
-        .await
-        .map_err(|error| report!(Self::Error::from(error)))
-        .async_and_then(|items| async {
-            let mut output = Vec::with_capacity(items.len());
-            for item in items.into_iter() {
-                output.push(
-                    item.convert(
-                        self.get_keymanager_state()
-                            .attach_printable("Missing KeyManagerState")?,
-                        key_store.key.get_inner(),
-                        key_store.merchant_id.clone().into(),
-                    )
-                    .await
-                    .change_context(Self::Error::DecryptionError)?,
-                )
-            }
-            Ok(output)
-        })
-        .await
+        decrypt_all(self, accounts, key_store).await
     }
 
     #[instrument(skip_all)]
@@ -579,32 +724,14 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
         get_disabled: bool,
         key_store: &MerchantKeyStore,
     ) -> CustomResult<domain::MerchantConnectorAccounts, Self::Error> {
-        let conn = pg_accounts_connection_read(self).await?;
-        let merchant_connector_account_vec =
-            storage::MerchantConnectorAccount::find_by_merchant_id(
-                &conn,
-                merchant_id,
-                get_disabled,
-            )
-            .await
-            .map_err(|error| report!(Self::Error::from(error)))
-            .async_and_then(|items| async {
-                let mut output = Vec::with_capacity(items.len());
-                for item in items.into_iter() {
-                    output.push(
-                        item.convert(
-                            self.get_keymanager_state()
-                                .attach_printable("Missing KeyManagerState")?,
-                            key_store.key.get_inner(),
-                            key_store.merchant_id.clone().into(),
-                        )
-                        .await
-                        .change_context(Self::Error::DecryptionError)?,
-                    )
-                }
-                Ok(output)
-            })
-            .await?;
+        let accounts = list_all_by_merchant_id(self, merchant_id)
+            .await?
+            .into_iter()
+            .filter(|account| get_disabled || account.is_enabled())
+            .collect();
+
+        let merchant_connector_account_vec = decrypt_all(self, accounts, key_store).await?;
+
         Ok(domain::MerchantConnectorAccounts::new(
             merchant_connector_account_vec,
         ))
@@ -616,17 +743,12 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
         merchant_id: &common_utils::id_type::MerchantId,
         get_disabled: bool,
     ) -> CustomResult<domain::MerchantConnectorAccountsWithoutEncrypted, Self::Error> {
-        let conn = pg_accounts_connection_read(self).await?;
-        let items = storage::MerchantConnectorAccount::find_by_merchant_id(
-            &conn,
-            merchant_id,
-            get_disabled,
-        )
-        .await
-        .map_err(|error| report!(Self::Error::from(error)))?;
-
-        let output = items
+        let accounts = list_all_by_merchant_id(self, merchant_id)
+            .await?
             .into_iter()
+            .filter(|account| get_disabled || account.is_enabled());
+
+        let output = accounts
             .map(domain::MerchantConnectorAccountWithoutEncrypted::try_from)
             .collect::<Result<Vec<_>, _>>()
             .change_context(Self::Error::DecryptionError)?;
@@ -642,17 +764,11 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
         merchant_id: &common_utils::id_type::MerchantId,
         profile_id: &common_utils::id_type::ProfileId,
     ) -> CustomResult<domain::MerchantConnectorAccountsWithoutEncrypted, Self::Error> {
-        let conn = pg_accounts_connection_read(self).await?;
-        let items = storage::MerchantConnectorAccount::list_merchant_connector_accounts_without_encrypted_including_disabled_by_merchant_id_profile_id(
-            &conn,
-            merchant_id,
-            profile_id,
-        )
-        .await
-        .map_err(|error| report!(Self::Error::from(error)))?;
+        let accounts = list_all_by_merchant_id_profile_id(self, merchant_id, profile_id)
+            .await?
+            .into_iter();
 
-        let output = items
-            .into_iter()
+        let output = accounts
             .map(domain::MerchantConnectorAccountWithoutEncrypted::try_from)
             .collect::<Result<Vec<_>, _>>()
             .change_context(Self::Error::DecryptionError)?;
@@ -668,17 +784,12 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
         merchant_id: &common_utils::id_type::MerchantId,
         profile_id: &common_utils::id_type::ProfileId,
     ) -> CustomResult<domain::MerchantConnectorAccountsWithoutEncrypted, Self::Error> {
-        let conn = pg_accounts_connection_read(self).await?;
-        let items = storage::MerchantConnectorAccount::list_enabled_merchant_connector_accounts_without_encrypted_by_merchant_id_profile_id(
-            &conn,
-            merchant_id,
-            profile_id,
-        )
-        .await
-        .map_err(|error| report!(Self::Error::from(error)))?;
-
-        let output = items
+        let accounts = list_all_by_merchant_id_profile_id(self, merchant_id, profile_id)
+            .await?
             .into_iter()
+            .filter(|account| account.is_enabled());
+
+        let output = accounts
             .map(domain::MerchantConnectorAccountWithoutEncrypted::try_from)
             .collect::<Result<Vec<_>, _>>()
             .change_context(Self::Error::DecryptionError)?;
@@ -695,27 +806,10 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
         profile_id: &common_utils::id_type::ProfileId,
         key_store: &MerchantKeyStore,
     ) -> CustomResult<Vec<domain::MerchantConnectorAccount>, Self::Error> {
-        let conn = pg_accounts_connection_read(self).await?;
-        storage::MerchantConnectorAccount::list_by_profile_id(&conn, profile_id)
-            .await
-            .map_err(|error| report!(Self::Error::from(error)))
-            .async_and_then(|items| async {
-                let mut output = Vec::with_capacity(items.len());
-                for item in items.into_iter() {
-                    output.push(
-                        item.convert(
-                            self.get_keymanager_state()
-                                .attach_printable("Missing KeyManagerState")?,
-                            key_store.key.get_inner(),
-                            key_store.merchant_id.clone().into(),
-                        )
-                        .await
-                        .change_context(Self::Error::DecryptionError)?,
-                    )
-                }
-                Ok(output)
-            })
-            .await
+        let accounts =
+            list_all_by_merchant_id_profile_id(self, &key_store.merchant_id, profile_id).await?;
+
+        decrypt_all(self, accounts, key_store).await
     }
 
     #[instrument(skip_all)]
@@ -796,7 +890,10 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
                                 )
                                 .into(),
                             ),
-                        ],
+                        ]
+                        .into_iter()
+                        .chain(list_cache::invalidation_kinds(&_merchant_id, &_profile_id))
+                        .collect::<Vec<_>>(),
                         || update,
                     ))
                     .await
@@ -901,7 +998,10 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
                         )
                         .into(),
                     ),
-                ],
+                ]
+                .into_iter()
+                .chain(list_cache::invalidation_kinds(&_merchant_id, &_profile_id))
+                .collect::<Vec<_>>(),
                 update_call,
             ))
             .await
@@ -978,7 +1078,10 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
                         )
                         .into(),
                     ),
-                ],
+                ]
+                .into_iter()
+                .chain(list_cache::invalidation_kinds(&_merchant_id, &_profile_id))
+                .collect::<Vec<_>>(),
                 update_call,
             ))
             .await
@@ -1054,7 +1157,13 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
                         )
                         .into(),
                     ),
-                ],
+                ]
+                .into_iter()
+                .chain(list_cache::invalidation_kinds(
+                    &mca.merchant_id,
+                    &_profile_id,
+                ))
+                .collect::<Vec<_>>(),
                 delete_call,
             )
             .await
@@ -1119,7 +1228,13 @@ impl<T: DatabaseStore> MerchantConnectorAccountInterface for RouterStore<T> {
                         )
                         .into(),
                     ),
-                ],
+                ]
+                .into_iter()
+                .chain(list_cache::invalidation_kinds(
+                    &mca.merchant_id,
+                    &_profile_id,
+                ))
+                .collect::<Vec<_>>(),
                 delete_call,
             )
             .await
@@ -1735,5 +1850,37 @@ impl MerchantConnectorAccountInterface for MockDb {
                 .into())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Any write to a single account has to drop both supersets that could contain it,
+    /// otherwise a cached list keeps serving the pre-write rows.
+    #[cfg(feature = "accounts_cache")]
+    #[test]
+    fn invalidation_covers_both_supersets() {
+        let merchant_id = common_utils::id_type::MerchantId::try_from(std::borrow::Cow::from(
+            "merchant_the_first",
+        ))
+        .expect("valid merchant id");
+        let profile_id =
+            common_utils::id_type::ProfileId::try_from(std::borrow::Cow::from("profile_the_first"))
+                .expect("valid profile id");
+
+        let keys = list_cache::invalidation_kinds(&merchant_id, &profile_id)
+            .into_iter()
+            .map(|kind| kind.get_key_without_prefix().to_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            keys,
+            vec![
+                "mca_list_m_merchant_the_first".to_string(),
+                "mca_list_mp_merchant_the_first_profile_the_first".to_string(),
+            ]
+        );
     }
 }

--- a/crates/storage_impl/src/redis/cache.rs
+++ b/crates/storage_impl/src/redis/cache.rs
@@ -44,6 +44,15 @@ pub static CONFIG_CACHE: LazyLock<Cache> =
 pub static ACCOUNTS_CACHE: LazyLock<Cache> =
     LazyLock::new(|| Cache::new("ACCOUNTS_CACHE", CACHE_TTL, CACHE_TTI, Some(MAX_CAPACITY)));
 
+/// Merchant connector account list cache.
+///
+/// Holds whole-scope supersets of merchant connector account rows (every account of a
+/// merchant, or of a profile) which the individual list queries project from. Kept
+/// separate from [`ACCOUNTS_CACHE`] so that list hit rates and entry counts are
+/// observable on their own, and so the two can be sized independently.
+pub static MCA_LIST_CACHE: LazyLock<Cache> =
+    LazyLock::new(|| Cache::new("MCA_LIST_CACHE", CACHE_TTL, CACHE_TTI, Some(MAX_CAPACITY)));
+
 /// Routing Cache
 pub static ROUTING_CACHE: LazyLock<Cache> =
     LazyLock::new(|| Cache::new("ROUTING_CACHE", CACHE_TTL, CACHE_TTI, Some(MAX_CAPACITY)));
@@ -121,6 +130,7 @@ pub struct CacheRedact<'a> {
 pub enum CacheKind<'a> {
     Config(Cow<'a, str>),
     Accounts(Cow<'a, str>),
+    MerchantConnectorAccountList(Cow<'a, str>),
     Routing(Cow<'a, str>),
     DecisionManager(Cow<'a, str>),
     Surcharge(Cow<'a, str>),
@@ -137,6 +147,7 @@ impl CacheKind<'_> {
         match self {
             CacheKind::Config(key)
             | CacheKind::Accounts(key)
+            | CacheKind::MerchantConnectorAccountList(key)
             | CacheKind::Routing(key)
             | CacheKind::DecisionManager(key)
             | CacheKind::Surcharge(key)

--- a/crates/storage_impl/src/redis/pub_sub.rs
+++ b/crates/storage_impl/src/redis/pub_sub.rs
@@ -7,8 +7,8 @@ use router_env::{logger, tracing::Instrument};
 use crate::redis::cache::{
     CacheKey, CacheKind, CacheRedact, ACCOUNTS_CACHE, CGRAPH_CACHE, CONFIG_CACHE,
     CONTRACT_BASED_DYNAMIC_ALGORITHM_CACHE, DECISION_MANAGER_CACHE,
-    ELIMINATION_BASED_DYNAMIC_ALGORITHM_CACHE, PM_FILTERS_CGRAPH_CACHE, ROUTING_CACHE,
-    SUCCESS_BASED_DYNAMIC_ALGORITHM_CACHE, SURCHARGE_CACHE,
+    ELIMINATION_BASED_DYNAMIC_ALGORITHM_CACHE, MCA_LIST_CACHE, PM_FILTERS_CGRAPH_CACHE,
+    ROUTING_CACHE, SUCCESS_BASED_DYNAMIC_ALGORITHM_CACHE, SURCHARGE_CACHE,
 };
 
 #[async_trait::async_trait]
@@ -115,6 +115,15 @@ impl PubSubInterface for std::sync::Arc<redis_interface::RedisConnectionPool> {
                                 .await;
                             key
                         }
+                        CacheKind::MerchantConnectorAccountList(key) => {
+                            MCA_LIST_CACHE
+                                .remove(CacheKey {
+                                    key: key.to_string(),
+                                    prefix: message.tenant.clone(),
+                                })
+                                .await;
+                            key
+                        }
                         CacheKind::CGraph(key) => {
                             CGRAPH_CACHE
                                 .remove(CacheKey {
@@ -195,6 +204,12 @@ impl PubSubInterface for std::sync::Arc<redis_interface::RedisConnectionPool> {
                                 })
                                 .await;
                             ACCOUNTS_CACHE
+                                .remove(CacheKey {
+                                    key: key.to_string(),
+                                    prefix: message.tenant.clone(),
+                                })
+                                .await;
+                            MCA_LIST_CACHE
                                 .remove(CacheKey {
                                     key: key.to_string(),
                                     prefix: message.tenant.clone(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

All seven merchant connector account list queries hit Postgres on every call, including hot paths in routing and payments. This PR caches them as two whole-scope supersets — every account of a merchant, and every account of a merchant's profile — which each list query then projects from in memory.

Keying on scope rather than on each query's arguments makes invalidation complete by construction: any insert, update or delete redacts exactly two keys, both derivable from the account alone, so a single MCA change drops every list entry that could contain it, and a list query added later is covered by adding a projection rather than by extending a write path.

- Add `MCA_LIST_CACHE` and `CacheKind::MerchantConnectorAccountList`, wired into the pub/sub invalidation handler, the `CacheKind::All` fan-out, and the background metrics collector
- Collapse the merchant- and profile-scoped queries into `list_by_merchant_id` and `list_by_merchant_id_profile_id`, removing the seven list builders they replace, leaving no way to read a list of MCAs that skips the cache
- Decrypt list results concurrently; with the encryption service enabled each conversion is its own keymanager round-trip
- Add `MerchantConnectorAccount::is_enabled()`, mirroring the SQL `disabled = false` check that does not match `NULL`
- Fix: `insert` previously performed no cache invalidation at all, so a newly created connector would never have appeared in a cached list

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Merchant connector account list queries are on hot paths (routing, payments) and were uncached, causing repeated Postgres round-trips for data that changes infrequently relative to how often it's read.

## How did you test it?

Verified with `cargo +nightly fmt --all`, `cargo clippy` (v1) and `check_v2` across all targets, plus unit tests. Not yet exercised against a live Postgres/Redis.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
