### PR TITLE
fix(connector): [Payshield] Use payment attempt creation time for FRM requests

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/absa_sanlam.rs
+++ b/crates/hyperswitch_connectors/src/connectors/absa_sanlam.rs
@@ -443,6 +443,7 @@ impl ConnectorSpecifications for AbsaSanlam {
                 .merchant_connector_id
                 .as_ref()
                 .map(|id| id.get_string_repr().to_owned()),
+            created_at: payment_attempt.created_at,
         };
         serde_json::to_value(metadata)
             .change_context(errors::ConnectorError::RequestEncodingFailed)

--- a/crates/hyperswitch_connectors/src/connectors/absa_sanlam/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/absa_sanlam/transformers.rs
@@ -16,6 +16,7 @@ use crate::{types::ResponseRouterData, utils};
 pub struct AbsaSanlamFrmMetadata {
     pub profile_id: String,
     pub connector_id: Option<String>,
+    pub created_at: time::PrimitiveDateTime,
 }
 
 pub struct AbsaSanlamAuthType {

--- a/crates/hyperswitch_connectors/src/connectors/sanlam_payshield/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/sanlam_payshield/transformers.rs
@@ -36,6 +36,7 @@ impl TryFrom<&ConnectorAuthType> for SanlamPayshieldAuthType {
 pub struct SanlamPayshieldFrmMetadata {
     pub profile_id: String,
     pub connector_id: Option<String>,
+    pub created_at: time::PrimitiveDateTime,
 }
 
 #[derive(Debug, Serialize)]
@@ -79,6 +80,7 @@ impl TryFrom<&FrmCheckoutRouterData> for SanlamPayshieldCheckoutRequest {
         let SanlamPayshieldFrmMetadata {
             profile_id,
             connector_id,
+            created_at,
         } = data
             .request
             .gateway_metadata
@@ -111,6 +113,14 @@ impl TryFrom<&FrmCheckoutRouterData> for SanlamPayshieldCheckoutRequest {
             )),
         }?;
 
+        let created_at = created_at
+            .assume_utc()
+            .to_offset(time::macros::offset!(+2))
+            .format(time::macros::format_description!(
+                "[year]-[month]-[day]T[hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"
+            ))
+            .change_context(ConnectorError::RequestEncodingFailed)?;
+
         Ok(Self {
             request_id: data.connector_request_reference_id.clone(),
             profile_id,
@@ -121,24 +131,11 @@ impl TryFrom<&FrmCheckoutRouterData> for SanlamPayshieldCheckoutRequest {
                 amount_in_cents: data.request.amount.to_string(),
                 currency: currency.to_string(),
                 payment_method_type,
-                created_at: get_current_time()?,
+                created_at,
             },
             metadata: data.frm_metadata.clone(),
         })
     }
-}
-
-fn get_current_time() -> Result<String, error_stack::Report<ConnectorError>> {
-    let format = time::macros::format_description!(
-        "[year]-[month]-[day]T[hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"
-    );
-
-    let time = time::OffsetDateTime::now_utc()
-        .to_offset(time::macros::offset!(+2))
-        .format(&format)
-        .change_context(ConnectorError::RequestEncodingFailed)?;
-
-    Ok(time)
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Added the payment attempt's `created_at` timestamp to the absa_sanlam FRM metadata.
- Used this timestamp when constructing the sanlam_payshield checkout request to send attempt creation time.
- Clippy rejects direct calls to `time::OffsetDateTime::now_utc()` 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This is a v2 compilation fix pr.
Original PR with tests: #13595 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
